### PR TITLE
test: remove two nondeterministic CI failures

### DIFF
--- a/test/mydia/events/writer_test.exs
+++ b/test/mydia/events/writer_test.exs
@@ -20,6 +20,22 @@ defmodule Mydia.Events.WriterTest do
     %{category: "downloads", type: type, metadata: %{"title" => "Test"}}
   end
 
+  # GenServer.cast/2 returns before the message reaches the mailbox, so a bare
+  # Process.info/2 read straight after an enqueue is a race. Poll instead.
+  defp await_mailbox_len(pid, expected, remaining_ms \\ 2_000) do
+    case Process.info(pid, :message_queue_len) do
+      {:message_queue_len, ^expected} ->
+        :ok
+
+      {:message_queue_len, _actual} when remaining_ms > 0 ->
+        Process.sleep(10)
+        await_mailbox_len(pid, expected, remaining_ms - 10)
+
+      {:message_queue_len, actual} ->
+        flunk("mailbox never reached #{expected}; last read #{actual}")
+    end
+  end
+
   describe "enqueue/2" do
     test "flushes when the buffer reaches max_batch" do
       writer = start_writer(max_batch: 3, flush_interval_ms: 60_000)
@@ -92,37 +108,44 @@ defmodule Mydia.Events.WriterTest do
       assert types == ["download.completed", "download.initiated"]
     end
 
-    test "the mailbox bound is soft under concurrent enqueue/2 callers" do
+    test "the mailbox bound holds under concurrent enqueue/2 callers" do
       # cast_or_drop/2 reads Process.info/2 and then calls GenServer.cast/2 as
-      # two separate steps. That is fine against a single caller looping,
-      # since each iteration re-reads the mailbox length before casting, but
-      # concurrent callers can each observe room under max_mailbox before any
-      # of them casts. The result is not a hard cap: it can overshoot by up
-      # to one event per caller enqueuing at the same instant. Closing that
-      # gap exactly would need something like :atomics.compare_exchange/4
-      # (a plain :counters get-then-add is just as racy) plus reconciling
-      # that counter against buffer-overflow drops and writer restarts, and a
-      # bug in that accounting either wedges every future event or silently
-      # removes the bound, which is worse than a small overshoot for a
-      # droppable activity log. So this test documents the real, soft
-      # guarantee instead of asserting a hard cap the implementation does
-      # not provide.
+      # two separate steps, so the bound is soft: concurrent callers can each
+      # observe room before any of them casts, overshooting by up to one event
+      # per caller. Closing that gap exactly would need something like
+      # :atomics.compare_exchange/4 (a plain :counters get-then-add is just as
+      # racy) plus reconciling that counter against buffer-overflow drops and
+      # writer restarts, and a bug in that accounting either wedges every
+      # future event or silently removes the bound, which is worse than a small
+      # overshoot for a droppable activity log.
       #
-      # caller_count is deliberately much larger than this machine's core
-      # count. A small burst (say 32) can race entirely within one wave of
-      # true parallelism and land every event, which would make the "some
-      # events get dropped" assertion below flaky. A few hundred concurrent
-      # callers cannot all be scheduled at once, so later callers reliably
-      # observe an already-elevated mailbox length and get dropped, even
-      # though which ones do is nondeterministic.
+      # An earlier formulation released 300 concurrent callers against an empty
+      # mailbox and asserted that fewer than 300 landed, reasoning that a few
+      # hundred callers cannot all be scheduled at once so the later ones would
+      # observe an elevated mailbox and drop. That asserted scheduler behavior
+      # rather than writer behavior, and it failed on CI (Test / PostgreSQL at
+      # 12bdd3d62, left 300, both sides equal) on a runner fast enough to
+      # schedule every caller in one wave.
+      #
+      # This formulation establishes the over-bound condition before any
+      # concurrent caller runs. cast_or_drop/2 drops on `len >= max_mailbox`
+      # (lib/mydia/events/writer.ex:132), and every caller reads the mailbox at
+      # its own enqueue time, which is after the pre-fill, so every caller
+      # drops no matter how they interleave. The soft overshoot is not asserted
+      # because it cannot be observed deterministically.
       caller_count = 300
       max_mailbox = 2
       writer = start_writer(max_batch: 1000, flush_interval_ms: 60_000, max_mailbox: max_mailbox)
 
-      # :sys.suspend/1 halts the writer's own receive loop without touching
-      # its real mailbox, so casts pile up there exactly as they would while
-      # the writer is genuinely blocked inside Repo.insert_all/2.
+      # :sys.suspend/1 halts the writer's own receive loop without touching its
+      # real mailbox, so casts pile up there exactly as they would while the
+      # writer is genuinely blocked inside Repo.insert_all/2.
       :sys.suspend(writer)
+
+      # Fill the mailbox to the bound. GenServer.cast/2 is asynchronous, so poll
+      # rather than assuming the messages have landed.
+      for _ <- 1..max_mailbox, do: Writer.enqueue(attrs(), writer)
+      await_mailbox_len(writer, max_mailbox)
 
       test_pid = self()
 
@@ -131,7 +154,7 @@ defmodule Mydia.Events.WriterTest do
           spawn(fn ->
             send(test_pid, :ready)
             receive do: (:go -> :ok)
-            Writer.enqueue(attrs("download.initiated"), writer)
+            Writer.enqueue(attrs("download.completed"), writer)
             send(test_pid, {:done, n})
           end)
         end
@@ -140,18 +163,15 @@ defmodule Mydia.Events.WriterTest do
       for pid <- callers, do: send(pid, :go)
       for _ <- callers, do: assert_receive({:done, _}, 5_000)
 
-      {:message_queue_len, len} = Process.info(writer, :message_queue_len)
-
-      # The bound still did real work: well under every offered event landed.
-      assert len < caller_count
-      # The bound is soft, not exact: the theoretical worst case is every
-      # caller landing between the check and the cast, i.e. max_mailbox
-      # plus caller_count. Actual runs land nowhere near that, but the test
-      # only asserts what is actually guaranteed.
-      assert len <= max_mailbox + caller_count
+      # Not one concurrent caller landed: the mailbox is still exactly at the
+      # bound. This is the assertion the earlier formulation was reaching for.
+      assert {:message_queue_len, ^max_mailbox} =
+               Process.info(writer, :message_queue_len)
 
       :sys.resume(writer)
-      Writer.flush(writer)
+
+      log = capture_log(fn -> Writer.flush(writer) end)
+      assert log =~ "Events.Writer mailbox full, dropped #{caller_count} event(s)"
     end
   end
 

--- a/test/mydia_web/feature_case_message_test.exs
+++ b/test/mydia_web/feature_case_message_test.exs
@@ -1,0 +1,31 @@
+defmodule MydiaWeb.FeatureCaseMessageTest do
+  # The message wait_for_liveview/2 raises on timeout, tested as a pure
+  # function. Deliberately not tagged :feature: it needs no browser, so it runs
+  # in the default suite where a regression is caught immediately rather than
+  # only in the E2E job.
+  use ExUnit.Case, async: true
+
+  alias MydiaWeb.FeatureCase
+
+  describe "liveview_failure_message/2" do
+    test "names the unconnected case when a root LiveView is present" do
+      message = FeatureCase.liveview_failure_message(true, 15_000)
+
+      assert message =~ "socket never joined"
+      assert message =~ "15000ms"
+      # The top cause in this repo is a worktree with no asset build, so the
+      # message has to name the fix rather than leaving it to be rediscovered.
+      assert message =~ "mix assets.build"
+      refute message =~ "no element matches"
+    end
+
+    test "names the absent case when no root LiveView rendered" do
+      message = FeatureCase.liveview_failure_message(false, 15_000)
+
+      assert message =~ "No root LiveView rendered"
+      assert message =~ "15000ms"
+      assert message =~ "redirect"
+      refute message =~ "mix assets.build"
+    end
+  end
+end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -259,6 +259,20 @@ defmodule MydiaWeb.FeatureCase do
   raise from `find/2` reports only that a selector did not match, which cannot
   say whether the page had no LiveView at all or had one that never connected.
 
+  Each poll reads the DOM through `eval_js/3` (`Wallaby.Browser.execute_script/4`),
+  not `Wallaby.Browser.has?/2`. `has?/2` goes through `execute_query/2` and
+  `retry/2`, which themselves poll up to the global `:max_wait_time` before
+  reporting a miss, so a single failed `has?/2` call can eat that entire budget
+  and make the `:timeout` option here a lower bound in name only. `execute_script`
+  issues one WebDriver call and returns, so `eventually/2`'s own budget is what
+  actually governs the wait.
+
+  A WebDriver-level failure (a crashed browser session, for example) surfaces
+  as a `RuntimeError` from deep inside Wallaby's HTTP client, indistinguishable
+  by type from `eventually/2`'s own timeout. Only the latter's exact message is
+  turned into the diagnostic below; anything else is re-raised unchanged so a
+  dead session is never reported as an ordinary unconnected socket.
+
   Options: `:timeout` (ms, default 15_000).
   """
   def wait_for_liveview(session, opts \\ []) do
@@ -267,10 +281,7 @@ defmodule MydiaWeb.FeatureCase do
     try do
       eventually(
         fn ->
-          if Wallaby.Browser.has?(
-               session,
-               Wallaby.Query.css("[data-phx-main].phx-connected", count: :any)
-             ) do
+          if root_connected?(session) do
             {:ok, session}
           else
             :error
@@ -280,14 +291,23 @@ defmodule MydiaWeb.FeatureCase do
         description: "the root LiveView to connect its socket"
       )
     rescue
-      RuntimeError ->
-        root_present? =
-          Wallaby.Browser.has?(session, Wallaby.Query.css("[data-phx-main]", count: :any))
-
-        reraise liveview_failure_message(root_present?, timeout), __STACKTRACE__
+      e in RuntimeError ->
+        if String.starts_with?(e.message, "eventually/2 timed out") do
+          reraise liveview_failure_message(root_present?(session), timeout), __STACKTRACE__
+        else
+          reraise e, __STACKTRACE__
+        end
     end
 
     session
+  end
+
+  defp root_connected?(session) do
+    eval_js(session, "return document.querySelector('[data-phx-main].phx-connected') !== null;")
+  end
+
+  defp root_present?(session) do
+    eval_js(session, "return document.querySelector('[data-phx-main]') !== null;")
   end
 
   @doc """

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -253,13 +253,78 @@ defmodule MydiaWeb.FeatureCase do
   on it alone proves nothing. LiveView adds `phx-connected` to the view
   container in `hideLoader()` once the join succeeds, which is the real signal.
 
-  `find/2` polls through `Wallaby.Browser.retry/2` until `:max_wait_time`
-  (10s, see config/test.exs), so this returns as soon as the socket is up
-  rather than after a fixed delay.
+  This polls through `eventually/2` with its own budget rather than through
+  `Wallaby.Browser.find/2` and the global `:max_wait_time`, for two reasons: a
+  socket join is slower than a DOM assertion and deserves a longer wait, and a
+  raise from `find/2` reports only that a selector did not match, which cannot
+  say whether the page had no LiveView at all or had one that never connected.
+
+  Options: `:timeout` (ms, default 15_000).
   """
-  def wait_for_liveview(session) do
-    Wallaby.Browser.find(session, Wallaby.Query.css("[data-phx-main].phx-connected"))
+  def wait_for_liveview(session, opts \\ []) do
+    timeout = Keyword.get(opts, :timeout, 15_000)
+
+    try do
+      eventually(
+        fn ->
+          if Wallaby.Browser.has?(
+               session,
+               Wallaby.Query.css("[data-phx-main].phx-connected", count: :any)
+             ) do
+            {:ok, session}
+          else
+            :error
+          end
+        end,
+        timeout: timeout,
+        description: "the root LiveView to connect its socket"
+      )
+    rescue
+      RuntimeError ->
+        root_present? =
+          Wallaby.Browser.has?(session, Wallaby.Query.css("[data-phx-main]", count: :any))
+
+        reraise liveview_failure_message(root_present?, timeout), __STACKTRACE__
+    end
+
     session
+  end
+
+  @doc """
+  The message `wait_for_liveview/2` raises when the socket does not join.
+
+  Public so it can be tested without a browser. `root_present?` is whether any
+  `[data-phx-main]` element exists, which is what separates the two causes.
+  """
+  def liveview_failure_message(true, timeout_ms) do
+    """
+    The root LiveView rendered but its socket never joined within #{timeout_ms}ms.
+    `[data-phx-main]` is present; `phx-connected` is not.
+
+    The usual cause is a missing asset build. Without priv/static/assets/app.js
+    there is no LiveView client, so the socket cannot connect. A fresh worktree
+    never has one, since the asset build is per-worktree. Fix with:
+
+        devenv shell -- bash -c 'mix assets.setup && mix assets.build'
+
+    Then confirm the setup with:
+
+        mix test test/mydia_web/features/smoke_test.exs --only feature
+
+    Other causes: a JavaScript exception before LiveView boots, or a server
+    crash during the join.
+    """
+  end
+
+  def liveview_failure_message(false, timeout_ms) do
+    """
+    No root LiveView rendered within #{timeout_ms}ms: no element matches
+    `[data-phx-main]`.
+
+    The page under test is probably not the page expected. Check for a redirect,
+    an unauthenticated session lands on the log-in page, or for a route that
+    renders a plain controller view rather than a LiveView.
+    """
   end
 
   @doc """


### PR DESCRIPTION
Two tests that fail without a code change.

## `Events.WriterTest`

The concurrency test released 300 callers against an empty mailbox and asserted
fewer than 300 landed, reasoning that a few hundred callers cannot all be
scheduled at once so the later ones would observe an elevated mailbox and drop.
That asserts BEAM scheduler behavior rather than writer behavior. It failed on
Test / PostgreSQL at 12bdd3d62 with `assert len < caller_count`, left 300, both
sides equal, on a runner fast enough to schedule every caller in one wave.

The mailbox is now filled to `max_mailbox` before the callers are released.
`cast_or_drop/2` drops on `len >= max_mailbox` and every caller reads the
mailbox at its own enqueue time, so every caller drops regardless of
interleaving. The soft overshoot is deliberately left unasserted: it cannot be
observed deterministically.

Verified over 20 consecutive runs with different seeds, not one.

## `wait_for_liveview/1`

It delegated to `Wallaby.Browser.find/2`, so a LiveView socket that never
joined surfaced as "expected to find 1 visible element that matched
`[data-phx-main].phx-connected`". That message cannot distinguish a page with
no LiveView from a LiveView whose socket never connected, and those have
different causes. It is how `GeometrySelfTest` failed at b802b04 with an error
mentioning geometry nowhere.

It now polls with its own budget and raises a message naming which of the two
happened. For the connect case it names the missing asset build, which is the
usual cause: a fresh worktree has no `priv/static/assets`, so there is no
`app.js` for the socket to boot from.

Two review findings were fixed before this PR:

- The `rescue RuntimeError` was too broad. Wallaby's `httpclient.ex` raises a
  bare `RuntimeError` for unenumerated WebDriver errors ("chrome not
  reachable", "invalid session id") from inside the polled function, so a dead
  browser session would have been reported as a LiveView connect failure. The
  rescue now matches only `eventually/2`'s own timeout and re-raises anything
  else with its original stacktrace.
- The new budget was not actually independent of Wallaby's `max_wait_time`.
  `has?/2` retries internally for up to 10s per call, so a stuck LiveView took
  20-30s to produce a diagnostic, worse than the 10s it replaced. Polling now
  goes through a single non-retrying `execute_script` call. Measured: a probe
  against a route with no LiveView and a 500ms budget raises in 0.9s.

## Scope

Test-only. No `lib/` changes.

`ui_hooks_test.exs`, which failed at 12bdd3d62 on a missing
`#auto-import-toggle`, passes here. That commit predates #600, which wired
`auto_import`, so it needed no fix.

Not addressed: the `FranchiseSectionTest` `render_async` timeout on SQLite. It
is a live-relay escape with its own design, and fixing it belongs there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved LiveView test failure diagnostics by distinguishing between unconnected and missing root views.
  - Added clearer timeout messages with relevant troubleshooting guidance and duration details.

- **Tests**
  - Made concurrent event-queue testing deterministic.
  - Added coverage confirming mailbox limits and accurate reporting of dropped events.
  - Added validation for LiveView failure messages and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->