### PR TITLE
fix(media): stop the History rail crowding the media detail page

### DIFF
--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -71,6 +71,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:timeline_events, timeline_events)
      |> assign(:page_title, media_item.title)
      |> assign(:show_delete_confirm, false)
+     |> assign(:timeline_expanded, false)
      |> assign(:delete_files, false)
      |> assign(:quality_profiles, quality_profiles)
      |> assign(:default_quality_profile_name, default_quality_profile_name)
@@ -530,6 +531,14 @@ defmodule MydiaWeb.MediaLive.Show do
   @impl true
   def handle_event("toggle_recommendations", params, socket),
     do: RecommendationEvents.toggle_expanded(params, socket)
+
+  # Not persisted to UserPreference the way recommendations_expanded is (see
+  # MydiaWeb.Live.Helpers.RecommendationsExpanded). History is reference
+  # material a user opens for one question and closes, not a rail state worth
+  # a schema column.
+  def handle_event("toggle_timeline", _params, socket) do
+    {:noreply, assign(socket, :timeline_expanded, !socket.assigns.timeline_expanded)}
+  end
 
   @impl true
   def handle_event("add_recommendation", params, socket),

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -288,7 +288,10 @@
           :if={@timeline_events != []}
           class="md:col-span-2 xl:col-span-1 xl:col-start-3 xl:row-start-1 xl:sticky xl:top-4 xl:self-start xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto"
         >
-          <Components.timeline_section timeline_events={@timeline_events} />
+          <Components.timeline_section
+            timeline_events={@timeline_events}
+            expanded={@timeline_expanded}
+          />
         </aside>
       </div>
     </div>

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -13,15 +13,43 @@
       <div class="absolute inset-0 bg-gradient-to-b from-transparent via-base-100/80 to-base-100">
       </div>
     <% end %>
-    <%!-- Content Container --%>
-    <div class="relative pt-8 md:pt-16 pb-8 px-3 sm:px-4 md:px-6 lg:px-8">
-      <div class={[
-        "grid gap-4 md:gap-6 grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] lg:grid-cols-[20rem_minmax(0,1fr)]",
-        if(@timeline_events == [],
-          do: "xl:grid-cols-[20rem_minmax(0,1fr)]",
-          else: "xl:grid-cols-[20rem_minmax(0,1fr)_22rem]"
-        )
-      ]}>
+    <%!-- @container, not a viewport breakpoint. `xl:` measures the window, but
+          this page never gets the window: `Layouts.app/1`'s sidebar is a hard
+          w-64 that is always open at lg and up. Measured, `xl:` turned the
+          third column on with 225px left for the main content column at a
+          1280px window, narrower than either rail, and the title's action
+          buttons overflowed it by 78px so two of the four landed underneath
+          this very rail.
+
+          `container-type: inline-size` queries this element's CONTENT box,
+          which is exactly the grid's available width, so the sidebar is
+          accounted for by construction rather than by a magic number, and the
+          layout stays correct if the sidebar ever gains a collapsed state.
+          @7xl is the stock 80rem container size: 1280px of grid, which is a
+          roughly 1616px window with the sidebar open. Measured main content
+          column: 597px at the threshold, 897px at 1920.
+
+          The md: and lg: templates below stay viewport queries on purpose.
+          Below lg the sidebar is a closed drawer taking no width, so the
+          window is the right measurement there; only the third-column
+          decision is the one the sidebar's 256px distorts.
+
+          Containment does not trap page content under the sidebar's z-40.
+          Measured with container-type: inline-size on this element, both a
+          plain z-50 element and a daisyUI dropdown-content z-50 still win
+          elementFromPoint over the sidebar, identically to the uncontained
+          control. --%>
+    <div class="@container relative pt-8 md:pt-16 pb-8 px-3 sm:px-4 md:px-6 lg:px-8">
+      <div
+        id="page-grid"
+        class={[
+          "grid gap-4 md:gap-6 grid-cols-1 md:grid-cols-[16rem_minmax(0,1fr)] lg:grid-cols-[20rem_minmax(0,1fr)]",
+          if(@timeline_events == [],
+            do: "@7xl:grid-cols-[20rem_minmax(0,1fr)]",
+            else: "@7xl:grid-cols-[20rem_minmax(0,1fr)_20rem]"
+          )
+        ]}
+      >
         <%!-- Left Column: Hero Section (Poster & Quick Actions) --%>
         <Components.hero_section
           media_item={@media_item}
@@ -40,7 +68,7 @@
           target_library_candidates={@target_library_candidates}
         />
         <%!-- Right Column: Main Content --%>
-        <div class="min-w-0">
+        <div id="main-column" class="min-w-0">
           <%!-- Title and Basic Info --%>
           <div class="mb-4 md:mb-6">
             <div class="flex items-start justify-between gap-2 md:gap-4 mb-2">
@@ -265,28 +293,45 @@
             libraries={@target_library_candidates}
           />
         </div>
-        <%!-- History. A sibling of the main column rather than part of it: at
-              xl it is the third grid column, and below xl md:col-span-2 drops
-              it to a full-width row under both other columns. One DOM node
-              serves both layouts, so there is no hidden/xl:block duplicate.
+        <%!-- History. A sibling of the main column rather than part of it: past
+              the container-query threshold it is the third grid column, and
+              below it md:col-span-2 drops it to a full-width row under both
+              other columns. One DOM node serves both layouts, so there is no
+              hidden/@7xl:block duplicate.
 
-              Sticky for the same reason and with the same caveats as the hero
-              column: see the note there on self-start and the inner scroll.
+              No max-height and no inner scroll. The rail used to be
+              max-h-[calc(100vh-2rem)] with overflow-y-auto over as many as 50
+              events, which put a third vertical scrollbar on screen next to
+              the poster column's and the page's, and its sticky still never
+              pinned: measured top offsets were 64 at rest, 0 mid-scroll and
+              -48 at the page bottom. Capping the collapsed render at five
+              dense rows makes the rail 506px, short enough that sticky pins
+              for the whole page instead.
+
+              The sticky classes come off when expanded. A sticky element
+              taller than the viewport has a permanently unreachable bottom,
+              so an expanded rail scrolls with the page like an ordinary
+              column.
 
               The :if here is load-bearing alongside the grid template's own
               @timeline_events == [] conditional above, and neither one makes
-              the other redundant: this aside carries xl:col-start-3 and
-              xl:row-start-1 unconditionally, so even when the grid template
+              the other redundant: this aside carries @7xl:col-start-3 and
+              @7xl:row-start-1 unconditionally, so even when the grid template
               picks the two-track layout, a rendered-but-empty aside would
               still force Grid to open an implicit third column (and, below
-              xl, an implicit row) to satisfy that placement, and gap-4/gap-6
-              still applies to a track that exists but is empty. The template
-              conditional stops the 22rem column from being reserved; this
-              :if stops the aside from existing in the grid at all when there
-              is nothing to place, which is what actually removes the gap. --%>
+              the threshold, an implicit row) to satisfy that placement, and
+              gap-4/gap-6 still applies to a track that exists but is empty.
+              The template conditional stops the 20rem column from being
+              reserved; this :if stops the aside from existing in the grid at
+              all when there is nothing to place, which is what actually
+              removes the gap. --%>
         <aside
           :if={@timeline_events != []}
-          class="md:col-span-2 xl:col-span-1 xl:col-start-3 xl:row-start-1 xl:sticky xl:top-4 xl:self-start xl:max-h-[calc(100vh-2rem)] xl:overflow-y-auto"
+          id="history-rail"
+          class={[
+            "md:col-span-2 @7xl:col-span-1 @7xl:col-start-3 @7xl:row-start-1",
+            !@timeline_expanded && "@7xl:sticky @7xl:top-4 @7xl:self-start"
+          ]}
         >
           <Components.timeline_section
             timeline_events={@timeline_events}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -1020,67 +1020,72 @@ defmodule MydiaWeb.MediaLive.Show.Components do
         <div class="card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">History</h2>
           <div class="relative">
-            <%!-- The spine. Inset to the centre of the 40px icon nodes below
-                  (left-5 is 20px), so every node sits on it. --%>
-            <div class="absolute left-5 top-0 bottom-0 w-0.5 bg-base-300"></div>
+            <%!-- The spine. Inset to the centre of the 32px icon nodes below
+                  (left-4 is 16px), so every node sits on it. --%>
+            <div class="absolute left-4 top-0 bottom-0 w-0.5 bg-base-300"></div>
 
-            <div class="flex flex-col gap-4">
+            <div class="flex flex-col gap-3">
               <div
                 :for={event <- @shown_events}
                 class="relative flex items-start gap-3"
               >
                 <%!-- Icon node on the spine --%>
-                <div class="w-10 h-10 rounded-full bg-base-200 flex items-center justify-center border-2 border-base-300 shrink-0 z-10">
-                  <.icon name={event.icon} class={"w-5 h-5 #{event.color}"} />
+                <div class="w-8 h-8 rounded-full bg-base-200 flex items-center justify-center border-2 border-base-300 shrink-0 z-10">
+                  <.icon name={event.icon} class={"w-4 h-4 #{event.color}"} />
                 </div>
 
-                <%!-- Event card, filling the rest of the column --%>
+                <%!-- Flat row rather than a nested card. Title and time share
+                      one baseline, both single-line, so the row height is
+                      driven by content and not by card padding. --%>
                 <div
-                  class="card bg-base-100 shadow-md flex-1 min-w-0 hover:shadow-xl transition-shadow"
+                  class="flex-1 min-w-0 pt-0.5"
                   title={format_absolute_time(event.timestamp)}
                 >
-                  <div class="card-body p-3">
+                  <div class="flex items-baseline justify-between gap-2">
+                    <span class="font-semibold text-sm truncate">{event.title}</span>
                     <time
-                      class="text-xs text-base-content/60 whitespace-nowrap"
+                      class="text-xs text-base-content/50 whitespace-nowrap shrink-0"
                       title={format_absolute_time(event.timestamp)}
                     >
-                      {format_relative_time(event.timestamp)}
+                      {format_relative_time_short(event.timestamp)}
                     </time>
-                    <div class="font-bold text-sm">{event.title}</div>
-                    <div class="text-sm text-base-content/80 line-clamp-2">
-                      {event.description}
-                    </div>
-                    <%= if event.metadata do %>
-                      <div class="flex flex-wrap gap-1">
-                        <%= if event.metadata[:quality] do %>
-                          <span class="badge badge-primary badge-xs">
-                            {format_download_quality(event.metadata.quality)}
-                          </span>
-                        <% end %>
-                        <%= if event.metadata[:indexer] do %>
-                          <span class="badge badge-outline badge-xs">
-                            {event.metadata.indexer}
-                          </span>
-                        <% end %>
-                        <%= if event.metadata[:resolution] do %>
-                          <span class="badge badge-primary badge-xs">
-                            {event.metadata.resolution}
-                          </span>
-                        <% end %>
-                        <%= if event.metadata[:size] do %>
-                          <span class="badge badge-ghost badge-xs">
-                            {format_file_size(event.metadata.size)}
-                          </span>
-                        <% end %>
-                        <%= if event.metadata[:error] do %>
-                          <div class="text-xs text-error mt-1 line-clamp-2">
-                            <.icon name="hero-exclamation-circle" class="w-3 h-3 inline" />
-                            {event.metadata.error}
-                          </div>
-                        <% end %>
-                      </div>
-                    <% end %>
                   </div>
+                  <div class="text-xs text-base-content/70 truncate">
+                    {event.description}
+                  </div>
+                  <%= if event.metadata do %>
+                    <div class="flex flex-wrap gap-1 mt-1">
+                      <%= if event.metadata[:quality] do %>
+                        <span class="badge badge-primary badge-xs">
+                          {format_download_quality(event.metadata.quality)}
+                        </span>
+                      <% end %>
+                      <%= if event.metadata[:indexer] do %>
+                        <span class="badge badge-outline badge-xs">
+                          {event.metadata.indexer}
+                        </span>
+                      <% end %>
+                      <%= if event.metadata[:resolution] do %>
+                        <span class="badge badge-primary badge-xs">
+                          {event.metadata.resolution}
+                        </span>
+                      <% end %>
+                      <%= if event.metadata[:size] do %>
+                        <span class="badge badge-ghost badge-xs">
+                          {format_file_size(event.metadata.size)}
+                        </span>
+                      <% end %>
+                      <%!-- w-full so the error takes its own line inside the
+                            wrapping badge row rather than being squeezed into
+                            the last badge's slot. --%>
+                      <%= if event.metadata[:error] do %>
+                        <div class="text-xs text-error mt-1 line-clamp-2 w-full">
+                          <.icon name="hero-exclamation-circle" class="w-3 h-3 inline" />
+                          {event.metadata.error}
+                        </div>
+                      <% end %>
+                    </div>
+                  <% end %>
                 </div>
               </div>
             </div>

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -1037,12 +1037,9 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                 <%!-- Flat row rather than a nested card. Title and time share
                       one baseline, both single-line, so the row height is
                       driven by content and not by card padding. --%>
-                <div
-                  class="flex-1 min-w-0 pt-0.5"
-                  title={format_absolute_time(event.timestamp)}
-                >
+                <div class="flex-1 min-w-0 pt-0.5">
                   <div class="flex items-baseline justify-between gap-2">
-                    <span class="font-semibold text-sm truncate">{event.title}</span>
+                    <span class="font-semibold text-sm truncate" title={event.title}>{event.title}</span>
                     <time
                       class="text-xs text-base-content/50 whitespace-nowrap shrink-0"
                       title={format_absolute_time(event.timestamp)}
@@ -1050,7 +1047,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       {format_relative_time_short(event.timestamp)}
                     </time>
                   </div>
-                  <div class="text-xs text-base-content/70 truncate">
+                  <div class="text-xs text-base-content/70 truncate" title={event.description}>
                     {event.description}
                   </div>
                   <%= if event.metadata do %>
@@ -1096,6 +1093,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             id="timeline-toggle"
             type="button"
             phx-click="toggle_timeline"
+            aria-expanded={@expanded}
             class="btn btn-ghost btn-sm justify-start self-start mt-2 -mb-1"
           >
             {if @expanded, do: "Show less", else: "Show #{@hidden_count} more"}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -975,15 +975,45 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   Timeline section showing history of events.
 
   Vertical, and positioned by the page grid rather than by its place in the
-  main column: at xl and up it is the third grid column, and below xl it falls
-  to a full-width row under the other two. See show.html.heex for the grid.
+  main column: past the grid's container-query threshold it is the third
+  column, and below it falls to a full-width row under the other two. See
+  show.html.heex for the grid.
 
   It renders nothing at all on an item with no events, which is why the page
   grid picks its column template from `@timeline_events != []`.
+
+  Collapsed, it renders at most five events. That cap is load-bearing rather
+  than cosmetic: `position: sticky` only pins usefully on an element shorter
+  than the viewport, and the rail used to be `max-h-[calc(100vh-2rem)]` with
+  an inner `overflow-y-auto` over as many as 50 events. Measured on the
+  shipped layout, its top offset ran 64 at rest, 0 mid-scroll and -48 at the
+  page bottom, so the heading scrolled off the top and never held. Five dense
+  rows measure 506px, which fits a 768px-tall laptop.
+
+  Expanded, it renders everything it was given, and show.html.heex drops the
+  `sticky` classes, because a taller-than-viewport sticky element has a
+  permanently unreachable bottom.
   """
+  @timeline_visible_count 5
+
   attr :timeline_events, :list, required: true
+  attr :expanded, :boolean, default: false
 
   def timeline_section(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        :shown_events,
+        if(assigns.expanded,
+          do: assigns.timeline_events,
+          else: Enum.take(assigns.timeline_events, @timeline_visible_count)
+        )
+      )
+      |> assign(
+        :hidden_count,
+        max(length(assigns.timeline_events) - @timeline_visible_count, 0)
+      )
+
     ~H"""
     <%= if length(@timeline_events) > 0 do %>
       <div id="timeline-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
@@ -996,7 +1026,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
 
             <div class="flex flex-col gap-4">
               <div
-                :for={event <- @timeline_events}
+                :for={event <- @shown_events}
                 class="relative flex items-start gap-3"
               >
                 <%!-- Icon node on the spine --%>
@@ -1055,6 +1085,16 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               </div>
             </div>
           </div>
+
+          <button
+            :if={@hidden_count > 0}
+            id="timeline-toggle"
+            type="button"
+            phx-click="toggle_timeline"
+            class="btn btn-ghost btn-sm justify-start self-start mt-2 -mb-1"
+          >
+            {if @expanded, do: "Show less", else: "Show #{@hidden_count} more"}
+          </button>
         </div>
       </div>
     <% end %>

--- a/lib/mydia_web/live/media_live/show/formatters.ex
+++ b/lib/mydia_web/live/media_live/show/formatters.ex
@@ -36,17 +36,23 @@ defmodule MydiaWeb.MediaLive.Show.Formatters do
   def format_download_status("grabbing"), do: "Grabbing…"
   def format_download_status(_), do: "Unknown"
 
-  def format_relative_time(timestamp) do
-    now = DateTime.utc_now()
-    diff = DateTime.diff(now, timestamp, :second)
+  @doc """
+  A compact relative time for the History rail: "5h", "2d", "7mo".
+
+  Compact because the label shares a baseline with the event title inside a
+  20rem column: a prose form like "3 hours ago" wraps there, and that wrap is
+  what made each row 156px tall.
+  """
+  def format_relative_time_short(timestamp) do
+    diff = DateTime.diff(DateTime.utc_now(), timestamp, :second)
 
     cond do
-      diff < 60 -> "Just now"
-      diff < 3600 -> "#{div(diff, 60)} minutes ago"
-      diff < 86400 -> "#{div(diff, 3600)} hours ago"
-      diff < 2_592_000 -> "#{div(diff, 86400)} days ago"
-      diff < 31_536_000 -> "#{div(diff, 2_592_000)} months ago"
-      true -> "#{div(diff, 31_536_000)} years ago"
+      diff < 60 -> "now"
+      diff < 3600 -> "#{div(diff, 60)}m"
+      diff < 86_400 -> "#{div(diff, 3600)}h"
+      diff < 2_592_000 -> "#{div(diff, 86_400)}d"
+      diff < 31_536_000 -> "#{div(diff, 2_592_000)}mo"
+      true -> "#{div(diff, 31_536_000)}y"
     end
   end
 

--- a/test/mydia_web/features/history_rail_test.exs
+++ b/test/mydia_web/features/history_rail_test.exs
@@ -1,0 +1,227 @@
+defmodule MydiaWeb.Features.HistoryRailTest do
+  @moduledoc """
+  Browser regression for the History rail's layout.
+
+  The shipped rail turned on at the `xl:` VIEWPORT breakpoint, but this page
+  never gets the viewport: `Layouts.app/1`'s sidebar is a hard `w-64` that is
+  always open at lg and up, so the grid only ever has about
+  `viewport - 256 - 64` to work with. Measured at a 1280px window, that left
+  the main content column at 225px, narrower than either rail, with 25
+  elements inside it overflowing past its right edge and two of the title's
+  four action buttons landing underneath the rail itself.
+
+  The rail's `sticky` also never pinned. Measured top offsets at 1300px were
+  64 at rest, 0 mid-scroll and -48 at the page bottom, never the intended 16.
+
+  A class-presence assertion cannot see any of that: the class was always
+  there. This asks the browser for real rectangles at two window sizes.
+  """
+
+  use MydiaWeb.FeatureCase, async: false
+
+  @moduletag :feature
+
+  import Mydia.MediaFixtures
+  import Mydia.MetadataCacheHelpers
+
+  alias Mydia.Events
+
+  # Every probe returns a distinct string when its target is missing or
+  # zero-sized, so a selector typo fails loudly instead of silently no-opping.
+
+  @track_count """
+  const grid = document.querySelector('#page-grid');
+  if (!grid) { return 'no grid rendered'; }
+  const tracks = getComputedStyle(grid).gridTemplateColumns.trim();
+  if (!tracks || tracks === 'none') { return 'grid has no column template'; }
+  return tracks.split(/\\s+/).length;
+  """
+
+  @track_widths """
+  const grid = document.querySelector('#page-grid');
+  if (!grid) { return 'no grid rendered'; }
+  return getComputedStyle(grid).gridTemplateColumns.trim()
+    .split(/\\s+/).map(function (t) { return Math.round(parseFloat(t)); });
+  """
+
+  @rail_top """
+  const rail = document.querySelector('#history-rail');
+  if (!rail) { return 'no rail rendered'; }
+  const r = rail.getBoundingClientRect();
+  if (r.width < 1 || r.height < 1) { return 'rail has no size'; }
+  return Math.round(r.top);
+  """
+
+  @rail_height """
+  const rail = document.querySelector('#history-rail');
+  if (!rail) { return 'no rail rendered'; }
+  const r = rail.getBoundingClientRect();
+  if (r.width < 1 || r.height < 1) { return 'rail has no size'; }
+  return [Math.round(r.height), document.documentElement.clientHeight];
+  """
+
+  # elementFromPoint down the sidebar's centre. Any answer outside the sidebar
+  # is page content painting over the chrome, which is the shape of the
+  # originally reported "overlaps the left sidebar".
+  @sidebar_probe """
+  const side = document.querySelector('.drawer-side');
+  if (!side) { return ['no sidebar rendered']; }
+  const r = side.getBoundingClientRect();
+  if (r.width < 1 || r.height < 1) { return ['sidebar has no size']; }
+  const problems = [];
+  const x = r.left + r.width / 2;
+  for (let i = 1; i <= 9; i++) {
+    const y = r.top + r.height * i / 10;
+    const hit = document.elementFromPoint(x, y);
+    if (!hit) { problems.push('nothing at y=' + Math.round(y)); continue; }
+    if (!side.contains(hit)) {
+      problems.push('sidebar lost at y=' + Math.round(y) + ' to ' +
+        hit.tagName.toLowerCase() + (hit.id ? '#' + hit.id : ''));
+    }
+  }
+  return problems;
+  """
+
+  # Anything inside the main column whose right edge is past the column's own
+  # right edge. Descendants of a deliberate `.overflow-x-auto` scroller are
+  # excluded: those are clipped by design.
+  @spill_probe """
+  const col = document.querySelector('#main-column');
+  if (!col) { return ['no main column rendered']; }
+  const cr = col.getBoundingClientRect();
+  if (cr.width < 1) { return ['main column has no width']; }
+  const problems = [];
+  const all = col.querySelectorAll('*');
+  for (let i = 0; i < all.length; i++) {
+    const el = all[i];
+    if (el.closest('.overflow-x-auto')) continue;
+    const r = el.getBoundingClientRect();
+    if (r.width > 0 && r.right > cr.right + 1) {
+      problems.push(el.tagName.toLowerCase() +
+        (el.id ? '#' + el.id : '') + ' over by ' + Math.round(r.right - cr.right));
+    }
+  }
+  return problems;
+  """
+
+  setup do
+    # The app disables Oban in test (engine: false), so Oban.insert cannot run
+    # from the LiveView process. Start an isolated, manual-mode instance so the
+    # recommendations load can enqueue without a live queue.
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    :ok
+  end
+
+  @tag :feature
+  test "past the threshold the rail is a third column that pins while scrolling",
+       %{session: session} do
+    show = seed_show_with_history()
+
+    session
+    |> login_as_admin()
+    |> resize_window(1700, 1000)
+    |> visit("/media/#{show.id}")
+    |> wait_for_liveview()
+
+    assert probe(session, @track_count) == 3
+
+    [poster, main, rail] = probe(session, @track_widths)
+    assert poster == 320, "poster column is #{poster}px, expected a 20rem track"
+    assert rail == 320, "History rail is #{rail}px, expected a 20rem track"
+
+    assert main > poster,
+           "main content column is #{main}px, narrower than the #{poster}px poster column"
+
+    [height, viewport] = probe(session, @rail_height)
+
+    assert height <= viewport - 32,
+           "rail is #{height}px tall in a #{viewport}px viewport, so sticky cannot pin"
+
+    assert probe(session, @sidebar_probe) == []
+    assert probe(session, @spill_probe) == []
+
+    scroll_to_bottom(session)
+
+    assert probe(session, @rail_top) == 16,
+           "the rail did not stay pinned at top-4 after scrolling"
+
+    assert probe(session, @sidebar_probe) == []
+  end
+
+  @tag :feature
+  test "below the threshold there is no third column and nothing overflows",
+       %{session: session} do
+    show = seed_show_with_history()
+
+    session
+    |> login_as_admin()
+    |> resize_window(1300, 1000)
+    |> visit("/media/#{show.id}")
+    |> wait_for_liveview()
+
+    assert probe(session, @track_count) == 2
+
+    [poster, main] = probe(session, @track_widths)
+
+    assert main > poster,
+           "main content column is #{main}px, narrower than the #{poster}px poster column"
+
+    assert probe(session, @spill_probe) == []
+    assert probe(session, @sidebar_probe) == []
+  end
+
+  defp probe(session, script) do
+    execute_script(session, script, [], fn result -> send(self(), {:probe, result}) end)
+
+    assert_receive {:probe, result}, 5_000
+    result
+  end
+
+  defp scroll_to_bottom(session) do
+    execute_script(
+      session,
+      "window.scrollTo(0, document.body.scrollHeight); return 'ok';",
+      [],
+      fn _ -> :ok end
+    )
+
+    session
+  end
+
+  defp seed_show_with_history do
+    tmdb_id = unique_provider_id()
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Fixture Rail Show",
+        year: 2014,
+        tmdb_id: tmdb_id
+      })
+
+    episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+    # Unwarmed, the recommendations load leaves the VM for the production
+    # metadata relay during tests.
+    warm_recommendations_cache(tmdb_id, :tv_show, [])
+
+    # More than the collapsed cap of five, so the rail is at its full
+    # collapsed height and the Show-more control is rendered.
+    for i <- 1..8 do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "downloads",
+          type: "download.completed",
+          actor_type: :system,
+          actor_id: "test",
+          resource_type: "media_item",
+          resource_id: show.id,
+          metadata: %{"title" => "Fixture Release #{i}"}
+        })
+    end
+
+    show
+  end
+end

--- a/test/mydia_web/features/history_rail_test.exs
+++ b/test/mydia_web/features/history_rail_test.exs
@@ -127,6 +127,10 @@ defmodule MydiaWeb.Features.HistoryRailTest do
 
     assert probe(session, @track_count) == 3
 
+    # At 1700px the old `xl:` breakpoint also fires, so @track_count == 3
+    # holds under old code too and does not discriminate old from new. The
+    # assertion that actually does is `rail == 320`: the old layout used a
+    # 22rem / 352px rail track, not the 20rem / 320px track this branch adds.
     [poster, main, rail] = probe(session, @track_widths)
     assert poster == 320, "poster column is #{poster}px, expected a 20rem track"
     assert rail == 320, "History rail is #{rail}px, expected a 20rem track"

--- a/test/mydia_web/live/media_live/show/formatters_short_time_test.exs
+++ b/test/mydia_web/live/media_live/show/formatters_short_time_test.exs
@@ -1,0 +1,46 @@
+defmodule MydiaWeb.MediaLive.Show.FormattersShortTimeTest do
+  @moduledoc """
+  The rail puts the relative time on the same baseline as the event title in a
+  20rem column. "3 hours ago" wraps there, and the wrap is what made each row
+  156px tall, which in turn forced the rail's inner scrollbar.
+  """
+
+  use ExUnit.Case, async: true
+
+  import MydiaWeb.MediaLive.Show.Formatters, only: [format_relative_time_short: 1]
+
+  defp ago(seconds), do: DateTime.add(DateTime.utc_now(), -seconds, :second)
+
+  test "under a minute reads now" do
+    assert format_relative_time_short(ago(30)) == "now"
+  end
+
+  test "minutes" do
+    assert format_relative_time_short(ago(300)) == "5m"
+  end
+
+  test "hours" do
+    assert format_relative_time_short(ago(3 * 3600)) == "3h"
+  end
+
+  test "days" do
+    assert format_relative_time_short(ago(2 * 86_400)) == "2d"
+  end
+
+  test "months" do
+    assert format_relative_time_short(ago(7 * 2_592_000)) == "7mo"
+  end
+
+  test "years" do
+    assert format_relative_time_short(ago(2 * 31_536_000)) == "2y"
+  end
+
+  test "never emits a unit longer than two characters" do
+    # The time sits in a `shrink-0` cell next to a `truncate` title, so a long
+    # unit steals width from the title rather than wrapping.
+    for seconds <- [30, 300, 3 * 3600, 2 * 86_400, 7 * 2_592_000, 2 * 31_536_000] do
+      formatted = format_relative_time_short(ago(seconds))
+      assert String.length(formatted) <= 5, "#{formatted} is too wide for the rail"
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/timeline_cap_test.exs
+++ b/test/mydia_web/live/media_live/show/timeline_cap_test.exs
@@ -1,0 +1,165 @@
+defmodule MydiaWeb.MediaLive.Show.TimelineCapTest do
+  @moduledoc """
+  The rail renders at most five events collapsed. That cap is not cosmetic:
+  it is what keeps the rail shorter than the viewport, which is the only
+  condition under which its `sticky` pins instead of sliding off the top.
+  """
+
+  # Connected LiveView tests cannot be async under the PostgreSQL sandbox.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import Mydia.MetadataCacheHelpers
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Events
+  alias MydiaWeb.MediaLive.Show.Components
+
+  defp fake_events(n) do
+    for i <- 1..n do
+      %{
+        icon: "hero-arrow-down-tray",
+        color: "text-success",
+        title: "Fixture Event #{i}",
+        description: "Fixture Description #{i}",
+        timestamp: DateTime.add(DateTime.utc_now(), -i * 3600, :second),
+        metadata: nil
+      }
+    end
+  end
+
+  describe "timeline_section/1" do
+    test "renders at most five events when collapsed" do
+      html =
+        render_component(&Components.timeline_section/1,
+          timeline_events: fake_events(9),
+          expanded: false
+        )
+
+      assert html =~ "Fixture Event 5"
+      refute html =~ "Fixture Event 6"
+    end
+
+    test "renders every event it was given when expanded" do
+      html =
+        render_component(&Components.timeline_section/1,
+          timeline_events: fake_events(9),
+          expanded: true
+        )
+
+      assert html =~ "Fixture Event 9"
+    end
+
+    test "the control counts what is hidden, not the total" do
+      # load_timeline_events/2 caps its query at 50, so "Show all" would be a
+      # lie on an item with more history than that.
+      html =
+        render_component(&Components.timeline_section/1,
+          timeline_events: fake_events(9),
+          expanded: false
+        )
+
+      assert html =~ "Show 4 more"
+    end
+
+    test "the control reads Show less when expanded" do
+      html =
+        render_component(&Components.timeline_section/1,
+          timeline_events: fake_events(9),
+          expanded: true
+        )
+
+      assert html =~ "Show less"
+    end
+
+    test "there is no control at all when nothing is hidden" do
+      html =
+        render_component(&Components.timeline_section/1,
+          timeline_events: fake_events(5),
+          expanded: false
+        )
+
+      refute html =~ ~s(id="timeline-toggle")
+    end
+
+    test "renders nothing for an item with no events" do
+      html =
+        render_component(&Components.timeline_section/1,
+          timeline_events: [],
+          expanded: false
+        )
+
+      refute html =~ ~s(id="timeline-section")
+    end
+  end
+
+  describe "toggling from the page" do
+    setup do
+      # The app disables Oban in test (engine: false), so Oban.insert cannot
+      # run from the LiveView process. Start an isolated, manual-mode instance
+      # so the recommendations load can enqueue without a live queue.
+      engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+      start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+      :ok
+    end
+
+    test "the toggle reveals the rest and collapses again", %{conn: conn} do
+      show = seed_show()
+
+      # media_item_fixture goes through Media.create_media_item/2, which records
+      # one media_item.added event, so eight more makes nine.
+      for i <- 1..8, do: completed_download(show, "Fixture Release #{i}")
+
+      conn = log_in_user(conn, admin_user_fixture())
+
+      {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
+      render_async(view, 5000)
+
+      assert render(view) =~ "Show 4 more"
+
+      expanded = view |> element("#timeline-toggle") |> render_click()
+      assert expanded =~ "Show less"
+
+      collapsed = view |> element("#timeline-toggle") |> render_click()
+      assert collapsed =~ "Show 4 more"
+    end
+  end
+
+  defp seed_show do
+    tmdb_id = unique_provider_id()
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Fixture Rail Show",
+        year: 2014,
+        tmdb_id: tmdb_id
+      })
+
+    episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+    # Unwarmed, the recommendations load leaves the VM for the production
+    # metadata relay during tests.
+    warm_recommendations_cache(tmdb_id, :tv_show, [])
+
+    show
+  end
+
+  defp completed_download(show, title) do
+    {:ok, event} =
+      Events.create_event(%{
+        category: "downloads",
+        type: "download.completed",
+        actor_type: :system,
+        actor_id: "test",
+        resource_type: "media_item",
+        resource_id: show.id,
+        metadata: %{"title" => title}
+      })
+
+    event
+  end
+end


### PR DESCRIPTION
The History rail added in #566 crowds the media detail page on anything short of a very wide monitor, and its `sticky` never actually pins. Both TV show and movie pages are affected, since they share `show.html.heex`.

## What was measured

Headless Chromium against the real built stylesheet, driving the actual `drawer` shell plus the show page's grid.

**The rail turned on far too early.** `xl:` is a viewport media query, but this page never gets the viewport: `Layouts.app/1`'s sidebar is a hard `w-64` that is always open at `lg` and up, so the grid only ever has about `viewport - 256 - 64`. The layout then reserved 20rem + 22rem of that in fixed track:

| viewport | poster | main content | History |
| -------- | ------ | ------------ | ------- |
| 1280     | 320px  | **225px**    | 352px   |
| 1300     | 320px  | **245px**    | 352px   |
| 1440     | 320px  | 385px        | 352px   |
| 1600     | 320px  | 545px        | 352px   |

From 1280 to roughly 1450 the main content column was the narrowest of the three. At 1300 the title wrapped to six lines, cast names collided, and the title's action buttons overflowed their column by 78px, which put two of the four physically underneath the History card. 25 elements inside the column measured a right edge past it.

**The sticky never pinned.** Rail top offset at 1300px: 64 at rest, 0 mid-scroll, -48 at the page bottom, never the intended 16. The rail was also `max-h-[calc(100vh-2rem)]` with an inner `overflow-y-auto` over up to 50 events, putting a third vertical scrollbar on screen next to the poster column's and the page's.

## What changed

- **Gate the third column on content width, not window width.** `@container` on the page wrapper and `@7xl:` on the grid and the rail. `container-type: inline-size` queries the content box, so the query width *is* the grid's available width and the sidebar is accounted for by construction rather than by a magic number. Crossover is 1280px of grid, roughly a 1616px window with the sidebar open. `@7xl` is a stock Tailwind container size, so no custom breakpoint.
- **Symmetric 20rem rails.** History drops 22rem to 20rem. Main content column is now 597px at the threshold and 897px at 1920. At 1300 the page is two columns with a 621px main column, up from 245px.
- **Cap the collapsed rail at five events** with a `Show n more` toggle, and rebuild the event row flat and dense (no nested per-event card, title and time on one baseline, 32px node). Five rows come to 506px, which fits a 768px-tall laptop, so `sticky` has something to pin. Measured `railTop == 16` at every scroll position at 1620, 1700 and 1920, on both 900px and 768px viewport heights. The inner scrollbar is gone.
- Expanded, the rail is taller than the viewport, so the sticky classes come off and it scrolls with the page.

The `md:` and `lg:` column templates stay viewport queries on purpose: below `lg` the sidebar is a closed drawer taking no width, so the window is the right measurement there.

## Not fixed

The report also mentioned the panel overlapping the left sidebar. That did not reproduce in any of 36 measured browser states: an `elementFromPoint` sweep down the sidebar's centre never returned page content, and the rail's left edge never crossed x=256. It is not claimed as fixed. `test/mydia_web/features/history_rail_test.exs` carries a standing sidebar hit-test probe so it would be caught if it recurs.

## Testing

`test/mydia_web/features/history_rail_test.exs` asks the browser for real rectangles at 1700x1000 and 1300x1000: track count, track widths, pinned offset after scrolling, the sidebar hit test, and an overflow sweep of the main column. Every probe returns a distinct string when its target is missing or zero-sized, so a selector typo fails loudly instead of passing vacuously.

Falsified: with the pre-change markup restored and the new DOM ids kept, both tests fail on real geometry, the 1300px one on track count (3 vs 2) and the 1700px one on rail width (352px vs 320px).

Full suite green (9545 tests, 13 doctests, 0 failures), format and `credo --strict` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timelines now show up to five events by default, with an option to expand or collapse the full history.
  * History entries use compact relative timestamps for easier scanning.
  * Media detail layouts adapt more smoothly across screen sizes.

* **Bug Fixes**
  * Improved history rail positioning and responsive behavior to prevent overlap and content overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->