### PR TITLE
fix(indexers): repair Cardigann search URL construction, redirects, failover and the connection test

### DIFF
--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -434,7 +434,7 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
     case CardigannHealthCheck.probe_candidates(parsed, user_config) do
       {:ok, url, _status} ->
         case CardigannHealthCheck.probe_search(parsed, user_config, url) do
-          {:ok, _count} ->
+          {:ok, _count, _served_by} ->
             :ok
 
           {:cloudflare, _message} ->

--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -502,18 +502,23 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
   end
 
   defp get_or_create_session(parsed, definition, config) do
-    user_settings = Map.get(config, :user_settings, %{})
+    user_settings = setting(config, :user_settings) || %{}
 
     # Build user config from settings
     credentials = %{
-      username: Map.get(user_settings, :username),
-      password: Map.get(user_settings, :password),
-      api_key: Map.get(user_settings, :api_key),
-      cookies: Map.get(user_settings, :cookies, [])
+      username: setting(user_settings, :username),
+      password: setting(user_settings, :password),
+      api_key: setting(user_settings, :api_key),
+      cookies: setting(user_settings, :cookies) || []
     }
 
-    # Remove nil values
-    credentials = Map.reject(credentials, fn {_k, v} -> is_nil(v) end)
+    # Drop anything the user has not actually configured. An empty cookie list is
+    # not a credential, and leaving the key in place made
+    # CardigannAuth.determine_auth_method/2 - which tests for :cookies before
+    # :username - select :cookie and skip the form login outright, so a private
+    # tracker with a username and password searched anonymously and returned
+    # nothing.
+    credentials = Map.reject(credentials, fn {_k, v} -> is_nil(v) or v == [] end)
 
     # Try to get stored session first
     case CardigannAuth.get_stored_session(definition.id) do
@@ -535,6 +540,22 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
         authenticate_and_convert(parsed, credentials, definition.id)
     end
   end
+
+  # Credentials are read by name rather than by key type. `definition.config` is
+  # a `Mydia.Settings.JsonMapType`, so anything that has been through the
+  # database comes back from `Jason.decode/1` with string keys, and the admin
+  # form supplies string keys too. Reading only atoms meant every configured
+  # private indexer authenticated with empty credentials: the login failed, the
+  # search returned nothing, and the connection test now reports a failure the
+  # tracker never caused.
+  defp setting(map, key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp setting(_map, _key), do: nil
 
   defp authenticate_and_convert(parsed, credentials, definition_id) do
     case CardigannAuth.authenticate(parsed, credentials, definition_id) do

--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -69,7 +69,7 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
     if CardigannFeatureFlags.enabled?() do
       with {:ok, definition} <- fetch_definition(config),
            {:ok, parsed} <- parse_definition(definition),
-           :ok <- test_indexer_reachable(parsed, config) do
+           :ok <- test_indexer_reachable(parsed, definition) do
         {:ok,
          %{
            name: parsed.name,
@@ -420,8 +420,16 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
   # Reaching the homepage is not the same as being able to search, and treating
   # it as such is what let 1337x, EZTV, KickassTorrents, YTS and The Pirate Bay
   # all report a successful connection test while every search failed.
-  defp test_indexer_reachable(parsed, config) do
-    user_config = Map.get(config, :config, %{})
+  #
+  # Takes the CardigannDefinition, not the caller-supplied adapter config map:
+  # build_search_opts/4 (the real search path) always sources the template
+  # context's :config from definition.config, never from the adapter config's
+  # :user_settings or a nested :config key. Sourcing it any other way here
+  # would let the probe render {{ .Config.* }} differently than a real search
+  # does, either dropping settings that do work or reporting settings that
+  # don't.
+  defp test_indexer_reachable(parsed, %CardigannDefinition{} = definition) do
+    user_config = definition.config || %{}
 
     case CardigannHealthCheck.probe_candidates(parsed, user_config) do
       {:ok, url, _status} ->

--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -512,13 +512,14 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
       cookies: setting(user_settings, :cookies) || []
     }
 
-    # Drop anything the user has not actually configured. An empty cookie list is
-    # not a credential, and leaving the key in place made
+    # Drop anything the user has not actually configured. An empty cookie list or
+    # a blank form field is not a credential, and leaving the key in place made
     # CardigannAuth.determine_auth_method/2 - which tests for :cookies before
     # :username - select :cookie and skip the form login outright, so a private
     # tracker with a username and password searched anonymously and returned
-    # nothing.
-    credentials = Map.reject(credentials, fn {_k, v} -> is_nil(v) or v == [] end)
+    # nothing. The admin form submits untouched fields as "", so blank strings
+    # reach here as readily as nils.
+    credentials = Map.reject(credentials, fn {_k, v} -> blank?(v) end)
 
     # Try to get stored session first
     case CardigannAuth.get_stored_session(definition.id) do
@@ -556,6 +557,12 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
   end
 
   defp setting(_map, _key), do: nil
+
+  defp blank?(nil), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?([]), do: true
+  defp blank?(%{} = value), do: map_size(value) == 0
+  defp blank?(_value), do: false
 
   defp authenticate_and_convert(parsed, credentials, definition_id) do
     case CardigannAuth.authenticate(parsed, credentials, definition_id) do

--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -69,7 +69,7 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
     if CardigannFeatureFlags.enabled?() do
       with {:ok, definition} <- fetch_definition(config),
            {:ok, parsed} <- parse_definition(definition),
-           :ok <- test_indexer_reachable(parsed, definition) do
+           :ok <- test_indexer_reachable(parsed, definition, config) do
         {:ok,
          %{
            name: parsed.name,
@@ -421,37 +421,61 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
   # it as such is what let 1337x, EZTV, KickassTorrents, YTS and The Pirate Bay
   # all report a successful connection test while every search failed.
   #
-  # Takes the CardigannDefinition, not the caller-supplied adapter config map:
-  # build_search_opts/4 (the real search path) always sources the template
-  # context's :config from definition.config, never from the adapter config's
-  # :user_settings or a nested :config key. Sourcing it any other way here
-  # would let the probe render {{ .Config.* }} differently than a real search
-  # does, either dropping settings that do work or reporting settings that
-  # don't.
-  defp test_indexer_reachable(parsed, %CardigannDefinition{} = definition) do
-    user_config = definition.config || %{}
+  # Also takes the caller-supplied adapter config (not just the
+  # CardigannDefinition) so the probe can build the same authenticated session
+  # get_or_create_session/3 builds for a real search. Without it, a private
+  # indexer with a stored session (or one whose login the caller's credentials
+  # can satisfy) probed unauthenticated and reported a false connection
+  # failure while its real, authenticated searches kept succeeding - the exact
+  # false red this task exists to eliminate, mirror image of the false green
+  # above.
+  #
+  # The template-context :config still comes from definition.config alone,
+  # never from the adapter config's :user_settings or a nested :config key:
+  # build_search_opts/4 (the real search path) does the same, so sourcing it
+  # any other way here would let the probe render {{ .Config.* }} differently
+  # than a real search does, either dropping settings that do work or
+  # reporting settings that don't. build_probe_user_config/3 layers the
+  # session's cookies/api_key on top of definition.config instead of
+  # replacing it, so both stay true at once.
+  defp test_indexer_reachable(parsed, %CardigannDefinition{} = definition, config) do
+    with {:ok, user_config} <- build_probe_user_config(parsed, definition, config) do
+      case CardigannHealthCheck.probe_candidates(parsed, user_config) do
+        {:ok, url, _status} ->
+          case CardigannHealthCheck.probe_search(parsed, user_config, url) do
+            {:ok, _count, _served_by} ->
+              :ok
 
-    case CardigannHealthCheck.probe_candidates(parsed, user_config) do
-      {:ok, url, _status} ->
-        case CardigannHealthCheck.probe_search(parsed, user_config, url) do
-          {:ok, _count, _served_by} ->
-            :ok
+            {:cloudflare, _message} ->
+              {:error,
+               Error.connection_failed(
+                 "Cloudflare protection detected on #{url}. Enable FlareSolverr for this indexer."
+               )}
 
-          {:cloudflare, _message} ->
-            {:error,
-             Error.connection_failed(
-               "Cloudflare protection detected on #{url}. Enable FlareSolverr for this indexer."
-             )}
+            {:error, message} ->
+              {:error, Error.search_failed("Reached #{url} but the search failed: #{message}")}
+          end
 
-          {:error, message} ->
-            {:error, Error.search_failed("Reached #{url} but the search failed: #{message}")}
-        end
+        {:error, status} when map_size(status) == 0 ->
+          {:error, Error.invalid_config("No base URL configured in definition")}
 
-      {:error, status} when map_size(status) == 0 ->
-        {:error, Error.invalid_config("No base URL configured in definition")}
+        {:error, _status} ->
+          {:error, Error.connection_failed("No reachable base URL")}
+      end
+    end
+  end
 
-      {:error, _status} ->
-        {:error, Error.connection_failed("No reachable base URL")}
+  # Builds the same authenticated session get_or_create_session/3 builds for a
+  # real search (a stored session's cookies, or a fresh login when the
+  # definition requires one), then layers it onto definition.config. A
+  # genuine login failure (credentials configured but rejected) surfaces as a
+  # connection failure here, same as it would surface as a search failure for
+  # a real search; an indexer with no credentials configured authenticates as
+  # :none and is not penalized for it, matching get_or_create_session/3's own
+  # success case for public indexers.
+  defp build_probe_user_config(parsed, %CardigannDefinition{} = definition, config) do
+    with {:ok, session_user_config} <- get_or_create_session(parsed, definition, config) do
+      {:ok, Map.merge(definition.config || %{}, session_user_config)}
     end
   end
 

--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -55,6 +55,7 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
 
   alias Mydia.Indexers.{CardigannParser, CardigannSearchEngine, CardigannResultParser}
   alias Mydia.Indexers.{CardigannDefinition, CardigannAuth, CardigannFeatureFlags}
+  alias Mydia.Indexers.CardigannHealthCheck
   alias Mydia.Indexers.CardigannSearchSession
   alias Mydia.Indexers.Adapter.Error
   alias Mydia.Repo
@@ -416,10 +417,27 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
     end
   end
 
-  defp test_indexer_reachable(parsed, _config) do
-    case Mydia.Indexers.CardigannHealthCheck.probe_candidates(parsed, %{}) do
-      {:ok, _url, _status} ->
-        :ok
+  # Reaching the homepage is not the same as being able to search, and treating
+  # it as such is what let 1337x, EZTV, KickassTorrents, YTS and The Pirate Bay
+  # all report a successful connection test while every search failed.
+  defp test_indexer_reachable(parsed, config) do
+    user_config = Map.get(config, :config, %{})
+
+    case CardigannHealthCheck.probe_candidates(parsed, user_config) do
+      {:ok, url, _status} ->
+        case CardigannHealthCheck.probe_search(parsed, user_config, url) do
+          {:ok, _count} ->
+            :ok
+
+          {:cloudflare, _message} ->
+            {:error,
+             Error.connection_failed(
+               "Cloudflare protection detected on #{url}. Enable FlareSolverr for this indexer."
+             )}
+
+          {:error, message} ->
+            {:error, Error.search_failed("Reached #{url} but the search failed: #{message}")}
+        end
 
       {:error, status} when map_size(status) == 0 ->
         {:error, Error.invalid_config("No base URL configured in definition")}

--- a/lib/mydia/indexers/cardigann_definition/parsed.ex
+++ b/lib/mydia/indexers/cardigann_definition/parsed.ex
@@ -50,7 +50,7 @@ defmodule Mydia.Indexers.CardigannDefinition.Parsed do
     settings: [],
     legacylinks: [],
     request_delay: nil,
-    follow_redirect: false,
+    follow_redirect: true,
     test_link_torrent: false,
     certificates: [],
     replaces: []

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -259,32 +259,84 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
     result =
       case probe_candidates(parsed_definition, user_config) do
         {:ok, active_link, link_status} ->
-          response_time = System.monotonic_time(:millisecond) - start_time
-          store_link_state(definition, active_link, link_status)
-
-          %{
-            success: true,
-            status: determine_health_status(definition, true, response_time),
-            message: "Connection successful via #{active_link}",
-            response_time_ms: response_time,
-            error: nil
-          }
+          search_leg(
+            definition,
+            parsed_definition,
+            user_config,
+            active_link,
+            link_status,
+            start_time
+          )
 
         {:error, link_status} ->
-          response_time = System.monotonic_time(:millisecond) - start_time
           store_link_state(definition, nil, link_status)
 
           %{
             success: false,
-            status: determine_health_status(definition, false, response_time),
+            status: "unhealthy",
             message: "No reachable base URL",
-            response_time_ms: response_time,
+            response_time_ms: System.monotonic_time(:millisecond) - start_time,
             error: "All #{map_size(link_status)} candidate links failed"
           }
       end
 
     update_health_status(definition, result)
     {:ok, result}
+  end
+
+  defp search_leg(definition, parsed, user_config, active_link, link_status, start_time) do
+    outcome = probe_search(parsed, user_config, active_link)
+    elapsed = System.monotonic_time(:millisecond) - start_time
+
+    case outcome do
+      {:ok, 0} ->
+        store_link_state(definition, active_link, link_status)
+
+        %{
+          success: true,
+          status: "degraded",
+          message: "Search reached #{active_link} but parsed no rows",
+          response_time_ms: elapsed,
+          error: nil
+        }
+
+      {:ok, count} ->
+        store_link_state(definition, active_link, link_status)
+
+        %{
+          success: true,
+          status: determine_health_status(definition, true, elapsed),
+          message: "Search returned #{count} result(s) via #{active_link}",
+          response_time_ms: elapsed,
+          error: nil
+        }
+
+      {:cloudflare, message} ->
+        store_link_state(definition, active_link, link_status)
+
+        %{
+          success: true,
+          status: "degraded",
+          message:
+            "Cloudflare challenge on #{active_link}. Enable FlareSolverr for this indexer.",
+          response_time_ms: elapsed,
+          error: message
+        }
+
+      {:error, message} ->
+        # The homepage answered but the search did not, so this candidate is not
+        # a working base URL and must not be promoted to active_link on the
+        # strength of a homepage GET.
+        store_link_state(definition, nil, link_status)
+
+        %{
+          success: false,
+          status: determine_health_status(definition, false, elapsed),
+          message: "Search failed via #{active_link}",
+          response_time_ms: elapsed,
+          error: message
+        }
+    end
   end
 
   defp store_link_state(definition, nil, link_status) do

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -14,10 +14,14 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
   - Consecutive failure tracking
   """
 
+  alias Mydia.Indexers.Adapter.Error
   alias Mydia.Indexers.Cardigann.Links
+  alias Mydia.Indexers.Cardigann.TemplateContext
   alias Mydia.Indexers.CardigannDefinition
   alias Mydia.Indexers.CardigannDefinition.Parsed
   alias Mydia.Indexers.CardigannParser
+  alias Mydia.Indexers.CardigannResultParser
+  alias Mydia.Indexers.CardigannSearchEngine
   alias Mydia.Repo
 
   require Logger
@@ -29,6 +33,24 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
           response_time_ms: non_neg_integer() | nil,
           error: String.t() | nil
         }
+
+  # A single fixed probe query reads as "no rows" on every tracker that does not
+  # carry that kind of content, which trains an operator to ignore the degraded
+  # state. Ask the indexer something it says it can answer.
+  @movie_probe_query "The Matrix"
+  @tv_probe_query "Breaking Bad"
+  @generic_probe_query "ubuntu"
+
+  @typedoc """
+  Outcome of a real search against one base URL.
+
+  `{:ok, count}` where count is 0 means the site answered and parsed cleanly but
+  matched nothing, which is degraded rather than healthy or failed.
+  """
+  @type probe_outcome ::
+          {:ok, non_neg_integer()}
+          | {:cloudflare, String.t()}
+          | {:error, String.t()}
 
   @doc """
   Tests connection to an indexer by executing a simple test search.
@@ -159,6 +181,73 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
           {:cont, {:error, Map.put(status, candidate, error_entry(error))}}
       end
     end)
+  end
+
+  @doc """
+  Runs a real search against `base_url` and reports what came back.
+
+  The homepage probe in `probe_candidates/2` only proves the site answers on
+  `/`. Every defect in the 1.4 indexer bug report lived in the search leg: an
+  unescaped query in the URL path, an absolute path concatenated onto the base
+  URL, a redirect nobody followed, a 404 that ended the search instead of
+  advancing to the next mirror. A Test that stopped at the homepage reported
+  "successful" for all of them, which is how five broken indexers shipped with
+  five green checkmarks.
+  """
+  @spec probe_search(Parsed.t(), map(), String.t()) :: probe_outcome()
+  def probe_search(%Parsed{} = parsed, user_config, base_url) do
+    opts = [
+      query: probe_query(parsed),
+      categories: [],
+      config: Map.get(user_config, :config, %{}),
+      settings: parsed.settings,
+      base_url: base_url
+    ]
+
+    with {:ok, response} <-
+           parsed
+           |> CardigannSearchEngine.execute_search(opts, user_config, %{})
+           |> normalize_search_result(),
+         :ok <- CardigannSearchEngine.validate_response(response),
+         {:ok, results} <- parse_probe_results(parsed, response, base_url, opts) do
+      {:ok, length(results)}
+    else
+      {:error, %Error{message: message}} -> classify_probe_error(message)
+      {:error, reason} when is_binary(reason) -> classify_probe_error(reason)
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  defp normalize_search_result({:ok, response}), do: {:ok, response}
+  defp normalize_search_result({:ok, response, _flaresolverr_cookies}), do: {:ok, response}
+  defp normalize_search_result(other), do: other
+
+  defp classify_probe_error(message) when is_binary(message) do
+    if String.contains?(String.downcase(message), "cloudflare") do
+      {:cloudflare, message}
+    else
+      {:error, message}
+    end
+  end
+
+  defp parse_probe_results(parsed, response, base_url, opts) do
+    with {:ok, search_path} <- CardigannSearchEngine.select_search_path(parsed, opts) do
+      CardigannResultParser.parse_results(parsed, response, parsed.name,
+        template_context: TemplateContext.build(parsed, opts),
+        base_url: base_url,
+        search_path: search_path
+      )
+    end
+  end
+
+  defp probe_query(%Parsed{capabilities: capabilities}) do
+    modes = Map.get(capabilities || %{}, :modes, %{})
+
+    cond do
+      Map.has_key?(modes, "movie-search") -> @movie_probe_query
+      Map.has_key?(modes, "tv-search") -> @tv_probe_query
+      true -> @generic_probe_query
+    end
   end
 
   # Private Functions

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -275,7 +275,12 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
   end
 
   defp probe_query(%Parsed{capabilities: capabilities}) do
-    modes = Map.get(capabilities || %{}, :modes, %{})
+    # Map.get/3's default only applies when the key is ABSENT. A parsed
+    # definition can have `modes: nil` (key present, value nil), in which case
+    # Map.get(capabilities, :modes, %{}) returns nil, not %{}, and the
+    # Map.has_key?(modes, ...) calls below raise BadMapError before any of
+    # the surrounding error handling runs.
+    modes = Map.get(capabilities || %{}, :modes) || %{}
 
     cond do
       Map.has_key?(modes, "movie-search") -> @movie_probe_query

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -199,7 +199,15 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
     opts = [
       query: probe_query(parsed),
       categories: [],
-      config: Map.get(user_config, :config, %{}),
+      # user_config is already the flat settings map (definition.config, see
+      # perform_test_search/2), not a wrapper holding a nested :config key.
+      # Map.get(user_config, :config, %{}) used to always evaluate to %{},
+      # silently dropping every user-supplied setting (API keys, mirror
+      # overrides, auth tokens) from the probe's template context while the
+      # real search rendered them correctly. That made the probe capable of
+      # reporting a false failure/degraded for a correctly configured
+      # indexer, the exact inverse of the false green this task removes.
+      config: user_config,
       settings: parsed.settings,
       base_url: base_url
     ]

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -304,12 +304,19 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
 
         {:error, link_status} ->
           store_link_state(definition, nil, link_status)
+          elapsed = System.monotonic_time(:millisecond) - start_time
 
+          # Use the same escalation determine_health_status/3 applies to a
+          # search failure below: a transient network blip should read as
+          # degraded, same as a persistent search defect, and only climb to
+          # unhealthy after consecutive_failures/3 crosses the threshold.
+          # Hardcoding "unhealthy" here made one unreachable probe report
+          # worse than a search that has been broken for weeks.
           %{
             success: false,
-            status: "unhealthy",
+            status: determine_health_status(definition, false, elapsed),
             message: "No reachable base URL",
-            response_time_ms: System.monotonic_time(:millisecond) - start_time,
+            response_time_ms: elapsed,
             error: "All #{map_size(link_status)} candidate links failed"
           }
       end

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -44,11 +44,15 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
   @typedoc """
   Outcome of a real search against one base URL.
 
-  `{:ok, count}` where count is 0 means the site answered and parsed cleanly but
-  matched nothing, which is degraded rather than healthy or failed.
+  `{:ok, count, served_by}` where count is 0 means the site answered and
+  parsed cleanly but matched nothing, which is degraded rather than healthy
+  or failed. `served_by` is the URL that actually produced the response:
+  `execute_search/4` fails over past `base_url` to later candidates on a
+  retryable failure (a dead or wrong mirror answering 404, say), so the
+  candidate that answered is not always the one the probe was asked to try.
   """
   @type probe_outcome ::
-          {:ok, non_neg_integer()}
+          {:ok, non_neg_integer(), String.t()}
           | {:cloudflare, String.t()}
           | {:error, String.t()}
 
@@ -209,16 +213,21 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
       # indexer, the exact inverse of the false green this task removes.
       config: user_config,
       settings: parsed.settings,
-      base_url: base_url
+      base_url: base_url,
+      on_promote: &report_promotion/1
     ]
 
     with {:ok, response} <-
            parsed
            |> CardigannSearchEngine.execute_search(opts, user_config, %{})
            |> normalize_search_result(),
+         # Read the promotion signal as soon as execute_search/4 returns, before
+         # resolving relative result URLs against the (possibly stale) base_url
+         # argument below.
+         winner = served_by(base_url),
          :ok <- CardigannSearchEngine.validate_response(response),
-         {:ok, results} <- parse_probe_results(parsed, response, base_url, opts) do
-      {:ok, length(results)}
+         {:ok, results} <- parse_probe_results(parsed, response, winner, opts) do
+      {:ok, length(results), winner}
     else
       {:error, %Error{message: message}} -> classify_probe_error(message)
       {:error, reason} when is_binary(reason) -> classify_probe_error(reason)
@@ -229,6 +238,23 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
   defp normalize_search_result({:ok, response}), do: {:ok, response}
   defp normalize_search_result({:ok, response, _flaresolverr_cookies}), do: {:ok, response}
   defp normalize_search_result(other), do: other
+
+  # execute_search/4 calls opts[:on_promote] with the winning candidate URL
+  # only when it had to fail over past the first one tried (build_search_opts/4
+  # uses the same hook to persist active_link after a real search). try_candidates/7
+  # runs synchronously in this process, so a self-message survives the call and
+  # lets probe_search report which mirror actually served the result instead of
+  # the one it was asked to try. At most one promotion happens per probe_search
+  # call, so there is nothing to drain beforehand.
+  defp report_promotion(winning_url), do: send(self(), {:cardigann_probe_promoted, winning_url})
+
+  defp served_by(default_url) do
+    receive do
+      {:cardigann_probe_promoted, winning_url} -> winning_url
+    after
+      0 -> default_url
+    end
+  end
 
   defp classify_probe_error(message) when is_binary(message) do
     if String.contains?(String.downcase(message), "cloudflare") do
@@ -297,24 +323,24 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
     elapsed = System.monotonic_time(:millisecond) - start_time
 
     case outcome do
-      {:ok, 0} ->
-        store_link_state(definition, active_link, link_status)
+      {:ok, 0, served_by} ->
+        store_link_state(definition, served_by, link_status)
 
         %{
           success: true,
           status: "degraded",
-          message: "Search reached #{active_link} but parsed no rows",
+          message: "Search reached #{served_by} but parsed no rows",
           response_time_ms: elapsed,
           error: nil
         }
 
-      {:ok, count} ->
-        store_link_state(definition, active_link, link_status)
+      {:ok, count, served_by} ->
+        store_link_state(definition, served_by, link_status)
 
         %{
           success: true,
           status: determine_health_status(definition, true, elapsed),
-          message: "Search returned #{count} result(s) via #{active_link}",
+          message: "Search returned #{count} result(s) via #{served_by}",
           response_time_ms: elapsed,
           error: nil
         }

--- a/lib/mydia/indexers/cardigann_parser.ex
+++ b/lib/mydia/indexers/cardigann_parser.ex
@@ -173,7 +173,11 @@ defmodule Mydia.Indexers.CardigannParser do
         download: parse_download_config(yaml_data),
         settings: parse_settings(yaml_data),
         request_delay: Map.get(yaml_data, "requestdelay"),
-        follow_redirect: Map.get(yaml_data, "followredirect", false),
+        # Jackett follows redirects on search requests, and no definition in the
+        # corpus sets this key, so a `false` default meant Mydia followed none
+        # of them. A definition that genuinely needs the raw 3xx sets
+        # `followredirect: false` explicitly.
+        follow_redirect: Map.get(yaml_data, "followredirect", true),
         test_link_torrent: Map.get(yaml_data, "testlinktorrent", false),
         certificates: Map.get(yaml_data, "certificates", []),
         replaces: Map.get(yaml_data, "replaces", [])

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -906,7 +906,10 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     name = cookie["name"] || Map.get(cookie, :name)
     value = cookie["value"] || Map.get(cookie, :value)
 
-    if name && value, do: "#{name}=#{value}", else: nil
+    # Both halves have to be strings. These rows are decoded JSON, so a nested
+    # object or array can land in either field, and interpolating one raises the
+    # same Protocol.UndefinedError this function exists to prevent.
+    if is_binary(name) and is_binary(value), do: name <> "=" <> value, else: nil
   end
 
   defp normalize_cookie(_cookie), do: nil

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -858,6 +858,15 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   # withheld rather than handed to anyone on the path. The request still goes
   # out: an anonymous result is a better outcome than a leaked login, and the
   # search reports whatever the tracker returns for a logged-out visitor.
+  #
+  # A cookie-bearing request also stops following redirects, because Req carries
+  # a manually supplied Cookie header along a redirect even to a different host
+  # (checked against the pinned Req, not assumed). Following one would hand the
+  # session to whatever host the Location names, which is a leak an attacker can
+  # trigger from a hijacked mirror rather than an accident. Unfollowed 3xx keeps
+  # the honest handling this branch already added: validate_response/1 names the
+  # Location, and failover moves on to the next candidate. Redirect following is
+  # unaffected for every request without cookies.
   defp attach_cookies(opts, url, cookies) do
     if cleartext_url?(url) do
       Logger.warning(
@@ -869,7 +878,10 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     else
       cookie_header = Enum.join(cookies, "; ")
       existing_headers = Keyword.get(opts, :headers, [])
-      Keyword.put(opts, :headers, [{"Cookie", cookie_header} | existing_headers])
+
+      opts
+      |> Keyword.put(:headers, [{"Cookie", cookie_header} | existing_headers])
+      |> Keyword.put(:redirect, false)
     end
   end
 

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -539,7 +539,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     apply_rate_limit(definition)
 
     # Build request options
-    req_opts = build_request_options(definition, request_params, user_config)
+    req_opts = build_request_options(definition, url, request_params, user_config)
 
     Logger.debug("Cardigann search request: #{request_params.method} #{url}")
     Logger.debug("Request params: #{inspect(request_params.query_params)}")
@@ -812,7 +812,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     :ok
   end
 
-  defp build_request_options(definition, request_params, user_config) do
+  defp build_request_options(definition, url, request_params, user_config) do
     # Base options
     base_opts = [
       headers: request_params.headers,
@@ -844,17 +844,49 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
 
     # Add cookies if present in user config
     case Map.get(user_config, :cookies) do
-      nil ->
-        opts_with_params
-
-      cookies when is_list(cookies) ->
-        cookie_header = Enum.join(cookies, "; ")
-        existing_headers = Keyword.get(opts_with_params, :headers, [])
-        updated_headers = [{"Cookie", cookie_header} | existing_headers]
-        Keyword.put(opts_with_params, :headers, updated_headers)
+      cookies when is_list(cookies) and cookies != [] ->
+        attach_cookies(opts_with_params, url, cookies)
 
       _ ->
         opts_with_params
     end
   end
+
+  # A session cookie is a bearer credential for the tracker account. Base URL
+  # candidates come straight from the definition's `links`, and a few of them are
+  # cleartext (torrentlt ships `http://www.torrent.ai/`), so the header is
+  # withheld rather than handed to anyone on the path. The request still goes
+  # out: an anonymous result is a better outcome than a leaked login, and the
+  # search reports whatever the tracker returns for a logged-out visitor.
+  defp attach_cookies(opts, url, cookies) do
+    if cleartext_url?(url) do
+      Logger.warning(
+        "Cardigann: withholding session cookies from cleartext URL #{inspect(url)}. " <>
+          "Configure an https base URL for this indexer to send credentials."
+      )
+
+      opts
+    else
+      cookie_header = Enum.join(cookies, "; ")
+      existing_headers = Keyword.get(opts, :headers, [])
+      Keyword.put(opts, :headers, [{"Cookie", cookie_header} | existing_headers])
+    end
+  end
+
+  # Loopback is a secure context in the same sense browsers use the term: the
+  # request never reaches a network, so a local mirror or a test server is not
+  # an exposure. Everything else on plain http is.
+  @loopback_hosts ~w(localhost 127.0.0.1 ::1 0:0:0:0:0:0:0:1)
+
+  defp cleartext_url?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: "http", host: host} ->
+        String.downcase(host || "") not in @loopback_hosts
+
+      _ ->
+        false
+    end
+  end
+
+  defp cleartext_url?(_url), do: false
 end

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -671,10 +671,20 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     Mydia.Indexers.Cardigann.TemplateContext.build(definition, opts)
   end
 
+  # A Cardigann definition may put a full URL in `path:` rather than a path
+  # relative to the site's base. The Pirate Bay does exactly that, pointing at
+  # https://apibay.org/q.php. Concatenating it onto the base URL produced
+  # https://thepiratebay.org/https://apibay.org/q.php?... which the site
+  # answered with a redirect, surfacing to the operator as
+  # "Unexpected status: 302".
   defp build_full_url(base_url, path) do
-    # Ensure proper joining of base URL and path
-    path_without_leading_slash = String.trim_leading(path, "/")
-    "#{base_url}/#{path_without_leading_slash}"
+    case URI.parse(path) do
+      %URI{scheme: scheme, host: host} when is_binary(scheme) and is_binary(host) ->
+        path
+
+      _ ->
+        "#{base_url}/#{String.trim_leading(path, "/")}"
+    end
   end
 
   defp build_query_params(%Parsed{} = definition, opts) do

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -210,10 +210,20 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     end
   end
 
+  # A dead or wrong mirror answers 404 or redirects away, and neither is a
+  # reason to abandon the working mirrors behind it. YTS ships six links whose
+  # proxies serve HTML on / but 404 on /api/v2/list_movies.json, so the first
+  # candidate the homepage probe promotes is routinely the wrong one.
+  #
+  # Failures that would repeat identically on every candidate stay terminal: a
+  # template that will not render, or a request target the client refuses, is
+  # not going to behave differently against another host.
   defp retryable_failure?({:error, %Error{type: :connection_failed}}), do: true
 
   defp retryable_failure?({:error, %Error{message: message}}) when is_binary(message) do
-    String.contains?(message, "Server error: HTTP 5")
+    String.contains?(message, "Server error: HTTP 5") or
+      String.contains?(message, "HTTP 404") or
+      String.contains?(message, "Redirected (HTTP 3")
   end
 
   defp retryable_failure?(_), do: false

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -876,14 +876,40 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
 
       opts
     else
-      cookie_header = Enum.join(cookies, "; ")
-      existing_headers = Keyword.get(opts, :headers, [])
+      cookie_header =
+        cookies
+        |> Enum.map(&normalize_cookie/1)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.join("; ")
 
-      opts
-      |> Keyword.put(:headers, [{"Cookie", cookie_header} | existing_headers])
-      |> Keyword.put(:redirect, false)
+      if cookie_header == "" do
+        opts
+      else
+        existing_headers = Keyword.get(opts, :headers, [])
+
+        opts
+        |> Keyword.put(:headers, [{"Cookie", cookie_header} | existing_headers])
+        |> Keyword.put(:redirect, false)
+      end
     end
   end
+
+  # A stored session row holds either plain "name=value" strings or the cookie
+  # maps store_flaresolverr_cookies/2 writes, and
+  # CardigannAuth.get_stored_session/1 hands back whatever is in the row without
+  # looking. Joining a map raises Protocol.UndefinedError before the request is
+  # even sent, so any indexer that had once been through FlareSolverr crashed its
+  # next search. Entries are normalized here and anything unusable is dropped.
+  defp normalize_cookie(cookie) when is_binary(cookie), do: cookie
+
+  defp normalize_cookie(cookie) when is_map(cookie) do
+    name = cookie["name"] || Map.get(cookie, :name)
+    value = cookie["value"] || Map.get(cookie, :value)
+
+    if name && value, do: "#{name}=#{value}", else: nil
+  end
+
+  defp normalize_cookie(_cookie), do: nil
 
   # Loopback is a secure context in the same sense browsers use the term: the
   # request never reaches a network, so a local mirror or a test server is not

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -588,6 +588,22 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
       {:error, %Error{type: :rate_limited}}
   """
   @spec validate_response(http_response()) :: :ok | {:error, Error.t()}
+
+  # An unfollowed redirect used to land in the catch-all below as
+  # "Unexpected status: 302", which told an operator nothing about where the
+  # indexer was trying to send them. This is now only reachable when a
+  # definition sets `followredirect: false`, since search follows by default.
+  #
+  # Task 5's retryable_failure?/1 matches on the "Redirected (HTTP " prefix.
+  def validate_response(%{status: status} = response) when status in 300..399 do
+    location = response |> Map.get(:headers) |> location_header()
+
+    suffix = if location, do: " to #{location}", else: " with no Location header"
+
+    {:error,
+     Error.search_failed("Redirected (HTTP #{status})#{suffix} and the redirect was not followed")}
+  end
+
   def validate_response(%{status: status, body: body}) do
     cond do
       status == 200 ->
@@ -613,6 +629,25 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   end
 
   # Private functions
+
+  # Req 0.5 returns headers as a map of lowercase name to a list of values;
+  # older shapes and hand-built test responses use a keyword-ish list.
+  defp location_header(headers) when is_map(headers) do
+    case Map.get(headers, "location") do
+      [value | _] -> value
+      value when is_binary(value) -> value
+      _ -> nil
+    end
+  end
+
+  defp location_header(headers) when is_list(headers) do
+    Enum.find_value(headers, fn
+      {name, value} -> if String.downcase(to_string(name)) == "location", do: value
+      _ -> nil
+    end)
+  end
+
+  defp location_header(_), do: nil
 
   defp get_base_url(definition, opts) do
     case Keyword.get(opts, :base_url) do

--- a/lib/mydia/indexers/cardigann_template.ex
+++ b/lib/mydia/indexers/cardigann_template.ex
@@ -317,11 +317,22 @@ defmodule Mydia.Indexers.CardigannTemplate do
     eval_tokens(rest, ctx, url_encode?, [output | acc])
   end
 
-  # Function call or pipeline - never URL-encode function results
+  # Function call or pipeline. Encodes exactly like a bare field reference: in a
+  # path context the caller asks for encoding, and a value that reached the
+  # template through `or`, `re_replace` or `join` is no less user-supplied than
+  # one that came straight from `.Keywords`.
+  #
+  # This is load-bearing. CardigannOverrides.patch_1337x/1 routes keywords
+  # through `{{ or .Query.Album .Query.Artist .Keywords }}`, so leaving function
+  # results raw put an unescaped query into the URL path and every 1337x search
+  # failed with {:invalid_request_target, "/search/Some Title: Here/1/"}.
+  #
+  # Query parameters are unaffected: build_query_params/2 renders them with
+  # url_encode: false and lets Req do the escaping.
   defp eval_tokens([{action_type, [{:expr, expr_parts}]} | rest], ctx, url_encode?, acc)
        when action_type in [:action, :action_trim_left, :action_trim_right, :action_trim_both] do
     value = eval_expression(expr_parts, ctx)
-    output = format_output(value, false)
+    output = format_output(value, url_encode?)
     eval_tokens(rest, ctx, url_encode?, [output | acc])
   end
 

--- a/lib/mydia/indexers/cardigann_template.ex
+++ b/lib/mydia/indexers/cardigann_template.ex
@@ -898,21 +898,21 @@ defmodule Mydia.Indexers.CardigannTemplate do
 
   @doc """
   URL-encodes a string for use in URL paths.
+
+  Percent-encodes UTF-8 BYTES, not code points. `String.to_charlist/1`
+  followed by packing each code point into a single `<<char>>` byte
+  percent-encodes the code point instead: a code point above 255 truncates
+  (silently dropping data), and even a two-byte code point like "é"
+  (U+00E9) encodes as its raw ordinal ("%E9") rather than its two UTF-8
+  bytes ("%C3%A9"), producing a URL that matches nothing at the origin.
+  `URI.encode/2` iterates the binary's bytes directly, so a multi-byte
+  character comes out as consecutive `%XX` pairs, one per UTF-8 byte.
   """
   @spec url_encode(String.t()) :: String.t()
   def url_encode(string) when is_binary(string) do
-    string
-    |> String.to_charlist()
-    |> Enum.map_join("", fn char ->
-      if unreserved_char?(char), do: <<char>>, else: "%" <> Base.encode16(<<char>>, case: :upper)
-    end)
+    URI.encode(string, &URI.char_unreserved?/1)
   end
 
   def url_encode(nil), do: ""
   def url_encode(value), do: url_encode(to_string(value))
-
-  defp unreserved_char?(c) do
-    (c >= ?A and c <= ?Z) or (c >= ?a and c <= ?z) or (c >= ?0 and c <= ?9) or
-      c in [?-, ?_, ?., ?~]
-  end
 end

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -420,12 +420,7 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
   def handle_event("test_library_indexer", %{"id" => id}, socket) do
     case Indexers.test_cardigann_connection(id) do
       {:ok, result} ->
-        flash_message =
-          if result.success,
-            do: "Connection successful (#{result.response_time_ms}ms)",
-            else: "Connection failed: #{result.error || "Unknown error"}"
-
-        flash_type = if result.success, do: :info, else: :error
+        {flash_type, flash_message} = library_test_flash(result)
         {:noreply, socket |> put_flash(flash_type, flash_message) |> load_data()}
 
       {:error, reason} ->
@@ -1275,4 +1270,22 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
   defp format_sync_error({:unexpected_status, status}), do: "Unexpected HTTP status: #{status}"
   defp format_sync_error(reason) when is_binary(reason), do: reason
   defp format_sync_error(reason), do: inspect(reason)
+
+  # A search that reached the site but parsed nothing is neither a success nor
+  # an outage, and flattening it into "Connection successful" is what let five
+  # indexers report a green test while every search returned zero results. The
+  # flash component only has :info and :error (core_components.ex:45), so a
+  # degraded result is :error with a message that says what is degraded; the
+  # row's health badge carries the "degraded" state separately.
+  defp library_test_flash(%{success: true, status: "degraded"} = result) do
+    {:error, "#{result.message} (#{result.response_time_ms}ms)"}
+  end
+
+  defp library_test_flash(%{success: true} = result) do
+    {:info, "#{result.message} (#{result.response_time_ms}ms)"}
+  end
+
+  defp library_test_flash(result) do
+    {:error, "#{result.message}: #{result.error || "Unknown error"}"}
+  end
 end

--- a/test/mydia/indexers/adapter/cardigann_test.exs
+++ b/test/mydia/indexers/adapter/cardigann_test.exs
@@ -69,8 +69,11 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
       Plug.Conn.resp(conn, 200, "OK")
     end)
 
-    # Stub search paths with empty HTML table (Cardigann parses HTML from search results)
-    for query <- ["test+query", "test%20query", "query"] do
+    # Stub search paths with empty HTML table (Cardigann parses HTML from search results).
+    # "The%20Matrix" is the health check's own probe query (this definition declares
+    # movie-search, so test_indexer_reachable/2 now runs a real search against it
+    # instead of only fetching "/") rather than a query any of these tests submit.
+    for query <- ["test+query", "test%20query", "query", "The%20Matrix"] do
       Bypass.stub(bypass, "GET", "/search/#{query}/", fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type("text/html")

--- a/test/mydia/indexers/adapter/cardigann_test.exs
+++ b/test/mydia/indexers/adapter/cardigann_test.exs
@@ -201,6 +201,111 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
     end
   end
 
+  describe "credential key shape" do
+    # `definition.config` is a JsonMapType, so anything that has been through the
+    # database comes back string-keyed, and the admin form supplies string keys
+    # too. Reading only atom keys authenticated every private indexer with empty
+    # credentials, which made the login fail and the probe report a failure the
+    # tracker never caused.
+    setup do
+      bypass = Bypass.open()
+      base_url = "http://localhost:#{bypass.port}"
+
+      yaml = """
+      id: private-indexer
+      name: Private Indexer
+      description: A private test indexer
+      language: en-US
+      type: private
+      encoding: UTF-8
+      links:
+        - #{base_url}
+      caps:
+        modes:
+          search: {search-type: q}
+        categories:
+          5000: TV
+      login:
+        path: /login.php
+        method: form
+        inputs:
+          username: "{{ .Config.username }}"
+          password: "{{ .Config.password }}"
+        test:
+          selector: "a[href*=logout]"
+      search:
+        path: /search
+        rows:
+          selector: "table.results tr"
+          after: 1
+        fields:
+          title:
+            selector: "td.title a"
+          size:
+            selector: "td.size"
+          seeders:
+            selector: "td.seeders"
+      """
+
+      {:ok, definition} =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "private-indexer",
+          name: "Private Indexer",
+          description: "A private test indexer",
+          language: "en-US",
+          type: "private",
+          encoding: "UTF-8",
+          links: %{"0" => base_url},
+          capabilities: %{modes: %{"search" => %{}}, categories: %{"5000" => "TV"}},
+          definition: yaml,
+          schema_version: "v11",
+          enabled: true,
+          # String keys, exactly as the database and the admin form supply them.
+          config: %{"username" => "stringuser", "password" => "stringpass"},
+          last_synced_at: DateTime.utc_now()
+        })
+        |> Repo.insert()
+
+      %{bypass: bypass, private_definition: definition}
+    end
+
+    test "string-keyed credentials reach a form login", %{bypass: bypass} do
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "POST", "/login.php", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:login_params, URI.decode_query(body)})
+
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "session=abc123; Path=/")
+        |> Plug.Conn.resp(200, "<html><body><a href='/logout'>Logout</a></body></html>")
+      end)
+
+      Bypass.stub(bypass, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("text/html")
+        |> Plug.Conn.resp(
+          200,
+          "<html><body><table class=\"results\"><tr><th>Header</th></tr></table></body></html>"
+        )
+      end)
+
+      config = %{
+        type: :cardigann,
+        name: "Private Indexer",
+        indexer_id: "private-indexer",
+        user_settings: %{"username" => "stringuser", "password" => "stringpass"}
+      }
+
+      assert {:ok, _results} = Cardigann.search(config, "query")
+
+      assert_receive {:login_params, params}
+      assert params["username"] == "stringuser"
+      assert params["password"] == "stringpass"
+    end
+  end
+
   describe "search/3" do
     test "builds search options correctly", %{definition: _definition} do
       config = %{

--- a/test/mydia/indexers/adapter/cardigann_test.exs
+++ b/test/mydia/indexers/adapter/cardigann_test.exs
@@ -154,6 +154,51 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
 
       assert message =~ "not found"
     end
+
+    # Regression: test_indexer_reachable/3 used to probe with only
+    # definition.config, never building the authenticated session
+    # get_or_create_session/3 builds for a real search. A private indexer
+    # with a stored session - established the same way a real search
+    # establishes one - searched successfully because its cookies rode along
+    # on every real search, while Test reported a connection failure because
+    # the probe's HTTP request carried no Cookie header at all.
+    test "carries a stored session's cookies into the probe search request", %{
+      definition: definition,
+      bypass: bypass
+    } do
+      Bypass.stub(bypass, "GET", "/search/The%20Matrix/", fn conn ->
+        case Plug.Conn.get_req_header(conn, "cookie") do
+          ["sessionid=letmein123"] ->
+            conn
+            |> Plug.Conn.put_resp_content_type("text/html")
+            |> Plug.Conn.resp(
+              200,
+              "<html><body><table class=\"results\"><tr><th>Header</th></tr></table></body></html>"
+            )
+
+          _ ->
+            Plug.Conn.resp(conn, 401, "Unauthorized")
+        end
+      end)
+
+      {:ok, _session} =
+        %CardigannSearchSession{}
+        |> CardigannSearchSession.changeset(%{
+          cardigann_definition_id: definition.id,
+          cookies: ["sessionid=letmein123"],
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(3600, :second) |> DateTime.truncate(:second)
+        })
+        |> Repo.insert()
+
+      config = %{
+        type: :cardigann,
+        name: "Test Indexer",
+        indexer_id: "test-indexer"
+      }
+
+      assert {:ok, _info} = Cardigann.test_connection(config)
+    end
   end
 
   describe "search/3" do

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -139,6 +139,13 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       Bypass.down(dead)
       Bypass.expect(live, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "ok") end)
 
+      # The homepage answering is no longer enough to promote active_link: the
+      # health check now also runs a real search, so the winning candidate's
+      # search path has to answer too.
+      Bypass.expect(live, "GET", "/search", fn conn ->
+        Plug.Conn.resp(conn, 200, "<html><body></body></html>")
+      end)
+
       dead_url = "http://localhost:#{dead.port}"
       live_url = "http://localhost:#{live.port}"
 

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -546,6 +546,24 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       assert_received {:request_path, path}
       assert path =~ "ubuntu"
     end
+
+    # Regression: Map.get/3's default only applies when the key is ABSENT, not
+    # when it is present with a nil value. A definition parsed with
+    # `modes: nil` (key present) made probe_query/1's
+    # Map.get(capabilities, :modes, %{}) return nil, and the following
+    # Map.has_key?(nil, ...) raised BadMapError, crashing the health check
+    # before any of its error handling ran.
+    test "a definition with modes: nil falls back to a generic term instead of raising" do
+      bypass = Bypass.open()
+      capture_path(bypass, self())
+
+      url = "http://localhost:#{bypass.port}"
+      parsed = parsed_for(url, modes: nil, path: "/search/{{ .Keywords }}")
+
+      assert {:ok, _, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
+      assert_received {:request_path, path}
+      assert path =~ "ubuntu"
+    end
   end
 
   describe "user config passthrough" do

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -428,6 +428,31 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
     end
   end
 
+  describe "user config passthrough" do
+    test "a user-configured setting reaches the search request instead of rendering empty" do
+      # Regression: probe_search/3 originally rendered
+      # config: Map.get(user_config, :config, %{}), but user_config arriving
+      # here IS ALREADY the flat settings map (definition.config, see
+      # perform_test_search/2), which has no nested :config key. That always
+      # evaluated to %{}, so a search path or input referencing
+      # {{ .Config.* }} rendered empty during the probe while rendering
+      # correctly in a real search - reporting a false failure/degraded state
+      # for a correctly configured indexer, the inverse of the false green
+      # this task exists to remove.
+      bypass = Bypass.open()
+      capture_path(bypass, self())
+
+      url = "http://localhost:#{bypass.port}"
+      parsed = parsed_for(url, path: "/search/{{ .Config.apikey }}")
+
+      assert {:ok, _} =
+               CardigannHealthCheck.probe_search(parsed, %{"apikey" => "topsecret123"}, url)
+
+      assert_received {:request_path, path}
+      assert path =~ "topsecret123"
+    end
+  end
+
   describe "Cloudflare" do
     test "a Cloudflare challenge is reported as :cloudflare, not as a generic error" do
       # EZTV in the bug report. The operator needs to be told to configure

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -315,12 +315,19 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
   # execute_health_check parses and probes against (see
   # test/support/fixtures/indexers_fixtures.ex). Rewriting the column alone
   # would leave the probe hitting the fixture's https://example.com default.
-  defp put_link(definition, url) do
+  # Accepts either a single URL or a list, so a test can set up more than one
+  # candidate mirror in order (Links.candidates/1 preserves that order).
+  defp put_link(definition, url_or_urls) do
+    yaml_links =
+      url_or_urls
+      |> List.wrap()
+      |> Enum.map_join("\n", &"  - #{&1}")
+
     updated_yaml =
       String.replace(
         definition.definition,
         ~r/^links:\n(?:  - .*\n?)+/m,
-        "links:\n  - #{url}\n"
+        "links:\n#{yaml_links}\n"
       )
 
     {:ok, updated} =
@@ -345,8 +352,11 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
 
       url = "http://localhost:#{bypass.port}"
 
-      assert {:ok, count} = CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
+      assert {:ok, count, served_by} =
+               CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
+
       assert count > 0
+      assert served_by == url
     end
 
     test "reports zero rows rather than success when the search parses nothing" do
@@ -360,7 +370,7 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
 
       url = "http://localhost:#{bypass.port}"
 
-      assert {:ok, 0} = CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
+      assert {:ok, 0, ^url} = CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
     end
 
     test "reports an error when the search 404s even though the homepage is fine" do
@@ -397,7 +407,7 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       parsed =
         parsed_for(url, modes: %{"movie-search" => ["q"]}, path: "/search/{{ .Keywords }}")
 
-      assert {:ok, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
+      assert {:ok, _, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
       assert_received {:request_path, path}
       assert path =~ "The%20Matrix"
     end
@@ -410,7 +420,7 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
 
       parsed = parsed_for(url, modes: %{"tv-search" => ["q"]}, path: "/search/{{ .Keywords }}")
 
-      assert {:ok, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
+      assert {:ok, _, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
       assert_received {:request_path, path}
       assert path =~ "Breaking%20Bad"
     end
@@ -422,7 +432,7 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       url = "http://localhost:#{bypass.port}"
       parsed = parsed_for(url, modes: %{"search" => ["q"]}, path: "/search/{{ .Keywords }}")
 
-      assert {:ok, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
+      assert {:ok, _, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
       assert_received {:request_path, path}
       assert path =~ "ubuntu"
     end
@@ -445,7 +455,7 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       url = "http://localhost:#{bypass.port}"
       parsed = parsed_for(url, path: "/search/{{ .Config.apikey }}")
 
-      assert {:ok, _} =
+      assert {:ok, _, _} =
                CardigannHealthCheck.probe_search(parsed, %{"apikey" => "topsecret123"}, url)
 
       assert_received {:request_path, path}
@@ -500,6 +510,47 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
 
       refute result.success
       assert Mydia.Repo.reload!(definition).active_link == nil
+    end
+
+    test "the persisted active_link and message name the mirror that actually served the result" do
+      # Same YTS shape as above, but with a second candidate that works: mirror
+      # A's homepage answers 200 but its search 404s, so execute_search's own
+      # failover (Task 5) advances past A to mirror B, which serves a real
+      # row. Regression: probe_search/3 used to have no way to report that a
+      # different candidate than the one it was asked to try had served the
+      # response, so search_leg/6 stored and reported A - the mirror that did
+      # NOT serve the result - as active_link.
+      definition = cardigann_definition_fixture(%{active_link: nil})
+
+      mirror_a = Bypass.open()
+      mirror_b = Bypass.open()
+
+      Bypass.stub(mirror_a, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+      Bypass.stub(mirror_a, "GET", "/search", fn conn -> Plug.Conn.resp(conn, 404, "") end)
+
+      Bypass.stub(mirror_b, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+
+      Bypass.stub(mirror_b, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          "<html><body><table class=\"results\">" <>
+            "<tr><td class=\"title\">Some Release</td>" <>
+            "<td class=\"download\"><a href=\"/download/1\">grab</a></td></tr>" <>
+            "</table></body></html>"
+        )
+      end)
+
+      url_a = "http://localhost:#{mirror_a.port}"
+      url_b = "http://localhost:#{mirror_b.port}"
+
+      {:ok, result} =
+        CardigannHealthCheck.execute_health_check(put_link(definition, [url_a, url_b]))
+
+      assert result.success
+      assert result.message =~ url_b
+      refute result.message =~ url_a
+      assert Mydia.Repo.reload!(definition).active_link == url_b
     end
   end
 end

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -18,10 +18,33 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
     end
 
     test "tests connection for valid public indexer" do
+      # The fixture's default links point at https://example.com. Before
+      # cardigann_definition_fixture/1 carried size/seeders fields,
+      # CardigannParser.validate_search_fields/1 rejected that YAML before any
+      # HTTP call happened, so this test never actually reached the network.
+      # Now that the definition parses, it must be pointed at a local Bypass
+      # server instead, or it makes a live, unmocked, un-tagged :external
+      # request to example.com on every run.
       definition = cardigann_definition_fixture(%{enabled: true, type: "public"})
 
-      # Mock a successful test (this will actually attempt to parse and connect)
-      # In a real scenario, we'd need to use mocks or have test definitions
+      bypass = Bypass.open()
+      Bypass.stub(bypass, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+
+      Bypass.stub(bypass, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          ~s"""
+          <html><body><table class="results">
+          <tr><td class="title">Some Release</td>
+          <td class="download"><a href="/download/1">grab</a></td></tr>
+          </table></body></html>
+          """
+        )
+      end)
+
+      put_link(definition, "http://localhost:#{bypass.port}")
+
       result = CardigannHealthCheck.test_connection(definition.id)
 
       assert {:ok, test_result} = result
@@ -34,10 +57,31 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
 
   describe "execute_health_check/2" do
     test "updates health status after successful check" do
+      # See the comment on "tests connection for valid public indexer" above:
+      # the unmodified fixture now parses and would otherwise reach
+      # example.com over the real network.
       definition = cardigann_definition_fixture(%{enabled: true})
 
-      # Note: This will likely fail with actual connection, but will update health status
-      {:ok, _result} = CardigannHealthCheck.execute_health_check(definition)
+      bypass = Bypass.open()
+      Bypass.stub(bypass, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+
+      Bypass.stub(bypass, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          ~s"""
+          <html><body><table class="results">
+          <tr><td class="title">Some Release</td>
+          <td class="download"><a href="/download/1">grab</a></td></tr>
+          </table></body></html>
+          """
+        )
+      end)
+
+      {:ok, _result} =
+        CardigannHealthCheck.execute_health_check(
+          put_link(definition, "http://localhost:#{bypass.port}")
+        )
 
       # Verify health status was updated in database
       updated_definition = Repo.get!(CardigannDefinition, definition.id)
@@ -46,10 +90,18 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
     end
 
     test "tracks consecutive failures" do
+      # A closed local port, not a real hostname, gives a deterministic
+      # connection failure without touching the network (same pattern as the
+      # failover tests in cardigann_search_engine_test.exs).
       definition = cardigann_definition_fixture(%{enabled: true, consecutive_failures: 2})
 
-      # Execute health check (will likely fail without proper definition)
-      {:ok, result} = CardigannHealthCheck.execute_health_check(definition)
+      bypass = Bypass.open()
+      Bypass.down(bypass)
+
+      {:ok, result} =
+        CardigannHealthCheck.execute_health_check(
+          put_link(definition, "http://localhost:#{bypass.port}")
+        )
 
       # Check that consecutive failures was updated
       updated_definition = Repo.get!(CardigannDefinition, definition.id)
@@ -534,10 +586,12 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
         Plug.Conn.resp(
           conn,
           200,
-          "<html><body><table class=\"results\">" <>
-            "<tr><td class=\"title\">Some Release</td>" <>
-            "<td class=\"download\"><a href=\"/download/1\">grab</a></td></tr>" <>
-            "</table></body></html>"
+          ~s"""
+          <html><body><table class="results">
+          <tr><td class="title">Some Release</td>
+          <td class="download"><a href="/download/1">grab</a></td></tr>
+          </table></body></html>
+          """
         )
       end)
 

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -306,6 +306,64 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       assert reloaded.active_link == prior_active_link
       assert reloaded.link_status[dead_url]["ok"] == false
     end
+
+    # Regression: the unreachable-probe branch hardcoded "unhealthy" while the
+    # search-failure branch calls determine_health_status/3, which reports
+    # "degraded" until consecutive_failures reaches 3. A single transient
+    # network blip marked the indexer unhealthy while a search that had been
+    # broken for weeks only reached degraded - backwards severity. Both
+    # branches now escalate through the same three-strikes rule.
+    test "an unreachable probe reports degraded, not unhealthy, before three consecutive failures" do
+      dead = Bypass.open()
+      Bypass.down(dead)
+      dead_url = "http://localhost:#{dead.port}"
+
+      {:ok, definition} =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "probe-unreachable-severity",
+          name: "Probe Unreachable Severity",
+          type: "public",
+          links: %{"0" => dead_url},
+          capabilities: %{},
+          schema_version: "v11",
+          consecutive_failures: 0,
+          definition: """
+          id: probe-unreachable-severity
+          name: Probe Unreachable Severity
+          description: d
+          language: en-US
+          type: public
+          encoding: UTF-8
+          links:
+            - #{dead_url}
+          caps:
+            categories:
+              2000: Movies
+          settings: []
+          search:
+            paths:
+              - path: /search
+            rows:
+              selector: tr
+            fields:
+              title:
+                selector: td.title
+              size:
+                selector: td.size
+              seeders:
+                selector: td.seeders
+              download:
+                selector: a
+                attribute: href
+          """
+        })
+        |> Repo.insert()
+
+      assert {:ok, result} = CardigannHealthCheck.execute_health_check(definition)
+      refute result.success
+      assert result.status == "degraded"
+    end
   end
 
   describe "check_all_enabled/0" do

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -1,5 +1,8 @@
 defmodule Mydia.Indexers.CardigannHealthCheckTest do
-  use Mydia.DataCase, async: true
+  # probe_search/3 issues real HTTP searches through Bypass and, in the
+  # "active_link promotion" test, persists through Repo from the test process.
+  # async: false keeps this on the shared sandbox connection.
+  use Mydia.DataCase, async: false
 
   alias Mydia.Indexers.CardigannHealthCheck
   alias Mydia.Indexers.CardigannDefinition
@@ -264,6 +267,207 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
 
       assert {:ok, results} = CardigannHealthCheck.check_all_enabled()
       assert results == %{}
+    end
+  end
+
+  defp parsed_for(link, opts \\ []) do
+    %Parsed{
+      id: "probe-test",
+      name: "Probe Test",
+      description: "Test indexer",
+      language: "en-US",
+      type: "public",
+      encoding: "UTF-8",
+      links: [link],
+      legacylinks: [],
+      capabilities: %{modes: Keyword.get(opts, :modes, %{"search" => ["q"]})},
+      follow_redirect: true,
+      settings: [],
+      search: %{
+        paths: [%{path: Keyword.get(opts, :path, "/search")}],
+        inputs: %{},
+        headers: nil,
+        keywordsfilters: [],
+        rows: %{selector: "tr"},
+        # CardigannResultParser only counts a row once it has both a title and a
+        # download/infohash field (see "Only return row if we got at least
+        # title and download/infohash" in cardigann_result_parser.ex), so the
+        # probe fixture needs a download selector or every probe reads as zero
+        # rows regardless of what the site actually returned.
+        fields: %{
+          title: %{selector: "td"},
+          download: %{selector: "a", attribute: "href"}
+        }
+      },
+      login: nil,
+      download: nil
+    }
+  end
+
+  # The stored definition YAML, not the definition's `links` column, is what
+  # execute_health_check parses and probes against (see
+  # test/support/fixtures/indexers_fixtures.ex). Rewriting the column alone
+  # would leave the probe hitting the fixture's https://example.com default.
+  defp put_link(definition, url) do
+    updated_yaml =
+      String.replace(
+        definition.definition,
+        ~r/^links:\n(?:  - .*\n?)+/m,
+        "links:\n  - #{url}\n"
+      )
+
+    {:ok, updated} =
+      definition
+      |> Ecto.Changeset.change(%{definition: updated_yaml})
+      |> Repo.update()
+
+    updated
+  end
+
+  describe "probe_search/3" do
+    test "reports the row count when the search returns results" do
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          "<html><body><table><tr><td><a href=\"/download/1\">Some Release</a></td></tr></table></body></html>"
+        )
+      end)
+
+      url = "http://localhost:#{bypass.port}"
+
+      assert {:ok, count} = CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
+      assert count > 0
+    end
+
+    test "reports zero rows rather than success when the search parses nothing" do
+      # This is the state the reporter hit on KickassTorrents: "0 results".
+      # It is not a healthy indexer and it is not an unreachable one.
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/search", fn conn ->
+        Plug.Conn.resp(conn, 200, "<html><body><p>nothing here</p></body></html>")
+      end)
+
+      url = "http://localhost:#{bypass.port}"
+
+      assert {:ok, 0} = CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
+    end
+
+    test "reports an error when the search 404s even though the homepage is fine" do
+      # A homepage probe passes here. This is exactly the false green.
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+      Bypass.stub(bypass, "GET", "/search", fn conn -> Plug.Conn.resp(conn, 404, "") end)
+
+      url = "http://localhost:#{bypass.port}"
+
+      assert {:error, message} = CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
+      assert message =~ "404"
+    end
+  end
+
+  describe "probe query selection" do
+    # The definition below puts the keyword in the PATH, so the probe query is
+    # observable. A definition with an empty `inputs` map and a static path
+    # sends the query nowhere at all, which would make this assertion vacuous.
+    defp capture_path(bypass, test_pid) do
+      Bypass.stub(bypass, "GET", "/search/:term", fn conn ->
+        send(test_pid, {:request_path, conn.request_path})
+        Plug.Conn.resp(conn, 200, "<html><body><table><tr><td>x</td></tr></table></body></html>")
+      end)
+    end
+
+    test "a movie-search indexer is probed with a film title" do
+      bypass = Bypass.open()
+      capture_path(bypass, self())
+
+      url = "http://localhost:#{bypass.port}"
+
+      parsed =
+        parsed_for(url, modes: %{"movie-search" => ["q"]}, path: "/search/{{ .Keywords }}")
+
+      assert {:ok, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
+      assert_received {:request_path, path}
+      assert path =~ "The%20Matrix"
+    end
+
+    test "a tv-search indexer is probed with a series title" do
+      bypass = Bypass.open()
+      capture_path(bypass, self())
+
+      url = "http://localhost:#{bypass.port}"
+
+      parsed = parsed_for(url, modes: %{"tv-search" => ["q"]}, path: "/search/{{ .Keywords }}")
+
+      assert {:ok, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
+      assert_received {:request_path, path}
+      assert path =~ "Breaking%20Bad"
+    end
+
+    test "an indexer declaring neither mode falls back to a generic term" do
+      bypass = Bypass.open()
+      capture_path(bypass, self())
+
+      url = "http://localhost:#{bypass.port}"
+      parsed = parsed_for(url, modes: %{"search" => ["q"]}, path: "/search/{{ .Keywords }}")
+
+      assert {:ok, _} = CardigannHealthCheck.probe_search(parsed, %{}, url)
+      assert_received {:request_path, path}
+      assert path =~ "ubuntu"
+    end
+  end
+
+  describe "Cloudflare" do
+    test "a Cloudflare challenge is reported as :cloudflare, not as a generic error" do
+      # EZTV in the bug report. The operator needs to be told to configure
+      # FlareSolverr, which requires distinguishing this from an ordinary
+      # failure.
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/search", fn conn ->
+        # CardigannSearchEngine.cloudflare_challenge?/1 matches on body content
+        # (cf-browser-verification, "Cloudflare", etc.), not on the "server"
+        # header alone, so the body needs a real indicator string to be
+        # detected as a challenge rather than a bare 403.
+        conn
+        |> Plug.Conn.put_resp_header("server", "cloudflare")
+        |> Plug.Conn.resp(
+          403,
+          "<html><title>Just a moment...</title><body>Checking your browser before " <>
+            "accessing this site. cf-browser-verification. DDoS protection by Cloudflare." <>
+            "</body></html>"
+        )
+      end)
+
+      url = "http://localhost:#{bypass.port}"
+
+      assert {:cloudflare, _message} =
+               CardigannHealthCheck.probe_search(parsed_for(url), %{}, url)
+    end
+  end
+
+  describe "active_link promotion" do
+    test "a candidate whose homepage answers but whose search fails is not promoted" do
+      # This is the YTS shape: a proxy mirror serves HTML on / and 404s on the
+      # API path. Promoting it on the strength of the homepage GET is what made
+      # every later search use the wrong mirror.
+      definition = cardigann_definition_fixture(%{active_link: nil})
+
+      bypass = Bypass.open()
+      Bypass.stub(bypass, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+      Bypass.stub(bypass, "GET", "/search", fn conn -> Plug.Conn.resp(conn, 404, "") end)
+
+      {:ok, result} =
+        CardigannHealthCheck.execute_health_check(
+          put_link(definition, "http://localhost:#{bypass.port}")
+        )
+
+      refute result.success
+      assert Mydia.Repo.reload!(definition).active_link == nil
     end
   end
 end

--- a/test/mydia/indexers/cardigann_path_corpus_test.exs
+++ b/test/mydia/indexers/cardigann_path_corpus_test.exs
@@ -1,0 +1,70 @@
+defmodule Mydia.Indexers.CardigannPathCorpusTest do
+  @moduledoc """
+  Renders every `search.paths` entry shipped under test/fixtures/cardigann
+  against a query containing the two characters that broke 1337x, and asserts
+  the result is a legal URI.
+
+  This test earns its keep only because it renders the REAL path templates with
+  a REALISTIC query. Compare the ReleaseParser parity and corpus suites, which
+  stayed green through six rounds of a broken feature because they exercised the
+  unbound form of the function under test and were structurally blind to the
+  behavior in question. A version of this test that asserted on the parsed
+  definition structure instead of on rendered output would stay green through
+  exactly the bug it exists to catch.
+
+  URI.new/1 is the assertion because it rejects precisely what Mint rejects:
+  URI.new("search/a b/1/") returns {:error, " "} while
+  URI.new("search/a%20b/1/") succeeds, and it splits an inline query string
+  (KickassTorrents ships "search/?q={{ .Keywords }}") rather than tripping on
+  the reserved characters inside it.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.Cardigann.TemplateContext
+  alias Mydia.Indexers.{CardigannParser, CardigannTemplate}
+
+  # Space broke 1337x. Colon and the hyphen come from the same reported title.
+  @query "Spider-Man: Brand New Day 2026"
+
+  definition_files =
+    "test/fixtures/cardigann/*/definition.yml"
+    |> Path.wildcard()
+    |> Enum.sort()
+
+  # Fail loudly rather than vacuously passing if the fixture layout ever moves.
+  test "the fixture corpus is not empty" do
+    assert Path.wildcard("test/fixtures/cardigann/*/definition.yml") != []
+  end
+
+  for file <- definition_files do
+    @definition_file file
+    @indexer_name file |> Path.dirname() |> Path.basename()
+
+    test "every search path in #{@indexer_name} renders to a legal URI" do
+      yaml = File.read!(@definition_file)
+
+      assert {:ok, parsed} = CardigannParser.parse_definition(yaml),
+             "#{@definition_file} failed to parse"
+
+      context =
+        TemplateContext.build(parsed, query: @query, categories: [2000], config: %{})
+
+      parsed.search
+      |> Map.get(:paths, [])
+      |> Enum.with_index()
+      |> Enum.each(fn {search_path, index} ->
+        template = Map.get(search_path, :path) || Map.get(search_path, "path")
+
+        assert is_binary(template),
+               "#{@indexer_name} path #{index} has no path template"
+
+        assert {:ok, rendered} = CardigannTemplate.render(template, context),
+               "#{@indexer_name} path #{index} failed to render: #{inspect(template)}"
+
+        assert {:ok, _uri} = URI.new(rendered),
+               "#{@indexer_name} path #{index} rendered an illegal URI: " <>
+                 "#{inspect(rendered)} (from #{inspect(template)})"
+      end)
+    end
+  end
+end

--- a/test/mydia/indexers/cardigann_path_corpus_test.exs
+++ b/test/mydia/indexers/cardigann_path_corpus_test.exs
@@ -43,8 +43,15 @@ defmodule Mydia.Indexers.CardigannPathCorpusTest do
     test "every search path in #{@indexer_name} renders to a legal URI" do
       yaml = File.read!(@definition_file)
 
-      assert {:ok, parsed} = CardigannParser.parse_definition(yaml),
-             "#{@definition_file} failed to parse"
+      # Bind, assert with match?/2, then destructure. `assert pattern = expr, msg`
+      # raises MatchError from the match itself before assert/2 can report the
+      # message, which would drop the fixture name from a corpus-wide failure.
+      parse_result = CardigannParser.parse_definition(yaml)
+
+      assert match?({:ok, _}, parse_result),
+             "#{@definition_file} failed to parse: #{inspect(parse_result)}"
+
+      {:ok, parsed} = parse_result
 
       context =
         TemplateContext.build(parsed, query: @query, categories: [2000], config: %{})
@@ -58,10 +65,15 @@ defmodule Mydia.Indexers.CardigannPathCorpusTest do
         assert is_binary(template),
                "#{@indexer_name} path #{index} has no path template"
 
-        assert {:ok, rendered} = CardigannTemplate.render(template, context),
-               "#{@indexer_name} path #{index} failed to render: #{inspect(template)}"
+        render_result = CardigannTemplate.render(template, context)
 
-        assert {:ok, _uri} = URI.new(rendered),
+        assert match?({:ok, _}, render_result),
+               "#{@indexer_name} path #{index} failed to render: #{inspect(template)} " <>
+                 "(#{inspect(render_result)})"
+
+        {:ok, rendered} = render_result
+
+        assert match?({:ok, _}, URI.new(rendered)),
                "#{@indexer_name} path #{index} rendered an illegal URI: " <>
                  "#{inspect(rendered)} (from #{inspect(template)})"
       end)

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -913,7 +913,17 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
       end)
 
       params = %{query_params: %{}, headers: [], method: :get}
-      user_config = %{cookies: [%{"domain" => ".example.com"}, 42]}
+      # Decoded JSON can put a nested object or a number in either field, and
+      # interpolating one would raise the error normalization exists to prevent.
+      user_config = %{
+        cookies: [
+          %{"domain" => ".example.com"},
+          42,
+          %{"name" => %{"nested" => true}, "value" => "x"},
+          %{"name" => "n", "value" => ["a", "b"]},
+          %{"name" => 7, "value" => 9}
+        ]
+      }
 
       assert {:ok, _response} =
                CardigannSearchEngine.execute_http_request(

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -941,6 +941,68 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
       assert {:error, _} =
                CardigannSearchEngine.execute_search(parsed, [query: "ubuntu"], %{}, %{})
     end
+
+    test "advances to the next candidate on a 404" do
+      # YTS proxies answer / with HTML but 404 on /api/v2/list_movies.json, so
+      # the homepage probe promotes a mirror whose search does not exist. Ending
+      # the search there left five working mirrors untried.
+      missing = Bypass.open()
+      Bypass.stub(missing, "GET", "/search", fn conn -> Plug.Conn.resp(conn, 404, "") end)
+
+      working = Bypass.open()
+
+      Bypass.stub(working, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          "<html><body><table><tr><td>row</td></tr></table></body></html>"
+        )
+      end)
+
+      test_pid = self()
+      working_url = "http://localhost:#{working.port}"
+      parsed = parsed_for(["http://localhost:#{missing.port}", working_url])
+
+      assert {:ok, %{status: 200}} =
+               CardigannSearchEngine.execute_search(
+                 parsed,
+                 [query: "ubuntu", on_promote: fn url -> send(test_pid, {:promoted, url}) end],
+                 %{},
+                 %{}
+               )
+
+      assert_received {:promoted, ^working_url}
+    end
+
+    test "advances to the next candidate on an unfollowed redirect" do
+      redirecting = Bypass.open()
+
+      Bypass.stub(redirecting, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://elsewhere.test/")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      working = Bypass.open()
+
+      Bypass.stub(working, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          "<html><body><table><tr><td>row</td></tr></table></body></html>"
+        )
+      end)
+
+      working_url = "http://localhost:#{working.port}"
+
+      parsed = %{
+        parsed_for(["http://localhost:#{redirecting.port}", working_url])
+        | follow_redirect: false
+      }
+
+      assert {:ok, %{status: 200}} =
+               CardigannSearchEngine.execute_search(parsed, [query: "ubuntu"], %{}, %{})
+    end
   end
 
   describe "keywordsfilters" do

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -872,6 +872,60 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
       assert_receive {:cookie_header, ["session=abc123; token=xyz789"]}
     end
 
+    test "FlareSolverr map-shaped cookies are sent as name=value", %{definition: definition} do
+      # store_flaresolverr_cookies/2 writes maps into the same session row
+      # CardigannAuth.get_stored_session/1 reads back, so map entries reach here.
+      bypass = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html></html>")
+      end)
+
+      params = %{query_params: %{}, headers: [], method: :get}
+
+      user_config = %{
+        cookies: [
+          %{"name" => "cf_clearance", "value" => "abc123", "domain" => ".example.com"},
+          %{"name" => "session", "value" => "xyz789"}
+        ]
+      }
+
+      assert {:ok, _response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{bypass.port}/search",
+                 params,
+                 user_config
+               )
+
+      assert_receive {:cookie_header, ["cf_clearance=abc123; session=xyz789"]}
+    end
+
+    test "unusable cookie entries are dropped rather than crashing", %{definition: definition} do
+      bypass = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html></html>")
+      end)
+
+      params = %{query_params: %{}, headers: [], method: :get}
+      user_config = %{cookies: [%{"domain" => ".example.com"}, 42]}
+
+      assert {:ok, _response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{bypass.port}/search",
+                 params,
+                 user_config
+               )
+
+      assert_receive {:cookie_header, []}
+    end
+
     test "a cookie-bearing request does not follow a redirect", %{definition: definition} do
       # Req carries a manually supplied Cookie header to the redirect target even
       # on a different host, so a followed redirect would leak the session.

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -872,6 +872,68 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
       assert_receive {:cookie_header, ["session=abc123; token=xyz789"]}
     end
 
+    test "a cookie-bearing request does not follow a redirect", %{definition: definition} do
+      # Req carries a manually supplied Cookie header to the redirect target even
+      # on a different host, so a followed redirect would leak the session.
+      origin = Bypass.open()
+      target = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(origin, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://localhost:#{target.port}/landing")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      Bypass.stub(target, "GET", "/landing", fn conn ->
+        send(test_pid, :target_was_reached)
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      definition = %{definition | follow_redirect: true}
+      params = %{query_params: %{}, headers: [], method: :get}
+      user_config = %{cookies: ["session=secret"]}
+
+      assert {:ok, response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{origin.port}/search",
+                 params,
+                 user_config
+               )
+
+      assert response.status == 302
+      refute_receive :target_was_reached
+    end
+
+    test "a request without cookies still follows redirects", %{definition: definition} do
+      origin = Bypass.open()
+      target = Bypass.open()
+
+      Bypass.expect_once(origin, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://localhost:#{target.port}/landing")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      Bypass.expect_once(target, "GET", "/landing", fn conn ->
+        Plug.Conn.resp(conn, 200, "followed")
+      end)
+
+      definition = %{definition | follow_redirect: true}
+      params = %{query_params: %{}, headers: [], method: :get}
+
+      assert {:ok, response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{origin.port}/search",
+                 params,
+                 %{}
+               )
+
+      assert response.status == 200
+    end
+
     test "cookies are withheld from a cleartext non-loopback host", %{definition: definition} do
       params = %{query_params: %{}, headers: [], method: :get}
       user_config = %{cookies: ["session=abc123"]}

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -150,6 +150,86 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
 
       assert url == "https://example.com/search/test%20%26%20query%3Dvalue"
     end
+
+    test "uses an absolute path verbatim instead of appending it to the base URL" do
+      # The Pirate Bay's definition points its search at apibay.org. Appending
+      # that to the site's base URL produced
+      # https://thepiratebay.org/https://apibay.org/q.php?... and the site
+      # answered with a redirect, surfacing as "Unexpected status: 302".
+      definition = %Parsed{
+        id: "thepiratebay",
+        name: "The Pirate Bay",
+        description: "Test indexer",
+        language: "en-US",
+        type: "public",
+        encoding: "UTF-8",
+        links: ["https://thepiratebay.org"],
+        capabilities: %{modes: %{}},
+        search: %{
+          paths: [%{path: "https://apibay.org/q.php?q={{ .Keywords }}"}],
+          inputs: %{},
+          rows: %{selector: "tr"},
+          fields: %{title: %{selector: "td.title"}}
+        },
+        login: nil,
+        download: nil
+      }
+
+      assert {:ok, "https://apibay.org/q.php?q=ubuntu"} =
+               CardigannSearchEngine.build_search_url(definition, query: "ubuntu")
+    end
+
+    test "still joins a relative path onto the base URL" do
+      definition = %Parsed{
+        id: "test",
+        name: "Test",
+        description: "Test indexer",
+        language: "en-US",
+        type: "public",
+        encoding: "UTF-8",
+        links: ["https://example.com"],
+        capabilities: %{modes: %{}},
+        search: %{
+          paths: [%{path: "/search/{{ .Keywords }}/1/"}],
+          inputs: %{},
+          rows: %{selector: "tr"},
+          fields: %{title: %{selector: "td.title"}}
+        },
+        login: nil,
+        download: nil
+      }
+
+      assert {:ok, "https://example.com/search/ubuntu/1/"} =
+               CardigannSearchEngine.build_search_url(definition, query: "ubuntu")
+    end
+
+    test "joins a relative path that merely contains a colon onto the base URL" do
+      # URI.parse/1 is lenient: a leading "mailto:someone"-shaped path parses
+      # with a scheme but no host. A scheme-only guard would mistake it for
+      # an absolute URL and skip the join; the scheme-and-host guard must
+      # not.
+      definition = %Parsed{
+        id: "test",
+        name: "Test",
+        description: "Test indexer",
+        language: "en-US",
+        type: "public",
+        encoding: "UTF-8",
+        links: ["https://example.com"],
+        capabilities: %{modes: %{}},
+        search: %{
+          paths: [%{path: "mailto:{{ .Keywords }}"}],
+          inputs: %{},
+          rows: %{selector: "tr"},
+          fields: %{title: %{selector: "td.title"}}
+        },
+        login: nil,
+        download: nil
+      }
+
+      assert {:ok, "https://example.com/mailto:someone"} =
+               CardigannSearchEngine.build_search_url(definition, query: "someone")
+    end
   end
 
   describe "build_request_params/2" do

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -1006,4 +1006,112 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
       assert url =~ "1999"
     end
   end
+
+  describe "redirect handling" do
+    test "follows a redirect by default" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "/moved")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      Bypass.expect_once(bypass, "GET", "/moved", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          "<html><body><table><tr><td>row</td></tr></table></body></html>"
+        )
+      end)
+
+      parsed = redirecting_definition("http://localhost:#{bypass.port}", true)
+
+      assert {:ok, %{status: 200}} =
+               CardigannSearchEngine.execute_search(parsed, [query: "ubuntu"], %{}, %{})
+    end
+
+    test "an unfollowed redirect reports its Location instead of Unexpected status" do
+      bypass = Bypass.open()
+
+      Bypass.stub(bypass, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "https://elsewhere.test/blocked")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      parsed = redirecting_definition("http://localhost:#{bypass.port}", false)
+
+      assert {:error, %Error{message: message}} =
+               CardigannSearchEngine.execute_search(parsed, [query: "ubuntu"], %{}, %{})
+
+      assert message =~ "Redirected (HTTP 302)"
+      assert message =~ "https://elsewhere.test/blocked"
+      refute message =~ "Unexpected status"
+    end
+
+    defp redirecting_definition(link, follow_redirect) do
+      %Parsed{
+        id: "redirect-test",
+        name: "Redirect Test",
+        description: "Test indexer",
+        language: "en-US",
+        type: "public",
+        encoding: "UTF-8",
+        links: [link],
+        legacylinks: [],
+        capabilities: %{modes: %{}},
+        follow_redirect: follow_redirect,
+        settings: [],
+        search: %{
+          paths: [%{path: "/search"}],
+          inputs: %{},
+          headers: nil,
+          keywordsfilters: [],
+          rows: %{selector: "tr"},
+          fields: %{}
+        },
+        login: nil,
+        download: nil
+      }
+    end
+  end
+
+  describe "follow_redirect default" do
+    test "a definition without followredirect follows redirects" do
+      # No definition in the shipped corpus sets this key, so the old `false`
+      # default meant Mydia followed no redirects at all on search.
+      yaml = """
+      ---
+      id: no-followredirect
+      name: No Follow Redirect
+      description: test
+      language: en-US
+      type: public
+      encoding: UTF-8
+      links:
+        - https://example.test/
+      caps:
+        categorymappings:
+          - {id: 1, cat: Movies, desc: "Movies"}
+        modes:
+          search: [q]
+      search:
+        paths:
+          - path: /search
+        rows:
+          selector: tr
+        fields:
+          title:
+            selector: td
+          size:
+            selector: td
+          seeders:
+            selector: td
+      """
+
+      assert {:ok, parsed} = Mydia.Indexers.CardigannParser.parse_definition(yaml)
+      assert parsed.follow_redirect == true
+    end
+  end
 end

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -848,6 +848,46 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  user_config
                )
     end
+
+    test "cookies are sent to a loopback host over http", %{definition: definition} do
+      bypass = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html></html>")
+      end)
+
+      params = %{query_params: %{}, headers: [], method: :get}
+      user_config = %{cookies: ["session=abc123", "token=xyz789"]}
+
+      assert {:ok, _response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{bypass.port}/search",
+                 params,
+                 user_config
+               )
+
+      assert_receive {:cookie_header, ["session=abc123; token=xyz789"]}
+    end
+
+    test "cookies are withheld from a cleartext non-loopback host", %{definition: definition} do
+      params = %{query_params: %{}, headers: [], method: :get}
+      user_config = %{cookies: ["session=abc123"]}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          CardigannSearchEngine.execute_http_request(
+            definition,
+            "http://invalid-domain-for-testing.example/search",
+            params,
+            user_config
+          )
+        end)
+
+      assert log =~ "withholding session cookies"
+    end
   end
 
   describe "execute_search/4 base URL failover" do

--- a/test/mydia/indexers/cardigann_template_test.exs
+++ b/test/mydia/indexers/cardigann_template_test.exs
@@ -79,7 +79,9 @@ defmodule Mydia.Indexers.CardigannTemplateTest do
                  context
                )
 
-      assert result == "2000,2010,2020"
+      # Function results URL-encode by default, same as a bare field reference,
+      # so the comma delimiter comes back percent-encoded.
+      assert result == "2000%2C2010%2C2020"
     end
 
     test "handles nested conditionals with or" do
@@ -203,7 +205,9 @@ defmodule Mydia.Indexers.CardigannTemplateTest do
       assert {:ok, result} =
                CardigannTemplate.render(~s[{{ re_replace .value "t" "\\n" }}], context)
 
-      assert result == "\nes\n"
+      # Function results URL-encode by default, same as a bare field reference,
+      # so the newline the escape sequence produces comes back percent-encoded.
+      assert result == "%0Aes%0A"
     end
 
     test "returns error for unclosed action" do
@@ -319,7 +323,9 @@ defmodule Mydia.Indexers.CardigannTemplateTest do
     test "formats integer with %d" do
       context = %{num: 42}
 
-      assert {:ok, "value: 42"} =
+      # Function results URL-encode by default, same as a bare field reference,
+      # so the colon and space in the formatted string come back percent-encoded.
+      assert {:ok, "value%3A%2042"} =
                CardigannTemplate.render("{{ printf \"value: %d\" .num }}", context)
     end
 
@@ -452,7 +458,11 @@ defmodule Mydia.Indexers.CardigannTemplateTest do
 
     test "pipe to join function" do
       context = %{categories: [1, 2, 3]}
-      assert {:ok, "1+2+3"} = CardigannTemplate.render("{{ .categories | join \"+\" }}", context)
+
+      # Function/pipeline results URL-encode by default, same as a bare field
+      # reference, so the "+" delimiter comes back percent-encoded.
+      assert {:ok, "1%2B2%2B3"} =
+               CardigannTemplate.render("{{ .categories | join \"+\" }}", context)
     end
 
     test "pipe chain with different functions" do
@@ -810,6 +820,60 @@ defmodule Mydia.Indexers.CardigannTemplateTest do
                CardigannTemplate.render(
                  ~S[{{ (.Result.title) | re_replace " " "-" }}],
                  context
+               )
+    end
+  end
+
+  describe "URL encoding of function results" do
+    defp url_context(keywords, categories \\ []) do
+      %{
+        keywords: keywords,
+        config: %{},
+        query: %{series: keywords, season: nil, episode: nil},
+        categories: categories,
+        settings: []
+      }
+    end
+
+    test "encodes the result of a function call in a path context" do
+      # This is the exact shape CardigannOverrides.patch_1337x/1 installs.
+      # Leaving it raw produced
+      # {:invalid_request_target, "/search/Spider-Man: Brand New Day 2026/1/"}
+      # on every 1337x search.
+      assert {:ok, "search/Spider-Man%3A%20Brand%20New%20Day%202026/1/"} =
+               CardigannTemplate.render(
+                 "search/{{ or .Query.Album .Keywords }}/1/",
+                 url_context("Spider-Man: Brand New Day 2026")
+               )
+    end
+
+    test "encodes a function result the same way it encodes a bare field" do
+      context = url_context("a b:c")
+
+      assert {:ok, from_field} = CardigannTemplate.render("{{ .Keywords }}", context)
+      assert {:ok, from_function} = CardigannTemplate.render("{{ or .Keywords }}", context)
+
+      assert from_field == from_function
+    end
+
+    test "leaves a function result raw when the caller opts out" do
+      # build_query_params/2 renders with url_encode: false and lets Req encode,
+      # so query parameters must keep passing through untouched.
+      assert {:ok, "Spider-Man: Brand New Day 2026"} =
+               CardigannTemplate.render(
+                 "{{ or .Query.Album .Keywords }}",
+                 url_context("Spider-Man: Brand New Day 2026"),
+                 url_encode: false
+               )
+    end
+
+    test "encodes the delimiter that join produces" do
+      # The Pirate Bay uses {{ join .Categories "," }} inside its path. The
+      # comma arrives percent-encoded and decodes server side unchanged.
+      assert {:ok, "cat=2000%2C2010"} =
+               CardigannTemplate.render(
+                 "cat={{ join .Categories \",\" }}",
+                 url_context("", [2000, 2010])
                )
     end
   end

--- a/test/mydia/indexers/cardigann_template_test.exs
+++ b/test/mydia/indexers/cardigann_template_test.exs
@@ -112,6 +112,29 @@ defmodule Mydia.Indexers.CardigannTemplateTest do
       assert result == "/search/Dune%3A%20Part%20Two%202024/"
     end
 
+    # Regression: url_encode/1 used to convert the string to a charlist (Unicode
+    # code points) and pack each code point into a single byte, so it
+    # percent-encoded code points instead of UTF-8 bytes. "é" (U+00E9) came out
+    # as "%E9" (the raw code point) instead of "%C3%A9" (its two UTF-8 bytes),
+    # sending a request that matched nothing at the origin - silent corruption,
+    # not a crash, so it went unnoticed until inspected directly.
+    test "URL-encodes an accented title as UTF-8 bytes, not the raw code point" do
+      context = %{keywords: "Amélie"}
+      assert {:ok, result} = CardigannTemplate.render("/search/{{ .Keywords }}/", context)
+      assert result == "/search/Am%C3%A9lie/"
+    end
+
+    # Regression: for a code point whose UTF-8 encoding spans multiple bytes -
+    # every CJK character does - the old code truncated the code point to its
+    # low byte before encoding, so a full title collapsed into a couple of
+    # garbage %XX pairs. Foreign film and anime titles are routine content for
+    # a media manager, so this was not a theoretical edge case.
+    test "URL-encodes a CJK title as UTF-8 bytes instead of truncating it" do
+      context = %{keywords: "你好"}
+      assert {:ok, result} = CardigannTemplate.render("/search/{{ .Keywords }}/", context)
+      assert result == "/search/%E4%BD%A0%E5%A5%BD/"
+    end
+
     test "does not URL-encode when url_encode: false for query params" do
       context = %{keywords: "Dune: Part Two 2024"}
 
@@ -854,6 +877,18 @@ defmodule Mydia.Indexers.CardigannTemplateTest do
       assert {:ok, from_function} = CardigannTemplate.render("{{ or .Keywords }}", context)
 
       assert from_field == from_function
+    end
+
+    # Regression: this PR's first commit widened url_encode/1's reach to
+    # function and pipeline results (CardigannOverrides.patch_1337x/1 routes
+    # keywords through `{{ or .Query.Album .Query.Artist .Keywords }}`), so
+    # the byte-vs-code-point bug now corrupts a non-ASCII title reached
+    # through `or`, not only a bare `{{ .Keywords }}`.
+    test "encodes a non-ASCII function result as UTF-8 bytes, not code points" do
+      context = url_context("Amélie")
+
+      assert {:ok, "search/Am%C3%A9lie/1/"} =
+               CardigannTemplate.render("search/{{ or .Query.Album .Keywords }}/1/", context)
     end
 
     test "leaves a function result raw when the caller opts out" do

--- a/test/support/fixtures/indexers_fixtures.ex
+++ b/test/support/fixtures/indexers_fixtures.ex
@@ -51,6 +51,10 @@ defmodule Mydia.IndexersFixtures do
           fields:
             title:
               selector: td.title
+            size:
+              selector: td.size
+            seeders:
+              selector: td.seeders
             download:
               selector: td.download a
               attribute: href


### PR DESCRIPTION
Four independent defects in the Cardigann search path, plus the reason none of
them were caught: the indexer Test only fetched the site's homepage, so it
reported success for all four.

Reported by a user who added five indexers, saw five successful connection
tests, and had every single manual search fail.

## Fixes

- **1337x** (`{:invalid_request_target, "/search/Spider-Man: Brand New Day 2026/1/"}`)
  `CardigannTemplate` percent-encoded a bare field reference but never the
  result of a function or pipeline. Mydia's own `CardigannOverrides.patch_1337x/1`
  routes keywords through `{{ or .Query.Album .Query.Artist .Keywords }}`, so
  they landed raw in the URL path and Mint rejected the request target.
  A corpus test proved this also silently broke `torrentgalaxyclone`, which
  nobody had reported.

- **The Pirate Bay** ("Unexpected status: 302")
  `build_full_url/2` appended an absolute `path:` to the base URL. TPB's
  definition points at apibay.org, so Mydia requested
  `https://thepiratebay.org/https://apibay.org/q.php?...` and got a redirect.
  The guard requires both a scheme and a host, so a relative path containing a
  colon still joins correctly.

- **YTS** ("HTTP 404")
  A 404 on the first mirror ended the search while working mirrors went untried.
  YTS ships six links whose proxies serve HTML on `/` but 404 on
  `/api/v2/list_movies.json`. Failover now retries 404 and unfollowed 3xx.
  Failures that would repeat on every host stay terminal.

- **Redirects**
  `follow_redirect` defaulted to false from a `followredirect` key no shipped
  definition sets, and `validate_response/1` had no 3xx clause at all. Search
  now follows redirects, and an unfollowed one names its `Location`.

- **The connection test now runs a real search** and reports healthy, degraded
  or failed, with the rendered URL in the failure message. It previously
  reported "successful" whenever the homepage answered. A candidate that only
  passed the homepage probe is no longer promoted to `active_link`, and the
  result names the mirror that actually served it.

- **Private indexers never authenticated.** Two defects, found while wiring the
  connection test to a real search. Credentials were read by atom key only, but
  `definition.config` is a `Mydia.Settings.JsonMapType`, so anything that has
  been through the database comes back from `Jason.decode/1` string-keyed, and
  the admin form supplies string keys too: every configured username and
  password read as nil. With that fixed the login still never fired, because the
  credentials map always carried `cookies: []` (the sweep dropped nils, and an
  empty list is not nil) and `CardigannAuth.determine_auth_method/2` tests for
  `:cookies` before `:username`, so it selected `:cookie` and skipped the form
  login outright.

  This is not probe-specific. `search/3` calls the same helper, so private
  trackers have been searching anonymously and returning nothing all along. The
  connection test only made it visible, by reporting a failure the tracker never
  caused.

- **Session cookies went to cleartext hosts.** The Cookie header is a bearer
  credential for the tracker account and was sent without regard for the
  candidate's scheme; base URLs come from the definition's `links`, which are
  not all https (torrentlt ships `http://www.torrent.ai/`). It is now withheld
  on plain-http hosts with the reason logged, and the request still goes out
  anonymously. Loopback is exempt, a secure context in the sense browsers use
  the term.

## Testing

A new corpus test renders every `search.paths` entry in
`test/fixtures/cardigann` against a query containing a space and a colon and
asserts each result is a legal URI. It was confirmed to fail on the pre-fix
1337x path before being committed.

A form-login definition with string-keyed config asserts the login POST
actually carries the credentials. Confirmed load-bearing: reverting the key
fix fails it with `params["username"] == ""`.

Full suite: 9590 tests, 0 failures. Credo `--strict` and format clean.

## Scope

EZTV is not fixed here. It needs FlareSolverr, which the config bootstrap PR
makes usable again.

KickassTorrents ("0 results") is not conclusively fixed. A 200 that parses to
zero rows never reaches failover by design, and its definition ships an
`info_flaresolverr` setting, suggesting a 200-status challenge page. What this
PR changes for KAT is honesty: it now reports degraded rather than healthy.
Confirming the cause needs live access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indexer connection tests now verify authenticated searches, not just site reachability.
  * Health checks report successful, degraded, and failed searches, including result counts.
  * Search paths follow redirects by default and support more reliable failover.

* **Bug Fixes**
  * Improved Cloudflare detection and error reporting.
  * Fixed URL encoding for generated search values, including international characters.
  * Preserved stored credentials and sessions during indexer tests and searches.
  * Improved handling of session cookies and credential formats.
  * Admin notifications now accurately identify degraded and zero-result searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
