### PR TITLE
fix(config): stop one malformed config_settings row disabling every database setting

### DIFF
--- a/lib/mydia/config/schema/paths.ex
+++ b/lib/mydia/config/schema/paths.ex
@@ -14,9 +14,13 @@ defmodule Mydia.Config.Schema.Paths do
   `Mydia.Settings.get_config_setting_by_key/1` and never reach that merge. They
   have no schema field, so the merge has always built them into its map and
   `Mydia.Config.Schema.changeset/2` has always dropped them again by ignoring
-  the unknown key. Three of the five name a section the schema does not have at
-  all. They are listed in `@direct_keys` with their reader, so the next person
-  to add a `get_config_setting_by_key/1` call with a literal key finds the list.
+  the unknown key. Four of the five keys name a section the schema does not
+  have at all, spread across three such sections: `crash_reporting`,
+  `feedback`, and `library` (which contributes two keys). The fifth,
+  `media.default_quality_profile_id`, names a section that does exist but
+  bypasses the merge anyway. They are listed in `@direct_keys` with their
+  reader, so the next person to add a `get_config_setting_by_key/1` call with
+  a literal key finds the list.
 
   `database.*` is deliberately in neither. The database section is consumed to
   open the repo, before the database layer can be read, so such a row can never
@@ -26,6 +30,16 @@ defmodule Mydia.Config.Schema.Paths do
   alias Mydia.Config.Schema
 
   @excluded_sections [:database]
+
+  # The environment variable that actually controls a key in an excluded
+  # section, for the ones that map to one. `Mydia.Repo`'s real pool_size and
+  # database_path come from these variables in config/runtime.exs, never from
+  # a config_settings row, which is why :database is excluded from
+  # @overlay_index below rather than folded into it.
+  @excluded_key_env_vars %{
+    "database.path" => "DATABASE_PATH",
+    "database.pool_size" => "POOL_SIZE"
+  }
 
   @direct_keys %{
     "crash_reporting.enabled" => "Mydia.CrashReporter",
@@ -53,6 +67,23 @@ defmodule Mydia.Config.Schema.Paths do
                    end
                  end)
                  |> Map.new()
+
+  # Every leaf of an excluded section, built the same way as @overlay_index
+  # above. Used only so cast_overlay_key/2 can tell an operator "this cannot
+  # be set from the database" apart from "this key does not exist"; never
+  # accepted anywhere else.
+  @excluded_index Schema.__schema__(:embeds)
+                  |> Enum.filter(&(&1 in @excluded_sections))
+                  |> Enum.flat_map(fn section ->
+                    case Schema.__schema__(:embed, section) do
+                      %Ecto.Embedded{cardinality: :one, related: related} ->
+                        Enum.map(related.__schema__(:fields), &"#{section}.#{&1}")
+
+                      _ ->
+                        []
+                    end
+                  end)
+                  |> MapSet.new()
 
   @doc "Every dotted key that maps to a leaf of an `embeds_one` schema section."
   @spec overlay_keys() :: [String.t()]
@@ -99,13 +130,31 @@ defmodule Mydia.Config.Schema.Paths do
         end
 
       :error ->
-        {:error, "#{key}: unknown configuration key"}
+        {:error, unknown_key_reason(key)}
+    end
+  end
+
+  # A key outside @overlay_index is either a genuine typo or a real schema
+  # field that was excluded on purpose. Telling those apart matters: an
+  # operator who sees "unknown configuration key" for database.pool_size will
+  # reasonably conclude they mistyped something, when the actionable fact is
+  # that the row can never take effect and POOL_SIZE is the real knob.
+  defp unknown_key_reason(key) do
+    case Map.fetch(@excluded_key_env_vars, key) do
+      {:ok, env_var} ->
+        "#{key}: set via the #{env_var} environment variable, not the database"
+
+      :error ->
+        if MapSet.member?(@excluded_index, key) do
+          "#{key}: cannot be set from the database; this section is read before the database layer exists"
+        else
+          "#{key}: unknown configuration key"
+        end
     end
   end
 
   # An empty value means unset, which is how clearing a field in the admin UI
-  # has always behaved, and how media.default_quality_profile_id records a
-  # cleared default.
+  # has always behaved, and how server.url_host records a cleared default.
   defp cast_value(_type, nil), do: {:ok, nil}
   defp cast_value(_type, ""), do: {:ok, nil}
 

--- a/lib/mydia/config/schema/paths.ex
+++ b/lib/mydia/config/schema/paths.ex
@@ -1,0 +1,137 @@
+defmodule Mydia.Config.Schema.Paths do
+  @moduledoc """
+  The dotted keys a `config_settings` row may legally carry, and the type each
+  one casts to.
+
+  `config_settings` holds two populations of row, consumed by unrelated code.
+
+  **Overlay rows** name a leaf of an `embeds_one` section of
+  `Mydia.Config.Schema`, for example `server.port`.
+  `Mydia.Settings.RuntimeConfig.build_config_map/1` merges these into the cached
+  runtime config, between the YAML and environment layers.
+
+  **Direct-lookup rows** are read by key through
+  `Mydia.Settings.get_config_setting_by_key/1` and never reach that merge. They
+  have no schema field, so the merge has always built them into its map and
+  `Mydia.Config.Schema.changeset/2` has always dropped them again by ignoring
+  the unknown key. Three of the five name a section the schema does not have at
+  all. They are listed in `@direct_keys` with their reader, so the next person
+  to add a `get_config_setting_by_key/1` call with a literal key finds the list.
+
+  `database.*` is deliberately in neither. The database section is consumed to
+  open the repo, before the database layer can be read, so such a row can never
+  take effect.
+  """
+
+  alias Mydia.Config.Schema
+
+  @excluded_sections [:database]
+
+  @direct_keys %{
+    "crash_reporting.enabled" => "Mydia.CrashReporter",
+    "feedback.enabled" => "Mydia.Feedback.enabled?/0",
+    "library.auto_repair_enabled" => "Mydia.Library.DatabaseHealthCheck",
+    "library.auto_repair_threshold" => "Mydia.Library.DatabaseHealthCheck",
+    "media.default_quality_profile_id" => "Mydia.Settings.QualityProfiles"
+  }
+
+  # Built at compile time from the schema itself. A hand-maintained list drifts
+  # from the schema and turns the write-side validation into a source of false
+  # rejections, so this must stay derived.
+  @overlay_index Schema.__schema__(:embeds)
+                 |> Enum.reject(&(&1 in @excluded_sections))
+                 |> Enum.flat_map(fn section ->
+                   case Schema.__schema__(:embed, section) do
+                     %Ecto.Embedded{cardinality: :one, related: related} ->
+                       Enum.map(related.__schema__(:fields), fn field ->
+                         {"#{section}.#{field}",
+                          {[section, field], related.__schema__(:type, field)}}
+                       end)
+
+                     _ ->
+                       []
+                   end
+                 end)
+                 |> Map.new()
+
+  @doc "Every dotted key that maps to a leaf of an `embeds_one` schema section."
+  @spec overlay_keys() :: [String.t()]
+  def overlay_keys, do: Map.keys(@overlay_index)
+
+  @doc "Every dotted key read directly by `get_config_setting_by_key/1`."
+  @spec direct_keys() :: [String.t()]
+  def direct_keys, do: Map.keys(@direct_keys)
+
+  @doc "Whether a key belongs to either population."
+  @spec known?(String.t()) :: boolean()
+  def known?(key), do: Map.has_key?(@overlay_index, key) or Map.has_key?(@direct_keys, key)
+
+  @doc "Whether a key is read directly rather than through the config merge."
+  @spec direct?(String.t()) :: boolean()
+  def direct?(key), do: Map.has_key?(@direct_keys, key)
+
+  @doc """
+  Resolves one row to the path and value it contributes to the merge.
+
+  Returns `{:ok, path, value}` for an overlay row, `:direct` for a row that is
+  read by key and contributes nothing, and `{:error, reason}` for a row that
+  cannot be used at all. Never raises: the caller decides what a bad row means.
+  """
+  @spec cast_overlay(String.t(), String.t() | nil) ::
+          {:ok, [atom()], term()} | :direct | {:error, String.t()}
+  def cast_overlay(key, value) do
+    if direct?(key) do
+      :direct
+    else
+      cast_overlay_key(key, value)
+    end
+  end
+
+  defp cast_overlay_key(key, value) do
+    case Map.fetch(@overlay_index, key) do
+      {:ok, {path, type}} ->
+        case cast_value(type, value) do
+          {:ok, casted} ->
+            {:ok, path, casted}
+
+          :error ->
+            {:error, "#{key}: #{inspect(value)} is not a valid #{inspect(type)}"}
+        end
+
+      :error ->
+        {:error, "#{key}: unknown configuration key"}
+    end
+  end
+
+  # An empty value means unset, which is how clearing a field in the admin UI
+  # has always behaved, and how media.default_quality_profile_id records a
+  # cleared default.
+  defp cast_value(_type, nil), do: {:ok, nil}
+  defp cast_value(_type, ""), do: {:ok, nil}
+
+  # Array fields arrive comma-separated, matching how the environment layer
+  # parses the same fields.
+  defp cast_value({:array, inner}, value) when is_binary(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.reduce_while({:ok, []}, fn part, {:ok, acc} ->
+      case Ecto.Type.cast(inner, part) do
+        {:ok, casted} -> {:cont, {:ok, [casted | acc]}}
+        _ -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, list} -> {:ok, Enum.reverse(list)}
+      :error -> :error
+    end
+  end
+
+  defp cast_value(type, value) do
+    case Ecto.Type.cast(type, value) do
+      {:ok, casted} -> {:ok, casted}
+      _ -> :error
+    end
+  end
+end

--- a/lib/mydia/settings.ex
+++ b/lib/mydia/settings.ex
@@ -840,6 +840,18 @@ defmodule Mydia.Settings do
   defdelegate load_database_config(loader), to: Mydia.Settings.RuntimeConfig
 
   @doc """
+  Every `config_settings` row that cannot be used, with the reason.
+
+  A row reaches this list by naming a key the schema does not have, or by
+  holding a value that will not cast to its field's type. This is what the
+  admin UI shows an operator to explain why a setting is not taking effect.
+  """
+  @spec invalid_config_settings() :: [
+          %{setting: Mydia.Settings.ConfigSetting.t(), reason: String.t()}
+        ]
+  defdelegate invalid_config_settings(), to: Mydia.Settings.RuntimeConfig
+
+  @doc """
   Gets the runtime configuration.
 
   Returns the full configuration struct loaded at application startup.

--- a/lib/mydia/settings/config_setting.ex
+++ b/lib/mydia/settings/config_setting.ex
@@ -117,9 +117,16 @@ defmodule Mydia.Settings.ConfigSetting do
     end)
   end
 
-  # Only overlay rows are typed; a direct-lookup row's reader parses its own
-  # value. Skipped entirely when the key is already invalid, so one bad row
-  # produces one error rather than two.
+  # validate_known_key/1 is built on validate_change/3, which Ecto skips
+  # whenever :key is absent from this changeset's changes — the case on a
+  # value-only update (e.g. the API's PATCH endpoint, which only ever sends
+  # :value and :description) against a row whose existing key predates this
+  # validation. Re-check known?/1 unconditionally here so an unknown key is
+  # always caught and always blamed on :key, rather than surfacing as a
+  # :value error from the cast_overlay/2 call below. Only overlay rows are
+  # typed beyond that; a direct-lookup row's reader parses its own value.
+  # Skipped entirely when :key already has an error, so one bad row produces
+  # one error rather than two.
   defp validate_value_type(%Ecto.Changeset{errors: errors} = changeset) do
     key = get_field(changeset, :key)
 
@@ -127,7 +134,13 @@ defmodule Mydia.Settings.ConfigSetting do
       Keyword.has_key?(errors, :key) ->
         changeset
 
-      key == nil or Paths.direct?(key) ->
+      key == nil ->
+        changeset
+
+      not Paths.known?(key) ->
+        add_error(changeset, :key, "is not a known configuration key")
+
+      Paths.direct?(key) ->
         changeset
 
       true ->

--- a/lib/mydia/settings/config_setting.ex
+++ b/lib/mydia/settings/config_setting.ex
@@ -48,6 +48,8 @@ defmodule Mydia.Settings.ConfigSetting do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Mydia.Config.Schema.Paths
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
@@ -96,7 +98,43 @@ defmodule Mydia.Settings.ConfigSetting do
     |> cast(attrs, [:key, :value, :category, :description, :updated_by_id])
     |> validate_required([:key, :category])
     |> validate_inclusion(:category, @categories)
+    |> validate_known_key()
+    |> validate_value_type()
     |> unique_constraint(:key)
     |> foreign_key_constraint(:updated_by_id)
+  end
+
+  # A key outside both populations names nothing. Merged, it was built into the
+  # config map and then dropped by Mydia.Config.Schema.changeset/2 ignoring the
+  # unknown field, so the operator saw a saved setting that never applied.
+  defp validate_known_key(changeset) do
+    validate_change(changeset, :key, fn :key, key ->
+      if Paths.known?(key) do
+        []
+      else
+        [key: "is not a known configuration key"]
+      end
+    end)
+  end
+
+  # Only overlay rows are typed; a direct-lookup row's reader parses its own
+  # value. Skipped entirely when the key is already invalid, so one bad row
+  # produces one error rather than two.
+  defp validate_value_type(%Ecto.Changeset{errors: errors} = changeset) do
+    key = get_field(changeset, :key)
+
+    cond do
+      Keyword.has_key?(errors, :key) ->
+        changeset
+
+      key == nil or Paths.direct?(key) ->
+        changeset
+
+      true ->
+        case Paths.cast_overlay(key, get_field(changeset, :value)) do
+          {:error, reason} -> add_error(changeset, :value, reason)
+          _ -> changeset
+        end
+    end
   end
 end

--- a/lib/mydia/settings/runtime_config.ex
+++ b/lib/mydia/settings/runtime_config.ex
@@ -6,6 +6,7 @@ defmodule Mydia.Settings.RuntimeConfig do
 
   require Logger
 
+  alias Mydia.Config.Schema.Paths
   alias Mydia.Repo
 
   alias Mydia.Settings.{
@@ -130,7 +131,9 @@ defmodule Mydia.Settings.RuntimeConfig do
   @spec load_database_config((-> [ConfigSetting.t()])) :: {:ok, map()}
   def load_database_config(loader \\ &list_config_settings/0) do
     try do
-      {:ok, loader.() |> build_config_map()}
+      {config_map, skipped} = build_config_map(loader.())
+      log_skipped_config_settings(skipped)
+      {:ok, config_map}
     rescue
       error in [
         DBConnection.ConnectionError,
@@ -145,6 +148,25 @@ defmodule Mydia.Settings.RuntimeConfig do
 
         {:ok, %{}}
     end
+  end
+
+  @doc """
+  Every `config_settings` row that cannot be used, with the reason.
+
+  A row reaches this list by naming a key the schema does not have, or by
+  holding a value that will not cast to its field's type. Each one is skipped
+  by the merge rather than invalidating it, so this is what the admin UI shows
+  an operator to explain why a setting is not taking effect.
+  """
+  @spec invalid_config_settings() :: [%{setting: ConfigSetting.t(), reason: String.t()}]
+  def invalid_config_settings do
+    list_config_settings()
+    |> Enum.flat_map(fn setting ->
+      case Paths.cast_overlay(setting.key, setting.value) do
+        {:error, reason} -> [%{setting: setting, reason: reason}]
+        _ -> []
+      end
+    end)
   end
 
   def get_runtime_config do
@@ -582,47 +604,32 @@ defmodule Mydia.Settings.RuntimeConfig do
     end)
   end
 
+  # Returns {config_map, skipped}. A row that names an unknown key or holds an
+  # uncastable value is skipped, never allowed to invalidate the batch: before
+  # this, one bad row made Loader.validate/1's changeset invalid and
+  # Mydia.Config.Bootstrap dropped every database-backed setting. Keys are
+  # resolved through the compile-time index, so a segment can no longer mint an
+  # atom from database content, and a parent/child key pair can no longer drive
+  # put_in_path/3 into Map.put/3 on a non-map.
   defp build_config_map(config_settings) do
-    Enum.reduce(config_settings, %{}, fn setting, acc ->
-      # Parse the dot-notation key into path segments
-      # e.g., "server.port" -> [:server, :port]
-      path =
-        setting.key
-        |> String.split(".")
-        |> Enum.map(&String.to_atom/1)
-
-      # Parse the value based on common patterns
-      parsed_value = parse_config_value(setting.value)
-
-      # Put the value into the nested map
-      put_in_path(acc, path, parsed_value)
+    Enum.reduce(config_settings, {%{}, []}, fn setting, {acc, skipped} ->
+      case Paths.cast_overlay(setting.key, setting.value) do
+        {:ok, path, value} -> {put_in_path(acc, path, value), skipped}
+        :direct -> {acc, skipped}
+        {:error, reason} -> {acc, [%{key: setting.key, reason: reason} | skipped]}
+      end
     end)
   end
 
-  defp parse_config_value(nil), do: nil
-  defp parse_config_value(""), do: nil
+  defp log_skipped_config_settings([]), do: :ok
 
-  defp parse_config_value(value) when is_binary(value) do
-    cond do
-      # Boolean values
-      value == "true" ->
-        true
-
-      value == "false" ->
-        false
-
-      # Integer values
-      match?({_int, ""}, Integer.parse(value)) ->
-        {int, ""} = Integer.parse(value)
-        int
-
-      # Default to string
-      true ->
-        value
+  defp log_skipped_config_settings(skipped) do
+    for %{reason: reason} <- Enum.reverse(skipped) do
+      Logger.warning("Ignoring unusable config_settings row: #{reason}")
     end
-  end
 
-  defp parse_config_value(value), do: value
+    :ok
+  end
 
   defp put_in_path(map, [key], value) do
     Map.put(map, key, value)

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -4,10 +4,44 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
 
   attr :config_settings_with_sources, :map, required: true
   attr :crash_report_stats, :map, required: true
+  attr :invalid_config_settings, :list, default: []
 
   def general_settings_tab(assigns) do
     ~H"""
     <div class="p-4 sm:p-6 space-y-6 sm:space-y-8">
+      <div
+        :if={@invalid_config_settings != []}
+        id="invalid-config-settings"
+        class="alert alert-warning mb-6"
+      >
+        <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
+        <div>
+          <h3 class="font-bold">Some saved settings are not being applied</h3>
+          <p class="text-sm">
+            These rows name a setting that no longer exists, or hold a value of the
+            wrong type. They are skipped so the rest of your configuration still
+            applies. Removing them is safe.
+          </p>
+          <ul class="mt-3 space-y-2">
+            <li
+              :for={%{setting: setting, reason: reason} <- @invalid_config_settings}
+              id={"invalid-config-setting-#{String.replace(setting.key, ".", "-")}"}
+              class="flex items-center justify-between gap-3"
+            >
+              <span class="font-mono text-sm">{reason}</span>
+              <button
+                type="button"
+                id={"delete-invalid-config-setting-#{String.replace(setting.key, ".", "-")}"}
+                class="btn btn-sm btn-ghost"
+                phx-click="delete_invalid_config_setting"
+                phx-value-id={setting.id}
+              >
+                Remove
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
       <%!-- Settings Categories --%>
       <%= for {category, settings} <- @config_settings_with_sources do %>
         <div class="space-y-2">

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -1,6 +1,7 @@
 defmodule MydiaWeb.AdminSettingsLive.Index do
   use MydiaWeb, :live_view
 
+  alias Mydia.Config.Schema.Paths
   alias Mydia.Settings
   alias MydiaWeb.AdminSettingsLive.Components
 
@@ -333,8 +334,16 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
     metadata = config.metadata || %Mydia.Config.Schema.Metadata{}
     streaming = config.streaming || %Mydia.Config.Schema.Streaming{}
 
-    # Fetch all DB settings in one query to avoid N+1 per-key lookups
-    all_db_settings = Settings.list_config_settings() |> Map.new(&{&1.key, &1})
+    # Fetch all DB settings in one query to avoid N+1 per-key lookups. A row
+    # the merge skips (unknown key, or a value that will not cast to the
+    # field's type) must not be reported as the source of a value it did not
+    # supply, or the source badge and the invalid-settings alert above would
+    # contradict each other for the same key. Direct-lookup rows resolve to
+    # `:direct`, not `{:error, _}`, so they are kept.
+    all_db_settings =
+      Settings.list_config_settings()
+      |> Enum.reject(&match?({:error, _}, Paths.cast_overlay(&1.key, &1.value)))
+      |> Map.new(&{&1.key, &1})
 
     %{
       "Server" => [

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -230,12 +230,41 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
         {:noreply, socket}
 
       %{setting: setting} ->
-        {:ok, _} = Settings.delete_config_setting(setting)
-        {:noreply, socket |> load_data() |> put_flash(:info, "Removed #{setting.key}")}
+        delete_invalid_config_setting(socket, setting)
     end
   end
 
   ## Private Helpers
+
+  # Mydia.Repo only wraps insert/update/insert_or_update (see its module doc),
+  # so this delete runs through stock Ecto. A row that is already gone by the
+  # time the delete reaches the database (an operator double-clicking Remove,
+  # or two admins clearing the same row) does not come back as
+  # {:error, changeset}: Ecto.Repo.delete/1 raises Ecto.StaleEntryError for a
+  # stale/missing row unless the caller passes :stale_error_field, which this
+  # call site does not. Since removing the row is the whole point of this
+  # handler, an already-absent row already satisfies the operator's intent,
+  # so it is treated the same as a successful delete rather than surfaced as
+  # an error.
+  defp delete_invalid_config_setting(socket, setting) do
+    case Settings.delete_config_setting(setting) do
+      {:ok, _} ->
+        {:noreply, socket |> load_data() |> put_flash(:info, "Removed #{setting.key}")}
+
+      {:error, changeset} ->
+        MydiaLogger.log_error(:liveview, "Failed to delete invalid config setting",
+          error: changeset,
+          error_details: inspect(changeset, pretty: true),
+          operation: :delete_invalid_config_setting,
+          setting_key: setting.key
+        )
+
+        {:noreply, put_flash(socket, :error, "Failed to remove #{setting.key}")}
+    end
+  rescue
+    Ecto.StaleEntryError ->
+      {:noreply, socket |> load_data() |> put_flash(:info, "Removed #{setting.key}")}
+  end
 
   # Validates, persists, and reloads a single key. Shared by the typed-input
   # path above; the toggle and select paths predate it and still inline the

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -367,12 +367,18 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
           source: Settings.config_source("URL_HOST", "server.url_host", all_db_settings)
         }
       ],
+      # Read-only: Mydia.Repo reads its pool_size and database_path straight
+      # from DATABASE_PATH/POOL_SIZE at boot (config/runtime.exs), never from
+      # this config layer. Mydia.Config.Schema.Paths deliberately excludes the
+      # `database` section, so a row here is rejected on write and would be
+      # inert even if it were allowed to save. Shown for visibility only.
       "Database" => [
         %{
           key: "database.path",
           label: "Database Path",
           type: :string,
           value: config.database.path,
+          editable: false,
           source: Settings.config_source("DATABASE_PATH", "database.path", all_db_settings)
         },
         %{
@@ -380,6 +386,7 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
           label: "Pool Size",
           type: :integer,
           value: config.database.pool_size,
+          editable: false,
           source: Settings.config_source("POOL_SIZE", "database.pool_size", all_db_settings)
         }
       ],

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -217,6 +217,23 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
      |> put_flash(:info, "Crash report queue cleared")}
   end
 
+  @impl true
+  def handle_event("delete_invalid_config_setting", %{"id" => id}, socket) do
+    # Only rows this page reported as unusable can be deleted here: the id is
+    # checked against that list rather than trusted, so this cannot be used to
+    # delete a working setting.
+    socket.assigns.invalid_config_settings
+    |> Enum.find(fn %{setting: setting} -> setting.id == id end)
+    |> case do
+      nil ->
+        {:noreply, socket}
+
+      %{setting: setting} ->
+        {:ok, _} = Settings.delete_config_setting(setting)
+        {:noreply, socket |> load_data() |> put_flash(:info, "Removed #{setting.key}")}
+    end
+  end
+
   ## Private Helpers
 
   # Validates, persists, and reloads a single key. Shared by the typed-input
@@ -300,6 +317,7 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
     socket
     |> assign(:config_settings_with_sources, get_all_settings_with_sources())
     |> assign(:crash_report_stats, Mydia.CrashReporter.stats())
+    |> assign(:invalid_config_settings, Settings.invalid_config_settings())
   end
 
   defp get_all_settings_with_sources do

--- a/lib/mydia_web/live/admin_settings_live/index.html.heex
+++ b/lib/mydia_web/live/admin_settings_live/index.html.heex
@@ -3,6 +3,7 @@
     <Components.general_settings_tab
       config_settings_with_sources={@config_settings_with_sources}
       crash_report_stats={@crash_report_stats}
+      invalid_config_settings={@invalid_config_settings}
     />
   </.admin_page>
 </Layouts.app>

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -993,6 +993,19 @@ defmodule Mydia.Config.LoaderTest do
           category: :server
         })
 
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.server.port == 5555
+    end
+
+    test "a database.* row never reaches the merge" do
+      # This used to pass with config.database.pool_size == 25: build_config_map/1
+      # minted a path from any dotted key it was given, with no notion of which
+      # keys were legal. Mydia.Config.Schema.Paths now excludes database.* from
+      # the overlay index on purpose (see its moduledoc) -- the database section
+      # is consumed to open the repo, before the database layer can even be
+      # read, so a config_settings row naming it could never actually take
+      # effect. The row is skipped rather than silently accepted.
       {:ok, _} =
         Repo.insert(%ConfigSetting{
           key: "database.pool_size",
@@ -1002,8 +1015,7 @@ defmodule Mydia.Config.LoaderTest do
 
       {:ok, config} = Loader.load(config_file: "nonexistent.yml")
 
-      assert config.server.port == 5555
-      assert config.database.pool_size == 25
+      assert config.database.pool_size == 5
     end
 
     test "database config parses booleans correctly" do

--- a/test/mydia/config/schema/paths_test.exs
+++ b/test/mydia/config/schema/paths_test.exs
@@ -82,6 +82,20 @@ defmodule Mydia.Config.Schema.PathsTest do
       assert reason =~ "unknown"
     end
 
+    test "reports an excluded-section key by its environment variable, not as unknown" do
+      assert {:error, unknown_reason} = Paths.cast_overlay("server.nonexistent", "1")
+      assert {:error, path_reason} = Paths.cast_overlay("database.path", "/data/mydia.db")
+      assert {:error, pool_size_reason} = Paths.cast_overlay("database.pool_size", "5")
+
+      refute path_reason =~ "unknown"
+      refute pool_size_reason =~ "unknown"
+      assert path_reason != unknown_reason
+      assert pool_size_reason != unknown_reason
+
+      assert path_reason =~ "DATABASE_PATH"
+      assert pool_size_reason =~ "POOL_SIZE"
+    end
+
     test "reports a direct-lookup key as :direct, not as an error" do
       assert :direct = Paths.cast_overlay("crash_reporting.enabled", "true")
       assert :direct = Paths.cast_overlay("media.default_quality_profile_id", "")

--- a/test/mydia/config/schema/paths_test.exs
+++ b/test/mydia/config/schema/paths_test.exs
@@ -1,0 +1,90 @@
+defmodule Mydia.Config.Schema.PathsTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Config.Schema.Paths
+
+  describe "overlay_keys/0" do
+    test "includes every leaf of an embeds_one section" do
+      keys = Paths.overlay_keys()
+
+      assert "server.port" in keys
+      assert "auth.oidc_enabled" in keys
+      assert "media.movies_path" in keys
+      assert "streaming.audio_language" in keys
+    end
+
+    test "excludes embeds_many sections, which have their own tables" do
+      keys = Paths.overlay_keys()
+
+      refute Enum.any?(keys, &String.starts_with?(&1, "indexers."))
+      refute Enum.any?(keys, &String.starts_with?(&1, "library_paths."))
+      refute Enum.any?(keys, &String.starts_with?(&1, "download_clients."))
+    end
+
+    test "excludes the database section, which is read before the db layer exists" do
+      refute Enum.any?(Paths.overlay_keys(), &String.starts_with?(&1, "database."))
+    end
+  end
+
+  describe "direct?/1 and known?/1" do
+    test "the five direct-lookup keys are known but are not overlay keys" do
+      for key <- [
+            "crash_reporting.enabled",
+            "feedback.enabled",
+            "library.auto_repair_enabled",
+            "library.auto_repair_threshold",
+            "media.default_quality_profile_id"
+          ] do
+        assert Paths.direct?(key), "#{key} should be a direct-lookup key"
+        assert Paths.known?(key), "#{key} should be known"
+        refute key in Paths.overlay_keys(), "#{key} should not be an overlay key"
+      end
+    end
+
+    test "an invented key is neither" do
+      refute Paths.known?("server.nonexistent")
+      refute Paths.direct?("server.nonexistent")
+    end
+  end
+
+  describe "cast_overlay/2" do
+    test "casts a value to the field's declared type" do
+      assert {:ok, [:server, :port], 8080} = Paths.cast_overlay("server.port", "8080")
+      assert {:ok, [:auth, :oidc_enabled], true} = Paths.cast_overlay("auth.oidc_enabled", "true")
+    end
+
+    test "does not guess a type the field did not declare" do
+      # A string field holding digits stays a string. Inferring the type from
+      # the value's shape put an integer into a path field.
+      assert {:ok, [:media, :movies_path], "2024"} =
+               Paths.cast_overlay("media.movies_path", "2024")
+    end
+
+    test "splits a comma-separated list into an array field" do
+      assert {:ok, [:streaming, :audio_language], ["en", "fr"]} =
+               Paths.cast_overlay("streaming.audio_language", "en, fr")
+    end
+
+    test "treats an empty or nil value as unset" do
+      # media.default_quality_profile_id is deliberately persisted with an empty
+      # value to mean "cleared", so empty must not be an error.
+      assert {:ok, [:server, :url_host], nil} = Paths.cast_overlay("server.url_host", "")
+      assert {:ok, [:server, :url_host], nil} = Paths.cast_overlay("server.url_host", nil)
+    end
+
+    test "reports an uncastable value without raising" do
+      assert {:error, reason} = Paths.cast_overlay("server.port", "abc")
+      assert reason =~ "server.port"
+    end
+
+    test "reports an unknown key without raising" do
+      assert {:error, reason} = Paths.cast_overlay("server.nonexistent", "1")
+      assert reason =~ "unknown"
+    end
+
+    test "reports a direct-lookup key as :direct, not as an error" do
+      assert :direct = Paths.cast_overlay("crash_reporting.enabled", "true")
+      assert :direct = Paths.cast_overlay("media.default_quality_profile_id", "")
+    end
+  end
+end

--- a/test/mydia/settings/config_row_isolation_test.exs
+++ b/test/mydia/settings/config_row_isolation_test.exs
@@ -1,0 +1,86 @@
+defmodule Mydia.Settings.ConfigRowIsolationTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Settings
+  alias Mydia.Settings.ConfigSetting
+  alias Mydia.Repo
+
+  # Rows are inserted straight through Repo so this exercises the read side in
+  # isolation. Task 6 makes ConfigSetting.changeset/2 reject most of these, at
+  # which point the only way to create one is a direct database edit, which is
+  # exactly the population this read-side isolation exists for.
+  defp insert_row(key, value, category \\ :server) do
+    Repo.insert!(%ConfigSetting{key: key, value: value, category: category})
+  end
+
+  describe "load_database_config/0" do
+    test "a good row applies" do
+      insert_row("server.port", "8080")
+
+      assert {:ok, config} = Settings.load_database_config()
+      assert config.server.port == 8080
+    end
+
+    test "one uncastable row does not take the others with it" do
+      insert_row("server.port", "8080")
+      insert_row("server.url_host", "example.com")
+      insert_row("auth.jwt_ttl_days", "not-a-number", :auth)
+
+      assert {:ok, config} = Settings.load_database_config()
+
+      # The good rows survived. Before this change the invalid changeset made
+      # Bootstrap.run/1 drop every database-backed setting.
+      assert config.server.port == 8080
+      assert config.server.url_host == "example.com"
+      refute Map.has_key?(config, :auth)
+    end
+
+    test "an unknown key is skipped rather than merged" do
+      insert_row("server.nonexistent", "whatever")
+      insert_row("server.port", "8080")
+
+      assert {:ok, config} = Settings.load_database_config()
+      assert config.server.port == 8080
+      refute Map.has_key?(config.server, :nonexistent)
+    end
+
+    test "a parent and child key pair does not raise" do
+      # Regression test for the boot failure. put_in_path/3 called Map.put/3 on
+      # the integer already stored under :server, raising BadMapError, which
+      # escaped Mydia.Config.Bootstrap.init/1 and stopped the application from
+      # starting. Both rows are now rejected as unknown keys.
+      insert_row("server", "4000")
+      insert_row("server.port", "8080")
+
+      assert {:ok, config} = Settings.load_database_config()
+      assert config.server.port == 8080
+    end
+
+    test "a direct-lookup row contributes nothing and is not an error" do
+      insert_row("crash_reporting.enabled", "true", :crash_reporting)
+      insert_row("server.port", "8080")
+
+      assert {:ok, config} = Settings.load_database_config()
+      assert config.server.port == 8080
+      refute Map.has_key?(config, :crash_reporting)
+      assert Settings.invalid_config_settings() == []
+    end
+  end
+
+  describe "invalid_config_settings/0" do
+    test "reports a bad row with its key and a reason" do
+      insert_row("server.port", "abc")
+
+      assert [%{setting: setting, reason: reason}] = Settings.invalid_config_settings()
+      assert setting.key == "server.port"
+      assert reason =~ "server.port"
+    end
+
+    test "is empty when every row is usable" do
+      insert_row("server.port", "8080")
+      insert_row("feedback.enabled", "false", :feedback)
+
+      assert Settings.invalid_config_settings() == []
+    end
+  end
+end

--- a/test/mydia/settings/config_setting_test.exs
+++ b/test/mydia/settings/config_setting_test.exs
@@ -1,0 +1,68 @@
+defmodule Mydia.Settings.ConfigSettingTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Settings.ConfigSetting
+
+  defp changeset(attrs) do
+    ConfigSetting.changeset(%ConfigSetting{}, attrs)
+  end
+
+  describe "changeset/2 key validation" do
+    test "accepts a key naming a schema field" do
+      assert changeset(%{"key" => "server.port", "value" => "8080", "category" => :server}).valid?
+    end
+
+    test "accepts a direct-lookup key with no schema field" do
+      assert changeset(%{
+               "key" => "crash_reporting.enabled",
+               "value" => "true",
+               "category" => :crash_reporting
+             }).valid?
+    end
+
+    test "rejects a key the schema does not have" do
+      cs = changeset(%{"key" => "server.nonexistent", "value" => "1", "category" => :server})
+
+      refute cs.valid?
+      assert %{key: [_ | _]} = errors_on(cs)
+    end
+
+    test "rejects a key that would collide with a section" do
+      # Two rows named `server` and `server.port` used to raise BadMapError
+      # during the merge and stop the application from starting.
+      cs = changeset(%{"key" => "server", "value" => "4000", "category" => :server})
+
+      refute cs.valid?
+      assert %{key: [_ | _]} = errors_on(cs)
+    end
+  end
+
+  describe "changeset/2 value validation" do
+    test "rejects a value that will not cast to the field's type" do
+      cs = changeset(%{"key" => "server.port", "value" => "abc", "category" => :server})
+
+      refute cs.valid?
+      assert %{value: [_ | _]} = errors_on(cs)
+    end
+
+    test "accepts an empty value, which means unset" do
+      # media.default_quality_profile_id is persisted with an empty value to
+      # record a cleared default, so empty must stay legal.
+      assert changeset(%{
+               "key" => "media.default_quality_profile_id",
+               "value" => "",
+               "category" => :media
+             }).valid?
+
+      assert changeset(%{"key" => "server.url_host", "value" => "", "category" => :server}).valid?
+    end
+
+    test "does not add a value error when the key is already invalid" do
+      cs = changeset(%{"key" => "nope.nope", "value" => "abc", "category" => :server})
+
+      refute cs.valid?
+      assert %{key: [_ | _]} = errors_on(cs)
+      refute Map.has_key?(errors_on(cs), :value)
+    end
+  end
+end

--- a/test/mydia/settings/config_setting_test.exs
+++ b/test/mydia/settings/config_setting_test.exs
@@ -64,5 +64,29 @@ defmodule Mydia.Settings.ConfigSettingTest do
       assert %{key: [_ | _]} = errors_on(cs)
       refute Map.has_key?(errors_on(cs), :value)
     end
+
+    test "does not add a value error when :key is absent from attrs" do
+      cs = changeset(%{"value" => "8080", "category" => :server})
+
+      refute cs.valid?
+      assert %{key: [_ | _]} = errors_on(cs)
+      refute Map.has_key?(errors_on(cs), :value)
+    end
+
+    test "blames the key, not the value, on a value-only update against a row whose existing key is already invalid" do
+      # validate_change/3 (inside validate_known_key/1) is skipped by Ecto
+      # whenever :key is absent from this changeset's changes, which is the
+      # case on a value-only update -- e.g. the API's PATCH endpoint, which
+      # only ever sends :value and :description. A row written before this
+      # validation existed may carry an unknown key; updating just :value
+      # must still blame :key, not surface as a :value error.
+      existing = %ConfigSetting{key: "server.nonexistent", value: "1", category: :server}
+
+      cs = ConfigSetting.changeset(existing, %{"value" => "2"})
+
+      refute cs.valid?
+      assert %{key: [_ | _]} = errors_on(cs)
+      refute Map.has_key?(errors_on(cs), :value)
+    end
   end
 end

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -2,7 +2,8 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
   use MydiaWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
-  alias Mydia.{Accounts, Settings}
+  alias Mydia.{Accounts, Repo, Settings}
+  alias Mydia.Settings.ConfigSetting
 
   setup do
     unique_id = System.unique_integer([:positive])
@@ -394,12 +395,17 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
     end
 
     test "tolerates a non-integer timeout value stored in the database", %{conn: conn} do
-      {:ok, _} =
-        Settings.upsert_config_setting(%{
-          key: "flaresolverr.timeout",
-          value: "not-a-number",
-          category: :flaresolverr
-        })
+      # ConfigSetting.changeset/2 now rejects a value that won't cast to its
+      # field's type, so upsert_config_setting/1 can no longer create this
+      # row. Insert straight through Repo, bypassing the changeset, to seed
+      # the malformed row this test exists to prove the panel survives, the
+      # kind of row a pre-validation write or a direct database edit can
+      # still leave behind.
+      Repo.insert!(%ConfigSetting{
+        key: "flaresolverr.timeout",
+        value: "not-a-number",
+        category: :flaresolverr
+      })
 
       # Should not crash on mount or when opening the edit modal; the malformed
       # value falls back to the schema default rather than raising.

--- a/test/mydia_web/live/admin_settings_live_invalid_settings_test.exs
+++ b/test/mydia_web/live/admin_settings_live_invalid_settings_test.exs
@@ -76,4 +76,25 @@ defmodule MydiaWeb.AdminSettingsLiveInvalidSettingsTest do
     refute has_element?(view, "#invalid-config-settings")
     refute Repo.get(ConfigSetting, setting.id)
   end
+
+  test "removing a row already deleted out from under the LiveView does not crash", %{
+    conn: conn
+  } do
+    setting = Repo.insert!(%ConfigSetting{key: "server.port", value: "abc", category: :server})
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
+
+    # Simulate a double-click, or a second admin clearing the same row first:
+    # the row is gone from the database, but the LiveView's assigns still
+    # hold it from mount, so the click still reaches the delete handler.
+    Repo.delete!(setting)
+
+    view
+    |> element("#delete-invalid-config-setting-server-port")
+    |> render_click()
+
+    assert Process.alive?(view.pid)
+    refute has_element?(view, "#invalid-config-settings")
+    refute Repo.get(ConfigSetting, setting.id)
+  end
 end

--- a/test/mydia_web/live/admin_settings_live_invalid_settings_test.exs
+++ b/test/mydia_web/live/admin_settings_live_invalid_settings_test.exs
@@ -1,0 +1,46 @@
+defmodule MydiaWeb.AdminSettingsLiveInvalidSettingsTest do
+  # Connected LiveView tests must stay sync: the Postgres sandbox is only
+  # shared with the mount process when the case is not async.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+
+  alias Mydia.Repo
+  alias Mydia.Settings.ConfigSetting
+
+  setup %{conn: conn} do
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "no alert when every row is usable", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
+
+    refute has_element?(view, "#invalid-config-settings")
+  end
+
+  test "an unusable row is listed with its key", %{conn: conn} do
+    # Inserted through Repo, bypassing the changeset: after the write-side
+    # validation this is the only way such a row exists.
+    Repo.insert!(%ConfigSetting{key: "server.port", value: "abc", category: :server})
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
+
+    assert has_element?(view, "#invalid-config-settings")
+    assert has_element?(view, "#invalid-config-setting-server-port")
+  end
+
+  test "deleting an unusable row removes it from the alert", %{conn: conn} do
+    setting = Repo.insert!(%ConfigSetting{key: "server.port", value: "abc", category: :server})
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
+
+    view
+    |> element("#delete-invalid-config-setting-server-port")
+    |> render_click()
+
+    refute has_element?(view, "#invalid-config-settings")
+    refute Repo.get(ConfigSetting, setting.id)
+  end
+end

--- a/test/mydia_web/live/admin_settings_live_invalid_settings_test.exs
+++ b/test/mydia_web/live/admin_settings_live_invalid_settings_test.exs
@@ -31,6 +31,39 @@ defmodule MydiaWeb.AdminSettingsLiveInvalidSettingsTest do
     assert has_element?(view, "#invalid-config-setting-server-port")
   end
 
+  test "an unusable row does not show a Database source badge", %{conn: conn} do
+    # streaming.max_transcode_height has no environment variable set in this
+    # test run, so its source badge is decided purely by whether the row
+    # survives into `all_db_settings`. It keeps rendering the schema default
+    # once the merge skips this row, so it must not also be tagged as coming
+    # from the database: that would tell the operator two different things
+    # about the same value on the same screen.
+    Repo.insert!(%ConfigSetting{
+      key: "streaming.max_transcode_height",
+      value: "not-a-number",
+      category: :streaming
+    })
+
+    {:ok, _view, html} = live(conn, ~p"/admin/config/settings")
+
+    # Scope to this setting's own row via its value control's phx-value-key,
+    # climbing to the row content div that also holds the source badge.
+    # setting_source_badge/1 (components.ex) renders :database as
+    # `badge badge-primary`, everything else (including :default) as
+    # `badge badge-ghost`.
+    row_html =
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query(~s([phx-value-key="streaming.max_transcode_height"]))
+      |> LazyHTML.parent_node()
+      |> LazyHTML.parent_node()
+      |> LazyHTML.parent_node()
+      |> LazyHTML.to_html()
+
+    refute row_html =~ "badge-primary"
+    assert row_html =~ "badge-ghost"
+  end
+
   test "deleting an unusable row removes it from the alert", %{conn: conn} do
     setting = Repo.insert!(%ConfigSetting{key: "server.port", value: "abc", category: :server})
 

--- a/test/mydia_web/live/admin_settings_live_test.exs
+++ b/test/mydia_web/live/admin_settings_live_test.exs
@@ -127,6 +127,21 @@ defmodule MydiaWeb.AdminSettingsLiveTest do
       refute has_element?(view, "input[phx-value-key='flaresolverr.url']")
     end
 
+    test "database settings render read-only, never as an editable input", %{view: view} do
+      # Mydia.Repo reads pool_size and database_path straight from
+      # DATABASE_PATH/POOL_SIZE at boot (config/runtime.exs); this config
+      # layer never reaches it. Mydia.Config.Schema.Paths deliberately
+      # excludes the `database` section, so a row written from this page is
+      # now rejected on write. Neither field is a per-setting :env source
+      # here (DATABASE_PATH/POOL_SIZE are unset in test), so without the
+      # explicit `editable: false` override these would render as editable
+      # text inputs and blurring one would surface "Invalid setting value".
+      refute has_element?(view, "input[phx-value-key='database.path']")
+      refute has_element?(view, "input[phx-value-key='database.pool_size']")
+      assert has_element?(view, "div.text-xs.font-mono.truncate", "database.path")
+      assert has_element?(view, "div.text-xs.font-mono.truncate", "database.pool_size")
+    end
+
     test "offers the transcode height ceiling", %{view: view} do
       # The escape hatch for an operator whose hardware cannot encode a 4K
       # file in realtime. It shipped once as a compile-time key in


### PR DESCRIPTION
`build_config_map/1` guessed each value's type from the shape of its string and
built paths by minting an atom per key segment from database content.

Two failure modes followed, with different severities.

**Soft: the whole layer is dropped.** A value that will not cast to its schema
field type, such as `server.port = "abc"`, made the changeset in
`Loader.validate/1` invalid. `Loader.load/1` returned `{:error, changeset}`,
`Config.Bootstrap.run/1` logged and continued with the phase-one config, and
the instance booted with every setting an operator saved through the admin UI
silently dropped. One bad row, the whole layer.

**Hard: the instance does not start.** Two rows whose keys form a parent and
child pair, `server` and `server.port`, drove `put_in_path/3` into `Map.put/3`
on a non-map. That `BadMapError` is a raise, not `{:error, reason}`, so it
passed straight through `Bootstrap.run/1`'s case expression, out of `init/1`,
and the child failed to start. The supervisor gave up and application start
failed.

## The fix

`Mydia.Config.Schema.Paths` is a compile-time index built by reflecting over
`Mydia.Config.Schema`'s `embeds_one` sections. Rows resolve through it one at a
time and cast to the field's declared type, so a bad row is skipped and
reported rather than poisoning the batch.

Both failure modes become structurally unreachable rather than screened for:
every accepted key resolves to a known two-element path, so `put_in_path/3` can
no longer be handed anything else, and `String.to_atom/1` is gone from the path
entirely since the atoms now come from the compile-time index.

`ConfigSetting.changeset/2` validates against the same index, so the admin UI
can no longer save a row that does nothing. Rows that predate that validation,
or arrive by direct database edit, are listed on the Configuration page with a
reason and a Remove button, so an operator can repair an instance from inside
it.

## Two populations, which shaped the design

`config_settings` turned out to hold two kinds of row. Five keys are read
directly through `get_config_setting_by_key/1` and never reach the merge, and
four of them name a section the schema does not have: `crash_reporting.enabled`,
`feedback.enabled`, `library.auto_repair_enabled`, `library.auto_repair_threshold`
and `media.default_quality_profile_id`. Validating against the schema alone
would have rejected all five and broken crash reporting, feedback, library
auto-repair and the default quality profile. They are enumerated in
`Paths` with their readers, so the next person to add a literal-key lookup
finds the list.

## Also fixed here

The admin page listed `database.path` and `database.pool_size` as editable, and
the new validation rejects both, so saving either would have shown "Invalid
setting value". They are now read-only. Those fields were always misleading:
`Mydia.Repo`'s real `pool_size` and `database_path` come from `System.get_env`
in `config/runtime.exs`, so a `database.*` row never affected the running
database. The validation only made an existing lie visible.

Their skip reason names the environment variable rather than calling the key
unknown, so an operator gets `database.pool_size: set via the POOL_SIZE
environment variable, not the database` instead of hunting for a typo.

## Verification

Full suite on both adapters: SQLite 9688 tests, PostgreSQL 9689 tests, green
apart from one pre-existing unrelated flake.

Beyond the unit tests, the two-phase boot was exercised directly: with a
parent/child key pair and an uncastable value both present in the database,
`Config.Bootstrap.run/1` returns `{:ok, config}` without raising, a good
`media.movies_path` row still applies, and the two bad rows are reported by
key.

## Follow-ups, not addressed here

- `library.auto_repair_enabled` and `library.auto_repair_threshold` have never
  been writable through the admin UI: `index.ex` maps that group to
  `category: :library`, but `ConfigSetting`'s `@categories` has never included
  `:library`. This predates the branch and is byte-identical on master.
- `api/config_controller.ex` did not get the read-only treatment the LiveView
  did for `database.*`, so a PUT for those keys now returns 422 rather than
  silently doing nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration keys and values are now validated against supported settings.
  * Invalid saved settings show clear reasons in Admin Settings and can be removed.
  * Database path and pool-size settings are displayed as read-only.
  * Direct-lookup settings are handled separately from runtime configuration overrides.

* **Bug Fixes**
  * Invalid entries no longer prevent other settings from loading.
  * Unsupported database settings are excluded from runtime configuration.
  * Improved handling of malformed values and conflicting configuration keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->