### PR TITLE
fix(ui): stop the show page's Media Files card listing every episode file

### DIFF
--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -673,30 +673,38 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   end
 
   @doc """
-  Media files section showing all files for this media item.
+  Media files section, showing the files that belong to this item directly and
+  to no episode.
 
-  Covers episode media files as well as the item's own, via
-  `all_media_files/1`: a movie's files live at `media_item.media_files`, but a
-  `MediaFile` belongs to either `media_item_id` or `episode_id`, never both, so
-  that list is always empty for a TV show. Without this the card was
-  permanently empty on every TV show page.
+  For a movie that is simply its files. For a TV show it is the files with
+  `media_item_id` set and `episode_id` nil, which `Mydia.Jobs.MediaImport`'s
+  catch-all fallback creates when a download's episode cannot be resolved and
+  `Mydia.Media.RecentlyAdded` documents as "unmatched files". No episode row
+  will ever render those, so this card is their only surface -- hence the
+  filter on `episode_id` rather than skipping the card for shows outright.
 
-  A `MediaFile` can also be attached directly to a TV show with no episode at
-  all (`media_item_id` set, `episode_id` nil) -- see
-  `Mydia.Jobs.MediaImport`'s catch-all fallback and `Mydia.Media.RecentlyAdded`'s
-  "unmatched files" -- so this card is not always redundant with the
-  per-episode listing even for a show. Its subtitle badge and manage button
-  therefore always render here, for every file, regardless of item type.
+  It deliberately does *not* list a show's episode files, even though
+  `all_media_files/1` reaches them. `episode_rows/1` already renders each of
+  those under its own episode, with the season and episode number attached.
+  Listing them again here produced a flat, unlabelled pile under a heading
+  that reads as show-level: on the reference deployment, 49 of 53 shows with
+  files rendered a card that was 100% episode files (Silo: 29 rows, every one
+  a duplicate of something already shown above). That is what the merged list
+  looked like in practice, and it read as detached files rather than as a
+  useful overview.
 
-  The one thing to watch: for a TV show, a file that *does* belong to an
-  episode renders a second time in `episode_file_row/1` once that episode is
-  expanded, with its own copy of the same badge/button. Those two renders
-  must never share a DOM id, so this component's copies are suffixed
-  `-file-` (`subtitle-open-file-<id>`, `subtitle-badges-file-<id>`) while
-  `episode_file_row/1` keeps its plain `subtitle-open-<id>` /
-  `subtitle-badges-<id>` -- the same idiom `subtitle_track_row/1` already
-  uses (folding `media_file_id` into its id) and `episode_rows/1` uses for
-  its own ids (`"episode-\#{episode.id}-actions"`, etc.).
+  Because the two surfaces are now disjoint, no file can render twice on the
+  page. The `-file-` DOM id suffix here (`subtitle-open-file-<id>`,
+  `subtitle-badges-file-<id>`) is kept anyway, distinct from
+  `episode_file_row/1`'s plain `subtitle-open-<id>` / `subtitle-badges-<id>`,
+  so a future change that widens either list cannot silently reintroduce a
+  duplicate-id crash.
+
+  Note the other four call sites fixed alongside this one in #591 -- the
+  quality filter and badge, the list view's Size column, and
+  `FileEvents.refresh_all_file_metadata/2` -- do still want the merged list
+  from `all_media_files/1`. They answer questions about the whole show; this
+  card does not.
   """
   attr :media_item, :map, required: true
   attr :refreshing_file_metadata, :boolean, required: true
@@ -704,7 +712,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
   attr :media_file_subtitle_tracks, :map, default: %{}
 
   def media_files_section(assigns) do
-    files = all_media_files(assigns.media_item)
+    files = Enum.filter(all_media_files(assigns.media_item), &is_nil(&1.episode_id))
     {extras, versions} = Enum.split_with(files, &(not is_nil(&1.extra_kind)))
 
     assigns = assign(assigns, files: files, versions: versions, extras: extras)

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -37,6 +37,13 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
     }
   end
 
+  # An episode's file, in the shape the database actually stores it:
+  # episode_id set, media_item_id nil. `file/2` alone leaves episode_id nil,
+  # which is a *show-level* file and would not exercise the split below.
+  defp episode_file(id, relative_path) do
+    %{file(id, relative_path) | episode_id: "ep-#{id}"}
+  end
+
   defp stub_socket(media_item) do
     %Phoenix.LiveView.Socket{
       assigns: %{__changed__: %{}, flash: %{}, media_item: media_item},
@@ -58,26 +65,48 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
       assert html =~ ~s|phx-value-file-id="mf-1"|
     end
 
-    # A MediaFile belongs to either media_item_id (movies) or episode_id (TV
-    # episodes), never both, so media_item.media_files alone is always empty
-    # for a TV show. Episode files live at media_item.episodes[].media_files
-    # instead; the section must reach into both.
-    test "renders files that belong to an episode, not just the item's own" do
+    # This card shows the item's *own* files. An episode's file already renders
+    # under its episode in `episode_rows/1`/`episode_file_row/1`, so merging
+    # `all_media_files/1` in here listed every episode file a second time, with
+    # no episode label, under a heading that reads as show-level. On the
+    # reference deployment that was 49 of 53 shows rendering a card that was
+    # 100% episode files -- Silo showed 29 unlabelled filenames, every one of
+    # them already listed above under its own episode.
+    test "does not render files that belong to an episode" do
       media_item = %{
         media_files: [],
         episodes: [
-          %{media_files: [file("mf-ep-1", "Breaking Bad/Season 01/S01E01.mkv")]},
-          %{media_files: [file("mf-ep-2", "Breaking Bad/Season 01/S01E02.mkv")]}
+          %{media_files: [episode_file("mf-ep-1", "Breaking Bad/Season 01/S01E01.mkv")]},
+          %{media_files: [episode_file("mf-ep-2", "Breaking Bad/Season 01/S01E02.mkv")]}
+        ]
+      }
+
+      html = section_html(media_item)
+
+      refute html =~ "media-files-section"
+      refute html =~ "S01E01.mkv"
+      refute html =~ "S01E02.mkv"
+    end
+
+    # media_item_id set, episode_id nil. `Mydia.Jobs.MediaImport`'s catch-all
+    # fallback creates exactly this when a TV download's episode cannot be
+    # resolved, and no episode row will ever render it. This card is its only
+    # surface, which is why the fix filters by episode_id rather than skipping
+    # `all_media_files/1` for shows outright.
+    test "renders a TV show's own file that belongs to no episode" do
+      media_item = %{
+        media_files: [file("mf-show", "Breaking Bad/unmatched-release.mkv")],
+        episodes: [
+          %{media_files: [episode_file("mf-ep-1", "Breaking Bad/Season 01/S01E01.mkv")]}
         ]
       }
 
       html = section_html(media_item)
 
       assert html =~ "media-files-section"
-      assert html =~ "S01E01.mkv"
-      assert html =~ "S01E02.mkv"
-      assert html =~ ~s|phx-value-file-id="mf-ep-1"|
-      assert html =~ ~s|phx-value-file-id="mf-ep-2"|
+      assert html =~ "unmatched-release.mkv"
+      assert html =~ ~s|phx-value-file-id="mf-show"|
+      refute html =~ "S01E01.mkv"
     end
 
     test "renders nothing when the item has no files anywhere" do
@@ -98,7 +127,7 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
         size: nil
       }
 
-      html = section_html(%{media_files: [], episodes: [%{media_files: [broken]}]})
+      html = section_html(%{media_files: [broken], episodes: []})
 
       assert html =~ "Unknown file"
       assert html =~ ~s|phx-value-file-id="mf-broken"|

--- a/test/mydia_web/live/media_live/show/subtitle_surface_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_surface_test.exs
@@ -114,7 +114,7 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleSurfaceTest do
     end
   end
 
-  describe "a TV episode's file rendered by both surfaces at once" do
+  describe "a TV episode's file is rendered by exactly one surface" do
     setup do
       user = user_fixture()
       show = media_item_fixture(%{type: "tv_show"})
@@ -124,25 +124,26 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleSurfaceTest do
       {:ok, user: user, show: show, episode: episode, media_file: media_file}
     end
 
-    test "expanding the episode does not collide with the flat file list's copy", ctx do
+    # media_files_section/1 used to merge episode files in via
+    # all_media_files/1, so this file rendered twice on one page: once under
+    # its episode and once in the flat card, unlabelled. The two renders were
+    # kept apart only by a DOM-id suffix. They are now disjoint by
+    # construction -- the card filters to files with no episode_id -- which is
+    # a stronger guarantee than distinct ids, so this asserts the split
+    # directly.
+    test "the flat Media Files card leaves it to the episode row", ctx do
       {:ok, view, _html} =
         ctx.conn
         |> log_in_user(ctx.user)
         |> live(~p"/media/#{ctx.show.id}")
 
-      # The flat Media Files card already rendered this file (all_media_files/1
-      # reaches into episode files too) before this click. If
-      # media_files_section/1 and episode_file_row/1 ever render the same id
-      # again for this file, Phoenix.LiveViewTest raises "Duplicate id found"
-      # here -- this is the connected repro for that bug.
+      refute has_element?(view, "#media-files-section")
+      refute has_element?(view, "#subtitle-open-file-#{ctx.media_file.id}")
+
       render_click(view, "toggle_episode_expanded", %{"episode-id" => ctx.episode.id})
 
-      flat_list_id = "subtitle-open-file-#{ctx.media_file.id}"
-      episode_row_id = "subtitle-open-#{ctx.media_file.id}"
-
-      assert has_element?(view, "##{flat_list_id}")
-      assert has_element?(view, "##{episode_row_id}")
-      assert flat_list_id != episode_row_id
+      assert has_element?(view, "#subtitle-open-#{ctx.media_file.id}")
+      refute has_element?(view, "#subtitle-open-file-#{ctx.media_file.id}")
     end
   end
 


### PR DESCRIPTION
## The report

"Why does a TV show like Silo have so many detached Media Files? This shouldn't even be possible."

It isn't. The data is correct — the card is misleading.

## Root cause

`1a686a13f` (#591, refs #587) pointed `media_files_section/1` at `Helpers.all_media_files/1` to fix a card that was permanently empty on TV show pages. That helper merges the item's own files with **every episode's file**, and the card renders no season or episode label under a heading that reads as show-level. So each show page grew a flat list of every episode file it owns — every row a duplicate of one already rendered by `episode_file_row/1` when the season is expanded.

Measured on the reference deployment:

| | |
|---|---|
| TV shows with files whose card is 100% episode files | **49 of 53** |
| Shows with any genuine show-level file | 4 |
| Silo | 29 rows, all correctly episode-attached, none orphaned or trashed |

Dark Matter (2024) and A Knight of the Seven Kingdoms show the same shape (10 and 7 files, zero show-level).

## The fix

Filter the card to files with no `episode_id`:

```elixir
files = Enum.filter(all_media_files(assigns.media_item), &is_nil(&1.episode_id))
```

- **Movies**: unchanged, their files carry `episode_id` nil.
- **Shows**: keep the case the card genuinely exists for — a file attached straight to the show with no episode, which `Mydia.Jobs.MediaImport`'s catch-all fallback creates and no episode row will ever render. That is why this filters on `episode_id` rather than skipping the card for shows outright.
- The other four sites #591 fixed — quality filter, quality badge, list-view Size column, `FileEvents.refresh_all_file_metadata/2` — ask about the whole show and keep the merged list.

The two surfaces are now disjoint, so the duplicate-id collision the `-file-` DOM suffix guards against cannot occur. The suffix stays as a guard against a future widening of either list.

## Tests

Two existing tests asserted the old behaviour and are inverted, including the connected test that was *guarding* the duplicate render via distinct DOM ids — it now asserts the split directly, which is a stronger guarantee. Added a case for the show-level file that must still render. The new `episode_file/2` helper sets `episode_id`, since `file/2` alone produces a show-level file and would not have exercised the split.

- 3 failures before the fix, 0 after
- Full `test/mydia_web/live/media_live/`: 449 tests, 0 failures
- `mix format` clean, `credo --strict` on the changed module: no issues

## Known gap, not a regression

TV *episode* extras become invisible, since the Extras disclosure lives only in this card. Zero rows affected on the reference deployment (all 144 extras sit on movies), and they were equally invisible before #591, so this restores prior behaviour rather than opening a hole. Worth closing if episode-level extras start appearing.

## Out of scope

Separately found while investigating, and deliberately untouched: 507 `media_files` rows with both parent keys NULL and 123 attached to a show with no episode. `media_files.episode_id` is `ON DELETE SET NULL`, so anything that recreates episodes strands its files. That is real detachment and wants its own investigation.

Refs #587


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TV episode files no longer appear redundantly in the show-level Media Files section.
  * Episode files now display only within their corresponding episode row.
  * Unmatched files attached directly to a show continue to appear correctly.
  * Subtitle and metadata display behavior remains consistent across episode and show views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->