### PR TITLE
feat(player): add a calendar to the player

### DIFF
--- a/lib/mydia/db.ex
+++ b/lib/mydia/db.ex
@@ -245,6 +245,53 @@ defmodule Mydia.DB do
   end
 
   @doc """
+  Runtime-switchable JSON date range check, both bounds inclusive.
+
+  Dates are stored through `Jason.encode!` as ISO-8601 strings, which sort
+  lexicographically, so a string comparison answers a date range correctly on
+  both adapters without any date parsing in SQL.
+
+  ## Parameters
+
+  - `field_atom` - The field name as an atom (e.g. `:metadata`)
+  - `path` - The JSON path string using SQLite `$.key` syntax
+  - `start_date` - Earliest date to match, inclusive
+  - `end_date` - Latest date to match, inclusive
+
+  ## Examples
+
+      from m in MediaItem,
+        where: ^Mydia.DB.json_date_between(:metadata, "$.release_date", ~D[2026-08-01], ~D[2026-08-31])
+
+  ## Database-specific behavior
+
+  - **SQLite**: `json_extract(field, path) BETWEEN ? AND ?`
+  - **PostgreSQL**: `field ->> 'key' BETWEEN ? AND ?`
+  """
+  @spec json_date_between(atom(), String.t(), Date.t(), Date.t()) :: Ecto.Query.dynamic_expr()
+  def json_date_between(field_atom, path, %Date{} = start_date, %Date{} = end_date)
+      when is_atom(field_atom) and is_binary(path) do
+    start_string = Date.to_iso8601(start_date)
+    end_string = Date.to_iso8601(end_date)
+
+    if postgres?() do
+      pg_key = sqlite_path_to_postgres_key(path)
+
+      dynamic(
+        [q],
+        fragment("?::jsonb ->> ?", field(q, ^field_atom), ^pg_key) >= ^start_string and
+          fragment("?::jsonb ->> ?", field(q, ^field_atom), ^pg_key) <= ^end_string
+      )
+    else
+      dynamic(
+        [q],
+        fragment("json_extract(?, ?)", field(q, ^field_atom), ^path) >= ^start_string and
+          fragment("json_extract(?, ?)", field(q, ^field_atom), ^path) <= ^end_string
+      )
+    end
+  end
+
+  @doc """
   Runtime-switchable JSON null check.
 
   Returns a dynamic expression that checks if a JSON field has a null value

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1584,7 +1584,7 @@ defmodule Mydia.Media do
       has_files:
         type(
           fragment(
-            "CASE WHEN EXISTS(SELECT 1 FROM media_files WHERE episode_id = ?) THEN true ELSE false END",
+            "CASE WHEN EXISTS(SELECT 1 FROM media_files WHERE episode_id = ? AND trashed_at IS NULL) THEN true ELSE false END",
             e.id
           ),
           :boolean
@@ -1647,7 +1647,7 @@ defmodule Mydia.Media do
       has_files:
         type(
           fragment(
-            "CASE WHEN EXISTS(SELECT 1 FROM media_files WHERE media_item_id = ?) THEN true ELSE false END",
+            "CASE WHEN EXISTS(SELECT 1 FROM media_files WHERE media_item_id = ? AND trashed_at IS NULL) THEN true ELSE false END",
             m.id
           ),
           :boolean

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1576,23 +1576,26 @@ defmodule Mydia.Media do
     query
     |> select([e, m], %{
       id: e.id,
-      type: "episode",
       air_date: e.air_date,
       title: e.title,
       season_number: e.season_number,
       episode_number: e.episode_number,
-      media_item_id: m.id,
-      media_item_title: m.title,
-      media_item_type: m.type,
+      show: m,
       has_files:
-        fragment(
-          "CASE WHEN EXISTS(SELECT 1 FROM media_files WHERE episode_id = ?) THEN true ELSE false END",
-          e.id
+        type(
+          fragment(
+            "CASE WHEN EXISTS(SELECT 1 FROM media_files WHERE episode_id = ?) THEN true ELSE false END",
+            e.id
+          ),
+          :boolean
         ),
       has_downloads:
-        fragment(
-          "CASE WHEN EXISTS(SELECT 1 FROM downloads WHERE episode_id = ?) THEN true ELSE false END",
-          e.id
+        type(
+          fragment(
+            "CASE WHEN EXISTS(SELECT 1 FROM downloads WHERE episode_id = ?) THEN true ELSE false END",
+            e.id
+          ),
+          :boolean
         )
     })
     |> order_by([e, m], asc: e.air_date, asc: m.title)
@@ -1604,12 +1607,13 @@ defmodule Mydia.Media do
         title: entry.title,
         season_number: entry.season_number,
         episode_number: entry.episode_number,
-        media_item_id: entry.media_item_id,
-        media_item_title: entry.media_item_title,
-        media_item_type: entry.media_item_type,
-        # SQLite returns 0/1 for booleans, convert to proper Elixir booleans
-        has_files: entry.has_files == 1,
-        has_downloads: entry.has_downloads == 1
+        media_item_id: entry.show.id,
+        media_item_title: entry.show.title,
+        media_item_type: entry.show.type,
+        has_files: entry.has_files,
+        has_downloads: entry.has_downloads,
+        poster_path: entry.show.metadata && entry.show.metadata.poster_path,
+        backdrop_path: entry.show.metadata && entry.show.metadata.backdrop_path
       )
     end)
   end
@@ -1668,7 +1672,9 @@ defmodule Mydia.Media do
         media_item_title: item.title,
         media_item_type: item.type,
         has_files: has_files,
-        has_downloads: has_downloads
+        has_downloads: has_downloads,
+        poster_path: item.metadata.poster_path,
+        backdrop_path: item.metadata.backdrop_path
       )
     end)
   end

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -1628,7 +1628,7 @@ defmodule Mydia.Media do
     query =
       MediaItem
       |> where([m], m.type == "movie")
-      |> where([m], ^Mydia.DB.json_is_not_null(:metadata, "$.release_date"))
+      |> where(^Mydia.DB.json_date_between(:metadata, "$.release_date", start_date, end_date))
 
     query =
       if is_nil(monitored) do
@@ -1638,21 +1638,28 @@ defmodule Mydia.Media do
       end
 
     query
+    |> select([m], %{
+      item: m,
+      has_files:
+        type(
+          fragment(
+            "CASE WHEN EXISTS(SELECT 1 FROM media_files WHERE media_item_id = ?) THEN true ELSE false END",
+            m.id
+          ),
+          :boolean
+        ),
+      has_downloads:
+        type(
+          fragment(
+            "CASE WHEN EXISTS(SELECT 1 FROM downloads WHERE media_item_id = ?) THEN true ELSE false END",
+            m.id
+          ),
+          :boolean
+        )
+    })
+    |> order_by([m], asc: m.title)
     |> Repo.all()
-    |> Enum.filter(fn item ->
-      release_date = item.metadata && item.metadata.release_date
-
-      release_date != nil and
-        Date.compare(release_date, start_date) != :lt and
-        Date.compare(release_date, end_date) != :gt
-    end)
-    |> Enum.map(fn item ->
-      has_files =
-        Repo.exists?(from f in Mydia.Library.MediaFile, where: f.media_item_id == ^item.id)
-
-      has_downloads =
-        Repo.exists?(from d in Mydia.Downloads.Download, where: d.media_item_id == ^item.id)
-
+    |> Enum.map(fn %{item: item, has_files: has_files, has_downloads: has_downloads} ->
       CalendarEntry.new_movie(
         id: item.id,
         air_date: item.metadata.release_date,

--- a/lib/mydia/media/structs/calendar_entry.ex
+++ b/lib/mydia/media/structs/calendar_entry.ex
@@ -25,7 +25,15 @@ defmodule Mydia.Media.Structs.CalendarEntry do
   Artwork fields (raw metadata paths, not URLs):
   - `:poster_path` - The parent item's poster path, or nil
   - `:backdrop_path` - The parent item's backdrop path, or nil
+
+  Player-only fields, populated after construction:
+  - `:files` - Playable files for this entry. Defaults to `[]`; the
+    `CalendarResolver` batch-loads these separately and attaches them, the
+    way `Mydia.Playback.OnDeckEntry` carries `:files`. Not set by
+    `new_episode/1` or `new_movie/1`, and not read by `MydiaWeb.CalendarLive`.
   """
+
+  alias Mydia.Library.MediaFile
 
   @enforce_keys [
     :id,
@@ -52,7 +60,8 @@ defmodule Mydia.Media.Structs.CalendarEntry do
     :has_files,
     :has_downloads,
     :poster_path,
-    :backdrop_path
+    :backdrop_path,
+    files: []
   ]
 
   @type t :: %__MODULE__{
@@ -68,7 +77,8 @@ defmodule Mydia.Media.Structs.CalendarEntry do
           has_files: boolean(),
           has_downloads: boolean(),
           poster_path: String.t() | nil,
-          backdrop_path: String.t() | nil
+          backdrop_path: String.t() | nil,
+          files: [MediaFile.t()]
         }
 
   @doc """

--- a/lib/mydia/media/structs/calendar_entry.ex
+++ b/lib/mydia/media/structs/calendar_entry.ex
@@ -21,6 +21,10 @@ defmodule Mydia.Media.Structs.CalendarEntry do
   Episode-specific fields:
   - `:season_number` - The season number (nil for movies)
   - `:episode_number` - The episode number (nil for movies)
+
+  Artwork fields (raw metadata paths, not URLs):
+  - `:poster_path` - The parent item's poster path, or nil
+  - `:backdrop_path` - The parent item's backdrop path, or nil
   """
 
   @enforce_keys [
@@ -46,7 +50,9 @@ defmodule Mydia.Media.Structs.CalendarEntry do
     :media_item_title,
     :media_item_type,
     :has_files,
-    :has_downloads
+    :has_downloads,
+    :poster_path,
+    :backdrop_path
   ]
 
   @type t :: %__MODULE__{
@@ -60,7 +66,9 @@ defmodule Mydia.Media.Structs.CalendarEntry do
           media_item_title: String.t(),
           media_item_type: String.t(),
           has_files: boolean(),
-          has_downloads: boolean()
+          has_downloads: boolean(),
+          poster_path: String.t() | nil,
+          backdrop_path: String.t() | nil
         }
 
   @doc """

--- a/lib/mydia_web/schema.ex
+++ b/lib/mydia_web/schema.ex
@@ -36,6 +36,7 @@ defmodule MydiaWeb.Schema do
     import_fields(:collection_queries)
     import_fields(:subtitle_queries)
     import_fields(:server_queries)
+    import_fields(:calendar_queries)
   end
 
   mutation do

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -691,6 +691,40 @@ defmodule MydiaWeb.Schema.CommonTypes do
       description: "Oldest player version this server would rather you ran"
   end
 
+  @desc "One dated item on the player's calendar"
+  object :calendar_entry do
+    field :id, non_null(:id), description: "Episode ID, or media item ID for a movie"
+
+    field :kind, non_null(:calendar_entry_kind), description: "Episode or movie" do
+      resolve(fn entry, _args, _info -> {:ok, String.to_existing_atom(entry.type)} end)
+    end
+
+    field :air_date, non_null(:date), description: "Air date, or release date for a movie"
+    field :title, non_null(:string), description: "Episode title, or movie title"
+
+    field :season_number, :integer, description: "Season number, null for a movie"
+    field :episode_number, :integer, description: "Episode number, null for a movie"
+
+    field :media_item_id, non_null(:id), description: "The parent show, or the movie itself"
+    field :media_item_title, non_null(:string), description: "Show name, or movie title"
+
+    field :artwork, :artwork do
+      resolve(fn entry, _args, _info ->
+        {:ok,
+         %{
+           poster_url: Mydia.Metadata.ImageUrl.poster_url(entry.poster_path),
+           backdrop_url: Mydia.Metadata.ImageUrl.backdrop_url(entry.backdrop_path),
+           thumbnail_url: nil
+         }}
+      end)
+    end
+
+    @desc "Playable files for this entry, empty when the library holds nothing"
+    field :files, non_null(list_of(non_null(:media_file))) do
+      resolve(&MydiaWeb.Schema.Resolvers.CalendarResolver.files/3)
+    end
+  end
+
   defp metadata_field(%{metadata: %Mydia.Library.Structs.FileMetadata{} = metadata}, key),
     do: Map.get(metadata, key)
 

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -720,9 +720,7 @@ defmodule MydiaWeb.Schema.CommonTypes do
     end
 
     @desc "Playable files for this entry, empty when the library holds nothing"
-    field :files, non_null(list_of(non_null(:media_file))) do
-      resolve(&MydiaWeb.Schema.Resolvers.CalendarResolver.files/3)
-    end
+    field :files, non_null(list_of(non_null(:media_file)))
   end
 
   defp metadata_field(%{metadata: %Mydia.Library.Structs.FileMetadata{} = metadata}, key),

--- a/lib/mydia_web/schema/enum_types.ex
+++ b/lib/mydia_web/schema/enum_types.ex
@@ -88,4 +88,10 @@ defmodule MydiaWeb.Schema.EnumTypes do
     value(:intro, description: "Opening theme")
     value(:credits, description: "Closing credits")
   end
+
+  @desc "Whether a calendar entry is an episode or a movie"
+  enum :calendar_entry_kind do
+    value(:episode, description: "A TV episode, dated by its air date")
+    value(:movie, description: "A movie, dated by its release date")
+  end
 end

--- a/lib/mydia_web/schema/query_types.ex
+++ b/lib/mydia_web/schema/query_types.ex
@@ -15,6 +15,7 @@ defmodule MydiaWeb.Schema.QueryTypes do
   alias MydiaWeb.Schema.Resolvers.SubtitleSearchResolver
   alias MydiaWeb.Schema.Resolvers.SubtitleSettingsResolver
   alias MydiaWeb.Schema.Resolvers.ServerResolver
+  alias MydiaWeb.Schema.Resolvers.CalendarResolver
 
   # Node interface for global node resolution with hierarchical navigation
   interface :node do
@@ -173,6 +174,16 @@ defmodule MydiaWeb.Schema.QueryTypes do
       arg(:category, :media_category)
       arg(:sort, :sort_input)
       resolve(&DiscoveryResolver.unwatched/3)
+    end
+  end
+
+  # Calendar queries
+  object :calendar_queries do
+    @desc "Get dated episodes and movies between two dates, both bounds inclusive"
+    field :calendar, non_null(list_of(non_null(:calendar_entry))) do
+      arg(:start, non_null(:date))
+      arg(:end, non_null(:date))
+      resolve(&CalendarResolver.calendar/3)
     end
   end
 

--- a/lib/mydia_web/schema/resolvers/calendar_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/calendar_resolver.ex
@@ -1,0 +1,50 @@
+defmodule MydiaWeb.Schema.Resolvers.CalendarResolver do
+  @moduledoc """
+  Resolves the player's calendar: episodes and movies inside a date window.
+
+  Deliberately narrower than `MydiaWeb.CalendarLive.Index`, which is an operator
+  view and surfaces downloading and missing state. The player is a playback
+  client, so availability is only ever "there is a file" or "there is not", and
+  `has_downloads` is never exposed.
+  """
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media
+  alias Mydia.Repo
+
+  import Ecto.Query
+
+  @doc """
+  Entries between `start` and `end`, both bounds inclusive.
+
+  Ordered the way the player renders them: by air date, then playable entries
+  first, then parent title. Sorting here rather than on the client keeps the
+  order testable in one place.
+  """
+  def calendar(_parent, %{start: start_date, end: end_date}, _resolution) do
+    episodes = Media.list_episodes_by_air_date(start_date, end_date, monitored: nil)
+    movies = Media.list_movies_by_release_date(start_date, end_date, monitored: nil)
+
+    entries =
+      (episodes ++ movies)
+      |> Enum.sort_by(&{&1.air_date, !&1.has_files, &1.media_item_title}, :asc)
+
+    {:ok, entries}
+  end
+
+  @doc """
+  Playable files for one entry.
+
+  Returns `[]` rather than nil when nothing is playable, so the client can treat
+  `files.isNotEmpty` as the single definition of playable.
+  """
+  def files(%{has_files: false}, _args, _resolution), do: {:ok, []}
+
+  def files(%{type: "episode", id: episode_id}, _args, _resolution) do
+    {:ok, Repo.all(from f in MediaFile, where: f.episode_id == ^episode_id)}
+  end
+
+  def files(%{type: "movie", media_item_id: media_item_id}, _args, _resolution) do
+    {:ok, Repo.all(from f in MediaFile, where: f.media_item_id == ^media_item_id)}
+  end
+end

--- a/lib/mydia_web/schema/resolvers/calendar_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/calendar_resolver.ex
@@ -75,12 +75,14 @@ defmodule MydiaWeb.Schema.Resolvers.CalendarResolver do
   defp load_files_by(_key_field, []), do: %{}
 
   defp load_files_by(:episode_id, episode_ids) do
-    Repo.all(from f in MediaFile, where: f.episode_id in ^episode_ids)
+    Repo.all(from f in MediaFile, where: f.episode_id in ^episode_ids and is_nil(f.trashed_at))
     |> Enum.group_by(& &1.episode_id)
   end
 
   defp load_files_by(:media_item_id, media_item_ids) do
-    Repo.all(from f in MediaFile, where: f.media_item_id in ^media_item_ids)
+    Repo.all(
+      from f in MediaFile, where: f.media_item_id in ^media_item_ids and is_nil(f.trashed_at)
+    )
     |> Enum.group_by(& &1.media_item_id)
   end
 end

--- a/lib/mydia_web/schema/resolvers/calendar_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/calendar_resolver.ex
@@ -20,6 +20,14 @@ defmodule MydiaWeb.Schema.Resolvers.CalendarResolver do
   Ordered the way the player renders them: by air date, then playable entries
   first, then parent title. Sorting here rather than on the client keeps the
   order testable in one place.
+
+  Files are attached to each entry here rather than resolved per-field:
+  Absinthe calls a field resolver once per entry, so a per-item `Repo.all`
+  on `:files` would issue one query per entry (a realistic response is 60+,
+  since the window is library-wide across 120 days). Batch-loading keeps the
+  query count constant, the same way `Mydia.Playback.OnDeck` attaches
+  `:files` to each `OnDeckEntry` before the continue-watching resolver ever
+  runs. See `MydiaWeb.Schema.Resolvers.DiscoveryResolver.continue_watching/3`.
   """
   def calendar(_parent, %{start: start_date, end: end_date}, _resolution) do
     episodes = Media.list_episodes_by_air_date(start_date, end_date, monitored: nil)
@@ -35,23 +43,44 @@ defmodule MydiaWeb.Schema.Resolvers.CalendarResolver do
         &{Date.to_erl(&1.air_date), !&1.has_files, &1.media_item_title},
         :asc
       )
+      |> attach_files()
 
     {:ok, entries}
   end
 
-  @doc """
-  Playable files for one entry.
+  # Two whole-collection queries, not one per entry: episode files keyed by
+  # `episode_id`, movie files keyed by `media_item_id`. A movie entry's `id`
+  # and `media_item_id` are equal, which is exactly the pair that hides a
+  # mistake here if the wrong key is used for the wrong type. Episodes have
+  # no `media_item_id` file rows and movies have no `episode_id` file rows,
+  # so a mix-up would silently return `[]` instead of raising.
+  defp attach_files(entries) do
+    episode_ids = for %{type: "episode", has_files: true, id: id} <- entries, do: id
 
-  Returns `[]` rather than nil when nothing is playable, so the client can treat
-  `files.isNotEmpty` as the single definition of playable.
-  """
-  def files(%{has_files: false}, _args, _resolution), do: {:ok, []}
+    movie_media_item_ids =
+      for %{type: "movie", has_files: true, media_item_id: id} <- entries, do: id
 
-  def files(%{type: "episode", id: episode_id}, _args, _resolution) do
-    {:ok, Repo.all(from f in MediaFile, where: f.episode_id == ^episode_id)}
+    files_by_episode_id = load_files_by(:episode_id, episode_ids)
+    files_by_media_item_id = load_files_by(:media_item_id, movie_media_item_ids)
+
+    Enum.map(entries, fn
+      %{type: "episode"} = entry ->
+        %{entry | files: Map.get(files_by_episode_id, entry.id, [])}
+
+      %{type: "movie"} = entry ->
+        %{entry | files: Map.get(files_by_media_item_id, entry.media_item_id, [])}
+    end)
   end
 
-  def files(%{type: "movie", media_item_id: media_item_id}, _args, _resolution) do
-    {:ok, Repo.all(from f in MediaFile, where: f.media_item_id == ^media_item_id)}
+  defp load_files_by(_key_field, []), do: %{}
+
+  defp load_files_by(:episode_id, episode_ids) do
+    Repo.all(from f in MediaFile, where: f.episode_id in ^episode_ids)
+    |> Enum.group_by(& &1.episode_id)
+  end
+
+  defp load_files_by(:media_item_id, media_item_ids) do
+    Repo.all(from f in MediaFile, where: f.media_item_id in ^media_item_ids)
+    |> Enum.group_by(& &1.media_item_id)
   end
 end

--- a/lib/mydia_web/schema/resolvers/calendar_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/calendar_resolver.ex
@@ -27,7 +27,14 @@ defmodule MydiaWeb.Schema.Resolvers.CalendarResolver do
 
     entries =
       (episodes ++ movies)
-      |> Enum.sort_by(&{&1.air_date, !&1.has_files, &1.media_item_title}, :asc)
+      |> Enum.sort_by(
+        # `Date.to_erl/1` turns the date into a plain `{year, month, day}`
+        # tuple. A bare `%Date{}` inside a sort tuple compares by struct
+        # field order (`day` before `month` before `year`), which is not
+        # chronological order. Do not "simplify" this back to `&1.air_date`.
+        &{Date.to_erl(&1.air_date), !&1.has_files, &1.media_item_title},
+        :asc
+      )
 
     {:ok, entries}
   end

--- a/player/lib/core/graphql/watch/query_key.dart
+++ b/player/lib/core/graphql/watch/query_key.dart
@@ -70,6 +70,7 @@ abstract final class QueryKeys {
   static final QueryKey home = QueryKey('HomeScreen');
   static final QueryKey favorites = QueryKey('Favorites');
   static final QueryKey recentlyAdded = QueryKey('RecentlyAddedFull');
+  static final QueryKey calendar = QueryKey('Calendar');
   static final QueryKey unwatched = QueryKey('Unwatched');
   static final QueryKey collections = QueryKey('Collections');
   static final QueryKey moviesList = QueryKey('MoviesList');

--- a/player/lib/core/router/app_router.dart
+++ b/player/lib/core/router/app_router.dart
@@ -21,6 +21,7 @@ import '../../presentation/screens/favorites/favorites_screen.dart';
 import '../../presentation/screens/recently_added/recently_added_screen.dart';
 import '../../presentation/screens/unwatched/unwatched_screen.dart';
 import '../../presentation/screens/continue_watching/continue_watching_screen.dart';
+import '../../presentation/screens/calendar/calendar_screen.dart';
 import '../../presentation/screens/collections/collections_screen.dart';
 import '../../presentation/screens/collections/collection_detail_screen.dart';
 import '../../presentation/screens/search/search_screen.dart';
@@ -227,6 +228,11 @@ GoRouter appRouter(Ref ref) {
             path: '/unwatched',
             name: 'unwatched',
             builder: (context, state) => const UnwatchedScreen(),
+          ),
+          GoRoute(
+            path: '/calendar',
+            name: 'calendar',
+            builder: (context, state) => const CalendarScreen(),
           ),
           GoRoute(
             path: '/collections',

--- a/player/lib/domain/models/calendar_entry.dart
+++ b/player/lib/domain/models/calendar_entry.dart
@@ -37,6 +37,11 @@ class CalendarEntry {
   bool get isPlayable => files.isNotEmpty;
 
   /// The day this entry belongs to, with no time component, for grouping.
+  ///
+  /// Deliberately not built on `presentation/screens/calendar/calendar_dates
+  /// .dart`'s `truncateToDay`: this is `domain/`, which stays plain Dart with
+  /// no dependency on `presentation/`, so the one-line truncation is repeated
+  /// here rather than reaching up a layer for it.
   DateTime get day => DateTime(airDate.year, airDate.month, airDate.day);
 
   factory CalendarEntry.fromJson(Map<String, dynamic> json) {

--- a/player/lib/domain/models/calendar_entry.dart
+++ b/player/lib/domain/models/calendar_entry.dart
@@ -1,0 +1,63 @@
+import 'artwork.dart';
+import 'media_file.dart';
+
+/// Whether a calendar entry is an episode or a movie.
+enum CalendarEntryKind { episode, movie }
+
+/// One dated item on the calendar.
+///
+/// Playability is `files.isNotEmpty` and nothing else. The server sends no
+/// separate flag, so the two cannot drift apart, and it never sends download
+/// state: the calendar is a playback surface, not a library-management one.
+class CalendarEntry {
+  final String id;
+  final CalendarEntryKind kind;
+  final DateTime airDate;
+  final String title;
+  final int? seasonNumber;
+  final int? episodeNumber;
+  final String mediaItemId;
+  final String mediaItemTitle;
+  final Artwork? artwork;
+  final List<MediaFile> files;
+
+  const CalendarEntry({
+    required this.id,
+    required this.kind,
+    required this.airDate,
+    required this.title,
+    required this.mediaItemId,
+    required this.mediaItemTitle,
+    this.seasonNumber,
+    this.episodeNumber,
+    this.artwork,
+    this.files = const [],
+  });
+
+  bool get isPlayable => files.isNotEmpty;
+
+  /// The day this entry belongs to, with no time component, for grouping.
+  DateTime get day => DateTime(airDate.year, airDate.month, airDate.day);
+
+  factory CalendarEntry.fromJson(Map<String, dynamic> json) {
+    final rawFiles = json['files'] as List<dynamic>? ?? const [];
+    final rawArtwork = json['artwork'] as Map<String, dynamic>?;
+
+    return CalendarEntry(
+      id: json['id'].toString(),
+      kind: json['kind'] == 'MOVIE'
+          ? CalendarEntryKind.movie
+          : CalendarEntryKind.episode,
+      airDate: DateTime.parse(json['airDate'] as String),
+      title: json['title'] as String,
+      seasonNumber: json['seasonNumber'] as int?,
+      episodeNumber: json['episodeNumber'] as int?,
+      mediaItemId: json['mediaItemId'].toString(),
+      mediaItemTitle: json['mediaItemTitle'] as String,
+      artwork: rawArtwork == null ? null : Artwork.fromJson(rawArtwork),
+      files: rawFiles
+          .map((e) => MediaFile.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}

--- a/player/lib/domain/navigation/nav_destination.dart
+++ b/player/lib/domain/navigation/nav_destination.dart
@@ -175,6 +175,14 @@ const List<BuiltinDestination> builtinDestinations = [
     defaultIndex: 130,
   ),
   BuiltinDestination(
+    id: 'calendar',
+    label: 'Calendar',
+    icon: Icons.calendar_month_outlined,
+    selectedIcon: Icons.calendar_month_rounded,
+    route: '/calendar',
+    defaultIndex: 135,
+  ),
+  BuiltinDestination(
     id: 'recently_added',
     label: 'Recently Added',
     icon: Icons.fiber_new_outlined,

--- a/player/lib/presentation/screens/calendar/calendar_controller.dart
+++ b/player/lib/presentation/screens/calendar/calendar_controller.dart
@@ -1,0 +1,98 @@
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/graphql/watch/controller_watcher.dart';
+import '../../../core/graphql/watch/query_key.dart';
+import '../../../core/graphql/watch/query_watcher.dart';
+import '../../../domain/models/calendar_entry.dart';
+
+part 'calendar_controller.g.dart';
+
+/// Days of past the window reaches back.
+const int kCalendarDaysBack = 30;
+
+/// Days of future the window reaches forward.
+const int kCalendarDaysForward = 90;
+
+const String calendarQuery = r'''
+query Calendar($start: Date!, $end: Date!) {
+  calendar(start: $start, end: $end) {
+    id
+    kind
+    airDate
+    title
+    seasonNumber
+    episodeNumber
+    mediaItemId
+    mediaItemTitle
+    artwork {
+      posterUrl
+      backdropUrl
+      thumbnailUrl
+    }
+    files {
+      id
+      resolution
+      directPlaySupported
+      hdrFormat
+      bitrate
+    }
+  }
+}
+''';
+
+String _isoDate(DateTime date) => '${date.year.toString().padLeft(4, '0')}-'
+    '${date.month.toString().padLeft(2, '0')}-'
+    '${date.day.toString().padLeft(2, '0')}';
+
+/// Turns a `calendar` response into entries.
+///
+/// Top-level rather than a closure inside `build` so the watcher test can
+/// exercise the real parse instead of a copy of it that could drift.
+List<CalendarEntry> parseCalendar(Map<String, dynamic> data) {
+  return (data['calendar'] as List<dynamic>?)
+          ?.map((e) => CalendarEntry.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [];
+}
+
+@riverpod
+class CalendarController extends _$CalendarController {
+  late QueryWatcher<List<CalendarEntry>> _watcher;
+
+  /// The window the calendar loads, as whole local days.
+  ///
+  /// Exposed so the screen and the tests share one definition instead of
+  /// each doing the arithmetic. The server takes explicit dates because only
+  /// the client knows the viewer's timezone.
+  ///
+  /// Built by overflowing the day field rather than adding a `Duration`:
+  /// `DateTime`'s constructor normalizes an out-of-range day by calendar
+  /// arithmetic, not by adding elapsed real time, so it lands on the right
+  /// calendar day even when the span crosses a daylight-saving transition. A
+  /// `Duration`-based add/subtract would drift by an hour across such a
+  /// transition, which running this in a DST-observing timezone reproduces.
+  static (DateTime, DateTime) windowFor(DateTime today) {
+    return (
+      DateTime(today.year, today.month, today.day - kCalendarDaysBack),
+      DateTime(today.year, today.month, today.day + kCalendarDaysForward),
+    );
+  }
+
+  @override
+  Stream<List<CalendarEntry>> build() {
+    final (start, end) = windowFor(DateTime.now());
+
+    _watcher = createWatcher<List<CalendarEntry>>(
+      ref,
+      key: QueryKeys.calendar,
+      document: gql(calendarQuery),
+      variables: {'start': _isoDate(start), 'end': _isoDate(end)},
+      parse: parseCalendar,
+    );
+
+    return _watcher.stream;
+  }
+
+  Future<void> refresh() => _watcher.refetch();
+}

--- a/player/lib/presentation/screens/calendar/calendar_controller.dart
+++ b/player/lib/presentation/screens/calendar/calendar_controller.dart
@@ -5,6 +5,7 @@ import '../../../core/graphql/watch/controller_watcher.dart';
 import '../../../core/graphql/watch/query_key.dart';
 import '../../../core/graphql/watch/query_watcher.dart';
 import '../../../domain/models/calendar_entry.dart';
+import 'calendar_dates.dart';
 
 part 'calendar_controller.g.dart';
 
@@ -40,10 +41,6 @@ query Calendar($start: Date!, $end: Date!) {
   }
 }
 ''';
-
-String _isoDate(DateTime date) => '${date.year.toString().padLeft(4, '0')}-'
-    '${date.month.toString().padLeft(2, '0')}-'
-    '${date.day.toString().padLeft(2, '0')}';
 
 /// Turns a `calendar` response into entries.
 ///
@@ -87,7 +84,7 @@ class CalendarController extends _$CalendarController {
       ref,
       key: QueryKeys.calendar,
       document: gql(calendarQuery),
-      variables: {'start': _isoDate(start), 'end': _isoDate(end)},
+      variables: {'start': isoDate(start), 'end': isoDate(end)},
       parse: parseCalendar,
     );
 

--- a/player/lib/presentation/screens/calendar/calendar_dates.dart
+++ b/player/lib/presentation/screens/calendar/calendar_dates.dart
@@ -1,0 +1,22 @@
+/// Shared date helpers for the calendar screen.
+///
+/// The calendar throws away time-of-day at several independent points: to
+/// send the window's `start`/`end` to the server, to decide which day
+/// section is "today", and to group and compare entries by calendar day.
+/// Kept in one file so those points cannot drift into subtly different
+/// definitions of "day" from one another.
+library;
+
+/// Zero-padded `yyyy-MM-dd`, the format the calendar's GraphQL query takes
+/// for its `start`/`end` date arguments.
+String isoDate(DateTime date) => '${date.year.toString().padLeft(4, '0')}-'
+    '${date.month.toString().padLeft(2, '0')}-'
+    '${date.day.toString().padLeft(2, '0')}';
+
+/// [date] with its time-of-day dropped, at local midnight.
+DateTime truncateToDay(DateTime date) =>
+    DateTime(date.year, date.month, date.day);
+
+/// Whether [a] and [b] fall on the same calendar day, ignoring time-of-day.
+bool isSameDay(DateTime a, DateTime b) =>
+    a.year == b.year && a.month == b.month && a.day == b.day;

--- a/player/lib/presentation/screens/calendar/calendar_row.dart
+++ b/player/lib/presentation/screens/calendar/calendar_row.dart
@@ -21,6 +21,7 @@ import '../../../core/cache/poster_cache_manager.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/calendar_entry.dart';
 import '../../widgets/smart_play_button.dart';
+import 'calendar_dates.dart';
 
 /// One dated entry on the calendar, rendered as a single row.
 ///
@@ -41,9 +42,7 @@ class CalendarRow extends ConsumerWidget {
   /// Injected rather than read from the clock so tests are deterministic.
   final DateTime today;
 
-  bool get _isFuture => entry.day.isAfter(
-        DateTime(today.year, today.month, today.day),
-      );
+  bool get _isFuture => entry.day.isAfter(truncateToDay(today));
 
   String get _subtitle {
     if (entry.kind == CalendarEntryKind.movie) return 'Movie';

--- a/player/lib/presentation/screens/calendar/calendar_row.dart
+++ b/player/lib/presentation/screens/calendar/calendar_row.dart
@@ -1,0 +1,225 @@
+// Resume: the player never trusts route absence as "no progress". Every
+// entry point into `PlayerScreen` independently queries `progress {
+// positionSeconds durationSeconds lastWatchedAt }` off `MovieDetail` /
+// `EpisodeDetail` in `_fetchProgressAndEpisodes`, and `resolveResumePlan`
+// (`core/player/resume_plan.dart`) offers a resume dialog through
+// `shouldOfferResume` whenever that saved position clears the existing
+// thresholds. The route's `resume` query parameter only lets a caller that
+// already asked the question (Continue Watching) skip that dialog and jump
+// straight to the saved position; its absence does not mean "start from
+// zero", it means "let the player ask". The calendar carries no progress, so
+// the consequence is simply that every calendar-initiated playback goes
+// through the normal resume prompt instead of bypassing it, exactly like
+// opening the same episode from its own detail screen would.
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/cache/poster_cache_manager.dart';
+import '../../../core/theme/colors.dart';
+import '../../../domain/models/calendar_entry.dart';
+import '../../widgets/smart_play_button.dart';
+
+/// One dated entry on the calendar, rendered as a single row.
+///
+/// The row body opens the detail screen; the trailing control plays. Two
+/// separate targets, deliberately: a mistap on the body cannot start
+/// playback, and on Android TV a list of single-target rows gives the D-pad
+/// nothing to do horizontally, while this one gives it the play control to
+/// land on.
+class CalendarRow extends ConsumerWidget {
+  const CalendarRow({
+    super.key,
+    required this.entry,
+    required this.today,
+  });
+
+  final CalendarEntry entry;
+
+  /// Injected rather than read from the clock so tests are deterministic.
+  final DateTime today;
+
+  bool get _isFuture => entry.day.isAfter(
+        DateTime(today.year, today.month, today.day),
+      );
+
+  String get _subtitle {
+    if (entry.kind == CalendarEntryKind.movie) return 'Movie';
+
+    final season = (entry.seasonNumber ?? 0).toString().padLeft(2, '0');
+    final episode = (entry.episodeNumber ?? 0).toString().padLeft(2, '0');
+    final numbering = 'S${season}E$episode';
+
+    return entry.title.isEmpty ? numbering : '$numbering · ${entry.title}';
+  }
+
+  void _openDetail(BuildContext context) {
+    if (entry.kind == CalendarEntryKind.movie) {
+      context.push('/movie/${entry.mediaItemId}');
+    } else {
+      context.push('/episode/${entry.id}');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dimmed = !entry.isPlayable;
+
+    return InkWell(
+      key: ValueKey('calendar-row-${entry.id}'),
+      onTap: () => _openDetail(context),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
+          children: [
+            _Poster(entry: entry, dimmed: dimmed),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    entry.kind == CalendarEntryKind.movie
+                        ? entry.title
+                        : entry.mediaItemTitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                      color: dimmed
+                          ? AppColors.textDisabled
+                          : AppColors.textPrimary,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    _subtitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: dimmed
+                              ? AppColors.textDisabled
+                              : AppColors.textSecondary,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 12),
+            _trailing(context),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _trailing(BuildContext context) {
+    if (entry.isPlayable) {
+      return SmartPlayButton(
+        key: ValueKey('calendar-play-${entry.id}'),
+        files: entry.files,
+        onFileSelected: (file) => context.push(
+          playerRouteForCalendar(entry, fileId: file.id),
+        ),
+      );
+    }
+
+    if (_isFuture) {
+      return _StatusChip(
+        key: ValueKey('calendar-upcoming-${entry.id}'),
+        label: 'Upcoming',
+      );
+    }
+
+    return _StatusChip(
+      key: ValueKey('calendar-absent-${entry.id}'),
+      label: 'Not in library',
+    );
+  }
+}
+
+/// The player route for one calendar entry.
+///
+/// Kept beside the row rather than inlined so the shape stays in one place
+/// if the player screen ever reads another query parameter. Mirrors
+/// `playerRouteForContinueWatching` in `home_screen.dart`, minus the resume
+/// suffix: the calendar has no saved progress of its own to pass, so the
+/// player is left to discover it (see the resume note at the top of this
+/// file). `fileId` is required because the player route renders an error
+/// screen without one.
+String playerRouteForCalendar(CalendarEntry entry, {required String fileId}) {
+  final title = Uri.encodeComponent(
+    entry.kind == CalendarEntryKind.movie ? entry.title : entry.mediaItemTitle,
+  );
+
+  if (entry.kind == CalendarEntryKind.movie) {
+    return '/player/movie/${entry.mediaItemId}?fileId=$fileId&title=$title';
+  }
+
+  final showId = entry.mediaItemId;
+  final seasonNumber = entry.seasonNumber;
+
+  return '/player/episode/${entry.id}'
+      '?fileId=$fileId'
+      '&title=$title'
+      '&showId=$showId'
+      '${seasonNumber != null ? '&seasonNumber=$seasonNumber' : ''}';
+}
+
+class _Poster extends StatelessWidget {
+  const _Poster({required this.entry, required this.dimmed});
+
+  final CalendarEntry entry;
+  final bool dimmed;
+
+  @override
+  Widget build(BuildContext context) {
+    final url = entry.artwork?.posterUrl;
+
+    return Opacity(
+      opacity: dimmed ? 0.45 : 1,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(4),
+        child: SizedBox(
+          width: 38,
+          height: 56,
+          child: url == null
+              ? const ColoredBox(color: AppColors.surfaceVariant)
+              : CachedNetworkImage(
+                  imageUrl: url,
+                  fit: BoxFit.cover,
+                  cacheManager: PosterCacheManager(),
+                  placeholder: (_, __) =>
+                      const ColoredBox(color: AppColors.surfaceVariant),
+                  errorWidget: (_, __, ___) =>
+                      const ColoredBox(color: AppColors.surfaceVariant),
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({super.key, required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        border: Border.all(color: AppColors.border),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(fontSize: 10, color: AppColors.textDisabled),
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/screens/calendar/calendar_screen.dart
+++ b/player/lib/presentation/screens/calendar/calendar_screen.dart
@@ -1,0 +1,350 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/graphql/watch/query_key.dart';
+import '../../../core/theme/colors.dart';
+import '../../../domain/models/calendar_entry.dart';
+import '../../widgets/browse_scaffold.dart';
+import 'calendar_controller.dart';
+import 'calendar_row.dart';
+
+/// Short weekday names, indexed by `DateTime.weekday - 1` (Monday first).
+///
+/// `package:intl` is not a dependency of this app (checked `pubspec.yaml`
+/// before writing this), so the day header is hand-formatted from these
+/// const tables rather than pulling in `DateFormat` for one label.
+const List<String> _weekdayAbbreviations = [
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat',
+  'Sun',
+];
+
+/// Full month names, indexed by `DateTime.month - 1`.
+const List<String> _monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/// Zero-padded `yyyy-MM-dd`, for the day header's test key.
+String _isoDate(DateTime date) => '${date.year.toString().padLeft(4, '0')}-'
+    '${date.month.toString().padLeft(2, '0')}-'
+    '${date.day.toString().padLeft(2, '0')}';
+
+/// Entries grouped into day sections, in the order the server sent them.
+///
+/// The resolver already orders by air date, then playable first, then title,
+/// so this preserves order rather than re-sorting. Days with no entries never
+/// appear, which is the whole reason an agenda beats a grid on a small
+/// library.
+List<MapEntry<DateTime, List<CalendarEntry>>> groupByDay(
+  List<CalendarEntry> entries,
+) {
+  final groups = <DateTime, List<CalendarEntry>>{};
+
+  for (final entry in entries) {
+    groups.putIfAbsent(entry.day, () => []).add(entry);
+  }
+
+  return groups.entries.toList();
+}
+
+/// The label above one day's entries.
+String formatDayHeader(DateTime day, DateTime today) {
+  final isToday = day.year == today.year &&
+      day.month == today.month &&
+      day.day == today.day;
+
+  final sameYear = day.year == today.year;
+  final weekday = _weekdayAbbreviations[day.weekday - 1];
+  final month = _monthNames[day.month - 1];
+
+  final formatted = sameYear
+      ? '$weekday ${day.day} $month'
+      : '$weekday ${day.day} $month ${day.year}';
+
+  return isToday ? '$formatted · Today' : formatted;
+}
+
+/// Index of the first day on or after [today], or null when every day is past.
+///
+/// Not simply "the group whose date is today": today may have no entries at
+/// all, and the calendar still has to open somewhere sensible. The first
+/// upcoming day is that place.
+int? indexOfToday(List<DateTime> days, DateTime today) {
+  final midnight = DateTime(today.year, today.month, today.day);
+
+  for (var i = 0; i < days.length; i++) {
+    if (!days[i].isBefore(midnight)) return i;
+  }
+  return null;
+}
+
+class CalendarScreen extends ConsumerStatefulWidget {
+  const CalendarScreen({super.key});
+
+  @override
+  ConsumerState<CalendarScreen> createState() => _CalendarScreenState();
+}
+
+class _CalendarScreenState extends ConsumerState<CalendarScreen> {
+  final ScrollController _scrollController = ScrollController();
+
+  /// Attached to the first day section on or after today.
+  ///
+  /// A key rather than an offset because day sections have no fixed height:
+  /// each holds a different number of rows, so there is no arithmetic that
+  /// turns an index into a scroll position. `Scrollable.ensureVisible` asks
+  /// the laid-out element where it actually is.
+  final GlobalKey _todayKey = GlobalKey();
+
+  /// Whether the one-time jump to today has already happened.
+  ///
+  /// The stream rebuilds on every refetch and cache write, and re-jumping on
+  /// each of those would yank the list out from under someone who had
+  /// scrolled away.
+  bool _jumped = false;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  /// Puts today's section at the top of the viewport.
+  ///
+  /// `alignment: 0` pins it to the leading edge rather than merely bringing it
+  /// into view, so past entries sit above the fold where they belong.
+  Future<void> _scrollToToday() async {
+    final context = _todayKey.currentContext;
+    if (context == null) return;
+
+    await Scrollable.ensureVisible(
+      context,
+      alignment: 0,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+    );
+  }
+
+  /// Jumps to today once, after the first frame that has laid the list out.
+  void _jumpToTodayOnce() {
+    if (_jumped) return;
+    _jumped = true;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final context = _todayKey.currentContext;
+      if (context == null) return;
+      Scrollable.ensureVisible(context, alignment: 0);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final today = DateTime.now();
+    final data = ref.watch(calendarControllerProvider);
+
+    return BrowseScaffold(
+      icon: Icons.calendar_month_outlined,
+      title: 'Calendar',
+      queryKeys: [QueryKeys.calendar],
+      onRefresh: () => ref.read(calendarControllerProvider.notifier).refresh(),
+      actions: [
+        TextButton(
+          onPressed: _scrollToToday,
+          child: const Text('Today'),
+        ),
+      ],
+      body: (context, scrollTopPadding) => switch (data) {
+        AsyncData(:final value) => _body(value, today, scrollTopPadding),
+        AsyncError(:final error) => _error(error, scrollTopPadding),
+        _ => const Center(child: CircularProgressIndicator()),
+      },
+    );
+  }
+
+  Widget _body(
+    List<CalendarEntry> entries,
+    DateTime today,
+    double scrollTopPadding,
+  ) {
+    if (entries.isEmpty) {
+      return _empty(scrollTopPadding);
+    }
+
+    final groups = groupByDay(entries);
+    final todayIndex = indexOfToday(groups.map((g) => g.key).toList(), today);
+
+    _jumpToTodayOnce();
+
+    return CustomScrollView(
+      controller: _scrollController,
+      slivers: [
+        // A spacer sliver, not SliverPadding: SliverPadding with no `sliver`
+        // child renders nothing at all, so the glass bar would overlap the
+        // first rows.
+        SliverToBoxAdapter(child: SizedBox(height: scrollTopPadding)),
+        for (final (index, group) in groups.indexed)
+          // SliverMainAxisGroup scopes the pinned header to its own group, so
+          // each date header sticks only while its own rows are on screen and
+          // is then pushed off by the next one. A bare pinned
+          // SliverPersistentHeader would pin all of them at once and stack
+          // every date at the top of the viewport.
+          SliverMainAxisGroup(
+            slivers: [
+              SliverPersistentHeader(
+                pinned: true,
+                delegate: _DayHeaderDelegate(
+                  headerKey: index == todayIndex ? _todayKey : null,
+                  label: formatDayHeader(group.key, today),
+                  isToday: _isSameDay(group.key, today),
+                  dayKey: ValueKey(
+                    'calendar-day-${_isoDate(group.key)}',
+                  ),
+                ),
+              ),
+              SliverList.builder(
+                itemCount: group.value.length,
+                itemBuilder: (context, itemIndex) {
+                  final entry = group.value[itemIndex];
+                  return CalendarRow(
+                    key: ValueKey('calendar-entry-${entry.id}'),
+                    entry: entry,
+                    today: today,
+                  );
+                },
+              ),
+            ],
+          ),
+        const SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(16, 28, 16, 40),
+            child: Text(
+              'That is everything scheduled in the next 90 days.',
+              style: TextStyle(fontSize: 12, color: AppColors.textDisabled),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _empty(double scrollTopPadding) {
+    return Padding(
+      key: const ValueKey('calendar-empty'),
+      padding: EdgeInsets.only(top: scrollTopPadding + 80, left: 32, right: 32),
+      child: const Column(
+        children: [
+          Icon(Icons.calendar_month_outlined,
+              size: 48, color: AppColors.textDisabled),
+          SizedBox(height: 16),
+          Text(
+            'Nothing scheduled',
+            style: TextStyle(fontSize: 17, color: AppColors.textSecondary),
+          ),
+          SizedBox(height: 8),
+          Text(
+            'The calendar covers 30 days back and 90 days ahead.',
+            textAlign: TextAlign.center,
+            style: TextStyle(fontSize: 13, color: AppColors.textDisabled),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _error(Object error, double scrollTopPadding) {
+    return Padding(
+      padding: EdgeInsets.only(top: scrollTopPadding + 80, left: 32, right: 32),
+      child: Column(
+        children: [
+          const Icon(Icons.error_outline, size: 48, color: AppColors.error),
+          const SizedBox(height: 16),
+          const Text(
+            'The calendar could not be loaded',
+            style: TextStyle(fontSize: 17, color: AppColors.textSecondary),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: () =>
+                ref.read(calendarControllerProvider.notifier).refresh(),
+            child: const Text('Try again'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+}
+
+class _DayHeaderDelegate extends SliverPersistentHeaderDelegate {
+  const _DayHeaderDelegate({
+    required this.label,
+    required this.isToday,
+    required this.dayKey,
+    this.headerKey,
+  });
+
+  final String label;
+  final bool isToday;
+  final Key dayKey;
+
+  /// Carried onto the rendered header so `Scrollable.ensureVisible` has an
+  /// element to target. Only the today header receives one.
+  final Key? headerKey;
+
+  static const double _height = 38;
+
+  @override
+  double get minExtent => _height;
+
+  @override
+  double get maxExtent => _height;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return Container(
+      key: headerKey,
+      height: _height,
+      // Opaque, or the rows scrolling underneath a pinned header show through.
+      color: AppColors.background,
+      alignment: Alignment.centerLeft,
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+      child: Text(
+        label,
+        key: dayKey,
+        style: TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w500,
+          color: isToday ? AppColors.primary : AppColors.textSecondary,
+        ),
+      ),
+    );
+  }
+
+  @override
+  bool shouldRebuild(_DayHeaderDelegate oldDelegate) =>
+      oldDelegate.label != label ||
+      oldDelegate.isToday != isToday ||
+      oldDelegate.headerKey != headerKey;
+}

--- a/player/lib/presentation/screens/calendar/calendar_screen.dart
+++ b/player/lib/presentation/screens/calendar/calendar_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
 
 import '../../../core/graphql/watch/query_key.dart';
+import '../../../core/graphql/watch/schema_downgrade.dart';
 import '../../../core/theme/colors.dart';
 import '../../../domain/models/calendar_entry.dart';
 import '../../widgets/browse_scaffold.dart';
@@ -91,6 +93,18 @@ int? indexOfToday(List<DateTime> days, DateTime today) {
     if (!days[i].isBefore(midnight)) return i;
   }
   return null;
+}
+
+/// Whether [error] is this server saying it has no calendar query.
+///
+/// A player installed from an app store can be newer than the server it talks
+/// to. There is no capability probe to ask in advance: `serverCompatibility`
+/// reports version strings and no feature list, and a brand new root field has
+/// no older shape for `QueryWatcher` to fall back to. So the rejection itself
+/// is the signal.
+bool isCalendarUnsupported(Object error) {
+  if (error is! OperationException) return false;
+  return isUnknownFieldError(error);
 }
 
 class CalendarScreen extends ConsumerStatefulWidget {
@@ -268,6 +282,31 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   }
 
   Widget _error(Object error, double scrollTopPadding) {
+    if (isCalendarUnsupported(error)) {
+      return Padding(
+        key: const ValueKey('calendar-unsupported'),
+        padding:
+            EdgeInsets.only(top: scrollTopPadding + 80, left: 32, right: 32),
+        child: const Column(
+          children: [
+            Icon(Icons.update, size: 48, color: AppColors.textDisabled),
+            SizedBox(height: 16),
+            Text(
+              'This server does not have the calendar yet',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 17, color: AppColors.textSecondary),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Update the server and the calendar will appear here.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 13, color: AppColors.textDisabled),
+            ),
+          ],
+        ),
+      );
+    }
+
     return Padding(
       padding: EdgeInsets.only(top: scrollTopPadding + 80, left: 32, right: 32),
       child: Column(

--- a/player/lib/presentation/screens/calendar/calendar_screen.dart
+++ b/player/lib/presentation/screens/calendar/calendar_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/theme/colors.dart';
 import '../../../domain/models/calendar_entry.dart';
 import '../../widgets/browse_scaffold.dart';
 import 'calendar_controller.dart';
+import 'calendar_dates.dart';
 import 'calendar_row.dart';
 
 /// Short weekday names, indexed by `DateTime.weekday - 1` (Monday first).
@@ -41,11 +42,6 @@ const List<String> _monthNames = [
   'December',
 ];
 
-/// Zero-padded `yyyy-MM-dd`, for the day header's test key.
-String _isoDate(DateTime date) => '${date.year.toString().padLeft(4, '0')}-'
-    '${date.month.toString().padLeft(2, '0')}-'
-    '${date.day.toString().padLeft(2, '0')}';
-
 /// Entries grouped into day sections, in the order the server sent them.
 ///
 /// The resolver already orders by air date, then playable first, then title,
@@ -66,9 +62,7 @@ List<MapEntry<DateTime, List<CalendarEntry>>> groupByDay(
 
 /// The label above one day's entries.
 String formatDayHeader(DateTime day, DateTime today) {
-  final isToday = day.year == today.year &&
-      day.month == today.month &&
-      day.day == today.day;
+  final isToday = isSameDay(day, today);
 
   final sameYear = day.year == today.year;
   final weekday = _weekdayAbbreviations[day.weekday - 1];
@@ -87,7 +81,7 @@ String formatDayHeader(DateTime day, DateTime today) {
 /// all, and the calendar still has to open somewhere sensible. The first
 /// upcoming day is that place.
 int? indexOfToday(List<DateTime> days, DateTime today) {
-  final midnight = DateTime(today.year, today.month, today.day);
+  final midnight = truncateToDay(today);
 
   for (var i = 0; i < days.length; i++) {
     if (!days[i].isBefore(midnight)) return i;
@@ -225,9 +219,9 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                 delegate: _DayHeaderDelegate(
                   headerKey: index == todayIndex ? _todayKey : null,
                   label: formatDayHeader(group.key, today),
-                  isToday: _isSameDay(group.key, today),
+                  isToday: isSameDay(group.key, today),
                   dayKey: ValueKey(
-                    'calendar-day-${_isoDate(group.key)}',
+                    'calendar-day-${isoDate(group.key)}',
                   ),
                 ),
               ),
@@ -327,9 +321,6 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
       ),
     );
   }
-
-  bool _isSameDay(DateTime a, DateTime b) =>
-      a.year == b.year && a.month == b.month && a.day == b.day;
 }
 
 class _DayHeaderDelegate extends SliverPersistentHeaderDelegate {

--- a/player/test/domain/navigation/sidebar_layout_test.dart
+++ b/player/test/domain/navigation/sidebar_layout_test.dart
@@ -336,4 +336,64 @@ void main() {
       expect(order, contains('collections'));
     });
   });
+
+  group('calendar destination', () {
+    test('is present in the default layout', () {
+      final ids = SidebarLayout.defaults
+          .reconcile(downloadSupported: true)
+          .map((d) => d.id)
+          .toList();
+
+      expect(ids, contains('calendar'));
+    });
+
+    test('sits between TV Shows and Recently Added', () {
+      final ids = SidebarLayout.defaults
+          .reconcile(downloadSupported: true)
+          .map((d) => d.id)
+          .toList();
+
+      expect(ids.indexOf('calendar'), greaterThan(ids.indexOf('shows')));
+      expect(ids.indexOf('calendar'), lessThan(ids.indexOf('recently_added')));
+    });
+
+    test('is inserted at its default position for a user who never had it', () {
+      const stored = SidebarLayout(
+        order: [
+          'search',
+          'home',
+          'continue_watching',
+          'movies',
+          'shows',
+          'recently_added',
+          'unwatched',
+          'favorites',
+          'collections',
+          'downloads',
+          'settings',
+        ],
+        hidden: {},
+        filters: {},
+      );
+
+      final ids =
+          stored.reconcile(downloadSupported: true).map((d) => d.id).toList();
+
+      expect(ids.indexOf('calendar'), greaterThan(ids.indexOf('shows')));
+      expect(ids.indexOf('calendar'), lessThan(ids.indexOf('recently_added')));
+    });
+
+    test('can be hidden, because it is not anchored', () {
+      final stored = SidebarLayout(
+        order: SidebarLayout.defaults.order,
+        hidden: const {'calendar'},
+        filters: const {},
+      );
+
+      final ids =
+          stored.reconcile(downloadSupported: true).map((d) => d.id).toList();
+
+      expect(ids, isNot(contains('calendar')));
+    });
+  });
 }

--- a/player/test/presentation/screens/calendar/calendar_controller_test.dart
+++ b/player/test/presentation/screens/calendar/calendar_controller_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/calendar_entry.dart';
+import 'package:player/presentation/screens/calendar/calendar_controller.dart';
+
+void main() {
+  group('CalendarEntry.fromJson', () {
+    test('parses an episode with a playable file', () {
+      final entry = CalendarEntry.fromJson({
+        'id': '42',
+        'kind': 'EPISODE',
+        'airDate': '2026-08-27',
+        'title': 'An Episode',
+        'seasonNumber': 3,
+        'episodeNumber': 4,
+        'mediaItemId': '7',
+        'mediaItemTitle': 'A Show',
+        'artwork': {'posterUrl': 'https://example.invalid/p.jpg'},
+        'files': [
+          {'id': 'file-1', 'resolution': '1080p', 'directPlaySupported': true},
+        ],
+      });
+
+      expect(entry.id, '42');
+      expect(entry.kind, CalendarEntryKind.episode);
+      expect(entry.airDate, DateTime(2026, 8, 27));
+      expect(entry.seasonNumber, 3);
+      expect(entry.mediaItemId, '7');
+      expect(entry.mediaItemTitle, 'A Show');
+      expect(entry.files.single.id, 'file-1');
+      expect(entry.isPlayable, isTrue);
+    });
+
+    test('parses a movie with no files as not playable', () {
+      final entry = CalendarEntry.fromJson({
+        'id': '9',
+        'kind': 'MOVIE',
+        'airDate': '2026-08-28',
+        'title': 'A Movie',
+        'seasonNumber': null,
+        'episodeNumber': null,
+        'mediaItemId': '9',
+        'mediaItemTitle': 'A Movie',
+        'artwork': null,
+        'files': <dynamic>[],
+      });
+
+      expect(entry.kind, CalendarEntryKind.movie);
+      expect(entry.seasonNumber, isNull);
+      expect(entry.isPlayable, isFalse);
+    });
+  });
+
+  group('CalendarController.windowFor', () {
+    test('spans 30 days back and 90 forward from the given day', () {
+      final (start, end) = CalendarController.windowFor(DateTime(2026, 8, 27));
+
+      expect(start, DateTime(2026, 7, 28));
+      expect(end, DateTime(2026, 11, 25));
+    });
+
+    test('drops the time component so the window is whole days', () {
+      final (start, end) =
+          CalendarController.windowFor(DateTime(2026, 8, 27, 23, 59, 59));
+
+      expect(start, DateTime(2026, 7, 28));
+      expect(end, DateTime(2026, 11, 25));
+    });
+  });
+}

--- a/player/test/presentation/screens/calendar/calendar_dates_test.dart
+++ b/player/test/presentation/screens/calendar/calendar_dates_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/calendar/calendar_dates.dart';
+
+void main() {
+  group('isoDate', () {
+    test('zero-pads single-digit month and day', () {
+      expect(isoDate(DateTime(2026, 1, 4)), '2026-01-04');
+    });
+
+    test('leaves double-digit month and day alone', () {
+      expect(isoDate(DateTime(2026, 11, 25)), '2026-11-25');
+    });
+
+    test('ignores the time component', () {
+      expect(isoDate(DateTime(2026, 8, 27, 23, 59, 59)), '2026-08-27');
+    });
+  });
+
+  group('truncateToDay', () {
+    test('drops the time component', () {
+      expect(
+          truncateToDay(DateTime(2026, 8, 27, 14, 30)), DateTime(2026, 8, 27));
+    });
+
+    test('is a no-op on a value that already has no time component', () {
+      final day = DateTime(2026, 8, 27);
+      expect(truncateToDay(day), day);
+    });
+  });
+
+  group('isSameDay', () {
+    test('true for the same day at different times', () {
+      expect(
+        isSameDay(DateTime(2026, 8, 27, 1), DateTime(2026, 8, 27, 23)),
+        isTrue,
+      );
+    });
+
+    test('false for a different day', () {
+      expect(isSameDay(DateTime(2026, 8, 27), DateTime(2026, 8, 28)), isFalse);
+    });
+
+    test('false for the same month/day in a different year', () {
+      expect(isSameDay(DateTime(2026, 8, 27), DateTime(2027, 8, 27)), isFalse);
+    });
+  });
+}

--- a/player/test/presentation/screens/calendar/calendar_row_test.dart
+++ b/player/test/presentation/screens/calendar/calendar_row_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/calendar_entry.dart';
+import 'package:player/domain/models/media_file.dart';
+import 'package:player/presentation/screens/calendar/calendar_row.dart';
+
+CalendarEntry _entry({
+  required String id,
+  required DateTime airDate,
+  bool playable = false,
+  CalendarEntryKind kind = CalendarEntryKind.episode,
+}) {
+  return CalendarEntry(
+    id: id,
+    kind: kind,
+    airDate: airDate,
+    title: 'An Episode',
+    mediaItemId: '7',
+    mediaItemTitle: 'A Show',
+    seasonNumber: kind == CalendarEntryKind.episode ? 3 : null,
+    episodeNumber: kind == CalendarEntryKind.episode ? 4 : null,
+    files: playable
+        ? const [MediaFile(id: 'file-1', directPlaySupported: true)]
+        : const [],
+  );
+}
+
+Future<void> _pump(WidgetTester tester, CalendarEntry entry) {
+  return tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: CalendarRow(entry: entry, today: DateTime(2026, 8, 27)),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('a playable past entry offers a play control', (tester) async {
+    await _pump(
+      tester,
+      _entry(id: '1', airDate: DateTime(2026, 8, 20), playable: true),
+    );
+
+    expect(find.byKey(const ValueKey('calendar-play-1')), findsOneWidget);
+    expect(find.byKey(const ValueKey('calendar-upcoming-1')), findsNothing);
+    expect(find.byKey(const ValueKey('calendar-absent-1')), findsNothing);
+  });
+
+  testWidgets('a future entry is marked upcoming and cannot be played',
+      (tester) async {
+    await _pump(
+      tester,
+      _entry(id: '2', airDate: DateTime(2026, 8, 30), playable: false),
+    );
+
+    expect(find.byKey(const ValueKey('calendar-upcoming-2')), findsOneWidget);
+    expect(find.byKey(const ValueKey('calendar-play-2')), findsNothing);
+  });
+
+  testWidgets('a future entry that is already in the library can be played',
+      (tester) async {
+    await _pump(
+      tester,
+      _entry(id: '3', airDate: DateTime(2026, 8, 30), playable: true),
+    );
+
+    expect(find.byKey(const ValueKey('calendar-play-3')), findsOneWidget);
+    expect(find.byKey(const ValueKey('calendar-upcoming-3')), findsNothing);
+  });
+
+  testWidgets('an aired entry with no file reads as not in the library',
+      (tester) async {
+    await _pump(
+      tester,
+      _entry(id: '4', airDate: DateTime(2026, 8, 20), playable: false),
+    );
+
+    expect(find.byKey(const ValueKey('calendar-absent-4')), findsOneWidget);
+    expect(find.text('Not in library'), findsOneWidget);
+    expect(find.byKey(const ValueKey('calendar-play-4')), findsNothing);
+  });
+
+  testWidgets('an episode shows its season and episode numbers',
+      (tester) async {
+    await _pump(
+      tester,
+      _entry(id: '5', airDate: DateTime(2026, 8, 20), playable: true),
+    );
+
+    expect(find.textContaining('S03E04'), findsOneWidget);
+    expect(find.text('A Show'), findsOneWidget);
+  });
+
+  testWidgets('a movie shows its own title and no episode numbering',
+      (tester) async {
+    await _pump(
+      tester,
+      _entry(
+        id: '6',
+        airDate: DateTime(2026, 8, 20),
+        playable: true,
+        kind: CalendarEntryKind.movie,
+      ),
+    );
+
+    expect(find.textContaining('S0'), findsNothing);
+    expect(find.text('Movie'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/screens/calendar/calendar_screen_test.dart
+++ b/player/test/presentation/screens/calendar/calendar_screen_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/calendar_entry.dart';
+import 'package:player/presentation/screens/calendar/calendar_screen.dart';
+
+CalendarEntry _entry(String id, DateTime airDate) => CalendarEntry(
+      id: id,
+      kind: CalendarEntryKind.episode,
+      airDate: airDate,
+      title: 'Episode $id',
+      mediaItemId: '7',
+      mediaItemTitle: 'A Show',
+    );
+
+void main() {
+  group('groupByDay', () {
+    test('groups entries under their date, preserving server order', () {
+      final grouped = groupByDay([
+        _entry('1', DateTime(2026, 8, 20)),
+        _entry('2', DateTime(2026, 8, 20)),
+        _entry('3', DateTime(2026, 8, 22)),
+      ]);
+
+      expect(grouped.length, 2);
+      expect(grouped.first.key, DateTime(2026, 8, 20));
+      expect(grouped.first.value.map((e) => e.id).toList(), ['1', '2']);
+      expect(grouped.last.key, DateTime(2026, 8, 22));
+    });
+
+    test('emits no group for a day with no entries', () {
+      final grouped = groupByDay([
+        _entry('1', DateTime(2026, 8, 20)),
+        _entry('2', DateTime(2026, 8, 25)),
+      ]);
+
+      expect(grouped.map((g) => g.key).toList(), [
+        DateTime(2026, 8, 20),
+        DateTime(2026, 8, 25),
+      ]);
+    });
+
+    test('ignores a time component when deciding the day', () {
+      final grouped = groupByDay([
+        _entry('1', DateTime(2026, 8, 20, 9)),
+        _entry('2', DateTime(2026, 8, 20, 21)),
+      ]);
+
+      expect(grouped.length, 1);
+    });
+
+    test('returns nothing for an empty list', () {
+      expect(groupByDay(const []), isEmpty);
+    });
+  });
+
+  group('indexOfToday', () {
+    test('finds the group for today when today has entries', () {
+      final index = indexOfToday(
+        [DateTime(2026, 8, 20), DateTime(2026, 8, 27), DateTime(2026, 8, 30)],
+        DateTime(2026, 8, 27),
+      );
+
+      expect(index, 1);
+    });
+
+    test('falls forward to the next day when today has no entries', () {
+      final index = indexOfToday(
+        [DateTime(2026, 8, 20), DateTime(2026, 8, 30)],
+        DateTime(2026, 8, 27),
+      );
+
+      expect(index, 1);
+    });
+
+    test('is null when every day is in the past', () {
+      final index = indexOfToday(
+        [DateTime(2026, 8, 20), DateTime(2026, 8, 21)],
+        DateTime(2026, 8, 27),
+      );
+
+      expect(index, isNull);
+    });
+
+    test('ignores the time of day on the reference date', () {
+      final index = indexOfToday(
+        [DateTime(2026, 8, 27)],
+        DateTime(2026, 8, 27, 23, 30),
+      );
+
+      expect(index, 0);
+    });
+
+    test('is null for an empty list', () {
+      expect(indexOfToday(const [], DateTime(2026, 8, 27)), isNull);
+    });
+  });
+
+  group('formatDayHeader', () {
+    test('marks today', () {
+      expect(
+        formatDayHeader(DateTime(2026, 8, 27), DateTime(2026, 8, 27)),
+        'Thu 27 August · Today',
+      );
+    });
+
+    test('omits the year inside the current year', () {
+      expect(
+        formatDayHeader(DateTime(2026, 8, 20), DateTime(2026, 8, 27)),
+        'Thu 20 August',
+      );
+    });
+
+    test('includes the year outside the current year', () {
+      expect(
+        formatDayHeader(DateTime(2027, 1, 4), DateTime(2026, 8, 27)),
+        'Mon 4 January 2027',
+      );
+    });
+  });
+}

--- a/player/test/presentation/screens/calendar/calendar_unsupported_test.dart
+++ b/player/test/presentation/screens/calendar/calendar_unsupported_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/presentation/screens/calendar/calendar_screen.dart';
+
+void main() {
+  group('isCalendarUnsupported', () {
+    test('recognises the server rejecting the calendar root field', () {
+      final exception = OperationException(
+        graphqlErrors: [
+          const GraphQLError(
+            message: 'Cannot query field "calendar" on type "RootQueryType".',
+          ),
+        ],
+      );
+
+      expect(isCalendarUnsupported(exception), isTrue);
+    });
+
+    test('does not claim an ordinary error is a version problem', () {
+      final exception = OperationException(
+        graphqlErrors: [const GraphQLError(message: 'Not authenticated')],
+      );
+
+      expect(isCalendarUnsupported(exception), isFalse);
+    });
+
+    test('does not claim a transport failure is a version problem', () {
+      final exception = OperationException(
+        linkException: NetworkException(
+          originalException: Exception('connection refused'),
+          message: 'connection refused',
+          uri: Uri.parse('https://example.invalid/graphql'),
+        ),
+      );
+
+      expect(isCalendarUnsupported(exception), isFalse);
+    });
+
+    test('is false for an error that is not a GraphQL exception at all', () {
+      expect(isCalendarUnsupported(StateError('boom')), isFalse);
+    });
+  });
+}

--- a/player/test/presentation/screens/calendar/calendar_watcher_test.dart
+++ b/player/test/presentation/screens/calendar/calendar_watcher_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:graphql_flutter/graphql_flutter.dart';
+import 'package:player/core/graphql/watch/fetch_log.dart';
+import 'package:player/core/graphql/watch/query_key.dart';
+import 'package:player/core/graphql/watch/query_watcher.dart';
+import 'package:player/domain/models/calendar_entry.dart';
+import 'package:player/presentation/screens/calendar/calendar_controller.dart';
+
+import '../../../test_utils/stub_graphql_client.dart';
+
+// `gql()` injects a `__typename` selection into every selection set, the
+// operation root included, and cache normalization rejects data that lacks a
+// matching one. That failure surfaces as a spurious `hasException`, not as an
+// obvious error, so every object below carries one.
+Map<String, dynamic> _calendarData() => {
+      '__typename': 'Query',
+      'calendar': [
+        {
+          '__typename': 'CalendarEntry',
+          'id': '42',
+          'kind': 'EPISODE',
+          'airDate': '2026-08-27',
+          'title': 'An Episode',
+          'seasonNumber': 3,
+          'episodeNumber': 4,
+          'mediaItemId': '7',
+          'mediaItemTitle': 'A Show',
+          'artwork': {
+            '__typename': 'Artwork',
+            'posterUrl': 'https://example.invalid/p.jpg',
+            'backdropUrl': null,
+            'thumbnailUrl': null,
+          },
+          'files': [
+            {
+              '__typename': 'MediaFile',
+              'id': 'file-1',
+              'resolution': '1080p',
+              'directPlaySupported': true,
+              'hdrFormat': null,
+              'bitrate': 8000000,
+            },
+          ],
+        },
+        {
+          '__typename': 'CalendarEntry',
+          'id': '43',
+          'kind': 'MOVIE',
+          'airDate': '2026-08-28',
+          'title': 'A Movie',
+          'seasonNumber': null,
+          'episodeNumber': null,
+          'mediaItemId': '43',
+          'mediaItemTitle': 'A Movie',
+          'artwork': null,
+          'files': <dynamic>[],
+        },
+      ],
+    };
+
+void main() {
+  QueryWatcher<List<CalendarEntry>> watcherFor(GraphQLClient client) {
+    return QueryWatcher<List<CalendarEntry>>(
+      key: QueryKeys.calendar,
+      client: Future<GraphQLClient>.value(client),
+      fetchLog: InMemoryFetchLog(),
+      document: gql(calendarQuery),
+      variables: const {'start': '2026-07-28', 'end': '2026-11-25'},
+      parse: parseCalendar,
+    );
+  }
+
+  test('parses a real calendar response into entries', () async {
+    final watcher =
+        watcherFor(stubClient(StubLink.responses([_calendarData()])));
+    addTearDown(watcher.close);
+
+    final entries = await watcher.stream.first;
+
+    // Assert the parsed values, never merely that nothing threw: StubLink
+    // can fail silently, and an empty list would satisfy a weaker assertion.
+    expect(entries, hasLength(2));
+    expect(entries.first.id, '42');
+    expect(entries.first.kind, CalendarEntryKind.episode);
+    expect(entries.first.mediaItemTitle, 'A Show');
+    expect(entries.first.files.single.id, 'file-1');
+    expect(entries.first.isPlayable, isTrue);
+    expect(entries.last.kind, CalendarEntryKind.movie);
+    expect(entries.last.isPlayable, isFalse);
+  });
+
+  test('an empty window parses to an empty list, not an error', () async {
+    final watcher = watcherFor(
+      stubClient(
+        StubLink.responses([
+          {'__typename': 'Query', 'calendar': <dynamic>[]},
+        ]),
+      ),
+    );
+    addTearDown(watcher.close);
+
+    await expectLater(watcher.stream, emits(isEmpty));
+  });
+
+  test('sends the window as variables', () async {
+    final link = StubLink.responses([_calendarData()]);
+    final watcher = watcherFor(stubClient(link));
+    addTearDown(watcher.close);
+
+    await watcher.stream.first;
+
+    expect(link.requests.first.variables['start'], '2026-07-28');
+    expect(link.requests.first.variables['end'], '2026-11-25');
+  });
+}

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -92,6 +92,9 @@ type RootQueryType {
 
   "Get this server's version and the player versions it supports"
   serverCompatibility: ServerCompatibility
+
+  "Get dated episodes and movies between two dates, both bounds inclusive"
+  calendar(start: Date!, end: Date!): [CalendarEntry!]!
 }
 
 type RootMutationType {
@@ -1423,6 +1426,38 @@ type ServerCompatibility {
   recommendedPlayerVersion: String!
 }
 
+"One dated item on the player's calendar"
+type CalendarEntry {
+  "Episode ID, or media item ID for a movie"
+  id: ID!
+
+  "Episode or movie"
+  kind: CalendarEntryKind!
+
+  "Air date, or release date for a movie"
+  airDate: Date!
+
+  "Episode title, or movie title"
+  title: String!
+
+  "Season number, null for a movie"
+  seasonNumber: Int
+
+  "Episode number, null for a movie"
+  episodeNumber: Int
+
+  "The parent show, or the movie itself"
+  mediaItemId: ID!
+
+  "Show name, or movie title"
+  mediaItemTitle: String!
+
+  artwork: Artwork
+
+  "Playable files for this entry, empty when the library holds nothing"
+  files: [MediaFile!]!
+}
+
 "Media content types"
 enum MediaType {
   "A movie"
@@ -1583,6 +1618,15 @@ enum SegmentType {
 
   "Closing credits"
   CREDITS
+}
+
+"Whether a calendar entry is an episode or a movie"
+enum CalendarEntryKind {
+  "A TV episode, dated by its air date"
+  EPISODE
+
+  "A movie, dated by its release date"
+  MOVIE
 }
 
 """

--- a/server/crates/api/src/query.rs
+++ b/server/crates/api/src/query.rs
@@ -14,11 +14,11 @@ use crate::types::common::{
     MediaCategory, MediaType, Node, PageInfo, SearchResultType, SortInput, SubtitleFormat,
 };
 use crate::types::discovery::{
-    Collection, ContinueWatchingItem, RemoteAccessStatus, SearchResults, ServerCompatibility,
-    UpNextItem,
+    CalendarEntry, Collection, ContinueWatchingItem, RemoteAccessStatus, SearchResults,
+    ServerCompatibility, UpNextItem,
 };
 use crate::types::media::{
-    Episode, LibraryPath, Movie, MovieConnection, MovieEdge, RecentlyAddedItem,
+    Date, Episode, LibraryPath, Movie, MovieConnection, MovieEdge, RecentlyAddedItem,
     SubtitleProviderStatus, SubtitleSearchPayload, SubtitleTrackSetting, TvShow, TvShowConnection,
     TvShowEdge,
 };
@@ -358,6 +358,20 @@ impl RootQueryType {
         _types: Option<Vec<Option<MediaType>>>,
     ) -> Result<Option<Vec<Option<RecentlyAddedItem>>>> {
         Ok(None)
+    }
+
+    /// Get dated episodes and movies between two dates, both bounds inclusive
+    ///
+    /// Schema-only stub for SDL parity with the Elixir server. The real
+    /// implementation lives in
+    /// `lib/mydia_web/schema/resolvers/calendar_resolver.ex`.
+    async fn calendar(
+        &self,
+        _ctx: &Context<'_>,
+        _start: Date,
+        _end: Date,
+    ) -> Result<Vec<CalendarEntry>> {
+        Ok(vec![])
     }
 
     /// Get next episodes to watch across all TV shows

--- a/server/crates/api/src/types/discovery.rs
+++ b/server/crates/api/src/types/discovery.rs
@@ -3,13 +3,13 @@
 //! Types owned by this module (keep in sync with tests/types_remaining.rs):
 //! ContinueWatchingItem, RemoveFromContinueWatchingResult, RecentlyAddedItem,
 //! UpNextItem, Collection, SearchResult, SearchSection, SearchResults,
-//! RemoteAccessStatus, ServerCompatibility.
+//! RemoteAccessStatus, ServerCompatibility, CalendarEntry, CalendarEntryKind.
 
-use async_graphql::{SimpleObject, ID};
+use async_graphql::{Enum, SimpleObject, ID};
 
 use crate::types::{
     common::{MediaType, SearchResultType},
-    media::{Artwork, Episode, MediaFile, Progress, RecentlyAddedItem, TvShow},
+    media::{Artwork, Date, Episode, MediaFile, Progress, RecentlyAddedItem, TvShow},
 };
 
 #[derive(SimpleObject)]
@@ -104,6 +104,39 @@ pub struct ServerCompatibility {
     pub recommended_player_version: String,
 }
 
+/// Whether a calendar entry is an episode or a movie
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum CalendarEntryKind {
+    /// A TV episode, dated by its air date
+    Episode,
+    /// A movie, dated by its release date
+    Movie,
+}
+
+/// One dated item on the player's calendar
+#[derive(SimpleObject)]
+pub struct CalendarEntry {
+    /// Episode ID, or media item ID for a movie
+    pub id: ID,
+    /// Episode or movie
+    pub kind: CalendarEntryKind,
+    /// Air date, or release date for a movie
+    pub air_date: Date,
+    /// Episode title, or movie title
+    pub title: String,
+    /// Season number, null for a movie
+    pub season_number: Option<i32>,
+    /// Episode number, null for a movie
+    pub episode_number: Option<i32>,
+    /// The parent show, or the movie itself
+    pub media_item_id: ID,
+    /// Show name, or movie title
+    pub media_item_title: String,
+    pub artwork: Option<Artwork>,
+    /// Playable files for this entry, empty when the library holds nothing
+    pub files: Vec<MediaFile>,
+}
+
 /// Renders just this group's types as SDL.
 pub fn sdl_fragment() -> String {
     use async_graphql::{EmptyMutation, EmptySubscription, Object, Schema};
@@ -145,6 +178,10 @@ pub fn sdl_fragment() -> String {
         }
 
         async fn server_compatibility(&self) -> ServerCompatibility {
+            std::future::pending().await
+        }
+
+        async fn calendar_entry(&self) -> CalendarEntry {
             std::future::pending().await
         }
     }

--- a/server/crates/api/tests/types_remaining.rs
+++ b/server/crates/api/tests/types_remaining.rs
@@ -40,6 +40,8 @@ const OWNED_DISCOVERY: &[&str] = &[
     "SearchResults",
     "RemoteAccessStatus",
     "ServerCompatibility",
+    "CalendarEntry",
+    "CalendarEntryKind",
 ];
 
 fn reference_sdl() -> String {

--- a/test/mydia/db_test.exs
+++ b/test/mydia/db_test.exs
@@ -407,6 +407,63 @@ defmodule Mydia.DBTest do
     end
   end
 
+  describe "json_date_between/4" do
+    test "matches rows whose JSON date falls inside the range, bounds included" do
+      before_range = media_item_fixture(%{type: "movie", title: "Before"})
+      first = media_item_fixture(%{type: "movie", title: "First"})
+      middle = media_item_fixture(%{type: "movie", title: "Middle"})
+      last = media_item_fixture(%{type: "movie", title: "Last"})
+      after_range = media_item_fixture(%{type: "movie", title: "After"})
+
+      set_release_date(before_range, ~D[2026-07-31])
+      set_release_date(first, ~D[2026-08-01])
+      set_release_date(middle, ~D[2026-08-15])
+      set_release_date(last, ~D[2026-08-31])
+      set_release_date(after_range, ~D[2026-09-01])
+
+      titles =
+        MediaItem
+        |> where([m], m.type == "movie")
+        |> where(
+          ^Mydia.DB.json_date_between(
+            :metadata,
+            "$.release_date",
+            ~D[2026-08-01],
+            ~D[2026-08-31]
+          )
+        )
+        |> select([m], m.title)
+        |> Repo.all()
+        |> Enum.sort()
+
+      assert titles == ["First", "Last", "Middle"]
+    end
+  end
+
+  # `Mydia.Media.MetadataType` wraps `Mydia.Metadata.Structs.MediaMetadata`,
+  # which enforces `:provider_id`, `:provider`, and `:media_type` via
+  # `@enforce_keys`. `%MediaMetadata{}` with none of those set is a compile
+  # error, so a fresh struct here must supply them explicitly.
+  defp set_release_date(item, date) do
+    metadata =
+      case item.metadata do
+        nil ->
+          %Mydia.Metadata.Structs.MediaMetadata{
+            provider_id: to_string(item.id),
+            provider: :metadata_relay,
+            media_type: :movie,
+            release_date: date
+          }
+
+        existing ->
+          %{existing | release_date: date}
+      end
+
+    item
+    |> Ecto.Changeset.change(metadata: metadata)
+    |> Mydia.Repo.update!()
+  end
+
   describe "avg_timestamp_diff_seconds/2" do
     test "calculates average difference between timestamps" do
       now = DateTime.utc_now()

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1395,6 +1395,31 @@ defmodule Mydia.MediaTest do
       assert entry.has_files == true
       assert entry.has_downloads == false
     end
+
+    test "has_files is false when the movie's only file is trashed" do
+      movie =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Movie With Trashed File",
+          year: 2025,
+          metadata: %{
+            provider_id: "7",
+            provider: :metadata_relay,
+            media_type: :movie,
+            release_date: ~D[2025-06-15]
+          }
+        })
+
+      media_file_fixture(
+        media_item_id: movie.id,
+        trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      entries = Media.list_movies_by_release_date(~D[2025-06-01], ~D[2025-06-30])
+
+      assert [%CalendarEntry{} = entry] = entries
+      assert entry.has_files == false
+    end
   end
 
   describe "list_movies_by_release_date/3 filtering" do
@@ -1564,6 +1589,28 @@ defmodule Mydia.MediaTest do
       assert first.has_files == true
       assert second.has_files == false
       assert first.has_downloads == false
+    end
+
+    test "has_files is false when the episode's only file is trashed" do
+      show = media_item_fixture(%{type: "tv_show", title: "Trashed File Show"})
+
+      episode =
+        episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 1,
+          episode_number: 1,
+          air_date: ~D[2026-08-10]
+        })
+
+      media_file_fixture(
+        episode_id: episode.id,
+        trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      )
+
+      [entry] =
+        Mydia.Media.list_episodes_by_air_date(~D[2026-08-01], ~D[2026-08-31], monitored: nil)
+
+      assert entry.has_files == false
     end
   end
 

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1407,7 +1407,7 @@ defmodule Mydia.MediaTest do
       outside = media_item_fixture(%{type: "movie", title: "Outside"})
       undated = media_item_fixture(%{type: "movie", title: "Undated"})
 
-      set_release_date(inside, ~D[2026-08-15])
+      inside = set_release_date(inside, ~D[2026-08-15])
       set_release_date(edge_low, ~D[2026-08-01])
       set_release_date(edge_high, ~D[2026-08-31])
       set_release_date(outside, ~D[2026-09-05])
@@ -1449,6 +1449,25 @@ defmodule Mydia.MediaTest do
       assert "Unmonitored" in titles
     end
 
+    test "carries the poster and backdrop paths from metadata", ctx do
+      metadata = %{
+        ctx.inside.metadata
+        | poster_path: "/poster.jpg",
+          backdrop_path: "/backdrop.jpg"
+      }
+
+      ctx.inside
+      |> Ecto.Changeset.change(metadata: metadata)
+      |> Mydia.Repo.update!()
+
+      entry =
+        Mydia.Media.list_movies_by_release_date(~D[2026-08-01], ~D[2026-08-31], monitored: nil)
+        |> Enum.find(&(&1.media_item_title == "Inside"))
+
+      assert entry.poster_path == "/poster.jpg"
+      assert entry.backdrop_path == "/backdrop.jpg"
+    end
+
     # Identical to the helper Task 1 added to test/mydia/db_test.exs. The struct
     # is Mydia.Metadata.Structs.MediaMetadata, and it carries @enforce_keys on
     # :provider_id, :provider and :media_type, so a fresh one cannot be built
@@ -1471,6 +1490,80 @@ defmodule Mydia.MediaTest do
       item
       |> Ecto.Changeset.change(metadata: metadata)
       |> Mydia.Repo.update!()
+    end
+  end
+
+  describe "list_episodes_by_air_date/3 artwork" do
+    import Mydia.MediaFixtures
+
+    test "carries the show's poster path onto each episode entry" do
+      show = media_item_fixture(%{type: "tv_show", title: "Artful Show"})
+
+      # Mydia.Metadata.Structs.MediaMetadata enforces :provider_id, :provider
+      # and :media_type, so a fresh struct must supply them. See the
+      # set_release_date helper in Task 2 for the same pattern.
+      metadata =
+        case show.metadata do
+          nil ->
+            %Mydia.Metadata.Structs.MediaMetadata{
+              provider_id: to_string(show.id),
+              provider: :metadata_relay,
+              media_type: :tv_show,
+              poster_path: "/show.jpg"
+            }
+
+          existing ->
+            %{existing | poster_path: "/show.jpg"}
+        end
+
+      show
+      |> Ecto.Changeset.change(metadata: metadata)
+      |> Mydia.Repo.update!()
+
+      episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: 1,
+        air_date: ~D[2026-08-15]
+      })
+
+      [entry] =
+        Mydia.Media.list_episodes_by_air_date(~D[2026-08-01], ~D[2026-08-31], monitored: nil)
+
+      assert entry.poster_path == "/show.jpg"
+    end
+
+    test "reports has_files as a real boolean on both adapters" do
+      show = media_item_fixture(%{type: "tv_show", title: "Boolean Show"})
+
+      with_file =
+        episode_fixture(%{
+          media_item_id: show.id,
+          season_number: 1,
+          episode_number: 1,
+          air_date: ~D[2026-08-10]
+        })
+
+      media_file_fixture(%{episode_id: with_file.id})
+
+      episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: 2,
+        air_date: ~D[2026-08-11]
+      })
+
+      entries =
+        Mydia.Media.list_episodes_by_air_date(~D[2026-08-01], ~D[2026-08-31], monitored: nil)
+
+      [first, second] = Enum.sort_by(entries, & &1.episode_number)
+
+      # `assert x == true` rather than `assert x`, on purpose. The bug this
+      # pins returned integer 1 on SQLite and boolean false on PostgreSQL, and
+      # a truthiness assertion passes for 1. Identity is the whole point.
+      assert first.has_files == true
+      assert second.has_files == false
+      assert first.has_downloads == false
     end
   end
 

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1397,6 +1397,83 @@ defmodule Mydia.MediaTest do
     end
   end
 
+  describe "list_movies_by_release_date/3 filtering" do
+    import Mydia.MediaFixtures
+
+    setup do
+      inside = media_item_fixture(%{type: "movie", title: "Inside"})
+      edge_low = media_item_fixture(%{type: "movie", title: "EdgeLow"})
+      edge_high = media_item_fixture(%{type: "movie", title: "EdgeHigh"})
+      outside = media_item_fixture(%{type: "movie", title: "Outside"})
+      undated = media_item_fixture(%{type: "movie", title: "Undated"})
+
+      set_release_date(inside, ~D[2026-08-15])
+      set_release_date(edge_low, ~D[2026-08-01])
+      set_release_date(edge_high, ~D[2026-08-31])
+      set_release_date(outside, ~D[2026-09-05])
+
+      %{inside: inside, edge_low: edge_low, edge_high: edge_high, undated: undated}
+    end
+
+    test "returns only movies inside the range, with both bounds included", ctx do
+      titles =
+        Mydia.Media.list_movies_by_release_date(~D[2026-08-01], ~D[2026-08-31], monitored: nil)
+        |> Enum.map(& &1.media_item_title)
+        |> Enum.sort()
+
+      assert titles == ["EdgeHigh", "EdgeLow", "Inside"]
+      refute ctx.undated.title in titles
+    end
+
+    test "reports has_files from the database", ctx do
+      Mydia.MediaFixtures.media_file_fixture(%{media_item_id: ctx.inside.id})
+
+      entries =
+        Mydia.Media.list_movies_by_release_date(~D[2026-08-01], ~D[2026-08-31], monitored: nil)
+
+      with_files = Enum.find(entries, &(&1.media_item_title == "Inside"))
+      without_files = Enum.find(entries, &(&1.media_item_title == "EdgeLow"))
+
+      assert with_files.has_files
+      refute without_files.has_files
+    end
+
+    test "monitored: nil includes unmonitored movies" do
+      unmonitored = media_item_fixture(%{type: "movie", title: "Unmonitored", monitored: false})
+      set_release_date(unmonitored, ~D[2026-08-10])
+
+      titles =
+        Mydia.Media.list_movies_by_release_date(~D[2026-08-01], ~D[2026-08-31], monitored: nil)
+        |> Enum.map(& &1.media_item_title)
+
+      assert "Unmonitored" in titles
+    end
+
+    # Identical to the helper Task 1 added to test/mydia/db_test.exs. The struct
+    # is Mydia.Metadata.Structs.MediaMetadata, and it carries @enforce_keys on
+    # :provider_id, :provider and :media_type, so a fresh one cannot be built
+    # empty. Copy this verbatim rather than reconstructing it.
+    defp set_release_date(item, date) do
+      metadata =
+        case item.metadata do
+          nil ->
+            %Mydia.Metadata.Structs.MediaMetadata{
+              provider_id: to_string(item.id),
+              provider: :metadata_relay,
+              media_type: :movie,
+              release_date: date
+            }
+
+          existing ->
+            %{existing | release_date: date}
+        end
+
+      item
+      |> Ecto.Changeset.change(metadata: metadata)
+      |> Mydia.Repo.update!()
+    end
+  end
+
   describe "resolve_library_provider/1 (U6)" do
     import Mydia.MediaFixtures
     import Mydia.SettingsFixtures

--- a/test/mydia_web/schema/calendar_test.exs
+++ b/test/mydia_web/schema/calendar_test.exs
@@ -1,0 +1,145 @@
+defmodule MydiaWeb.Schema.CalendarTest do
+  use MydiaWeb.ConnCase
+
+  alias Mydia.AccountsFixtures
+  alias Mydia.MediaFixtures
+
+  @query """
+  query Calendar($start: Date!, $end: Date!) {
+    calendar(start: $start, end: $end) {
+      id
+      kind
+      airDate
+      title
+      seasonNumber
+      episodeNumber
+      mediaItemId
+      mediaItemTitle
+      artwork { posterUrl }
+      files { id }
+    }
+  }
+  """
+
+  @vars %{"start" => "2026-08-01", "end" => "2026-08-31"}
+
+  setup do
+    %{user: AccountsFixtures.user_fixture()}
+  end
+
+  test "returns episodes and movies inside the window", ctx do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "A Show"})
+
+    episode =
+      MediaFixtures.episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 3,
+        episode_number: 4,
+        title: "An Episode",
+        air_date: ~D[2026-08-15]
+      })
+
+    MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+
+    assert {:ok, %{data: %{"calendar" => [entry]}}} = run_query(@query, @vars, ctx.user)
+
+    assert entry["kind"] == "EPISODE"
+    assert entry["airDate"] == "2026-08-15"
+    assert entry["title"] == "An Episode"
+    assert entry["seasonNumber"] == 3
+    assert entry["episodeNumber"] == 4
+    assert entry["mediaItemId"] == show.id
+    assert entry["mediaItemTitle"] == "A Show"
+    assert length(entry["files"]) == 1
+  end
+
+  test "an entry with no file comes back with an empty files list", ctx do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Fileless"})
+
+    MediaFixtures.episode_fixture(%{
+      media_item_id: show.id,
+      season_number: 1,
+      episode_number: 1,
+      air_date: ~D[2026-08-10]
+    })
+
+    assert {:ok, %{data: %{"calendar" => [entry]}}} = run_query(@query, @vars, ctx.user)
+    assert entry["files"] == []
+  end
+
+  test "excludes entries outside the window, bounds included", ctx do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Edges"})
+
+    for {season, episode, date} <- [
+          {1, 1, ~D[2026-07-31]},
+          {1, 2, ~D[2026-08-01]},
+          {1, 3, ~D[2026-08-31]},
+          {1, 4, ~D[2026-09-01]}
+        ] do
+      MediaFixtures.episode_fixture(%{
+        media_item_id: show.id,
+        season_number: season,
+        episode_number: episode,
+        air_date: date
+      })
+    end
+
+    assert {:ok, %{data: %{"calendar" => entries}}} = run_query(@query, @vars, ctx.user)
+    assert Enum.map(entries, & &1["airDate"]) == ["2026-08-01", "2026-08-31"]
+  end
+
+  test "orders by air date, then playable first, then title", ctx do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Zebra Show"})
+    other = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Alpha Show"})
+
+    playable =
+      MediaFixtures.episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: 1,
+        air_date: ~D[2026-08-10]
+      })
+
+    MediaFixtures.media_file_fixture(%{episode_id: playable.id})
+
+    MediaFixtures.episode_fixture(%{
+      media_item_id: other.id,
+      season_number: 1,
+      episode_number: 1,
+      air_date: ~D[2026-08-10]
+    })
+
+    assert {:ok, %{data: %{"calendar" => entries}}} = run_query(@query, @vars, ctx.user)
+
+    assert Enum.map(entries, & &1["mediaItemTitle"]) == ["Zebra Show", "Alpha Show"]
+  end
+
+  test "never exposes download state", ctx do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "No Leaks"})
+
+    MediaFixtures.episode_fixture(%{
+      media_item_id: show.id,
+      season_number: 1,
+      episode_number: 1,
+      air_date: ~D[2026-08-05]
+    })
+
+    leaky = """
+    query Calendar($start: Date!, $end: Date!) {
+      calendar(start: $start, end: $end) { hasDownloads }
+    }
+    """
+
+    assert {:ok, %{errors: [%{message: message}]}} = run_query(leaky, @vars, ctx.user)
+    assert message =~ "Cannot query field"
+  end
+
+  test "requires an authenticated user" do
+    assert {:ok, %{errors: [_ | _]}} = run_query(@query, @vars, nil)
+  end
+
+  defp run_query(query, variables, user) do
+    context = if user, do: %{current_user: user}, else: %{}
+    Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: context)
+  end
+end

--- a/test/mydia_web/schema/calendar_test.exs
+++ b/test/mydia_web/schema/calendar_test.exs
@@ -166,6 +166,104 @@ defmodule MydiaWeb.Schema.CalendarTest do
     assert {:ok, %{errors: [_ | _]}} = run_query(@query, @vars, nil)
   end
 
+  describe "files query count" do
+    # `files` used to be a per-entry field resolver, so a response with N
+    # playable entries issued N extra `Repo.all` calls (one per entry) on top
+    # of the two list queries. This pins the fix: the query count must stay
+    # flat as the number of playable entries grows, and every entry's `files`
+    # must still come back correct once batched.
+    #
+    # Counting queries via a `:telemetry` handler on `[:mydia, :repo, :query]`
+    # only measures this test in isolation because `MydiaWeb.ConnCase` tests
+    # default to `async: false` (no `async: true` was passed when this module
+    # called `use MydiaWeb.ConnCase`), so ExUnit never runs this module's
+    # tests concurrently with another test module's queries.
+    test "does not grow with the number of playable entries", ctx do
+      count_queries = fn fun ->
+        ref = make_ref()
+        parent = self()
+
+        handler = fn _event, _measurements, _metadata, _config ->
+          send(parent, {ref, :query})
+        end
+
+        :telemetry.attach(
+          "calendar-files-query-count-#{inspect(ref)}",
+          [:mydia, :repo, :query],
+          handler,
+          nil
+        )
+
+        fun.()
+
+        :telemetry.detach("calendar-files-query-count-#{inspect(ref)}")
+
+        count_messages = fn count_messages ->
+          receive do
+            {^ref, :query} -> 1 + count_messages.(count_messages)
+          after
+            0 -> 0
+          end
+        end
+
+        count_messages.(count_messages)
+      end
+
+      # A show with `episode_count` playable episodes, plus one playable
+      # movie, all inside `@vars`'s window.
+      build_playable_entries = fn episode_count, label ->
+        show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Show #{label}"})
+
+        for n <- 1..episode_count do
+          episode =
+            MediaFixtures.episode_fixture(%{
+              media_item_id: show.id,
+              season_number: 1,
+              episode_number: n,
+              air_date: ~D[2026-08-10]
+            })
+
+          MediaFixtures.media_file_fixture(%{episode_id: episode.id})
+        end
+
+        movie =
+          MediaFixtures.media_item_fixture(%{
+            type: "movie",
+            title: "Movie #{label}",
+            metadata: %{
+              provider_id: "movie-#{label}",
+              provider: :metadata_relay,
+              media_type: :movie,
+              release_date: ~D[2026-08-20]
+            }
+          })
+
+        MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+      end
+
+      build_playable_entries.(3, "small")
+
+      small =
+        count_queries.(fn ->
+          assert {:ok, %{data: %{"calendar" => entries}}} = run_query(@query, @vars, ctx.user)
+          assert length(entries) == 4
+          assert Enum.all?(entries, &(length(&1["files"]) == 1))
+        end)
+
+      build_playable_entries.(20, "large")
+
+      large =
+        count_queries.(fn ->
+          assert {:ok, %{data: %{"calendar" => entries}}} = run_query(@query, @vars, ctx.user)
+          assert length(entries) == 25
+          assert Enum.all?(entries, &(length(&1["files"]) == 1))
+        end)
+
+      assert small == large,
+             "expected a constant query count, got #{small} for 4 entries and #{large} for 25"
+    end
+  end
+
   defp run_query(query, variables, user) do
     context = if user, do: %{current_user: user}, else: %{}
     Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: context)

--- a/test/mydia_web/schema/calendar_test.exs
+++ b/test/mydia_web/schema/calendar_test.exs
@@ -67,6 +67,26 @@ defmodule MydiaWeb.Schema.CalendarTest do
     assert entry["files"] == []
   end
 
+  test "an entry whose only file is trashed comes back with an empty files list", ctx do
+    show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Trashed Only"})
+
+    episode =
+      MediaFixtures.episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 1,
+        episode_number: 1,
+        air_date: ~D[2026-08-10]
+      })
+
+    MediaFixtures.media_file_fixture(%{
+      episode_id: episode.id,
+      trashed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+
+    assert {:ok, %{data: %{"calendar" => [entry]}}} = run_query(@query, @vars, ctx.user)
+    assert entry["files"] == []
+  end
+
   test "excludes entries outside the window, bounds included", ctx do
     show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Edges"})
 

--- a/test/mydia_web/schema/calendar_test.exs
+++ b/test/mydia_web/schema/calendar_test.exs
@@ -89,6 +89,11 @@ defmodule MydiaWeb.Schema.CalendarTest do
   end
 
   test "orders by air date, then playable first, then title", ctx do
+    # Widened beyond @vars on purpose: the July/September entries below only
+    # catch a regression to day-only date comparison if they land on
+    # opposite sides of a month boundary while still both being in-window.
+    vars = %{"start" => "2026-07-01", "end" => "2026-09-30"}
+
     show = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Zebra Show"})
     other = MediaFixtures.media_item_fixture(%{type: "tv_show", title: "Alpha Show"})
 
@@ -109,9 +114,32 @@ defmodule MydiaWeb.Schema.CalendarTest do
       air_date: ~D[2026-08-10]
     })
 
-    assert {:ok, %{data: %{"calendar" => entries}}} = run_query(@query, @vars, ctx.user)
+    # A `%Date{}` compared as a bare tuple element sorts by struct field
+    # order (day, then month, then year), which would put 2026-07-31 AFTER
+    # 2026-08-10 and 2026-09-01. These two entries fail under that bug and
+    # pass only when the sort compares dates chronologically.
+    MediaFixtures.episode_fixture(%{
+      media_item_id: show.id,
+      season_number: 1,
+      episode_number: 2,
+      air_date: ~D[2026-07-31]
+    })
 
-    assert Enum.map(entries, & &1["mediaItemTitle"]) == ["Zebra Show", "Alpha Show"]
+    MediaFixtures.episode_fixture(%{
+      media_item_id: other.id,
+      season_number: 1,
+      episode_number: 2,
+      air_date: ~D[2026-09-01]
+    })
+
+    assert {:ok, %{data: %{"calendar" => entries}}} = run_query(@query, vars, ctx.user)
+
+    assert Enum.map(entries, &{&1["airDate"], &1["mediaItemTitle"]}) == [
+             {"2026-07-31", "Zebra Show"},
+             {"2026-08-10", "Zebra Show"},
+             {"2026-08-10", "Alpha Show"},
+             {"2026-09-01", "Alpha Show"}
+           ]
   end
 
   test "never exposes download state", ctx do


### PR DESCRIPTION
Adds a Calendar screen to the Flutter player at `/calendar`: an agenda list of episodes and movies by air or release date, opening at today, with one-tap play on anything the library actually holds.

The Phoenix app already has a calendar, but that one is an operator view. It is a month grid and it surfaces downloading and missing state. This one is built for a viewer instead: past dates play, future dates preview, and it never names a download state.

## Design decisions

- **Agenda list, not a month grid.** On a phone, seven columns leave about 48px per day, so a grid collapses to dots and pushes every real interaction into a day sheet. The agenda puts play one tap from the screen you land on, and a quiet month collapses to a short list instead of a page of blanks.
- **Library-wide, fixed window.** 30 days back and 90 forward, fetched in one request. No pagination.
- **Rows have two targets.** The body opens detail, a separate control plays. That prevents a mistap starting playback, and it gives the D-pad a horizontal target on Android TV, which a list of single-target rows does not have.
- **`hasDownloads` is deliberately absent from the schema.** Keeping operator state out of a playback client is enforced at the contract boundary rather than by convention in the UI. There is a test asserting the field is rejected.
- **Playability is `files.isNotEmpty`.** No separate boolean that could drift from it.

## Three bugs fixed along the way

**Every episode reported `has_files: false` on PostgreSQL.** `list_episodes_by_air_date/3` did `entry.has_files == 1`, which is correct on SQLite, where the `CASE WHEN` fragment comes back as an integer, and wrong on PostgreSQL, where it comes back as a real boolean and `true == 1` is false. This predates the calendar work: on a Postgres install it already mis-colors every entry on the existing Phoenix calendar, and it would have made every entry in the new player calendar unplayable. Both fragments now cast with `type(..., :boolean)`, and a test asserts `has_files == true` by identity rather than truthiness, since the old integer `1` would satisfy a truthiness check.

**`list_movies_by_release_date/3` was O(library), not O(window).** It loaded every movie with a release date, filtered the date range in Elixir, then ran two `Repo.exists?` calls per surviving row. It now filters in SQL through a new adapter-agnostic `Mydia.DB.json_date_between/4`.

**An N+1 on the calendar's `files` field**, one query per playable entry, on the main query of the screen. Now two batched queries regardless of entry count, pinned by a telemetry query-count test that asserts a 25-entry response costs the same as a 4-entry one.

## Server contract

New root field:

```graphql
calendar(start: Date!, end: Date!): [CalendarEntry!]!
```

Mirrored in the Rust `mydia-api` crate so the `sdl_parity` gate stays green, with `priv/graphql/schema.graphql` regenerated and committed.

Entries come back ordered by air date, then playable first, then parent title. The client groups by day and does not re-sort. `files` carries the fields `pickBestFile` needs, so the calendar and the existing rails cannot disagree about which file an item plays.

## Version skew

A player newer than its server gets a specific "this server does not have the calendar yet" state rather than a generic failure. A brand new root field has no older shape for `QueryWatcher` to fall back to, and `serverCompatibility` reports version strings with no feature list, so the rejection itself is the only available signal. That state deliberately offers no retry, because retrying cannot help.

## Testing

| Suite | Result |
|---|---|
| Elixir, SQLite | 9412 tests, 0 failures |
| Elixir, PostgreSQL | 9413 tests, 0 failures |
| Rust `mydia-api` | 48 passed, including `sdl_parity` |
| Flutter | 3030 passed, 0 failed |
| `flutter analyze` | at existing baseline, nothing new |
| `mix precommit` | green |

The sidebar destination lands at `defaultIndex: 135`, between TV Shows and Recently Added, so an existing user with a saved sidebar arrangement gets Calendar in that position without losing their ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Calendar view for upcoming and recently aired episodes and movies.
  * Added artwork, availability indicators, and playback controls for calendar entries.
  * Added navigation and date-range calendar queries.
  * Calendar entries can open media details or start playback when available.
* **Bug Fixes**
  * Improved date filtering, artwork display, and media-file availability detection across supported databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->