### PR TITLE
fix(library): make scans build the import inbox, and wire up auto_import

### DIFF
--- a/lib/mydia/jobs/apply_import_groups.ex
+++ b/lib/mydia/jobs/apply_import_groups.ex
@@ -48,7 +48,7 @@ defmodule Mydia.Jobs.ApplyImportGroups do
   require Logger
 
   alias Mydia.ImportGroups
-  alias Mydia.Library.{FileIngest, ImportGroup}
+  alias Mydia.Library.{FileIngest, ImportGroup, MatchCandidate}
   alias Mydia.Repo
 
   @member_page 1_000
@@ -165,58 +165,27 @@ defmodule Mydia.Jobs.ApplyImportGroups do
   end
 
   defp ingest_member(%{media_file: media_file, candidate: candidate}, group) do
+    base = MatchCandidate.to_match(candidate)
+
     match = %{
-      provider_id: candidate.provider_id || group.provider_id,
-      provider_type: provider_type(candidate, group),
-      title: candidate.title || group.suggested_title,
-      year: candidate.year || group.suggested_year,
-      match_confidence: candidate.confidence || group.min_confidence || 1.0,
-      parsed_info: parsed_info(candidate, group)
+      base
+      | provider_id: candidate.provider_id || group.provider_id,
+        provider_type:
+          MatchCandidate.known_provider(candidate.provider_type) ||
+            MatchCandidate.known_provider(group.provider_type) || :tvdb,
+        title: candidate.title || group.suggested_title,
+        year: candidate.year || group.suggested_year,
+        match_confidence: candidate.confidence || group.min_confidence || 1.0,
+        parsed_info: %{
+          MatchCandidate.parsed_info(candidate)
+          | type: MatchCandidate.media_type_atom(candidate.media_type || group.media_type)
+        }
     }
 
     media_file = Repo.preload(media_file, :library_path)
 
     FileIngest.ingest(media_file, match, policy: :create_items)
   end
-
-  # `provider_type` is a free-text database column with no inclusion
-  # validation, so `String.to_existing_atom/1` on it could raise for a value
-  # this VM has never interned as an atom. That would leave `safe_ingest/2`
-  # catching the raise, the member unresolved, and the group stuck
-  # "accepted" until `max_attempts` strands it -- rather than trust the
-  # column, map the two providers this ever legitimately holds and fall back
-  # to the same default a `nil` value already took.
-  defp provider_type(candidate, group),
-    do:
-      known_provider(Map.get(candidate, :provider_type)) || known_provider(group.provider_type) ||
-        :tvdb
-
-  defp known_provider("tmdb"), do: :tmdb
-  defp known_provider("tvdb"), do: :tvdb
-  defp known_provider(_), do: nil
-
-  # `candidate.parsed_info` round-trips through JSON (`MatchCandidate`'s
-  # `parsed_info` column is `Mydia.Settings.JsonMapType`), so its keys and its
-  # "type" value are strings. `MetadataEnricher.determine_media_type/1`
-  # pattern-matches on `%{parsed_info: %{type: :movie}}` / `%{type: :tv_show}}`
-  # with atom keys and an atom value, so handing the stored map through
-  # unchanged never matches either clause and silently falls through to the
-  # movie default for every file, regardless of the group's real media type.
-  # This rebuilds the atom-keyed shape `FileIngest`/`MetadataEnricher` expect
-  # (see `test/mydia/library/file_ingest_test.exs`'s `match/1` and
-  # `local_tv_match/2` helpers).
-  defp parsed_info(candidate, group) do
-    stored = candidate.parsed_info || %{}
-
-    %{
-      type: media_type_atom(candidate.media_type || group.media_type),
-      season: Map.get(stored, "season"),
-      episodes: Map.get(stored, "episodes") || []
-    }
-  end
-
-  defp media_type_atom("tv_show"), do: :tv_show
-  defp media_type_atom(_), do: :movie
 
   defp broadcast(library_path_id) do
     Phoenix.PubSub.broadcast(

--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -908,8 +908,20 @@ defmodule Mydia.Jobs.LibraryScanner do
   # `:status` from an existing row but not `:import_run_id`, so rebuilding with
   # no run id would detach the running import's own groups from it. The run
   # rebuilds them itself when it finishes, so yielding costs nothing.
+  #
+  # A failure here must not fail the scan either: by the time this runs,
+  # process_scan_result/2 has already committed every file change and the
+  # caller already reports the scan a success, so letting an exception here
+  # crash the whole Oban job would report a false failure over work that
+  # already landed. upsert_for_library/2 is idempotent, so the next scan (or
+  # the import run this raced against, once it finishes) redoes any group
+  # this attempt missed, for free. Concretely, `write_group/4` hard-matches
+  # `{:ok, group} = Repo.insert_or_update()`, and the active-run check above
+  # is check-then-act with a real window: if this rebuild races a freshly
+  # started import run's own upsert on the same new cluster_key, the loser
+  # hits a genuine unique-constraint collision and that match raises.
   @spec rebuild_import_groups(LibraryPath.t()) ::
-          {:ok, %{groups: non_neg_integer(), files: non_neg_integer()}} | :skipped
+          {:ok, %{groups: non_neg_integer(), files: non_neg_integer()}} | :skipped | :error
   def rebuild_import_groups(library_path) do
     case Library.active_import_run(library_path.id) do
       nil ->
@@ -922,6 +934,14 @@ defmodule Mydia.Jobs.LibraryScanner do
 
         :skipped
     end
+  rescue
+    error ->
+      Logger.warning("Import group rebuild failed",
+        library_path_id: library_path.id,
+        error: Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      :error
   end
 
   defp process_media_file(media_file, file_info, metadata_config) do

--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -32,7 +32,6 @@ defmodule Mydia.Jobs.LibraryScanner do
 
   alias Mydia.Library.{
     FileIngest,
-    MediaFile,
     MetadataMatcher,
     SampleDetector,
     ScanSummary

--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -296,6 +296,7 @@ defmodule Mydia.Jobs.LibraryScanner do
        new_files: length(changes.new_files),
        modified_files: length(changes.modified_files),
        deleted_files: length(changes.deleted_files),
+       auto_linked: details |> Map.get(:cleanup_stats, %{}) |> Map.get(:auto_linked, 0),
        details: details
      }}
   end
@@ -665,6 +666,14 @@ defmodule Mydia.Jobs.LibraryScanner do
         result == {:error, :library_type_mismatch}
       end)
 
+    # Both populations, deliberately. The new-file stream alone would report
+    # zero on a library whose backlog is all existing orphans, which is the
+    # shape this change exists to fix.
+    new_file_auto_linked =
+      Enum.count(enrichment_results, fn {_file, result} ->
+        result == {:ok, :auto_linked}
+      end)
+
     # Initialize tracking for robust cleanup operations
     cleanup_stats = %{
       orphaned_files_fixed: 0,
@@ -673,7 +682,8 @@ defmodule Mydia.Jobs.LibraryScanner do
       invalid_paths_removed: 0,
       type_mismatches_detected: type_mismatch_count,
       movies_in_series_libs: 0,
-      tv_in_movies_libs: 0
+      tv_in_movies_libs: 0,
+      auto_linked: 0
     }
 
     # 1. Re-enrich completely orphaned files (no media_item_id and no episode_id)
@@ -706,7 +716,13 @@ defmodule Mydia.Jobs.LibraryScanner do
     # the new-file stream's count to this one. Galactica's orphans are all
     # existing files, so a total taken from the new-file stream alone would
     # report zero while items were being created.
-    _orphan_auto_linked = orphan_stats.auto_linked
+    orphan_auto_linked = orphan_stats.auto_linked
+
+    # Both populations, summed only now that both are computed:
+    # new_file_auto_linked comes from the new-file stream above, and
+    # orphan_auto_linked from the orphan branch that just ran.
+    auto_linked_count = new_file_auto_linked + orphan_auto_linked
+    cleanup_stats = Map.put(cleanup_stats, :auto_linked, auto_linked_count)
 
     # 2. Fix orphaned TV show files (have media_item_id for TV show but no episode_id)
     # Preload media_item to check type
@@ -856,6 +872,7 @@ defmodule Mydia.Jobs.LibraryScanner do
          associations_updated: Map.get(cleanup_stats, :associations_updated, 0),
          invalid_paths_removed: Map.get(cleanup_stats, :invalid_paths_removed, 0),
          type_mismatches_detected: Map.get(cleanup_stats, :type_mismatches_detected, 0),
+         auto_linked: Map.get(cleanup_stats, :auto_linked, 0),
          movies_in_series_libs: Map.get(cleanup_stats, :movies_in_series_libs, 0),
          tv_in_movies_libs: Map.get(cleanup_stats, :tv_in_movies_libs, 0)
        }}
@@ -998,14 +1015,16 @@ defmodule Mydia.Jobs.LibraryScanner do
         # library that has not opted in, which is what keeps a scheduled scan
         # from inventing items behind the user: an external match is cached as
         # a candidate and the file stays orphaned for the inbox to offer.
+        policy = FileIngest.policy_for(library_path, media_file)
+
         ingest_result =
           FileIngest.ingest(media_file, match_result,
-            policy: FileIngest.policy_for(library_path, media_file),
+            policy: policy,
             config: metadata_config
           )
 
         log_ingest_result(ingest_result, match_result, file_info)
-        scan_result_from_ingest(ingest_result)
+        scan_result_from_ingest(ingest_result, auto_linked?(policy, match_result))
 
       {:error, :unknown_media_type} ->
         Logger.debug("Could not determine media type",
@@ -1072,22 +1091,38 @@ defmodule Mydia.Jobs.LibraryScanner do
   defp log_ingest_result(_ingest_result, _match_result, _file_info), do: :ok
 
   @doc false
-  # Public only so the mapping from a `FileIngest.ingest/3` result to the
-  # scanner's legacy return contract can be tested directly. The caller,
-  # `match_file_to_existing_items/4`, is private and its only entry point
-  # (`perform_job/1`) is tagged `:external` and excluded from the default
-  # test suite, so without this seam the translation — including the
-  # ordering that makes `{:library_type_mismatch, _}` take priority over the
-  # generic `{:error, _}` catch-all — would have zero coverage.
-  @spec scan_result_from_ingest(FileIngest.result()) :: {:ok, :enriched} | {:error, atom()}
-  def scan_result_from_ingest({:linked, _media_item}), do: {:ok, :enriched}
-  def scan_result_from_ingest({:candidate, _candidate}), do: {:error, :no_local_match}
+  # True only for a link that `:local_only` would not have made: the library
+  # opted into auto-import and the match came from an external provider. A
+  # local-database link would have happened on any scan, so counting it would
+  # overstate what auto-import actually did.
+  @spec auto_linked?(FileIngest.policy(), map()) :: boolean()
+  def auto_linked?(:create_items, match_result),
+    do: not Map.get(match_result, :from_local_db, false)
 
-  def scan_result_from_ingest({:error, {:library_type_mismatch, _message}}),
+  def auto_linked?(:local_only, _match_result), do: false
+
+  @doc false
+  # Public only so the mapping from a `FileIngest.ingest/3` result plus its
+  # auto-import classification to the scanner's legacy return contract can be
+  # tested directly. The caller, `match_file_to_existing_items/4`, is private
+  # and its only entry point (`perform_job/1`) is tagged `:external` and
+  # excluded from the default test suite, so without this seam the
+  # translation, including the ordering that makes `{:library_type_mismatch,
+  # _}` take priority over the generic `{:error, _}` catch-all, would have
+  # zero coverage.
+  @spec scan_result_from_ingest(FileIngest.result(), boolean()) ::
+          {:ok, :enriched | :auto_linked} | {:error, atom()}
+  def scan_result_from_ingest({:linked, _media_item}, true), do: {:ok, :auto_linked}
+  def scan_result_from_ingest({:linked, _media_item}, false), do: {:ok, :enriched}
+
+  def scan_result_from_ingest({:candidate, _candidate}, _auto_linked?),
+    do: {:error, :no_local_match}
+
+  def scan_result_from_ingest({:error, {:library_type_mismatch, _message}}, _auto_linked?),
     do: {:error, :library_type_mismatch}
 
-  def scan_result_from_ingest({:error, _reason}), do: {:error, :enrichment_failed}
-  def scan_result_from_ingest(:no_match), do: {:error, :no_matches_found}
+  def scan_result_from_ingest({:error, _reason}, _auto_linked?), do: {:error, :enrichment_failed}
+  def scan_result_from_ingest(:no_match, _auto_linked?), do: {:error, :no_matches_found}
 
   # Detects type mismatches in existing files based on library path type
   defp detect_type_mismatches(existing_files, library_path, mismatch_type) do

--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -32,10 +32,14 @@ defmodule Mydia.Jobs.LibraryScanner do
 
   alias Mydia.Library.{
     FileIngest,
+    MediaFile,
     MetadataMatcher,
     SampleDetector,
     ScanSummary
   }
+
+  alias Mydia.ImportGroups
+  alias Mydia.Settings.LibraryPath
 
   alias Mydia.Library.ReleaseParser, as: FileParser
 
@@ -231,7 +235,12 @@ defmodule Mydia.Jobs.LibraryScanner do
              video_extensions: extensions
            ) do
       summary = summarize(process_scan_result(library_path, scan_result))
-      if reconcile_sidecars?(summary), do: reconcile_sidecars(library_path)
+
+      if reconcile_sidecars?(summary) do
+        reconcile_sidecars(library_path)
+        rebuild_import_groups(library_path)
+      end
+
       summary
     else
       {:error, :not_found} ->
@@ -879,6 +888,36 @@ defmodule Mydia.Jobs.LibraryScanner do
   end
 
   defp updatable_library_path?(_), do: true
+
+  @doc false
+  # Public so the rebuild can be tested directly. Its caller `scan_library_path/1`
+  # is private and the entry point `perform_job/1` is tagged `:external` and
+  # excluded from the default suite.
+  #
+  # The scan caches matches as `MatchCandidate` rows, but `/import` renders
+  # `ImportGroup` rows, and nothing built the second from the first unless a
+  # human started an import run. That is why a library could hold hundreds of
+  # matched orphans while the inbox said there was nothing to review.
+  #
+  # Skipped while a run is active. `ImportGroups.write_group/4` strips
+  # `:status` from an existing row but not `:import_run_id`, so rebuilding with
+  # no run id would detach the running import's own groups from it. The run
+  # rebuilds them itself when it finishes, so yielding costs nothing.
+  @spec rebuild_import_groups(LibraryPath.t()) ::
+          {:ok, %{groups: non_neg_integer(), files: non_neg_integer()}} | :skipped
+  def rebuild_import_groups(library_path) do
+    case Library.active_import_run(library_path.id) do
+      nil ->
+        ImportGroups.upsert_for_library(library_path)
+
+      _run ->
+        Logger.debug("Skipping import group rebuild, a run is active",
+          library_path_id: library_path.id
+        )
+
+        :skipped
+    end
+  end
 
   defp process_media_file(media_file, file_info, metadata_config) do
     Logger.debug("Processing media file for metadata", path: file_info.path)

--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -33,6 +33,7 @@ defmodule Mydia.Jobs.LibraryScanner do
   alias Mydia.Library.{
     FileIngest,
     MetadataMatcher,
+    OrphanReenricher,
     SampleDetector,
     ScanSummary
   }
@@ -676,7 +677,7 @@ defmodule Mydia.Jobs.LibraryScanner do
     }
 
     # 1. Re-enrich completely orphaned files (no media_item_id and no episode_id)
-    # Skip extras/samples/trailers — they should remain orphaned
+    # Skip extras/samples/trailers, they should remain orphaned.
     completely_orphaned =
       existing_files
       |> Enum.filter(fn file ->
@@ -690,34 +691,22 @@ defmodule Mydia.Jobs.LibraryScanner do
           SampleDetector.excluded?(SampleDetector.detect(abs_path))
       end)
 
-    cleanup_stats =
-      if completely_orphaned != [] do
-        Logger.info("Re-enriching completely orphaned files",
-          count: length(completely_orphaned)
-        )
+    file_info_by_path =
+      Map.new(result.scan_result.files, fn file_info -> {file_info.path, file_info} end)
 
-        fixed_count =
-          Enum.count(completely_orphaned, fn media_file ->
-            # Preload library_path association for path resolution
-            media_file = Mydia.Repo.preload(media_file, :library_path)
-            absolute_path = Mydia.Library.MediaFile.absolute_path(media_file)
+    orphan_stats =
+      OrphanReenricher.run(library_path, completely_orphaned, file_info_by_path,
+        reenrich: &process_media_file/3,
+        config: metadata_config
+      )
 
-            file_info =
-              Enum.find(result.scan_result.files, fn f -> f.path == absolute_path end)
+    cleanup_stats = Map.put(cleanup_stats, :orphaned_files_fixed, orphan_stats.fixed)
 
-            if file_info do
-              Logger.debug("Re-enriching orphaned file", path: absolute_path)
-              process_media_file(media_file, file_info, metadata_config)
-              true
-            else
-              false
-            end
-          end)
-
-        Map.put(cleanup_stats, :orphaned_files_fixed, fixed_count)
-      else
-        cleanup_stats
-      end
+    # Kept separate from cleanup_stats so Task 5's auto_linked total can add
+    # the new-file stream's count to this one. Galactica's orphans are all
+    # existing files, so a total taken from the new-file stream alone would
+    # report zero while items were being created.
+    _orphan_auto_linked = orphan_stats.auto_linked
 
     # 2. Fix orphaned TV show files (have media_item_id for TV show but no episode_id)
     # Preload media_item to check type

--- a/lib/mydia/jobs/library_scanner.ex
+++ b/lib/mydia/jobs/library_scanner.ex
@@ -933,7 +933,7 @@ defmodule Mydia.Jobs.LibraryScanner do
     case validate_file_type_for_library(parsed.type, library_path, file_info.path) do
       :ok ->
         # Type is compatible, proceed with matching
-        match_file_to_existing_items(media_file, file_info, metadata_config, parsed)
+        match_file_to_existing_items(media_file, file_info, metadata_config, library_path)
 
       {:error, _reason} = error ->
         # Type mismatch, skip processing
@@ -987,9 +987,9 @@ defmodule Mydia.Jobs.LibraryScanner do
     end
   end
 
-  defp match_file_to_existing_items(media_file, file_info, metadata_config, _parsed) do
+  defp match_file_to_existing_items(media_file, file_info, metadata_config, library_path) do
     # Use the library's configured TV metadata source for new matches.
-    provider = media_file.library_path && media_file.library_path.tv_metadata_source
+    provider = library_path && library_path.tv_metadata_source
 
     # Try to match the file to metadata
     case MetadataMatcher.match_file(file_info.path,
@@ -1005,12 +1005,13 @@ defmodule Mydia.Jobs.LibraryScanner do
           from_local_db: Map.get(match_result, :from_local_db, false)
         )
 
-        # :local_only is what keeps the scheduled scan from inventing items.
-        # An external match is cached as a candidate and the file stays
-        # orphaned for the import inbox to offer. See Library.FileIngest.
+        # The policy is the auto-import gate. It stays `:local_only` for every
+        # library that has not opted in, which is what keeps a scheduled scan
+        # from inventing items behind the user: an external match is cached as
+        # a candidate and the file stays orphaned for the inbox to offer.
         ingest_result =
           FileIngest.ingest(media_file, match_result,
-            policy: :local_only,
+            policy: FileIngest.policy_for(library_path, media_file),
             config: metadata_config
           )
 

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -2363,6 +2363,26 @@ defmodule Mydia.Library do
   end
 
   @doc """
+  Rank-0 candidates for many files at once, keyed by `media_file_id`.
+
+  `list_match_candidates/1` is per file. `OrphanReenricher` decides what to do
+  with every orphan in a library, so calling it per file would issue one query
+  per orphan on a library that can hold hundreds.
+
+  Files with no rank-0 candidate are simply absent from the map, which is the
+  same thing the caller's "no candidate" branch already means.
+  """
+  @spec rank_zero_candidates_by_file_id([binary()]) :: %{binary() => MatchCandidate.t()}
+  def rank_zero_candidates_by_file_id([]), do: %{}
+
+  def rank_zero_candidates_by_file_id(media_file_ids) do
+    MatchCandidate
+    |> where([c], c.media_file_id in ^media_file_ids and c.rank == 0)
+    |> Repo.all()
+    |> Map.new(fn candidate -> {candidate.media_file_id, candidate} end)
+  end
+
+  @doc """
   Lists the cached match candidates for a media file, best first.
   """
   @spec list_match_candidates(binary()) :: [MatchCandidate.t()]

--- a/lib/mydia/library/file_ingest.ex
+++ b/lib/mydia/library/file_ingest.ex
@@ -76,6 +76,32 @@ defmodule Mydia.Library.FileIngest do
   def default_threshold, do: @default_threshold
 
   @doc """
+  The ingest policy for one file in one library.
+
+  Lives here rather than on a caller because this module owns the policy type
+  and both callers need it: `Jobs.LibraryScanner` for new files and
+  `Library.OrphanReenricher` for existing orphans.
+
+  Fails closed on everything that is not an auto-import library holding a
+  regular file. A nil association, a read-only `runtime::` struct, and a row
+  whose flag is false all keep the historical `:local_only` behavior, which is
+  what makes enabling this a per-library opt-in rather than a global change.
+
+  Extras are excluded because nothing filters them out of the enrichment stream
+  on the scanner's new-file branch the way `SampleDetector.excluded?/1` does for
+  re-enriched orphans. Under `:local_only` that was harmless, since only a local
+  match could link. Under `:create_items` a trailer drawing an above-threshold
+  external match would create a `MediaItem` of its own. `extra_kind` is already
+  persisted at creation time, so this needs no re-detection: nil means the file
+  is a version of its item, non-nil means it is an extra.
+  """
+  @spec policy_for(Mydia.Settings.LibraryPath.t() | nil, MediaFile.t()) :: policy()
+  def policy_for(%Mydia.Settings.LibraryPath{auto_import: true}, %MediaFile{extra_kind: nil}),
+    do: :create_items
+
+  def policy_for(_library_path, _media_file), do: :local_only
+
+  @doc """
   Decides what to do with a matched file and commits that decision.
 
   See the module doc for the policies. Returns `:no_match` when the matcher

--- a/lib/mydia/library/match_candidate.ex
+++ b/lib/mydia/library/match_candidate.ex
@@ -66,4 +66,65 @@ defmodule Mydia.Library.MatchCandidate do
     |> foreign_key_constraint(:media_file_id)
     |> unique_constraint([:media_file_id, :rank])
   end
+
+  @doc """
+  Builds the match map `FileIngest.ingest/3` expects from a stored candidate.
+
+  The single conversion, shared by `Jobs.ApplyImportGroups` (which layers its
+  group-level fallbacks on top) and `Library.OrphanReenricher` (which uses it
+  as is). Both traps below are why this is one function rather than two.
+
+  `provider_type` is a free-text column with no inclusion validation, so
+  `String.to_existing_atom/1` on it could raise for a value this VM has never
+  interned. Only the two providers this ever legitimately holds are mapped;
+  anything else takes the same default a nil would.
+
+  `parsed_info` round-trips through JSON (`Mydia.Settings.JsonMapType`), so its
+  keys and its "type" value are strings.
+  `MetadataEnricher.determine_media_type/1` pattern-matches
+  `%{parsed_info: %{type: :movie}}` with atom keys and an atom value, so the
+  stored shape matches neither clause and silently falls through to the movie
+  default for every file. This rebuilds the atom-keyed shape it expects.
+  """
+  @spec to_match(t()) :: map()
+  def to_match(%__MODULE__{} = candidate) do
+    %{
+      provider_id: candidate.provider_id,
+      provider_type: known_provider(candidate.provider_type) || :tvdb,
+      title: candidate.title,
+      year: candidate.year,
+      match_confidence: candidate.confidence || 1.0,
+      # A cached candidate was written from a provider lookup, never from the
+      # local database, so auto-import accounting counts it as external.
+      from_local_db: false,
+      parsed_info: parsed_info(candidate)
+    }
+  end
+
+  @doc "Maps the two provider strings this column legitimately holds, nil otherwise."
+  @spec known_provider(String.t() | nil) :: :tmdb | :tvdb | nil
+  def known_provider("tmdb"), do: :tmdb
+  def known_provider("tvdb"), do: :tvdb
+  def known_provider(_other), do: nil
+
+  @doc "Rebuilds the atom-keyed parsed_info shape from the stored JSON map."
+  @spec parsed_info(t()) :: %{
+          type: :movie | :tv_show,
+          season: integer() | nil,
+          episodes: [integer()]
+        }
+  def parsed_info(%__MODULE__{} = candidate) do
+    stored = candidate.parsed_info || %{}
+
+    %{
+      type: media_type_atom(candidate.media_type),
+      season: Map.get(stored, "season"),
+      episodes: Map.get(stored, "episodes") || []
+    }
+  end
+
+  @doc "The two media types this column holds, defaulting to movie."
+  @spec media_type_atom(String.t() | nil) :: :movie | :tv_show
+  def media_type_atom("tv_show"), do: :tv_show
+  def media_type_atom(_other), do: :movie
 end

--- a/lib/mydia/library/orphan_reenricher.ex
+++ b/lib/mydia/library/orphan_reenricher.ex
@@ -1,0 +1,168 @@
+defmodule Mydia.Library.OrphanReenricher do
+  @moduledoc """
+  Decides what a scan does with the media files it finds already orphaned.
+
+  Extracted from `Jobs.LibraryScanner`, where it was roughly forty lines of
+  inline work in a module too large to test, reachable only through a job
+  tagged `:external` and excluded from the default suite.
+
+  Two things were wrong with it.
+
+  It re-paid the relay for answers it already had. `Library.MetadataMatcher`
+  never consults `Library.MatchCandidate`, so every scheduled scan issued a
+  fresh match for every orphan a library had ever accumulated, including the
+  ones already matched. `Library.unmatched_media_files_query/2` has skipped
+  exactly those files for `Jobs.ImportRun` all along; this brings the same rule
+  here.
+
+  And it lied about its results: it discarded the outcome of each attempt and
+  reported every orphan it merely located on disk as fixed, which is what
+  `orphaned_files_fixed` has always counted.
+
+  ## The decision, per orphan
+
+      Cached rank-0 candidate      | auto_import: false | auto_import: true
+      -----------------------------|--------------------|---------------------------
+      Real match (provider_id set) | skip, no relay     | link from cache, no relay
+      Failed, inside next_retry_at | skip               | skip
+      Failed expired, or none      | fresh match         | fresh match
+
+  `FileIngest.ingest/3` applies the confidence threshold itself, so a cached
+  candidate below it comes back as `{:candidate, _}` and is simply not counted
+  as fixed. There is deliberately no threshold check here.
+
+  This module must not reference `Jobs.LibraryScanner`: the scanner passes its
+  own re-enrich function in as `:reenrich`, which is also the seam the tests
+  use to prove that no relay call happened.
+  """
+
+  require Logger
+
+  alias Mydia.Library
+  alias Mydia.Library.{FileIngest, MatchCandidate, MediaFile}
+  alias Mydia.Metadata
+
+  @type stats :: %{
+          fixed: non_neg_integer(),
+          auto_linked: non_neg_integer(),
+          relay_matches: non_neg_integer()
+        }
+
+  @empty %{fixed: 0, auto_linked: 0, relay_matches: 0}
+
+  @doc """
+  Runs the decision above over every orphan, returning what actually happened.
+
+  `file_info_by_path` maps an absolute path to the scan's file info for it. An
+  orphan absent from that map is not on disk in this scan and is left alone,
+  which is the one piece of the old branch's behavior worth keeping.
+
+  ## Options
+
+    * `:reenrich` - `(MediaFile.t(), map(), map() -> {:ok, atom()} | {:error, term()})`,
+      the fresh-match path. Required in tests, defaulted by the scanner.
+    * `:config` - relay config, defaults to `Metadata.default_relay_config/0`.
+    * `:now` - clock for backoff comparisons, defaults to `DateTime.utc_now/0`.
+  """
+  @spec run(Mydia.Settings.LibraryPath.t(), [MediaFile.t()], %{String.t() => map()}, keyword()) ::
+          stats()
+  def run(_library_path, [], _file_info_by_path, _opts), do: @empty
+
+  def run(library_path, orphans, file_info_by_path, opts) do
+    reenrich = Keyword.fetch!(opts, :reenrich)
+    config = Keyword.get(opts, :config) || Metadata.default_relay_config()
+    now = Keyword.get(opts, :now) || DateTime.utc_now()
+
+    candidates = Library.rank_zero_candidates_by_file_id(Enum.map(orphans, & &1.id))
+
+    Enum.reduce(orphans, @empty, fn media_file, stats ->
+      # Built from the library path argument, never MediaFile.absolute_path/1:
+      # that helper returns nil with a warning when :library_path is not
+      # preloaded, and these orphans arrive unpreloaded. Using it here would
+      # make every lookup miss, decide every orphan :absent, and do nothing at
+      # all, silently.
+      file_info =
+        Map.get(file_info_by_path, Path.join(library_path.path, media_file.relative_path))
+
+      media_file
+      |> decide(Map.get(candidates, media_file.id), library_path, file_info, now)
+      |> apply_decision(media_file, file_info, library_path, config, reenrich)
+      |> tally(stats)
+    end)
+  end
+
+  ## Decision
+
+  defp decide(_media_file, _candidate, _library_path, nil, _now), do: :absent
+
+  defp decide(media_file, %MatchCandidate{provider_id: id} = candidate, library_path, _info, _now)
+       when not is_nil(id) do
+    case FileIngest.policy_for(library_path, media_file) do
+      :create_items -> {:link_from_cache, candidate}
+      :local_only -> :cached
+    end
+  end
+
+  defp decide(_media_file, %MatchCandidate{next_retry_at: %DateTime{} = retry}, _lp, _info, now) do
+    if DateTime.compare(retry, now) == :gt, do: :backoff, else: :rematch
+  end
+
+  # A NULL next_retry_at means a failure recorded before the backoff shipped.
+  # Treating it as "not yet due" would strand that entire backlog, since being
+  # excluded here is what stops a new failure from ever populating the column.
+  defp decide(_media_file, _candidate, _library_path, _file_info, _now), do: :rematch
+
+  ## Commit
+
+  defp apply_decision({:link_from_cache, candidate}, media_file, _info, _lp, config, _reenrich) do
+    media_file = Mydia.Repo.preload(media_file, :library_path)
+
+    case FileIngest.ingest(media_file, MatchCandidate.to_match(candidate),
+           policy: :create_items,
+           config: config
+         ) do
+      {:linked, _item} ->
+        :auto_linked
+
+      other ->
+        Logger.debug("Cached candidate did not link",
+          media_file_id: media_file.id,
+          outcome: inspect(other)
+        )
+
+        :unresolved
+    end
+  end
+
+  defp apply_decision(:rematch, media_file, file_info, _lp, config, reenrich) do
+    case reenrich.(media_file, file_info, config) do
+      {:ok, :auto_linked} -> :relayed_auto_linked
+      {:ok, _other} -> :relayed_fixed
+      _error -> :relayed_unresolved
+    end
+  end
+
+  defp apply_decision(skipped, _media_file, _info, _lp, _config, _reenrich), do: skipped
+
+  ## Tally
+
+  defp tally(:auto_linked, stats),
+    do: %{stats | fixed: stats.fixed + 1, auto_linked: stats.auto_linked + 1}
+
+  defp tally(:relayed_auto_linked, stats),
+    do: %{
+      stats
+      | fixed: stats.fixed + 1,
+        auto_linked: stats.auto_linked + 1,
+        relay_matches: stats.relay_matches + 1
+    }
+
+  defp tally(:relayed_fixed, stats),
+    do: %{stats | fixed: stats.fixed + 1, relay_matches: stats.relay_matches + 1}
+
+  defp tally(:relayed_unresolved, stats),
+    do: %{stats | relay_matches: stats.relay_matches + 1}
+
+  # :absent, :cached, :backoff and :unresolved all changed nothing.
+  defp tally(_outcome, stats), do: stats
+end

--- a/lib/mydia/library/scan_summary.ex
+++ b/lib/mydia/library/scan_summary.ex
@@ -9,14 +9,20 @@ defmodule Mydia.Library.ScanSummary do
 
   `details` carries the processor's own return value unchanged, so data such as
   `new_media_files` stays reachable by the code that already relies on it.
+
+  `auto_linked` counts files this scan linked only because the library has
+  `auto_import` enabled, across both the new-file stream and the orphan
+  re-enrichment branch. It is a subset of the files the scan touched, not a
+  separate kind of change.
   """
 
   @type t :: %__MODULE__{
           new_files: non_neg_integer(),
           modified_files: non_neg_integer(),
           deleted_files: non_neg_integer(),
+          auto_linked: non_neg_integer(),
           details: map()
         }
 
-  defstruct new_files: 0, modified_files: 0, deleted_files: 0, details: %{}
+  defstruct new_files: 0, modified_files: 0, deleted_files: 0, auto_linked: 0, details: %{}
 end

--- a/lib/mydia_web/live/admin_library_paths_live/components.ex
+++ b/lib/mydia_web/live/admin_library_paths_live/components.ex
@@ -202,7 +202,9 @@ defmodule MydiaWeb.AdminLibraryPathsLive.Components do
                     <.icon name="hero-arrow-down-tray" class="w-4 h-4 text-base-content/60" />
                     <div>
                       <span class="text-sm font-medium">Auto Import</span>
-                      <p class="text-xs text-base-content/50">Import new files automatically</p>
+                      <p class="text-xs text-base-content/50">
+                        Let background scans import confident matches
+                      </p>
                     </div>
                   </div>
                   <input type="hidden" name={@library_path_form[:auto_import].name} value="false" />

--- a/lib/mydia_web/live/import_media_live/run_control.ex
+++ b/lib/mydia_web/live/import_media_live/run_control.ex
@@ -79,7 +79,9 @@ defmodule MydiaWeb.ImportMediaLive.RunControl do
           phx-update="ignore"
           class="toggle toggle-primary toggle-sm"
         />
-        <span class="text-sm font-medium whitespace-nowrap">Automatically import confident matches</span>
+        <span class="text-sm font-medium whitespace-nowrap">
+          Automatically import confident matches in this run
+        </span>
       </label>
 
       <.button id="start-run-button" type="submit" variant="primary">

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -584,7 +584,8 @@ defmodule MydiaWeb.MediaLive.Index do
            type: scan_type,
            new_files: new_files,
            modified_files: modified_files,
-           deleted_files: deleted_files
+           deleted_files: deleted_files,
+           auto_linked: auto_linked
          }},
         socket
       ) do
@@ -599,18 +600,13 @@ defmodule MydiaWeb.MediaLive.Index do
 
     socket =
       if should_process do
-        total_changes = new_files + modified_files + deleted_files
-
         message =
-          if total_changes > 0 do
-            parts = []
-            parts = if new_files > 0, do: ["#{new_files} new" | parts], else: parts
-            parts = if modified_files > 0, do: ["#{modified_files} modified" | parts], else: parts
-            parts = if deleted_files > 0, do: ["#{deleted_files} removed" | parts], else: parts
-            "Library scan completed: " <> Enum.join(parts, ", ")
-          else
-            "Library scan completed: No changes detected"
-          end
+          scan_completed_message(%{
+            new_files: new_files,
+            modified_files: modified_files,
+            deleted_files: deleted_files,
+            auto_linked: auto_linked
+          })
 
         socket
         |> assign(:scanning, false)
@@ -1058,4 +1054,34 @@ defmodule MydiaWeb.MediaLive.Index do
        do: "#{downloaded}/#{total} episodes"
 
   defp format_episode_count(_), do: nil
+
+  @doc false
+  # Public so the copy can be unit-tested without mounting the LiveView.
+  #
+  # `auto_linked` is a subset of the files a scan touched, so it is appended as
+  # detail and kept out of the change total. It is also counted on its own,
+  # because the orphan branch links existing files: a scan can auto-import
+  # without any on-disk change at all, and reporting "No changes detected"
+  # there would hide the exact work the flag was turned on for.
+  @spec scan_completed_message(map()) :: String.t()
+  def scan_completed_message(%{
+        new_files: new_files,
+        modified_files: modified_files,
+        deleted_files: deleted_files,
+        auto_linked: auto_linked
+      }) do
+    parts = []
+    parts = if new_files > 0, do: ["#{new_files} new" | parts], else: parts
+    parts = if modified_files > 0, do: ["#{modified_files} modified" | parts], else: parts
+    parts = if deleted_files > 0, do: ["#{deleted_files} removed" | parts], else: parts
+
+    parts =
+      if auto_linked > 0, do: parts ++ ["#{auto_linked} imported automatically"], else: parts
+
+    if parts == [] do
+      "Library scan completed: No changes detected"
+    else
+      "Library scan completed: " <> Enum.join(parts, ", ")
+    end
+  end
 end

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -302,7 +302,9 @@ defmodule MydiaWeb.Schema.CommonTypes do
     field :scan_interval, :integer, description: "Scan interval in seconds"
     field :last_scan_at, :datetime, description: "Last scan timestamp"
     field :auto_organize, non_null(:boolean), description: "Whether auto-organization is enabled"
-    field :auto_import, non_null(:boolean), description: "Whether auto-import is enabled"
+
+    field :auto_import, non_null(:boolean),
+      description: "Whether background scans of this library import confident matches"
 
     field :write_nfo, non_null(:boolean),
       description: "Whether NFO files are written alongside media"

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -968,7 +968,7 @@ type LibraryPath implements Node {
   "Whether auto-organization is enabled"
   autoOrganize: Boolean!
 
-  "Whether auto-import is enabled"
+  "Whether background scans of this library import confident matches"
   autoImport: Boolean!
 
   "Whether NFO files are written alongside media"

--- a/test/mydia/jobs/library_scanner_import_groups_test.exs
+++ b/test/mydia/jobs/library_scanner_import_groups_test.exs
@@ -19,6 +19,8 @@ defmodule Mydia.Jobs.LibraryScannerImportGroupsTest do
   alias Mydia.ImportGroups
   alias Mydia.Jobs.LibraryScanner
   alias Mydia.Library
+  alias Mydia.Library.MatchCandidate
+  alias Mydia.Repo
 
   defp orphan_with_candidate(library_path, opts) do
     file =
@@ -40,6 +42,69 @@ defmodule Mydia.Jobs.LibraryScannerImportGroupsTest do
       })
 
     file
+  end
+
+  # `ImportGroup.changeset/2` refuses a `min_confidence` outside [0.0, 1.0]
+  # via `validate_number/3`, and every real write path
+  # (`Library.upsert_match_candidate/1`) runs `MatchCandidate.changeset/2`,
+  # which enforces that same range on `confidence` before a row can ever be
+  # written. So the only way to get an out-of-range value into the table at
+  # all is to skip the module's own changeset, which is what this does: it
+  # builds the insert with `Ecto.Changeset.change/2` directly instead of
+  # `MatchCandidate.changeset/2`.
+  defp orphan_with_out_of_range_confidence(library_path, opts) do
+    file =
+      orphaned_media_file_fixture(%{
+        library_path_id: library_path.id,
+        relative_path: Keyword.fetch!(opts, :relative_path)
+      })
+
+    %MatchCandidate{}
+    |> Ecto.Changeset.change(%{
+      media_file_id: file.id,
+      rank: 0,
+      provider_type: "tmdb",
+      provider_id: Keyword.fetch!(opts, :provider_id),
+      title: Keyword.fetch!(opts, :title),
+      year: 1999,
+      media_type: "movie",
+      confidence: 5.0
+    })
+    |> Repo.insert!()
+
+    file
+  end
+
+  test "an exception while rebuilding groups is caught and does not crash the scan" do
+    # This is not a reproduction of the real failure mode described in the
+    # code review finding (a genuine unique-constraint collision from a
+    # rebuild racing a freshly started import run's own upsert on the same
+    # cluster_key). That race needs two processes interleaved between
+    # write_group/4's existence check and its insert, which is not
+    # reproducible deterministically against the sandboxed test connection
+    # (both sides would serialize onto the same connection and the race
+    # window would never open).
+    #
+    # Instead this forces `ImportGroup.changeset/2`'s existing
+    # `validate_number(:min_confidence, ...)` to fail by smuggling an
+    # out-of-range confidence into `write_group/4`'s attrs (see
+    # `orphan_with_out_of_range_confidence/2`). An invalid changeset makes
+    # `Repo.insert_or_update/1` return `{:error, changeset}` without ever
+    # touching the database, which is the exact same shape write_group/4's
+    # hard match `{:ok, group} = Repo.insert_or_update()` fails on for a real
+    # unique-constraint collision: both raise a MatchError from that one
+    # line. So while the trigger is artificial, the exception this test
+    # proves gets caught is the same MatchError the real race produces.
+    library_path = library_path_fixture(%{type: "movies"})
+
+    orphan_with_out_of_range_confidence(library_path,
+      relative_path: "Broken (2000)/broken.2000.mkv",
+      provider_id: "1",
+      title: "Broken"
+    )
+
+    assert LibraryScanner.rebuild_import_groups(library_path) == :error
+    assert ImportGroups.count_pending() == 0
   end
 
   test "a scan rebuild makes matched orphans visible as groups" do

--- a/test/mydia/jobs/library_scanner_import_groups_test.exs
+++ b/test/mydia/jobs/library_scanner_import_groups_test.exs
@@ -1,0 +1,106 @@
+defmodule Mydia.Jobs.LibraryScannerImportGroupsTest do
+  @moduledoc """
+  A scheduled scan writes `MatchCandidate` rows, but the `/import` inbox renders
+  `ImportGroup` rows, and nothing built the second from the first unless a human
+  started an import run. That is why a library could hold hundreds of matched
+  orphans while `/import` said "Nothing to review".
+
+  `upsert_for_library/2` is idempotent and preserves human decisions, so the
+  scan can simply call it. The one thing it must not do is run while an import
+  run is in flight: `write_group/4` does not strip `:import_run_id` from an
+  existing row, so a rebuild with no run id would detach that run's own groups
+  from it mid-run.
+  """
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.ImportGroups
+  alias Mydia.Jobs.LibraryScanner
+  alias Mydia.Library
+
+  defp orphan_with_candidate(library_path, opts) do
+    file =
+      orphaned_media_file_fixture(%{
+        library_path_id: library_path.id,
+        relative_path: Keyword.fetch!(opts, :relative_path)
+      })
+
+    {:ok, _candidate} =
+      Library.upsert_match_candidate(%{
+        media_file_id: file.id,
+        rank: 0,
+        provider_type: "tmdb",
+        provider_id: Keyword.fetch!(opts, :provider_id),
+        title: Keyword.fetch!(opts, :title),
+        year: 1999,
+        media_type: "movie",
+        confidence: Keyword.get(opts, :confidence, 0.95)
+      })
+
+    file
+  end
+
+  test "a scan rebuild makes matched orphans visible as groups" do
+    library_path = library_path_fixture(%{type: "movies"})
+
+    orphan_with_candidate(library_path,
+      relative_path: "The Matrix (1999)/The.Matrix.1999.mkv",
+      provider_id: "603",
+      title: "The Matrix"
+    )
+
+    assert ImportGroups.count_pending() == 0
+
+    assert {:ok, %{groups: groups}} = LibraryScanner.rebuild_import_groups(library_path)
+    assert groups >= 1
+    assert ImportGroups.count_pending() > 0
+  end
+
+  test "an orphan with no candidate at all still gets a group" do
+    # The left join in unresolved_base/1 is what makes this work. A file the
+    # matcher has never resolved is exactly the file an operator most needs to
+    # see, so it must not be filtered out for lacking a candidate.
+    library_path = library_path_fixture(%{type: "movies"})
+
+    orphaned_media_file_fixture(%{
+      library_path_id: library_path.id,
+      relative_path: "Unknown Thing/unknown.thing.mkv"
+    })
+
+    assert {:ok, %{groups: groups}} = LibraryScanner.rebuild_import_groups(library_path)
+    assert groups >= 1
+  end
+
+  test "the rebuild is skipped while an import run is active" do
+    library_path = library_path_fixture(%{type: "movies"})
+
+    orphan_with_candidate(library_path,
+      relative_path: "Heat (1995)/heat.1995.mkv",
+      provider_id: "949",
+      title: "Heat"
+    )
+
+    {:ok, _run} =
+      Library.create_import_run(%{library_path_id: library_path.id, mode: :review})
+
+    assert LibraryScanner.rebuild_import_groups(library_path) == :skipped
+  end
+
+  test "rebuilding twice is idempotent and does not duplicate groups" do
+    library_path = library_path_fixture(%{type: "movies"})
+
+    orphan_with_candidate(library_path,
+      relative_path: "Alien (1979)/alien.1979.mkv",
+      provider_id: "348",
+      title: "Alien"
+    )
+
+    assert {:ok, %{groups: first}} = LibraryScanner.rebuild_import_groups(library_path)
+    assert {:ok, %{groups: second}} = LibraryScanner.rebuild_import_groups(library_path)
+
+    assert first == second
+    assert ImportGroups.count_pending() == first
+  end
+end

--- a/test/mydia/jobs/library_scanner_ingest_test.exs
+++ b/test/mydia/jobs/library_scanner_ingest_test.exs
@@ -109,33 +109,64 @@ defmodule Mydia.Jobs.LibraryScannerIngestTest do
     end
   end
 
-  describe "scan_result_from_ingest/1" do
-    test "maps a link to the enriched contract" do
-      assert LibraryScanner.scan_result_from_ingest({:linked, %Mydia.Media.MediaItem{}}) ==
+  describe "auto_linked?/2" do
+    test "an external match under :create_items is a link auto-import caused" do
+      assert LibraryScanner.auto_linked?(:create_items, %{from_local_db: false})
+    end
+
+    test "a local match under :create_items would have linked anyway" do
+      refute LibraryScanner.auto_linked?(:create_items, %{from_local_db: true})
+    end
+
+    test "a match missing the key is treated as external" do
+      assert LibraryScanner.auto_linked?(:create_items, %{})
+    end
+
+    test "nothing under :local_only counts, whatever the match says" do
+      refute LibraryScanner.auto_linked?(:local_only, %{from_local_db: false})
+      refute LibraryScanner.auto_linked?(:local_only, %{from_local_db: true})
+    end
+  end
+
+  describe "scan_result_from_ingest/2" do
+    test "maps a local link to the enriched contract" do
+      assert LibraryScanner.scan_result_from_ingest({:linked, %Mydia.Media.MediaItem{}}, false) ==
                {:ok, :enriched}
     end
 
+    test "maps an auto-import link to its own atom so it can be counted" do
+      assert LibraryScanner.scan_result_from_ingest({:linked, %Mydia.Media.MediaItem{}}, true) ==
+               {:ok, :auto_linked}
+    end
+
     test "maps a cached candidate to :no_local_match" do
-      assert LibraryScanner.scan_result_from_ingest({:candidate, %Library.MatchCandidate{}}) ==
+      assert LibraryScanner.scan_result_from_ingest(
+               {:candidate, %Library.MatchCandidate{}},
+               false
+             ) ==
                {:error, :no_local_match}
     end
 
     test "maps a library type mismatch to its own atom, ahead of the generic error clause" do
       assert LibraryScanner.scan_result_from_ingest(
-               {:error, {:library_type_mismatch, "series file in a movies-only library"}}
+               {:error, {:library_type_mismatch, "series file in a movies-only library"}},
+               false
              ) == {:error, :library_type_mismatch}
     end
 
     test "maps any other error to :enrichment_failed" do
-      assert LibraryScanner.scan_result_from_ingest({:error, :some_other_reason}) ==
+      assert LibraryScanner.scan_result_from_ingest({:error, :some_other_reason}, false) ==
                {:error, :enrichment_failed}
 
-      assert LibraryScanner.scan_result_from_ingest({:error, {:metadata_fetch_failed, :timeout}}) ==
-               {:error, :enrichment_failed}
+      assert LibraryScanner.scan_result_from_ingest(
+               {:error, {:metadata_fetch_failed, :timeout}},
+               false
+             ) == {:error, :enrichment_failed}
     end
 
     test "maps :no_match to :no_matches_found" do
-      assert LibraryScanner.scan_result_from_ingest(:no_match) == {:error, :no_matches_found}
+      assert LibraryScanner.scan_result_from_ingest(:no_match, false) ==
+               {:error, :no_matches_found}
     end
   end
 end

--- a/test/mydia/jobs/library_scanner_ingest_test.exs
+++ b/test/mydia/jobs/library_scanner_ingest_test.exs
@@ -1,8 +1,10 @@
 defmodule Mydia.Jobs.LibraryScannerIngestTest do
   @moduledoc """
-  Pins the contract between the scheduled scan and `FileIngest`: an external
-  provider match must never create a `MediaItem` from the cron scan, and it
-  must leave a cached candidate behind so the import inbox can offer it.
+  Pins the contract between the scheduled scan and `FileIngest`: on a library
+  that has not opted into auto-import, an external provider match must never
+  create a `MediaItem` from the cron scan, and it must leave a cached candidate
+  behind so the import inbox can offer it. `FileIngest.policy_for/2` is what
+  decides which libraries those are.
 
   This exercises `FileIngest.ingest/3` directly with `policy: :local_only`,
   which is exactly what `Jobs.LibraryScanner.match_file_to_existing_items/4`

--- a/test/mydia/jobs/library_scanner_test.exs
+++ b/test/mydia/jobs/library_scanner_test.exs
@@ -144,4 +144,17 @@ defmodule Mydia.Jobs.LibraryScannerTest do
     on_exit(fn -> File.rm_rf(path) end)
     path
   end
+
+  describe "ScanSummary auto_linked" do
+    test "defaults to zero so a scan that imported nothing reports nothing" do
+      assert %ScanSummary{}.auto_linked == 0
+    end
+
+    test "carries a count independent of the new-file count" do
+      summary = %ScanSummary{new_files: 5, auto_linked: 2}
+
+      assert summary.auto_linked == 2
+      assert summary.new_files == 5
+    end
+  end
 end

--- a/test/mydia/jobs/scan_makes_orphans_visible_test.exs
+++ b/test/mydia/jobs/scan_makes_orphans_visible_test.exs
@@ -1,0 +1,56 @@
+defmodule Mydia.Jobs.ScanMakesOrphansVisibleTest do
+  @moduledoc """
+  The acceptance test for the whole change: a library holding orphans with
+  cached matches must render groups in the import inbox after a scan rebuild,
+  with no import run involved.
+
+  This is the shape that was broken. A production library held hundreds of
+  matched orphans while /import said there was nothing to review, because the
+  scan cached matches as MatchCandidate rows and nothing ever built the
+  ImportGroup rows the inbox renders.
+  """
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.ImportGroups
+  alias Mydia.Jobs.LibraryScanner
+  alias Mydia.Library
+
+  test "matched and unmatched orphans both become visible, with no import run" do
+    library_path = library_path_fixture(%{type: "movies", auto_import: false})
+
+    matched =
+      orphaned_media_file_fixture(%{
+        library_path_id: library_path.id,
+        relative_path: "The Matrix (1999)/matrix.mkv"
+      })
+
+    {:ok, _} =
+      Library.upsert_match_candidate(%{
+        media_file_id: matched.id,
+        rank: 0,
+        provider_type: "tmdb",
+        provider_id: "603",
+        title: "The Matrix",
+        year: 1999,
+        media_type: "movie",
+        confidence: 0.95
+      })
+
+    _unmatched =
+      orphaned_media_file_fixture(%{
+        library_path_id: library_path.id,
+        relative_path: "Mystery Thing/mystery.mkv"
+      })
+
+    assert ImportGroups.count_pending() == 0
+    assert Library.active_import_run(library_path.id) == nil
+
+    assert {:ok, %{groups: groups}} = LibraryScanner.rebuild_import_groups(library_path)
+
+    assert groups >= 2
+    assert ImportGroups.count_pending() >= 2
+  end
+end

--- a/test/mydia/library/file_ingest_test.exs
+++ b/test/mydia/library/file_ingest_test.exs
@@ -13,9 +13,11 @@ defmodule Mydia.Library.FileIngestTest do
   alias Mydia.Library
   alias Mydia.Library.FileIngest
   alias Mydia.Library.MatchCandidate
+  alias Mydia.Library.MediaFile
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.Structs.ParsedFileInfo
   alias Mydia.Library.Structs.Quality
+  alias Mydia.Settings.LibraryPath
 
   defp match(overrides) do
     Map.merge(
@@ -339,6 +341,36 @@ defmodule Mydia.Library.FileIngestTest do
   describe "auto-link threshold" do
     test "links at 0.85 and holds below it" do
       assert FileIngest.default_threshold() == 0.85
+    end
+  end
+
+  describe "policy_for/2" do
+    test "an auto-import library holding a regular file creates items" do
+      library_path = %LibraryPath{auto_import: true}
+      file = %MediaFile{extra_kind: nil}
+
+      assert FileIngest.policy_for(library_path, file) == :create_items
+    end
+
+    test "a library without auto-import keeps the historical local-only policy" do
+      assert FileIngest.policy_for(%LibraryPath{auto_import: false}, %MediaFile{}) ==
+               :local_only
+    end
+
+    test "a nil library path fails closed" do
+      assert FileIngest.policy_for(nil, %MediaFile{}) == :local_only
+    end
+
+    test "an extra is never auto-imported, even on an auto-import library" do
+      # The regression this clause exists for. Nothing filters extras out of
+      # the enrichment stream on the new-file branch, so without it a trailer
+      # with an above-threshold external match would create a MediaItem.
+      library_path = %LibraryPath{auto_import: true}
+
+      for kind <- [:trailer, :sample, :featurette, :behind_the_scenes] do
+        assert FileIngest.policy_for(library_path, %MediaFile{extra_kind: kind}) == :local_only,
+               "#{kind} must not be auto-imported"
+      end
     end
   end
 end

--- a/test/mydia/library/match_candidate_test.exs
+++ b/test/mydia/library/match_candidate_test.exs
@@ -4,6 +4,7 @@ defmodule Mydia.Library.MatchCandidateTest do
   import Mydia.MediaFixtures
 
   alias Mydia.Library
+  alias Mydia.Library.MatchCandidate
 
   describe "upsert_match_candidate/1" do
     test "creates a candidate for a media file" do
@@ -86,6 +87,93 @@ defmodule Mydia.Library.MatchCandidateTest do
 
       assert {3, nil} = Library.delete_match_candidates(file.id)
       assert Library.list_match_candidates(file.id) == []
+    end
+  end
+
+  # `to_match/1` is the single conversion from a stored candidate to the map
+  # `FileIngest.ingest/3` expects. It carries two traps that predate it.
+  #
+  # `provider_type` is free text with no inclusion validation, so it can hold a
+  # value this VM has never interned as an atom.
+  #
+  # `parsed_info` round-trips through JSON, so its keys and its "type" value come
+  # back as strings, while `MetadataEnricher.determine_media_type/1` matches atom
+  # keys and an atom value. Passing the stored map through unchanged silently
+  # classifies every file as a movie.
+  describe "to_match/1" do
+    defp candidate(overrides \\ %{}) do
+      struct!(
+        %MatchCandidate{
+          provider_type: "tmdb",
+          provider_id: "603",
+          title: "The Matrix",
+          year: 1999,
+          media_type: "movie",
+          confidence: 0.97,
+          parsed_info: %{}
+        },
+        overrides
+      )
+    end
+
+    test "carries the provider fields and confidence through" do
+      match = MatchCandidate.to_match(candidate())
+
+      assert match.provider_id == "603"
+      assert match.provider_type == :tmdb
+      assert match.title == "The Matrix"
+      assert match.year == 1999
+      assert match.match_confidence == 0.97
+    end
+
+    test "a cached candidate is never a local-database match" do
+      # It was written from a provider lookup, so auto-import counting must see
+      # it as externally sourced.
+      assert MatchCandidate.to_match(candidate()).from_local_db == false
+    end
+
+    test "maps the two real providers and defaults anything else" do
+      assert MatchCandidate.to_match(candidate(%{provider_type: "tvdb"})).provider_type == :tvdb
+      assert MatchCandidate.to_match(candidate(%{provider_type: "tmdb"})).provider_type == :tmdb
+    end
+
+    test "an unknown provider_type never raises" do
+      # String.to_existing_atom/1 on this column could raise for a value this VM
+      # has never interned. The column has no inclusion validation.
+      match = MatchCandidate.to_match(candidate(%{provider_type: "wikidata-scraper"}))
+
+      assert match.provider_type == :tvdb
+    end
+
+    test "a nil provider_type defaults rather than crashing" do
+      assert MatchCandidate.to_match(candidate(%{provider_type: nil})).provider_type == :tvdb
+    end
+
+    test "rebuilds parsed_info with atom keys and an atom type" do
+      # The stored map has string keys after its JSON round trip.
+      # MetadataEnricher.determine_media_type/1 matches atom keys, so passing the
+      # stored shape through would classify this TV file as a movie.
+      match =
+        MatchCandidate.to_match(
+          candidate(%{
+            media_type: "tv_show",
+            parsed_info: %{"season" => 2, "episodes" => [5, 6], "type" => "tv_show"}
+          })
+        )
+
+      assert match.parsed_info == %{type: :tv_show, season: 2, episodes: [5, 6]}
+    end
+
+    test "a movie candidate gets the movie type and empty episodes" do
+      match = MatchCandidate.to_match(candidate(%{media_type: "movie", parsed_info: %{}}))
+
+      assert match.parsed_info == %{type: :movie, season: nil, episodes: []}
+    end
+
+    test "a nil parsed_info is treated as an empty one" do
+      match = MatchCandidate.to_match(candidate(%{parsed_info: nil}))
+
+      assert match.parsed_info == %{type: :movie, season: nil, episodes: []}
     end
   end
 end

--- a/test/mydia/library/orphan_reenricher_test.exs
+++ b/test/mydia/library/orphan_reenricher_test.exs
@@ -1,0 +1,270 @@
+defmodule Mydia.Library.OrphanReenricherTest do
+  @moduledoc """
+  The orphan branch was wrong in two independent ways.
+
+  It called the relay for every orphan on every scan, including the ones whose
+  answer was already cached, because `MetadataMatcher` never consults
+  `MatchCandidate`. And it discarded the outcome of the work it did, reporting
+  every orphan it merely located on disk as "fixed".
+
+  These tests assert relay calls by counting invocations of an injected
+  re-enrich function, so "no relay call" is proven rather than assumed.
+  """
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library
+  alias Mydia.Library.OrphanReenricher
+
+  defp orphan(library_path, name) do
+    orphaned_media_file_fixture(%{
+      library_path_id: library_path.id,
+      relative_path: "#{name}/#{name}.mkv"
+    })
+  end
+
+  defp cache_match(file, attrs) do
+    {:ok, _} =
+      Library.upsert_match_candidate(
+        Map.merge(
+          %{
+            media_file_id: file.id,
+            rank: 0,
+            provider_type: "tmdb",
+            provider_id: "603",
+            title: "The Matrix",
+            year: 1999,
+            media_type: "movie",
+            confidence: 0.97
+          },
+          attrs
+        )
+      )
+  end
+
+  defp cache_failure(file, next_retry_at) do
+    {:ok, _} =
+      Library.upsert_match_candidate(%{
+        media_file_id: file.id,
+        rank: 0,
+        attempts: 1,
+        last_error: "no_match",
+        next_retry_at: next_retry_at
+      })
+  end
+
+  # Records every call so a test can assert the relay was not touched.
+  defp counting_reenrich(pid) do
+    fn media_file, _file_info, _config ->
+      send(pid, {:reenriched, media_file.id})
+      {:error, :no_matches_found}
+    end
+  end
+
+  defp file_infos(files, library_path) do
+    Map.new(files, fn file ->
+      {Path.join(library_path.path, file.relative_path), %{path: file.relative_path, size: 1}}
+    end)
+  end
+
+  describe "a library without auto-import" do
+    test "skips an orphan whose match is already cached, with no relay call" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "matrix")
+      cache_match(file, %{})
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      refute_receive {:reenriched, _}, 100
+      assert stats.relay_matches == 0
+      assert stats.fixed == 0
+      assert stats.auto_linked == 0
+    end
+
+    test "re-matches an orphan with no candidate at all" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "unknown")
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      assert_receive {:reenriched, id}, 100
+      assert id == file.id
+      assert stats.relay_matches == 1
+    end
+  end
+
+  describe "backoff on a failed candidate" do
+    test "skips a failure whose retry window has not passed" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "failed")
+
+      cache_failure(
+        file,
+        DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+      )
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      refute_receive {:reenriched, _}, 100
+      assert stats.relay_matches == 0
+    end
+
+    test "retries a failure whose window has passed" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "expired")
+
+      cache_failure(
+        file,
+        DateTime.utc_now() |> DateTime.add(-3600, :second) |> DateTime.truncate(:second)
+      )
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      assert_receive {:reenriched, _}, 100
+      assert stats.relay_matches == 1
+    end
+
+    test "retries a failure with no window recorded at all" do
+      # A NULL next_retry_at means a failure recorded before the backoff
+      # shipped. Treating it as "not yet due" would strand that backlog.
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "nullwindow")
+      cache_failure(file, nil)
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      assert_receive {:reenriched, _}, 100
+      assert stats.relay_matches == 1
+    end
+  end
+
+  describe "a library with auto-import" do
+    test "links a cached above-threshold match without touching the relay" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: true})
+      item = media_item_fixture(%{type: "movie", tmdb_id: 603, title: "The Matrix"})
+      file = orphan(library_path, "matrix")
+      cache_match(file, %{confidence: 0.97})
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      refute_receive {:reenriched, _}, 100
+      assert stats.relay_matches == 0
+      assert stats.fixed == 1
+      assert stats.auto_linked == 1
+      assert Library.get_media_file!(file.id).media_item_id == item.id
+    end
+
+    test "leaves a cached below-threshold match unlinked and uncounted" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: true})
+      _item = media_item_fixture(%{type: "movie", tmdb_id: 603, title: "The Matrix"})
+      file = orphan(library_path, "lowconf")
+      cache_match(file, %{confidence: 0.55})
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      assert stats.relay_matches == 0
+      assert stats.fixed == 0
+      assert stats.auto_linked == 0
+      assert Library.get_media_file!(file.id).media_item_id == nil
+    end
+
+    test "an extra is never linked from cache" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: true})
+      _item = media_item_fixture(%{type: "movie", tmdb_id: 603, title: "The Matrix"})
+
+      file =
+        orphaned_media_file_fixture(%{
+          library_path_id: library_path.id,
+          relative_path: "matrix/trailer.mkv",
+          extra_kind: :trailer,
+          extra_source: :filename
+        })
+
+      cache_match(file, %{confidence: 0.99})
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: counting_reenrich(self())
+        )
+
+      assert stats.auto_linked == 0
+      assert Library.get_media_file!(file.id).media_item_id == nil
+    end
+  end
+
+  describe "honest counting" do
+    test "a file the re-enrich attempt failed on is not counted as fixed" do
+      # The regression against the previous behavior, which returned true
+      # whenever the file was found on disk regardless of outcome.
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "stillbroken")
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: fn _f, _i, _c -> {:error, :no_matches_found} end
+        )
+
+      assert stats.relay_matches == 1
+      assert stats.fixed == 0
+    end
+
+    test "a file the re-enrich attempt linked is counted as fixed" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "fixed")
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: fn _f, _i, _c -> {:ok, :enriched} end
+        )
+
+      assert stats.fixed == 1
+      assert stats.auto_linked == 0
+    end
+
+    test "a file the re-enrich attempt auto-linked counts in both totals" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: true})
+      file = orphan(library_path, "autolinked")
+
+      stats =
+        OrphanReenricher.run(library_path, [file], file_infos([file], library_path),
+          reenrich: fn _f, _i, _c -> {:ok, :auto_linked} end
+        )
+
+      assert stats.fixed == 1
+      assert stats.auto_linked == 1
+    end
+
+    test "an orphan not present in this scan's file list is left alone" do
+      library_path = library_path_fixture(%{type: "movies", auto_import: false})
+      file = orphan(library_path, "missing")
+
+      stats = OrphanReenricher.run(library_path, [file], %{}, reenrich: counting_reenrich(self()))
+
+      refute_receive {:reenriched, _}, 100
+      assert stats == %{fixed: 0, auto_linked: 0, relay_matches: 0}
+    end
+  end
+end

--- a/test/mydia/library_test.exs
+++ b/test/mydia/library_test.exs
@@ -1204,4 +1204,29 @@ defmodule Mydia.LibraryTest do
       assert length(all_files) == 2
     end
   end
+
+  describe "rank_zero_candidates_by_file_id/1" do
+    test "returns a map keyed by media_file_id" do
+      file_a = Mydia.MediaFixtures.orphaned_media_file_fixture()
+      file_b = Mydia.MediaFixtures.orphaned_media_file_fixture()
+
+      {:ok, _} =
+        Library.upsert_match_candidate(%{
+          media_file_id: file_a.id,
+          rank: 0,
+          provider_type: "tmdb",
+          provider_id: "603",
+          confidence: 0.9
+        })
+
+      result = Library.rank_zero_candidates_by_file_id([file_a.id, file_b.id])
+
+      assert result[file_a.id].provider_id == "603"
+      refute Map.has_key?(result, file_b.id)
+    end
+
+    test "an empty list issues no query and returns an empty map" do
+      assert Library.rank_zero_candidates_by_file_id([]) == %{}
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/scan_flash_test.exs
+++ b/test/mydia_web/live/media_live/scan_flash_test.exs
@@ -1,0 +1,64 @@
+defmodule MydiaWeb.MediaLive.ScanFlashTest do
+  @moduledoc """
+  Pins the scan-completed flash copy. `auto_linked` is a subset of the files a
+  scan touched, not a fourth kind of change, so it must never enter the change
+  total: a scan that found 3 new files and auto-imported 2 of them found 3
+  things, not 5.
+  """
+  use ExUnit.Case, async: true
+
+  alias MydiaWeb.MediaLive.Index
+
+  test "reports nothing when a scan changed nothing" do
+    assert Index.scan_completed_message(%{
+             new_files: 0,
+             modified_files: 0,
+             deleted_files: 0,
+             auto_linked: 0
+           }) == "Library scan completed: No changes detected"
+  end
+
+  test "keeps today's copy for a scan that auto-imported nothing" do
+    # The existing builder prepends, so the emitted order is removed, modified,
+    # new. That is pre-existing behavior and this change must not alter it.
+    assert Index.scan_completed_message(%{
+             new_files: 3,
+             modified_files: 1,
+             deleted_files: 2,
+             auto_linked: 0
+           }) == "Library scan completed: 2 removed, 1 modified, 3 new"
+  end
+
+  test "appends the auto-imported count when auto-import linked something" do
+    assert Index.scan_completed_message(%{
+             new_files: 3,
+             modified_files: 0,
+             deleted_files: 0,
+             auto_linked: 2
+           }) == "Library scan completed: 3 new, 2 imported automatically"
+  end
+
+  test "omits the auto-imported clause entirely when nothing was auto-imported" do
+    message =
+      Index.scan_completed_message(%{
+        new_files: 1,
+        modified_files: 0,
+        deleted_files: 0,
+        auto_linked: 0
+      })
+
+    refute message =~ "automatically"
+  end
+
+  test "reports auto-imports even when no files were new or changed" do
+    # The orphan branch links existing files, so a scan can auto-import
+    # without any on-disk change at all. Reporting "No changes detected" here
+    # would hide exactly the work the operator turned the flag on for.
+    assert Index.scan_completed_message(%{
+             new_files: 0,
+             modified_files: 0,
+             deleted_files: 0,
+             auto_linked: 4
+           }) == "Library scan completed: 4 imported automatically"
+  end
+end


### PR DESCRIPTION
Two defects, one of which had been measured in production.

## A scan reported to nobody

`Jobs.LibraryScanner` wrote `MatchCandidate` rows, but `/import` renders `ImportGroup` rows, and nothing built the second from the first unless a human started an import run. A production library held 507 orphaned files, 382 of them already matched and 302 of those at confidence >= 0.90, while the inbox said "Nothing to review".

The scan now calls the existing idempotent `ImportGroups.upsert_for_library/2` after every successful scan. It is skipped while an import run is active, because `write_group/4` does not strip `import_run_id` from an existing row and an unguarded rebuild would detach that run's own groups from it. The underlying query left-joins candidates, so orphans that were never matched surface too, not just the matched ones.

Unconditional on success, deliberately: a library whose backlog predates this change has no new files on disk to trigger a conditional rebuild, which is exactly the situation being fixed.

## The `auto_import` flag was dead

Column, schema field, GraphQL field, admin toggle labelled "Import new files automatically", and no readers. `FileIngest.policy_for/2` now selects the ingest policy from it, failing closed on a nil association, a read-only `runtime::` struct, and an unset flag.

It also excludes extras, which is load-bearing rather than tidy: nothing filters extras out of the scanner's new-file enrichment stream the way `SampleDetector` does for re-enriched orphans, so `:create_items` would have let a trailer with an above-threshold external match create a `MediaItem` of its own.

## Two things found along the way, fixed here

**The orphan branch re-paid the relay on every scan.** `MetadataMatcher` never consults `MatchCandidate`, so every scheduled scan issued a fresh match for every orphan the library had accumulated, including ones already matched. It now follows the same rule `Library.unmatched_media_files_query/2` has applied for import runs all along, and with auto-import on it links a cached match with no relay call at all. Extracted to `Library.OrphanReenricher` so the logic is testable; its previous home is reachable only through a job tagged `:external` and excluded from the default suite.

**`orphaned_files_fixed` was lying.** The branch discarded each attempt's outcome and reported every orphan it merely located on disk as fixed. It now counts files that actually gained a parent.

## Effect per scan on the measured library

| | Relay match calls | Items created |
| --- | --- | --- |
| Before | 507 | 0, and all 507 invisible |
| After, `auto_import: false` | 125 | 0, all 507 visible in `/import` |
| After, `auto_import: true` | 125 | 302 linked from cache, 80 remain as sub-threshold groups |

## Opt-in

`auto_import` defaults to `false`, nothing writes `true`, and `LibraryPathSync.upsert_library_path/1` does not carry the field, so the DB overlay stays authoritative and env-configured libraries remain editable from the admin UI. Only the inbox fix, the relay-call reduction, and the corrected count change behavior by default. That is the intended change.

## Verification

Full suite 9601 tests, 0 failures. `mix compile --warnings-as-errors` exit 0, `credo --strict` clean, `format --check-formatted` clean. An acceptance test (`test/mydia/jobs/scan_makes_orphans_visible_test.exs`) pins the original defect: one matched and one unmatched orphan become pending `ImportGroup` rows after a rebuild, with no `ImportRun` involved.

Design doc: `docs/superpowers/specs/2026-08-28-auto-import-scan-gate-design.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background scans can now automatically import confident matches when Auto Import is enabled.
  * Orphaned media files are rebuilt into the import inbox, including files without matches.
  * Scan results report how many files were imported automatically.

* **Bug Fixes**
  * Cached matches are handled more reliably, avoiding unnecessary reprocessing and respecting retry delays.

* **Documentation**
  * Updated Auto Import labels and descriptions to clarify that it applies to confident matches during background scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->