### PR TITLE
fix(config): stop dropping database-backed settings at every boot

### DIFF
--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -316,7 +316,11 @@ defmodule Mydia.Application do
   end
 
   defp load_config! do
-    Mydia.Config.Loader.load!()
+    # Phase one: no database layer. Mydia.Repo is a child of the tree this
+    # config is used to build, and on a fresh install config_settings has not
+    # been migrated. Mydia.Config.Bootstrap merges the database layer after
+    # Ecto.Migrator.
+    Mydia.Config.Loader.load!(sources: [:yaml, :env])
   end
 
   defp ensure_default_quality_profiles do

--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -99,6 +99,11 @@ defmodule Mydia.Application do
       {Mydia.Release.MigrationBackup, skip: skip_migrations?()},
       {Ecto.Migrator,
        repos: Application.fetch_env!(:mydia, :ecto_repos), skip: skip_migrations?()},
+      # Re-merges the database configuration layer, which start/2 could not read
+      # because it runs before this tree exists. Must sit after the migrator: on
+      # a fresh install config_settings does not exist until the migrator has
+      # run. Returns :ignore once done. See the module doc.
+      {Mydia.Config.Bootstrap, skip: skip_config_merge?()},
       # Releases import runs whose coordinator died with the previous node.
       # Must run after the migrator (it queries import_runs) and before the
       # Oban child below, because "no queue has started yet" is exactly what
@@ -313,6 +318,18 @@ defmodule Mydia.Application do
   defp skip_migrations? do
     # By default, sqlite migrations are run when using a release
     System.get_env("RELEASE_NAME") == nil
+  end
+
+  # The merge reads config_settings from the supervisor's own process, which
+  # owns no SQL Sandbox connection, so running it under `mix test` raises
+  # DBConnection.OwnershipError before any test starts, and that error is
+  # deliberately absent from load_database_config/1's rescue list. Same reason
+  # ClientHealth, IndexerHealth and MediaServerHealth are gated in test; those
+  # use `++ []` splicing because their position does not matter, while this
+  # child has to stay between Ecto.Migrator and its consumers, so it stays in
+  # the list and no-ops instead.
+  defp skip_config_merge? do
+    not Application.get_env(:mydia, :start_health_monitors, true)
   end
 
   defp load_config! do

--- a/lib/mydia/config/bootstrap.ex
+++ b/lib/mydia/config/bootstrap.ex
@@ -1,0 +1,88 @@
+defmodule Mydia.Config.Bootstrap do
+  @moduledoc """
+  Merges the database configuration layer into the cached runtime config, once,
+  at boot.
+
+  `Mydia.Application.start/2` has to load configuration before the supervision
+  tree exists, because `children/0` reads from it. At that point `Mydia.Repo` is
+  not running and, on a fresh install, `config_settings` has not been migrated,
+  so that first load deliberately asks for `sources: [:yaml, :env]` only.
+
+  This child closes the gap. It sits after `Ecto.Migrator`, so the table is
+  guaranteed to exist, and calls `Mydia.Config.Loader.reload/1` to re-merge all
+  four layers into `Application.get_env(:mydia, :runtime_config)`. Every child
+  after it, and every request and job, sees database-backed settings.
+
+  ## Why position is load-bearing
+
+  Above `Ecto.Migrator` this reads a table that may not exist. Below a consumer
+  of a database-backed setting, that consumer boots with file and environment
+  values only.
+
+  Before this child existed there was no second merge at all. The pre-supervisor
+  load rescued Ecto's "repo not started" error into an empty database layer, and
+  the only `Loader.reload/0` callers were three save handlers, so a setting saved
+  in the admin UI worked until the next restart and then silently reverted. The
+  FlareSolverr row is where that surfaced: its badge read the `ConfigSetting`
+  rows directly and said Enabled while the client read the cached config and
+  answered "FlareSolverr is disabled".
+
+  Work happens synchronously in `init/1`, which then returns `:ignore`, so no
+  process lingers. This mirrors `Mydia.Release.MigrationBackup`.
+
+  ## Failure policy
+
+  A failed merge logs at `:error` and startup continues with the phase-one
+  config. Refusing to boot would lock an operator out of an instance over a
+  configuration they can only repair from inside it.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @doc false
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    # `skip: true` is how the test environment opts out. The merge queries
+    # config_settings from the supervisor's own process, which owns no SQL
+    # Sandbox connection, so running it under `mix test` raises
+    # DBConnection.OwnershipError before a single test starts. That error is
+    # deliberately not in load_database_config/1's rescue list, so it would
+    # take the whole suite down at boot. Tests call run/1 directly instead.
+    unless Keyword.get(opts, :skip, false) do
+      run(Keyword.delete(opts, :skip))
+    end
+
+    :ignore
+  end
+
+  @doc """
+  Re-merges every configuration layer into the cached runtime config.
+
+  Never raises. Returns `{:error, reason}` when the merged configuration fails
+  schema validation, in which case `Mydia.Config.Loader.reload/1` has left the
+  previously cached config untouched.
+  """
+  @spec run(keyword()) :: {:ok, Mydia.Config.Schema.t()} | {:error, term()}
+  def run(opts \\ []) do
+    case Mydia.Config.Loader.reload(opts) do
+      {:ok, config} ->
+        Logger.info("Merged the database configuration layer into the runtime config")
+        {:ok, config}
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to merge the database configuration layer at startup: #{inspect(reason)}. " <>
+            "Settings saved in the admin UI will NOT take effect until the merged " <>
+            "configuration is valid. Continuing with file and environment configuration only."
+        )
+
+        {:error, reason}
+    end
+  end
+end

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -15,24 +15,44 @@ defmodule Mydia.Config.Loader do
   alias Mydia.Config.Schema
   alias Mydia.Settings
 
+  @default_sources [:yaml, :database, :env]
+
   @doc """
   Loads configuration from all sources and returns validated config.
 
   ## Options
     - `:config_file` - Path to YAML config file (default: "config/config.yml")
-    - `:env` - Environment to use for config (default: Mix.env())
+    - `:sources` - Which layers to merge. Defaults to yaml, database and env.
+      An omitted layer contributes an empty map rather than failing.
+
+  `Mydia.Application.start/2` passes `sources: [:yaml, :env]` because it runs
+  before `Mydia.Repo` is in the supervision tree. `Mydia.Config.Bootstrap`
+  re-merges the full list once the Repo and the migrator have run.
 
   Returns `{:ok, config}` or `{:error, errors}`.
   """
   def load(opts \\ []) do
     config_file = Keyword.get(opts, :config_file, default_config_path())
+    sources = Keyword.get(opts, :sources, @default_sources)
 
-    with {:ok, yaml_config} <- load_yaml(config_file),
-         {:ok, db_config} <- load_database_config(),
-         env_config <- load_env(),
+    with {:ok, yaml_config} <- maybe_load_yaml(config_file, sources),
+         {:ok, db_config} <- maybe_load_database_config(sources),
+         env_config <- maybe_load_env(sources),
          merged <- merge_all_configs(yaml_config, db_config, env_config) do
       validate(merged)
     end
+  end
+
+  defp maybe_load_yaml(config_file, sources) do
+    if :yaml in sources, do: load_yaml(config_file), else: {:ok, %{}}
+  end
+
+  defp maybe_load_database_config(sources) do
+    if :database in sources, do: load_database_config(), else: {:ok, %{}}
+  end
+
+  defp maybe_load_env(sources) do
+    if :env in sources, do: load_env(), else: %{}
   end
 
   @doc """

--- a/lib/mydia/settings.ex
+++ b/lib/mydia/settings.ex
@@ -833,6 +833,13 @@ defmodule Mydia.Settings do
   defdelegate load_database_config(), to: Mydia.Settings.RuntimeConfig
 
   @doc """
+  Same as `load_database_config/0`, but takes a loader function so callers can
+  exercise the rescue policy without standing up a broken Repo.
+  """
+  @spec load_database_config((-> [Mydia.Settings.ConfigSetting.t()])) :: {:ok, map()}
+  defdelegate load_database_config(loader), to: Mydia.Settings.RuntimeConfig
+
+  @doc """
   Gets the runtime configuration.
 
   Returns the full configuration struct loaded at application startup.

--- a/lib/mydia/settings/runtime_config.ex
+++ b/lib/mydia/settings/runtime_config.ex
@@ -4,6 +4,8 @@ defmodule Mydia.Settings.RuntimeConfig do
   import Ecto.Query, warn: false
   import Mydia.QueryHelpers
 
+  require Logger
+
   alias Mydia.Repo
 
   alias Mydia.Settings.{
@@ -106,20 +108,42 @@ defmodule Mydia.Settings.RuntimeConfig do
 
   ## Runtime Configuration Loading
 
-  def load_database_config do
+  @doc """
+  Builds the database configuration layer from the `config_settings` table.
+
+  Takes an optional loader so the rescue policy below can be exercised without
+  standing up a broken Repo.
+
+  ## Rescue policy
+
+  A database that is unreachable or not yet migrated is a legitimate state
+  during initial setup, and an empty layer is the right answer for it.
+
+  A bare `RuntimeError` is deliberately NOT rescued. That is what Ecto raises
+  when the Repo has not started, and nothing calls this before the Repo is up
+  any more: `Mydia.Application.start/2` loads its pre-supervisor config with
+  `sources: [:yaml, :env]`, and `Mydia.Config.Bootstrap` merges this layer only
+  after `Ecto.Migrator`. Rescuing it again would restore the original defect, in
+  which every database-backed setting was dropped on every boot with nothing
+  logged and nothing failing.
+  """
+  @spec load_database_config((-> [ConfigSetting.t()])) :: {:ok, map()}
+  def load_database_config(loader \\ &list_config_settings/0) do
     try do
-      config_settings = list_config_settings()
-      config_map = build_config_map(config_settings)
-      {:ok, config_map}
+      {:ok, loader.() |> build_config_map()}
     rescue
-      # Database might not be available during initial setup
-      DBConnection.ConnectionError -> {:ok, %{}}
-      # Catch query errors during app startup (e.g., table doesn't exist yet)
-      Ecto.QueryError -> {:ok, %{}}
-      # Catch SQLite-specific errors
-      Exqlite.Error -> {:ok, %{}}
-      # Catch Repo not started yet error during application startup
-      RuntimeError -> {:ok, %{}}
+      error in [
+        DBConnection.ConnectionError,
+        Ecto.QueryError,
+        Exqlite.Error,
+        Postgrex.Error
+      ] ->
+        Logger.warning(
+          "Database configuration layer unavailable (#{inspect(error.__struct__)}); " <>
+            "continuing with file and environment configuration only"
+        )
+
+        {:ok, %{}}
     end
   end
 

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -988,45 +988,31 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
     assign(socket, :flaresolverr, summary)
   end
 
-  # Returns `{values, sources}` for the four flaresolverr.* keys. Display values
-  # come from the DB side when a row exists (so a save reflects without an app
-  # restart); env- and default-sourced fields use the effective runtime config.
+  # Returns `{values, sources}` for the four flaresolverr.* keys.
+  #
+  # Values come only from the merged runtime config, which is the same thing
+  # `Mydia.Indexers.FlareSolverr.get_config/0` reads. `all_db` is consulted to
+  # label a field ENV / DB / Default and for nothing else.
+  #
+  # A second reader here is precisely how the row's Enabled badge came to
+  # contradict the client's "FlareSolverr is disabled": the badge read the
+  # ConfigSetting rows while the client read the cached merged config, and the
+  # two disagreed for as long as the database layer was being dropped at boot.
+  # Reading rows for values again would reintroduce that class of bug even
+  # though the underlying boot defect is fixed.
   defp flaresolverr_values_and_sources do
     config = Settings.get_runtime_config()
     config = if is_struct(config), do: config, else: Mydia.Config.Schema.defaults()
     fs = config.flaresolverr || %Mydia.Config.Schema.FlareSolverr{}
     all_db = Settings.list_config_settings() |> Map.new(&{&1.key, &1})
 
-    Enum.reduce(@flaresolverr_specs, {%{}, %{}}, fn {field, env_var, key, type},
+    Enum.reduce(@flaresolverr_specs, {%{}, %{}}, fn {field, env_var, key, _type},
                                                     {values, sources} ->
       source = Settings.config_source(env_var, key, all_db)
-      fallback = Map.get(fs, field)
 
-      value =
-        case source do
-          :database -> parse_flaresolverr_value(Map.get(all_db, key).value, type, fallback)
-          _ -> fallback
-        end
-
-      {Map.put(values, field, value), Map.put(sources, key, source)}
+      {Map.put(values, field, Map.get(fs, field)), Map.put(sources, key, source)}
     end)
   end
-
-  # A missing/NULL stored value falls back to the schema default rather than
-  # coercing to a misleading empty string (or "nil") in the UI.
-  defp parse_flaresolverr_value(nil, _type, fallback), do: fallback
-
-  defp parse_flaresolverr_value(raw, :boolean, _fallback),
-    do: Settings.parse_setting_boolean(raw)
-
-  defp parse_flaresolverr_value(raw, :integer, fallback) do
-    case Integer.parse(to_string(raw)) do
-      {int, _} -> int
-      :error -> fallback
-    end
-  end
-
-  defp parse_flaresolverr_value(raw, :string, _fallback), do: to_string(raw)
 
   defp flaresolverr_changeset(params, sources \\ %{}) do
     changeset =

--- a/test/mydia/config/bootstrap_test.exs
+++ b/test/mydia/config/bootstrap_test.exs
@@ -1,0 +1,118 @@
+defmodule Mydia.Config.BootstrapTest do
+  # async: false because these tests write Application.get_env(:mydia, :runtime_config),
+  # which is process-global.
+  use ExUnit.Case, async: false
+
+  alias Mydia.Config.{Bootstrap, Loader}
+  alias Mydia.Settings
+
+  setup do
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Mydia.Repo, shared: true)
+    original = Application.get_env(:mydia, :runtime_config)
+
+    on_exit(fn ->
+      Application.put_env(:mydia, :runtime_config, original)
+      Ecto.Adapters.SQL.Sandbox.stop_owner(pid)
+    end)
+
+    :ok
+  end
+
+  describe "supervision position" do
+    test "starts after the Repo and after the migrator" do
+      # This ordering IS the correctness argument for the whole module. Above
+      # Ecto.Migrator it reads config_settings on a fresh install where that
+      # table does not exist yet. Missing entirely, the database layer is
+      # dropped on every boot, which is the defect this child exists to fix.
+      children = Mydia.Application.children()
+
+      repo = Enum.find_index(children, &(&1 == Mydia.Repo))
+      migrator = Enum.find_index(children, &match?({Ecto.Migrator, _}, &1))
+      bootstrap = Enum.find_index(children, &match?({Mydia.Config.Bootstrap, _}, &1))
+
+      assert repo, "expected a Mydia.Repo child"
+      assert migrator, "expected an Ecto.Migrator child"
+      assert bootstrap, "expected a Mydia.Config.Bootstrap child"
+
+      assert repo < migrator
+      assert migrator < bootstrap
+    end
+
+    test "returns :ignore so no process lingers" do
+      assert :ignore = Bootstrap.start_link(skip: true)
+    end
+
+    test "the child is skipped in the test environment" do
+      # The merge queries config_settings from the supervisor's process, which
+      # owns no sandbox connection. Without this gate the suite would not boot.
+      children = Mydia.Application.children()
+
+      assert {Mydia.Config.Bootstrap, skip: true} in children,
+             "the test environment must not run the merge at boot"
+    end
+
+    test "skip: true does not perform the merge" do
+      {:ok, _} =
+        Settings.upsert_config_setting(%{
+          key: "flaresolverr.url",
+          value: "http://should-not-be-merged:8191",
+          category: :flaresolverr
+        })
+
+      phase_one = Loader.load!(sources: [:yaml, :env])
+      Application.put_env(:mydia, :runtime_config, phase_one)
+
+      assert :ignore = Bootstrap.start_link(skip: true)
+      assert Settings.get_runtime_config().flaresolverr.url == nil
+    end
+  end
+
+  describe "run/1" do
+    test "a ConfigSetting written before boot reaches the cached runtime config" do
+      {:ok, _} =
+        Settings.upsert_config_setting(%{
+          key: "flaresolverr.enabled",
+          value: "true",
+          category: :flaresolverr
+        })
+
+      {:ok, _} =
+        Settings.upsert_config_setting(%{
+          key: "flaresolverr.url",
+          value: "http://fs.test:8191",
+          category: :flaresolverr
+        })
+
+      # Reproduce phase one: the load Mydia.Application.start/2 performs before
+      # the supervision tree exists, with no database layer available.
+      phase_one = Loader.load!(sources: [:yaml, :env])
+      Application.put_env(:mydia, :runtime_config, phase_one)
+
+      refute Settings.get_runtime_config().flaresolverr.enabled,
+             "phase one must not see the database layer"
+
+      assert {:ok, _config} = Bootstrap.run()
+
+      assert Settings.get_runtime_config().flaresolverr.enabled
+      assert Settings.get_runtime_config().flaresolverr.url == "http://fs.test:8191"
+    end
+
+    test "a failed merge leaves the phase-one config in place" do
+      phase_one = Loader.load!(sources: [:yaml, :env])
+      Application.put_env(:mydia, :runtime_config, phase_one)
+
+      # An enabled FlareSolverr with no URL fails schema validation
+      # (validate_flaresolverr_url/1), so the merge is rejected and reload/1
+      # must not clobber the cached config.
+      {:ok, _} =
+        Settings.upsert_config_setting(%{
+          key: "flaresolverr.enabled",
+          value: "true",
+          category: :flaresolverr
+        })
+
+      assert {:error, _reason} = Bootstrap.run()
+      assert Settings.get_runtime_config() == phase_one
+    end
+  end
+end

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -1049,6 +1049,44 @@ defmodule Mydia.Config.LoaderTest do
     end
   end
 
+  describe "load/1 :sources option" do
+    test "the default source list includes the database layer" do
+      {:ok, _} =
+        Mydia.Settings.upsert_config_setting(%{
+          key: "flaresolverr.url",
+          value: "http://from-the-database:8191",
+          category: :flaresolverr
+        })
+
+      assert {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+      assert config.flaresolverr.url == "http://from-the-database:8191"
+    end
+
+    test "sources: [:yaml, :env] skips the database layer entirely" do
+      {:ok, _} =
+        Mydia.Settings.upsert_config_setting(%{
+          key: "flaresolverr.url",
+          value: "http://from-the-database:8191",
+          category: :flaresolverr
+        })
+
+      assert {:ok, config} =
+               Loader.load(config_file: "nonexistent.yml", sources: [:yaml, :env])
+
+      assert config.flaresolverr.url == nil
+    end
+
+    test "sources: [:yaml, :env] still reads environment variables" do
+      System.put_env("FLARESOLVERR_URL", "http://from-the-environment:8191")
+      on_exit(fn -> System.delete_env("FLARESOLVERR_URL") end)
+
+      assert {:ok, config} =
+               Loader.load(config_file: "nonexistent.yml", sources: [:yaml, :env])
+
+      assert config.flaresolverr.url == "http://from-the-environment:8191"
+    end
+  end
+
   describe "reload/0" do
     setup do
       original = Application.get_env(:mydia, :runtime_config)

--- a/test/mydia/settings/runtime_config_database_layer_test.exs
+++ b/test/mydia/settings/runtime_config_database_layer_test.exs
@@ -1,0 +1,43 @@
+defmodule Mydia.Settings.RuntimeConfigDatabaseLayerTest do
+  @moduledoc """
+  The rescue list in load_database_config/1 is load-bearing in both directions.
+
+  Too narrow and a fresh install fails to boot because config_settings has not
+  been migrated yet. Too wide and an ordering bug becomes an empty configuration
+  layer: rescuing the bare RuntimeError that Ecto raises for an unstarted Repo
+  is exactly how every database-backed setting came to be dropped on every boot,
+  with no log line and no failed boot to point at it.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Settings.RuntimeConfig
+
+  test "an unmigrated database yields an empty layer rather than a crash" do
+    assert {:ok, %{}} =
+             RuntimeConfig.load_database_config(fn ->
+               raise Exqlite.Error, message: "no such table: config_settings"
+             end)
+  end
+
+  test "a lost connection yields an empty layer rather than a crash" do
+    assert {:ok, %{}} =
+             RuntimeConfig.load_database_config(fn ->
+               raise DBConnection.ConnectionError, "connection not available"
+             end)
+  end
+
+  test "a Postgres error yields an empty layer rather than a crash" do
+    assert {:ok, %{}} =
+             RuntimeConfig.load_database_config(fn ->
+               raise Postgrex.Error, message: "relation config_settings does not exist"
+             end)
+  end
+
+  test "a repo-not-started error is NOT swallowed into an empty layer" do
+    assert_raise RuntimeError, ~r/could not lookup Ecto repo/, fn ->
+      RuntimeConfig.load_database_config(fn ->
+        raise "could not lookup Ecto repo Mydia.Repo because it was not started"
+      end)
+    end
+  end
+end

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -409,4 +409,74 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       assert has_element?(view, "#flaresolverr-form")
     end
   end
+
+  describe "FlareSolverr row and client agreement" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+      Mydia.Indexers.register_adapters()
+
+      original = Application.get_env(:mydia, :runtime_config)
+      on_exit(fn -> Application.put_env(:mydia, :runtime_config, original) end)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      %{conn: conn}
+    end
+
+    test "the Enabled badge reflects the merged config, not the raw rows", %{conn: conn} do
+      # A row saying enabled, with a cached config that has not been reloaded,
+      # is exactly the state that produced "badge says Enabled, Test says
+      # disabled". Both readers must now answer the same way.
+      {:ok, _} =
+        Mydia.Settings.upsert_config_setting(%{
+          key: "flaresolverr.enabled",
+          value: "true",
+          category: :flaresolverr
+        })
+
+      {:ok, _} =
+        Mydia.Settings.upsert_config_setting(%{
+          key: "flaresolverr.url",
+          value: "http://fs.test:8191",
+          category: :flaresolverr
+        })
+
+      stale = Mydia.Config.Loader.load!(sources: [:yaml, :env])
+      Application.put_env(:mydia, :runtime_config, stale)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+
+      refute Mydia.Indexers.FlareSolverr.enabled?()
+
+      assert has_element?(view, "#flaresolverr-panel .badge-ghost", "Disabled"),
+             "the badge must agree with FlareSolverr.enabled?/0"
+    end
+
+    test "the Enabled badge turns on once the merged config carries the rows", %{conn: conn} do
+      {:ok, _} =
+        Mydia.Settings.upsert_config_setting(%{
+          key: "flaresolverr.enabled",
+          value: "true",
+          category: :flaresolverr
+        })
+
+      {:ok, _} =
+        Mydia.Settings.upsert_config_setting(%{
+          key: "flaresolverr.url",
+          value: "http://fs.test:8191",
+          category: :flaresolverr
+        })
+
+      assert {:ok, _} = Mydia.Config.Bootstrap.run()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+
+      assert Mydia.Indexers.FlareSolverr.enabled?()
+      assert has_element?(view, "#flaresolverr-panel .badge-success", "Enabled")
+    end
+  end
 end

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -415,8 +415,27 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       start_supervised!(Mydia.Indexers.Health)
       Mydia.Indexers.register_adapters()
 
+      # Env is the highest-precedence config layer (defaults > YAML > database >
+      # env), so a FLARESOLVERR_* variable exported on the host running the
+      # tests would defeat the stale-config state these tests deliberately
+      # build with `Loader.load!(sources: [:yaml, :env])` below, flipping the
+      # client to enabled for reasons unrelated to the code under test.
+      fs_env_vars = ~w(
+        FLARESOLVERR_URL FLARESOLVERR_ENABLED FLARESOLVERR_TIMEOUT FLARESOLVERR_MAX_TIMEOUT
+      )
+      original_env = Map.new(fs_env_vars, &{&1, System.get_env(&1)})
+      Enum.each(fs_env_vars, &System.delete_env/1)
+
       original = Application.get_env(:mydia, :runtime_config)
-      on_exit(fn -> Application.put_env(:mydia, :runtime_config, original) end)
+
+      on_exit(fn ->
+        Enum.each(original_env, fn
+          {key, nil} -> System.delete_env(key)
+          {key, value} -> System.put_env(key, value)
+        end)
+
+        Application.put_env(:mydia, :runtime_config, original)
+      end)
 
       conn =
         conn


### PR DESCRIPTION
Configuration loaded in `Mydia.Application.start/2` runs before `Mydia.Repo` is
started, and `load_database_config/0` rescued the resulting error into an empty
layer. Every `ConfigSetting` row was silently dropped on every boot, and nothing
re-merged it afterwards, so a setting saved in the admin UI worked until the
next restart and then reverted with nothing logged.

FlareSolverr is where this surfaced: its admin row read the rows directly and
showed Enabled while its client read the cached config and answered
"FlareSolverr is disabled. Enable it in configuration."

## Changes

- `Loader.load/1` takes a `:sources` option; `Application.start/2` uses
  `[:yaml, :env]` and no longer needs a rescue at all.
- New `Mydia.Config.Bootstrap` child, after `Ecto.Migrator`, re-merges all four
  layers. Placement after the migrator is required: `config_settings` does not
  exist on a fresh install until it has run. It is gated `skip:` in test, where
  the supervisor process owns no SQL Sandbox connection.
- `load_database_config/1` no longer rescues the bare `RuntimeError` Ecto raises
  for an unstarted Repo, and now covers `Postgrex.Error` alongside
  `Exqlite.Error` (a pre-existing gap on a first-class adapter).
- The FlareSolverr admin row reads values from the merged config only. Rows are
  consulted to label ENV/DB/Default and nothing else, so the badge and the
  client can no longer disagree.

## Verification

Beyond the unit tests, this was confirmed end to end against a real
dev-environment boot: with `flaresolverr.enabled=true` and a URL in
`config_settings`, the boot-time merged config now reports `enabled: true` with
the URL set, and `health_check/0` returns a connection error for the fake probe
host rather than `{:error, :disabled}`. Before the fix the same probe produced
`enabled: false`, `url: nil`, `{:error, :disabled}`.

Full suite: 9561 tests, 0 failures. Credo `--strict` clean, format clean.
The Postgres suite was not run locally (the devenv Postgres service was not
started); CI covers both adapters.

Regressed in a51171e60, which moved `FlareSolverr.get_config/0` off
`Application.get_env(:mydia, :flaresolverr)`. That key is set unconditionally in
`config/runtime.exs`, which is why 1.3 worked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime configuration now incorporates database settings after migrations complete during startup.
  * Admin indexer settings consistently reflect the active runtime configuration.
  * Improved handling of unavailable or uninitialized databases without disrupting startup.

* **Improvements**
  * Configuration loading can selectively use YAML, database, and environment sources.
  * Invalid database settings no longer replace the last valid runtime configuration.
  * FlareSolverr settings now consistently reflect the active runtime configuration across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->