### PR TITLE
fix(indexers): scope Cardigann session cookies to a definition's own origins

### DIFF
--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -878,7 +878,11 @@ defmodule Mydia.Indexers do
          {:ok, parsed} <- CardigannParser.parse_definition(definition.definition) do
       CardigannDownload.resolve(parsed, download_url, %{
         cookies: get_cardigann_auth_cookies(indexer_name),
-        base_url: definition.active_link
+        base_url: definition.active_link,
+        # The credential scope renders absolute `{{ .Config.apiurl }}` paths, so
+        # it needs the operator's settings. Without them an API host reached
+        # through a setting would fall outside the scope and lose its session.
+        config: definition.config || %{}
       })
     else
       nil ->

--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -529,16 +529,16 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
           {:ok, convert_session_to_user_config(session)}
         else
           # Session expired, re-authenticate
-          authenticate_and_convert(parsed, credentials, definition.id)
+          authenticate_and_convert(parsed, credentials, definition.id, definition.config || %{})
         end
 
       {:error, :not_found} ->
         # No stored session, authenticate if needed
-        authenticate_and_convert(parsed, credentials, definition.id)
+        authenticate_and_convert(parsed, credentials, definition.id, definition.config || %{})
 
       {:error, :expired} ->
         # Session expired, re-authenticate
-        authenticate_and_convert(parsed, credentials, definition.id)
+        authenticate_and_convert(parsed, credentials, definition.id, definition.config || %{})
     end
   end
 
@@ -564,14 +564,19 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
   defp blank?(%{} = value), do: map_size(value) == 0
   defp blank?(_value), do: false
 
-  defp authenticate_and_convert(parsed, credentials, definition_id) do
-    case CardigannAuth.authenticate(parsed, credentials, definition_id) do
+  defp authenticate_and_convert(parsed, credentials, definition_id, definition_config) do
+    case CardigannAuth.authenticate(
+           parsed,
+           Map.put(credentials, :config, definition_config),
+           definition_id
+         ) do
       {:ok, session} ->
         {:ok, convert_session_to_user_config(session)}
 
       {:error, error} ->
-        # If authentication is required but failed, return error
-        # Otherwise return empty config for public indexers
+        # `credentials` deliberately stays free of :config here: this test asks
+        # whether the operator configured any credential at all, and a settings
+        # map is not a credential.
         if parsed.login != nil and credentials != %{} do
           {:error, error}
         else

--- a/lib/mydia/indexers/adapter/cardigann.ex
+++ b/lib/mydia/indexers/adapter/cardigann.ex
@@ -492,9 +492,16 @@ defmodule Mydia.Indexers.Adapter.Cardigann do
       settings: parsed.settings,
       base_url: definition.active_link,
       on_promote: fn winning_url ->
-        definition
-        |> Ecto.Changeset.change(%{active_link: winning_url})
-        |> Mydia.Repo.update()
+        # A legacy mirror that answers must not become sticky for a definition
+        # that has a session to protect; the credential scope would then withhold
+        # its cookies on every subsequent search.
+        if CardigannHealthCheck.promotable?(parsed, definition.config || %{}, winning_url) do
+          definition
+          |> Ecto.Changeset.change(%{active_link: winning_url})
+          |> Mydia.Repo.update()
+        else
+          :ok
+        end
       end
     ]
 

--- a/lib/mydia/indexers/cardigann/credential_scope.ex
+++ b/lib/mydia/indexers/cardigann/credential_scope.ex
@@ -1,0 +1,149 @@
+defmodule Mydia.Indexers.Cardigann.CredentialScope do
+  @moduledoc """
+  Decides which hosts may receive a definition's session cookies and login
+  credentials.
+
+  A Cardigann session cookie is a bearer credential for a tracker account. It is
+  scoped to the hosts a definition names as its own site: every entry in
+  `links`, plus the host of any `search.paths` or `login.path` that renders to an
+  absolute URL. Those absolute paths are operator-configurable settings such as
+  `{{ .Config.apiurl }}`, and every one shipped in the v11 corpus resolves to a
+  sibling subdomain of the site (`api.v3x.club` beside `v3x.club`).
+
+  `legacylinks` are deliberately excluded. `Mydia.Indexers.Cardigann.Links`
+  offers them as failover targets, which is a public tracker recovery path, but
+  they are by construction stale rotated domains: 149 of the 545 shipped v11
+  definitions carry a legacy host absent from their `links`, 95 of them private.
+  A re-registered legacy domain must not be handed a live session.
+
+  Matching is an exact, case-insensitive host comparison. There is deliberately
+  no eTLD+1 and no subdomain-suffix rule. `limetorrents.proxyninja.net` and
+  `extratorrent.ninjaproxy1.com` are shipped `links` entries on shared proxy
+  services that front many unrelated trackers, so a suffix rule would admit
+  `sometracker.proxyninja.net` and leak one tracker's session to a neighbour.
+  """
+
+  alias Mydia.Indexers.CardigannDefinition.Parsed
+  alias Mydia.Indexers.CardigannTemplate
+
+  # Read under both spellings. `definition.config` is a
+  # `Mydia.Settings.JsonMapType` and comes back string-keyed from
+  # `Jason.decode/1`, while a session map built in code is atom-keyed.
+  @credential_keys [:cookies, :cookie, :username, :password, :api_key, :apikey, :passkey]
+
+  @doc """
+  Returns the downcased hosts this definition's credentials may be sent to.
+  """
+  @spec trusted_hosts(Parsed.t(), map()) :: MapSet.t(String.t())
+  def trusted_hosts(%Parsed{} = parsed, config) when is_map(config) do
+    link_hosts =
+      parsed.links
+      |> List.wrap()
+      |> Enum.flat_map(&host_of/1)
+
+    template_hosts =
+      parsed
+      |> absolute_templates()
+      |> Enum.flat_map(&rendered_host(&1, parsed, config))
+
+    MapSet.new(link_hosts ++ template_hosts)
+  end
+
+  def trusted_hosts(%Parsed{} = parsed, _config), do: trusted_hosts(parsed, %{})
+
+  @doc """
+  True when `url`'s host is in `hosts`. A url without a parseable host is never
+  allowed.
+  """
+  @spec allows?(MapSet.t(String.t()), String.t()) :: boolean()
+  def allows?(%MapSet{} = hosts, url) when is_binary(url) do
+    case host_of(url) do
+      [host] -> MapSet.member?(hosts, host)
+      [] -> false
+    end
+  end
+
+  def allows?(_hosts, _url), do: false
+
+  @doc """
+  True when the map carries a credential worth protecting.
+
+  Blank values do not count. The admin form submits untouched fields as "", and
+  an empty cookie list is not a credential, which is the distinction that made
+  every private indexer skip its form login before #601.
+  """
+  @spec credentialed?(map()) :: boolean()
+  def credentialed?(config) when is_map(config) do
+    Enum.any?(@credential_keys, fn key -> config |> lookup(key) |> present?() end)
+  end
+
+  def credentialed?(_config), do: false
+
+  defp lookup(map, key) when is_atom(key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp present?(nil), do: false
+  defp present?([]), do: false
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_value), do: true
+
+  defp host_of(url) when is_binary(url) do
+    case URI.parse(String.trim(url)) do
+      %URI{host: host} when is_binary(host) and host != "" -> [String.downcase(host)]
+      _ -> []
+    end
+  end
+
+  defp host_of(_url), do: []
+
+  defp absolute_templates(%Parsed{} = parsed) do
+    search_paths =
+      parsed.search
+      |> case do
+        %{} = search -> Map.get(search, :paths) || Map.get(search, "paths") || []
+        _ -> []
+      end
+      |> List.wrap()
+      |> Enum.map(fn
+        %{} = path -> Map.get(path, :path) || Map.get(path, "path")
+        _ -> nil
+      end)
+
+    login_path =
+      case parsed.login do
+        %{} = login -> Map.get(login, :path) || Map.get(login, "path")
+        _ -> nil
+      end
+
+    [login_path | search_paths]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.filter(&absolute_template?/1)
+  end
+
+  # Only a template that already opens with a scheme can render to another host.
+  # A relative path can never introduce one, so it is skipped without being
+  # rendered at all.
+  defp absolute_template?(template), do: Regex.match?(~r{^https?://}i, template)
+
+  defp rendered_host(template, %Parsed{} = parsed, config) do
+    context = %{
+      keywords: "",
+      config: config,
+      query: %{series: "", season: nil, episode: nil, imdb_id: nil, tmdb_id: nil, tvdb_id: nil},
+      categories: [],
+      settings: parsed.settings
+    }
+
+    # url_encode: false because only the host is wanted and percent-encoding a
+    # config value would corrupt it. A template that will not render contributes
+    # no host, which withholds rather than leaks.
+    case CardigannTemplate.render(template, context, url_encode: false) do
+      {:ok, rendered} -> host_of(rendered)
+      _ -> []
+    end
+  end
+end

--- a/lib/mydia/indexers/cardigann/credential_scope.ex
+++ b/lib/mydia/indexers/cardigann/credential_scope.ex
@@ -45,7 +45,7 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
 
     template_origins =
       parsed
-      |> absolute_templates()
+      |> template_candidates()
       |> Enum.flat_map(&rendered_origin(&1, parsed, config))
 
     MapSet.new(link_origins ++ template_origins)
@@ -137,7 +137,10 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
 
   defp origin_of(_url), do: []
 
-  defp absolute_templates(%Parsed{} = parsed) do
+  # Not "absolute templates": whether a template is absolute can only be
+  # decided after it is rendered, since the scheme itself may come from
+  # configuration. This collects the candidates worth rendering at all.
+  defp template_candidates(%Parsed{} = parsed) do
     search_paths =
       parsed.search
       |> case do
@@ -157,13 +160,23 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
       end
 
     [login_path | search_paths]
-    |> Enum.filter(fn template -> is_binary(template) and absolute_template?(template) end)
+    |> Enum.filter(fn template -> is_binary(template) and worth_rendering?(template) end)
   end
 
-  # Only a template that already opens with a scheme can render to another host.
-  # A relative path can never introduce one, so it is skipped without being
-  # rendered at all.
-  defp absolute_template?(template), do: Regex.match?(~r{^https?://}i, template)
+  # A template can name its own host through configuration, as in
+  # `{{ .Config.apiurl }}/search`, so a literal-only check for a leading
+  # `http` on the unrendered text misses every candidate whose scheme comes
+  # from a setting rather than the template itself. The only template that
+  # can be ruled out without rendering is one with no `{{` at all and no
+  # leading scheme: that is a bare relative literal, and rendering can never
+  # turn it into an absolute URL. Everything else is rendered, and
+  # `rendered_origin/3` (via `origin_of/1`) decides whether the result is
+  # actually absolute; it already returns `[]` for a template that fails to
+  # render or renders to a relative path, so this is only a cheap prefilter,
+  # not the decision itself.
+  defp worth_rendering?(template) do
+    String.contains?(template, "{{") or Regex.match?(~r{^https?://}i, template)
+  end
 
   defp rendered_origin(template, %Parsed{} = parsed, config) do
     context = %{

--- a/lib/mydia/indexers/cardigann/credential_scope.ex
+++ b/lib/mydia/indexers/cardigann/credential_scope.ex
@@ -67,6 +67,28 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
 
   def allows?(_hosts, _url), do: false
 
+  # Loopback is a secure context in the same sense browsers use the term: the
+  # request never reaches a network, so a local mirror or a test server is not
+  # an exposure. Everything else on plain http is.
+  @loopback_hosts ~w(localhost 127.0.0.1 ::1 0:0:0:0:0:0:0:1)
+
+  @doc """
+  True when `url` would send a credential over an unencrypted connection to a
+  host other than loopback.
+  """
+  @spec cleartext?(String.t()) :: boolean()
+  def cleartext?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: "http", host: host} ->
+        String.downcase(host || "") not in @loopback_hosts
+
+      _ ->
+        false
+    end
+  end
+
+  def cleartext?(_url), do: false
+
   @doc """
   True when the map carries a credential worth protecting.
 

--- a/lib/mydia/indexers/cardigann/credential_scope.ex
+++ b/lib/mydia/indexers/cardigann/credential_scope.ex
@@ -1,14 +1,14 @@
 defmodule Mydia.Indexers.Cardigann.CredentialScope do
   @moduledoc """
-  Decides which hosts may receive a definition's session cookies and login
+  Decides which origins may receive a definition's session cookies and login
   credentials.
 
   A Cardigann session cookie is a bearer credential for a tracker account. It is
-  scoped to the hosts a definition names as its own site: every entry in
-  `links`, plus the host of any `search.paths` or `login.path` that renders to an
-  absolute URL. Those absolute paths are operator-configurable settings such as
-  `{{ .Config.apiurl }}`, and every one shipped in the v11 corpus resolves to a
-  sibling subdomain of the site (`api.v3x.club` beside `v3x.club`).
+  scoped to the origins a definition names as its own site: every entry in
+  `links`, plus the origin of any `search.paths` or `login.path` that renders to
+  an absolute URL. Those absolute paths are operator-configurable settings such
+  as `{{ .Config.apiurl }}`, and every one shipped in the v11 corpus resolves to
+  a sibling subdomain of the site (`api.v3x.club` beside `v3x.club`).
 
   `legacylinks` are deliberately excluded. `Mydia.Indexers.Cardigann.Links`
   offers them as failover targets, which is a public tracker recovery path, but
@@ -16,11 +16,12 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
   definitions carry a legacy host absent from their `links`, 95 of them private.
   A re-registered legacy domain must not be handed a live session.
 
-  Matching is an exact, case-insensitive host comparison. There is deliberately
-  no eTLD+1 and no subdomain-suffix rule. `limetorrents.proxyninja.net` and
-  `extratorrent.ninjaproxy1.com` are shipped `links` entries on shared proxy
-  services that front many unrelated trackers, so a suffix rule would admit
-  `sometracker.proxyninja.net` and leak one tracker's session to a neighbour.
+  Matching is an exact, case-insensitive origin comparison: host and port both
+  have to agree. There is deliberately no eTLD+1 and no subdomain-suffix rule.
+  `limetorrents.proxyninja.net` and `extratorrent.ninjaproxy1.com` are shipped
+  `links` entries on shared proxy services that front many unrelated trackers,
+  so a suffix rule would admit `sometracker.proxyninja.net` and leak one
+  tracker's session to a neighbour.
   """
 
   alias Mydia.Indexers.CardigannDefinition.Parsed
@@ -32,33 +33,34 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
   @credential_keys [:cookies, :cookie, :username, :password, :api_key, :apikey, :passkey]
 
   @doc """
-  Returns the downcased hosts this definition's credentials may be sent to.
+  Returns the normalized `"host:port"` origins this definition's credentials
+  may be sent to.
   """
-  @spec trusted_hosts(Parsed.t(), map()) :: MapSet.t(String.t())
-  def trusted_hosts(%Parsed{} = parsed, config) when is_map(config) do
-    link_hosts =
+  @spec trusted_origins(Parsed.t(), map()) :: MapSet.t(String.t())
+  def trusted_origins(%Parsed{} = parsed, config) when is_map(config) do
+    link_origins =
       parsed.links
       |> List.wrap()
-      |> Enum.flat_map(&host_of/1)
+      |> Enum.flat_map(&origin_of/1)
 
-    template_hosts =
+    template_origins =
       parsed
       |> absolute_templates()
-      |> Enum.flat_map(&rendered_host(&1, parsed, config))
+      |> Enum.flat_map(&rendered_origin(&1, parsed, config))
 
-    MapSet.new(link_hosts ++ template_hosts)
+    MapSet.new(link_origins ++ template_origins)
   end
 
-  def trusted_hosts(%Parsed{} = parsed, _config), do: trusted_hosts(parsed, %{})
+  def trusted_origins(%Parsed{} = parsed, _config), do: trusted_origins(parsed, %{})
 
   @doc """
-  True when `url`'s host is in `hosts`. A url without a parseable host is never
-  allowed.
+  True when `url`'s origin is in `origins`. A url without a parseable host is
+  never allowed.
   """
   @spec allows?(MapSet.t(String.t()), String.t()) :: boolean()
-  def allows?(%MapSet{} = hosts, url) when is_binary(url) do
-    case host_of(url) do
-      [host] -> MapSet.member?(hosts, host)
+  def allows?(%MapSet{} = origins, url) when is_binary(url) do
+    case origin_of(url) do
+      [origin] -> MapSet.member?(origins, origin)
       [] -> false
     end
   end
@@ -91,14 +93,27 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
   defp present?(value) when is_binary(value), do: String.trim(value) != ""
   defp present?(_value), do: true
 
-  defp host_of(url) when is_binary(url) do
+  # Scope is an origin, not a bare host. `URI.parse/1` already fills in the
+  # scheme's default port (443 for https, 80 for http), so an explicit
+  # `https://x:443` and a bare `https://x` normalize to the same origin.
+  #
+  # Ports matter because Mydia is self-hosted: several services behind one host
+  # on different ports is the normal deployment, and the corpus ships that shape
+  # already (bitmagnet lists 127.0.0.1). Matching on the host alone would let a
+  # session for one local service be handed to another service on the same host,
+  # the same failure that rules out subdomain-suffix matching for the shared
+  # proxy domains in `links`.
+  defp origin_of(url) when is_binary(url) do
     case URI.parse(String.trim(url)) do
-      %URI{host: host} when is_binary(host) and host != "" -> [String.downcase(host)]
-      _ -> []
+      %URI{host: host, port: port} when is_binary(host) and host != "" ->
+        ["#{String.downcase(host)}:#{port || 0}"]
+
+      _ ->
+        []
     end
   end
 
-  defp host_of(_url), do: []
+  defp origin_of(_url), do: []
 
   defp absolute_templates(%Parsed{} = parsed) do
     search_paths =
@@ -120,8 +135,7 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
       end
 
     [login_path | search_paths]
-    |> Enum.filter(&is_binary/1)
-    |> Enum.filter(&absolute_template?/1)
+    |> Enum.filter(fn template -> is_binary(template) and absolute_template?(template) end)
   end
 
   # Only a template that already opens with a scheme can render to another host.
@@ -129,7 +143,7 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
   # rendered at all.
   defp absolute_template?(template), do: Regex.match?(~r{^https?://}i, template)
 
-  defp rendered_host(template, %Parsed{} = parsed, config) do
+  defp rendered_origin(template, %Parsed{} = parsed, config) do
     context = %{
       keywords: "",
       config: config,
@@ -138,11 +152,11 @@ defmodule Mydia.Indexers.Cardigann.CredentialScope do
       settings: parsed.settings
     }
 
-    # url_encode: false because only the host is wanted and percent-encoding a
+    # url_encode: false because only the origin is wanted and percent-encoding a
     # config value would corrupt it. A template that will not render contributes
-    # no host, which withholds rather than leaks.
+    # no origin, which withholds rather than leaks.
     case CardigannTemplate.render(template, context, url_encode: false) do
-      {:ok, rendered} -> host_of(rendered)
+      {:ok, rendered} -> origin_of(rendered)
       _ -> []
     end
   end

--- a/lib/mydia/indexers/cardigann_auth.ex
+++ b/lib/mydia/indexers/cardigann_auth.ex
@@ -40,6 +40,7 @@ defmodule Mydia.Indexers.CardigannAuth do
       {:ok, session} = CardigannAuth.authenticate(definition, user_config)
   """
 
+  alias Mydia.Indexers.Cardigann.CredentialScope
   alias Mydia.Indexers.CardigannDefinition.Parsed
   alias Mydia.Indexers.CardigannSearchEngine
   alias Mydia.Indexers.CardigannSearchSession
@@ -266,6 +267,7 @@ defmodule Mydia.Indexers.CardigannAuth do
 
   defp perform_form_login(definition, user_config, cardigann_definition_id) do
     with {:ok, login_url} <- build_login_url(definition, config_for(user_config)),
+         :ok <- check_login_transport(login_url),
          {:ok, login_params} <- build_login_params(definition, user_config),
          {:ok, response} <- execute_login_request(definition, login_url, login_params),
          {:ok, cookies} <- extract_cookies(response),
@@ -276,6 +278,28 @@ defmodule Mydia.Indexers.CardigannAuth do
       end
 
       {:ok, %{cookies: cookies, expires_at: calculate_expiration(), method: :form}}
+    end
+  end
+
+  # A form login POSTs the username and password, and #601 already withholds a
+  # session cookie from a cleartext non-loopback host. That asymmetry is the
+  # hole: Mydia would send the password in the clear, receive a session, and
+  # then refuse to use it, so the login leaks the credentials and buys nothing.
+  #
+  # There is deliberately NO origin check here, and one should not be added. The
+  # login URL is derived from the definition, and the definition also defines
+  # the credential scope, so comparing them is circular: trusted_origins/2
+  # includes an absolute login.path's own origin by construction. An adversary
+  # who can set login.path can set links too.
+  defp check_login_transport(login_url) do
+    if CredentialScope.cleartext?(login_url) do
+      {:error,
+       Error.connection_failed(
+         "Refusing to send credentials to #{login_url} over an unencrypted connection. " <>
+           "Configure an https URL for this indexer."
+       )}
+    else
+      :ok
     end
   end
 

--- a/lib/mydia/indexers/cardigann_auth.ex
+++ b/lib/mydia/indexers/cardigann_auth.ex
@@ -41,7 +41,9 @@ defmodule Mydia.Indexers.CardigannAuth do
   """
 
   alias Mydia.Indexers.CardigannDefinition.Parsed
+  alias Mydia.Indexers.CardigannSearchEngine
   alias Mydia.Indexers.CardigannSearchSession
+  alias Mydia.Indexers.CardigannTemplate
   alias Mydia.Indexers.Adapter.Error
   alias Mydia.Repo
 
@@ -263,7 +265,7 @@ defmodule Mydia.Indexers.CardigannAuth do
   end
 
   defp perform_form_login(definition, user_config, cardigann_definition_id) do
-    with {:ok, login_url} <- build_login_url(definition),
+    with {:ok, login_url} <- build_login_url(definition, config_for(user_config)),
          {:ok, login_params} <- build_login_params(definition, user_config),
          {:ok, response} <- execute_login_request(definition, login_url, login_params),
          {:ok, cookies} <- extract_cookies(response),
@@ -276,6 +278,19 @@ defmodule Mydia.Indexers.CardigannAuth do
       {:ok, %{cookies: cookies, expires_at: calculate_expiration(), method: :form}}
     end
   end
+
+  # The adapter passes the operator's settings under :config alongside the
+  # credentials. The bare-map fallback covers a direct caller (tests, and
+  # authenticate/3 called with a plain settings map) that passes settings
+  # without wrapping them.
+  defp config_for(user_config) when is_map(user_config) do
+    case Map.get(user_config, :config) || Map.get(user_config, "config") do
+      %{} = config -> config
+      _ -> user_config
+    end
+  end
+
+  defp config_for(_user_config), do: %{}
 
   defp perform_api_key_auth(_definition, user_config) do
     case Map.get(user_config, :api_key) do
@@ -318,15 +333,45 @@ defmodule Mydia.Indexers.CardigannAuth do
     end
   end
 
-  defp build_login_url(%Parsed{} = definition) do
-    case definition.login do
-      %{path: path} when is_binary(path) ->
-        base_url = List.first(definition.links)
-        url = "#{String.trim_trailing(base_url, "/")}/#{String.trim_leading(path, "/")}"
-        {:ok, url}
+  @doc """
+  Builds the login URL for a definition.
 
-      _ ->
-        {:error, Error.search_failed("Login path not configured")}
+  The path is rendered first, because five shipped v11 definitions declare
+  `login.path` as `https://{{ .Config.apiurl }}/...`, and then joined with
+  `build_full_url/2` so an absolute path is used as-is rather than appended to
+  the site link. Concatenating one produced
+  `https://abn.lol/https://{{ .Config.apiurl }}/api`, curly braces intact.
+  """
+  @spec build_login_url(Parsed.t(), map()) :: {:ok, String.t()} | {:error, Error.t()}
+  def build_login_url(%Parsed{} = definition, config) do
+    with {:ok, path} <- login_path(definition),
+         {:ok, base_url} <- site_link(definition),
+         {:ok, rendered} <- render_login_path(path, definition, config) do
+      {:ok, CardigannSearchEngine.build_full_url(String.trim_trailing(base_url, "/"), rendered)}
+    end
+  end
+
+  defp login_path(%Parsed{login: %{path: path}}) when is_binary(path), do: {:ok, path}
+  defp login_path(%Parsed{}), do: {:error, Error.search_failed("Login path not configured")}
+
+  defp site_link(%Parsed{links: [link | _]}) when is_binary(link), do: {:ok, link}
+  defp site_link(%Parsed{}), do: {:error, Error.search_failed("No site link configured")}
+
+  defp render_login_path(path, %Parsed{} = definition, config) do
+    context = %{
+      keywords: "",
+      config: config,
+      query: %{series: "", season: nil, episode: nil, imdb_id: nil, tmdb_id: nil, tvdb_id: nil},
+      categories: [],
+      settings: definition.settings
+    }
+
+    case CardigannTemplate.render(path, context, url_encode: false) do
+      {:ok, rendered} ->
+        {:ok, rendered}
+
+      {:error, reason} ->
+        {:error, Error.search_failed("Login path failed to render: #{inspect(reason)}")}
     end
   end
 

--- a/lib/mydia/indexers/cardigann_download.ex
+++ b/lib/mydia/indexers/cardigann_download.ex
@@ -43,8 +43,10 @@ defmodule Mydia.Indexers.CardigannDownload do
   Resolves `download_url` through the definition's `download:` block.
 
   `user_config` is passed through to the HTTP layer for cookies, and matches
-  the shape `Mydia.Indexers.CardigannSearchEngine.execute_http_request/4`
-  expects.
+  the shape `Mydia.Indexers.CardigannSearchEngine.execute_http_request/5`
+  expects. The operator config map that call takes is passed as an empty map
+  here: the credential scope it derives falls back to the definition's own
+  `links`, which is what a download request resolves against.
 
   Returns `:not_applicable` when the definition has no `download:` block, or has
   one carrying neither a usable `infohash` nor any `selectors`, which lets the
@@ -118,7 +120,7 @@ defmodule Mydia.Indexers.CardigannDownload do
 
       Logger.debug("Cardigann download before-request: #{url} #{inspect(inputs)}")
 
-      CardigannSearchEngine.execute_http_request(definition, url, params, user_config)
+      CardigannSearchEngine.execute_http_request(definition, url, params, user_config, %{})
     end
   end
 
@@ -262,7 +264,7 @@ defmodule Mydia.Indexers.CardigannDownload do
 
   defp fetch(definition, url, user_config) do
     params = %{query_params: %{}, headers: [], method: :get, decode_body: false}
-    CardigannSearchEngine.execute_http_request(definition, url, params, user_config)
+    CardigannSearchEngine.execute_http_request(definition, url, params, user_config, %{})
   end
 
   defp to_body(%{body: body}), do: to_body(body)

--- a/lib/mydia/indexers/cardigann_download.ex
+++ b/lib/mydia/indexers/cardigann_download.ex
@@ -44,9 +44,13 @@ defmodule Mydia.Indexers.CardigannDownload do
 
   `user_config` is passed through to the HTTP layer for cookies, and matches
   the shape `Mydia.Indexers.CardigannSearchEngine.execute_http_request/5`
-  expects. The operator config map that call takes is passed as an empty map
-  here: the credential scope it derives falls back to the definition's own
-  `links`, which is what a download request resolves against.
+  expects. Its optional `:config` key carries the operator's settings, which
+  are threaded through to the credential scope so a templated absolute path
+  (`{{ .Config.apiurl }}` in `search.paths` or `login.path`) resolves against
+  the operator's real configuration rather than a definition's shipped
+  default. A caller that omits `:config` still gets a scope built from
+  `links` plus whatever a shipped default renders, just not the operator's
+  actual value.
 
   Returns `:not_applicable` when the definition has no `download:` block, or has
   one carrying neither a usable `infohash` nor any `selectors`, which lets the
@@ -120,7 +124,13 @@ defmodule Mydia.Indexers.CardigannDownload do
 
       Logger.debug("Cardigann download before-request: #{url} #{inspect(inputs)}")
 
-      CardigannSearchEngine.execute_http_request(definition, url, params, user_config, %{})
+      CardigannSearchEngine.execute_http_request(
+        definition,
+        url,
+        params,
+        user_config,
+        scope_config(user_config)
+      )
     end
   end
 
@@ -264,7 +274,14 @@ defmodule Mydia.Indexers.CardigannDownload do
 
   defp fetch(definition, url, user_config) do
     params = %{query_params: %{}, headers: [], method: :get, decode_body: false}
-    CardigannSearchEngine.execute_http_request(definition, url, params, user_config, %{})
+
+    CardigannSearchEngine.execute_http_request(
+      definition,
+      url,
+      params,
+      user_config,
+      scope_config(user_config)
+    )
   end
 
   defp to_body(%{body: body}), do: to_body(body)
@@ -288,6 +305,19 @@ defmodule Mydia.Indexers.CardigannDownload do
   defp http_method(_), do: :get
 
   # -- urls and templates -----------------------------------------------------
+
+  # The credential scope needs the operator's settings to render an absolute
+  # `{{ .Config.apiurl }}` path. resolve_cardigann_download/2 supplies them under
+  # :config; a caller that omits them still gets links plus whatever a shipped
+  # default renders, narrower than the operator's real scope, never wider.
+  defp scope_config(user_config) when is_map(user_config) do
+    case Map.get(user_config, :config) || Map.get(user_config, "config") do
+      %{} = config -> config
+      _ -> %{}
+    end
+  end
+
+  defp scope_config(_user_config), do: %{}
 
   # Phase 1 gave definitions a probed `active_link`; honour it here so a
   # definition that failed over to a mirror resolves its download block against

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -15,6 +15,7 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
   """
 
   alias Mydia.Indexers.Adapter.Error
+  alias Mydia.Indexers.Cardigann.CredentialScope
   alias Mydia.Indexers.Cardigann.Links
   alias Mydia.Indexers.Cardigann.TemplateContext
   alias Mydia.Indexers.CardigannDefinition
@@ -274,6 +275,23 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
     end
   end
 
+  @doc """
+  True when `candidate` may become the definition's sticky `active_link`.
+
+  `Links.candidates/1` offers `legacylinks` as failover targets, and a legacy
+  domain that answers would otherwise become sticky, silently readmitting a host
+  the credential scope excludes. The rule is conditional on credentials because
+  42 of the 81 public v11 definitions ship legacylinks and depend on promoting
+  them, while having no session to protect.
+  """
+  @spec promotable?(Parsed.t(), map(), String.t() | nil) :: boolean()
+  def promotable?(%Parsed{} = parsed, user_config, candidate) when is_binary(candidate) do
+    not CredentialScope.credentialed?(user_config) or
+      CredentialScope.allows?(CredentialScope.trusted_origins(parsed, user_config), candidate)
+  end
+
+  def promotable?(_parsed, _user_config, _candidate), do: false
+
   defp probe_query(%Parsed{capabilities: capabilities}) do
     # Map.get/3's default only applies when the key is ABSENT. A parsed
     # definition can have `modes: nil` (key present, value nil), in which case
@@ -336,7 +354,11 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
 
     case outcome do
       {:ok, 0, served_by} ->
-        store_link_state(definition, served_by, link_status)
+        store_link_state(
+          definition,
+          promoted_link(definition, parsed, user_config, served_by),
+          link_status
+        )
 
         %{
           success: true,
@@ -347,7 +369,11 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
         }
 
       {:ok, count, served_by} ->
-        store_link_state(definition, served_by, link_status)
+        store_link_state(
+          definition,
+          promoted_link(definition, parsed, user_config, served_by),
+          link_status
+        )
 
         %{
           success: true,
@@ -358,7 +384,11 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
         }
 
       {:cloudflare, message} ->
-        store_link_state(definition, active_link, link_status)
+        store_link_state(
+          definition,
+          promoted_link(definition, parsed, user_config, active_link),
+          link_status
+        )
 
         %{
           success: true,
@@ -382,6 +412,18 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
           response_time_ms: elapsed,
           error: message
         }
+    end
+  end
+
+  # Links.candidates/1 offers legacylinks as failover targets, so a probe can
+  # land on one. Persisting it as the sticky active_link would quietly readmit a
+  # host the credential scope excludes, for every later request. Falling back to
+  # the current active_link leaves the field untouched rather than clearing it.
+  defp promoted_link(definition, parsed, user_config, candidate) do
+    if promotable?(parsed, user_config, candidate) do
+      candidate
+    else
+      definition.active_link
     end
   end
 

--- a/lib/mydia/indexers/cardigann_health_check.ex
+++ b/lib/mydia/indexers/cardigann_health_check.ex
@@ -363,7 +363,9 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
         %{
           success: true,
           status: "degraded",
-          message: "Search reached #{served_by} but parsed no rows",
+          message:
+            "Search reached #{served_by} but parsed no rows" <>
+              (anonymous_search_note(parsed, user_config, served_by) || ""),
           response_time_ms: elapsed,
           error: nil
         }
@@ -375,10 +377,13 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
           link_status
         )
 
+        note = anonymous_search_note(parsed, user_config, served_by)
+
         %{
           success: true,
-          status: determine_health_status(definition, true, elapsed),
-          message: "Search returned #{count} result(s) via #{served_by}",
+          status:
+            if(note, do: "degraded", else: determine_health_status(definition, true, elapsed)),
+          message: "Search returned #{count} result(s) via #{served_by}#{note}",
           response_time_ms: elapsed,
           error: nil
         }
@@ -412,6 +417,24 @@ defmodule Mydia.Indexers.CardigannHealthCheck do
           response_time_ms: elapsed,
           error: message
         }
+    end
+  end
+
+  # An operator whose private tracker suddenly returns nothing deserves to be
+  # told why. A search served by a host outside the credential scope went out
+  # without its session, so it is degraded rather than healthy no matter how
+  # many rows it parsed.
+  defp anonymous_search_note(parsed, user_config, served_by) do
+    cond do
+      not CredentialScope.credentialed?(user_config) ->
+        nil
+
+      CredentialScope.allows?(CredentialScope.trusted_origins(parsed, user_config), served_by) ->
+        nil
+
+      true ->
+        " Searched anonymously: #{served_by} is not one of this definition's own hosts, " <>
+          "so its session was withheld."
     end
   end
 

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -175,9 +175,11 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
 
     with {:ok, url} <- build_search_url(definition, opts_for_candidate),
          {:ok, request_params} <- build_request_params(definition, opts_for_candidate) do
+      config = Keyword.get(opts, :config, %{})
+
       result =
         if should_use_flaresolverr?(flaresolverr_opts) do
-          execute_with_flaresolverr(definition, url, request_params, user_config)
+          execute_with_flaresolverr(definition, url, request_params, user_config, config)
         else
           execute_direct_request(
             definition,
@@ -185,7 +187,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
             request_params,
             user_config,
             flaresolverr_opts,
-            Keyword.get(opts, :config, %{})
+            config
           )
         end
 
@@ -253,7 +255,8 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
             url,
             request_params,
             user_config,
-            flaresolverr_opts
+            flaresolverr_opts,
+            config
           )
         else
           with :ok <- validate_response(response) do
@@ -272,12 +275,13 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
          url,
          request_params,
          user_config,
-         _flaresolverr_opts
+         _flaresolverr_opts,
+         config
        ) do
     Logger.info("Cloudflare challenge detected for #{definition.id}, attempting FlareSolverr")
 
     if FlareSolverr.enabled?() do
-      case execute_with_flaresolverr(definition, url, request_params, user_config) do
+      case execute_with_flaresolverr(definition, url, request_params, user_config, config) do
         {:ok, response, cookies} ->
           # Return with indicator that FlareSolverr was used and indexer should be flagged
           {:ok, response, [{:flaresolverr_required, true} | cookies]}
@@ -309,11 +313,18 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   end
 
   # Execute request through FlareSolverr
-  defp execute_with_flaresolverr(definition, url, request_params, user_config) do
+  #
+  # FlareSolverr used to receive user_config's cookies unconditionally, whatever
+  # host url named, while the direct Req path gated every request through
+  # attach_cookies/4. The two paths carry the same session credential, so they
+  # now consult the same cookie_disposition/2 decision before it is forwarded.
+  defp execute_with_flaresolverr(definition, url, request_params, user_config, config) do
     Logger.debug("Executing request through FlareSolverr: #{url}")
 
     # Apply rate limiting if configured
     apply_rate_limit(definition)
+
+    user_config = withhold_flaresolverr_cookies(user_config, url, definition, config)
 
     # Build FlareSolverr options from user_config
     flaresolverr_request_opts = build_flaresolverr_opts(user_config)
@@ -371,6 +382,28 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
       {:error, reason} ->
         Logger.error("FlareSolverr error for #{definition.id}: #{inspect(reason)}")
         {:error, Error.search_failed("FlareSolverr error: #{inspect(reason)}")}
+    end
+  end
+
+  # Only consult the scope when there is a cookie to protect. Mirrors the gate
+  # in build_request_options/5, so a cookie-less FlareSolverr request never
+  # logs a withholding warning it has nothing to withhold.
+  defp withhold_flaresolverr_cookies(user_config, url, definition, config) do
+    case Map.get(user_config, :cookies) do
+      cookies when is_list(cookies) and cookies != [] ->
+        trusted_origins = CredentialScope.trusted_origins(definition, config)
+
+        case cookie_disposition(url, trusted_origins) do
+          {:withhold, reason} ->
+            Logger.warning("Cardigann: withholding session cookies from #{reason}")
+            Map.delete(user_config, :cookies)
+
+          :ok ->
+            user_config
+        end
+
+      _ ->
+        user_config
     end
   end
 
@@ -899,24 +932,12 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   # download link is remote content rather than shipped YAML. Withhold and
   # continue, because an anonymous result beats a leaked login.
   defp attach_cookies(opts, url, cookies, trusted_origins) do
-    cond do
-      CredentialScope.cleartext?(url) ->
-        Logger.warning(
-          "Cardigann: withholding session cookies from cleartext URL #{inspect(url)}. " <>
-            "Configure an https base URL for this indexer to send credentials."
-        )
-
+    case cookie_disposition(url, trusted_origins) do
+      {:withhold, reason} ->
+        Logger.warning("Cardigann: withholding session cookies from #{reason}")
         opts
 
-      not CredentialScope.allows?(trusted_origins, url) ->
-        Logger.warning(
-          "Cardigann: withholding session cookies from #{inspect(url)}, which is not " <>
-            "one of this definition's own hosts. Searching anonymously."
-        )
-
-        opts
-
-      true ->
+      :ok ->
         cookie_header =
           cookies
           |> Enum.map(&normalize_cookie/1)
@@ -932,6 +953,28 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
           |> Keyword.put(:headers, [{"Cookie", cookie_header} | existing_headers])
           |> Keyword.put(:redirect, false)
         end
+    end
+  end
+
+  # The one place that decides whether a URL may receive the definition's
+  # session. Both the direct Req path (attach_cookies/4) and the FlareSolverr
+  # path (withhold_flaresolverr_cookies/4) consult it, so the policy cannot
+  # drift between them. It drifted once: FlareSolverr forwarded cookies to any
+  # host at all while the direct path was gated.
+  defp cookie_disposition(url, trusted_origins) do
+    cond do
+      CredentialScope.cleartext?(url) ->
+        {:withhold,
+         "cleartext URL #{inspect(url)}. Configure an https base URL for this indexer to " <>
+           "send credentials."}
+
+      not CredentialScope.allows?(trusted_origins, url) ->
+        {:withhold,
+         "#{inspect(url)}, which is not one of this definition's own hosts. Searching " <>
+           "anonymously."}
+
+      true ->
+        :ok
     end
   end
 

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -900,7 +900,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   # continue, because an anonymous result beats a leaked login.
   defp attach_cookies(opts, url, cookies, trusted_origins) do
     cond do
-      cleartext_url?(url) ->
+      CredentialScope.cleartext?(url) ->
         Logger.warning(
           "Cardigann: withholding session cookies from cleartext URL #{inspect(url)}. " <>
             "Configure an https base URL for this indexer to send credentials."
@@ -954,21 +954,4 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   end
 
   defp normalize_cookie(_cookie), do: nil
-
-  # Loopback is a secure context in the same sense browsers use the term: the
-  # request never reaches a network, so a local mirror or a test server is not
-  # an exposure. Everything else on plain http is.
-  @loopback_hosts ~w(localhost 127.0.0.1 ::1 0:0:0:0:0:0:0:1)
-
-  defp cleartext_url?(url) when is_binary(url) do
-    case URI.parse(url) do
-      %URI{scheme: "http", host: host} ->
-        String.downcase(host || "") not in @loopback_hosts
-
-      _ ->
-        false
-    end
-  end
-
-  defp cleartext_url?(_url), do: false
 end

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -52,6 +52,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
       {:ok, response} = CardigannSearchEngine.execute_search(definition, opts)
   """
 
+  alias Mydia.Indexers.Cardigann.CredentialScope
   alias Mydia.Indexers.Cardigann.Links
   alias Mydia.Indexers.CardigannDefinition.Parsed
   alias Mydia.Indexers.CardigannTemplate
@@ -178,7 +179,14 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
         if should_use_flaresolverr?(flaresolverr_opts) do
           execute_with_flaresolverr(definition, url, request_params, user_config)
         else
-          execute_direct_request(definition, url, request_params, user_config, flaresolverr_opts)
+          execute_direct_request(
+            definition,
+            url,
+            request_params,
+            user_config,
+            flaresolverr_opts,
+            Keyword.get(opts, :config, %{})
+          )
         end
 
       cond do
@@ -229,8 +237,15 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   defp retryable_failure?(_), do: false
 
   # Execute request directly and detect Cloudflare challenges
-  defp execute_direct_request(definition, url, request_params, user_config, flaresolverr_opts) do
-    case execute_http_request(definition, url, request_params, user_config) do
+  defp execute_direct_request(
+         definition,
+         url,
+         request_params,
+         user_config,
+         flaresolverr_opts,
+         config
+       ) do
+    case execute_http_request(definition, url, request_params, user_config, config) do
       {:ok, response} ->
         if cloudflare_challenge?(response) do
           handle_cloudflare_challenge(
@@ -528,18 +543,18 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   ## Examples
 
       iex> params = %{query_params: %{}, headers: [], method: :get}
-      iex> {:ok, response} = execute_http_request(definition, url, params, %{})
+      iex> {:ok, response} = execute_http_request(definition, url, params, %{}, %{})
       iex> response.status
       200
   """
-  @spec execute_http_request(Parsed.t(), String.t(), map(), map()) ::
+  @spec execute_http_request(Parsed.t(), String.t(), map(), map(), map()) ::
           {:ok, http_response()} | {:error, Error.t()}
-  def execute_http_request(%Parsed{} = definition, url, request_params, user_config) do
+  def execute_http_request(%Parsed{} = definition, url, request_params, user_config, config) do
     # Apply rate limiting if configured
     apply_rate_limit(definition)
 
     # Build request options
-    req_opts = build_request_options(definition, url, request_params, user_config)
+    req_opts = build_request_options(definition, url, request_params, user_config, config)
 
     Logger.debug("Cardigann search request: #{request_params.method} #{url}")
     Logger.debug("Request params: #{inspect(request_params.query_params)}")
@@ -816,7 +831,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     :ok
   end
 
-  defp build_request_options(definition, url, request_params, user_config) do
+  defp build_request_options(definition, url, request_params, user_config, config) do
     # Base options
     base_opts = [
       headers: request_params.headers,
@@ -849,7 +864,12 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     # Add cookies if present in user config
     case Map.get(user_config, :cookies) do
       cookies when is_list(cookies) and cookies != [] ->
-        attach_cookies(opts_with_params, url, cookies)
+        attach_cookies(
+          opts_with_params,
+          url,
+          cookies,
+          CredentialScope.trusted_origins(definition, config)
+        )
 
       _ ->
         opts_with_params
@@ -871,30 +891,47 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   # the honest handling this branch already added: validate_response/1 names the
   # Location, and failover moves on to the next candidate. Redirect following is
   # unaffected for every request without cookies.
-  defp attach_cookies(opts, url, cookies) do
-    if cleartext_url?(url) do
-      Logger.warning(
-        "Cardigann: withholding session cookies from cleartext URL #{inspect(url)}. " <>
-          "Configure an https base URL for this indexer to send credentials."
-      )
-
-      opts
-    else
-      cookie_header =
-        cookies
-        |> Enum.map(&normalize_cookie/1)
-        |> Enum.reject(&is_nil/1)
-        |> Enum.join("; ")
-
-      if cookie_header == "" do
-        opts
-      else
-        existing_headers = Keyword.get(opts, :headers, [])
+  #
+  # A session cookie is scoped to the origins the definition names as its own:
+  # its links, plus any absolute search or login path it renders. A mirror
+  # failover onto a stale legacylinks domain, or a download link parsed out
+  # of a result row, can both name an origin the operator never trusted, and a
+  # download link is remote content rather than shipped YAML. Withhold and
+  # continue, because an anonymous result beats a leaked login.
+  defp attach_cookies(opts, url, cookies, trusted_origins) do
+    cond do
+      cleartext_url?(url) ->
+        Logger.warning(
+          "Cardigann: withholding session cookies from cleartext URL #{inspect(url)}. " <>
+            "Configure an https base URL for this indexer to send credentials."
+        )
 
         opts
-        |> Keyword.put(:headers, [{"Cookie", cookie_header} | existing_headers])
-        |> Keyword.put(:redirect, false)
-      end
+
+      not CredentialScope.allows?(trusted_origins, url) ->
+        Logger.warning(
+          "Cardigann: withholding session cookies from #{inspect(url)}, which is not " <>
+            "one of this definition's own hosts. Searching anonymously."
+        )
+
+        opts
+
+      true ->
+        cookie_header =
+          cookies
+          |> Enum.map(&normalize_cookie/1)
+          |> Enum.reject(&is_nil/1)
+          |> Enum.join("; ")
+
+        if cookie_header == "" do
+          opts
+        else
+          existing_headers = Keyword.get(opts, :headers, [])
+
+          opts
+          |> Keyword.put(:headers, [{"Cookie", cookie_header} | existing_headers])
+          |> Keyword.put(:redirect, false)
+        end
     end
   end
 

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -716,13 +716,17 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     Mydia.Indexers.Cardigann.TemplateContext.build(definition, opts)
   end
 
-  # A Cardigann definition may put a full URL in `path:` rather than a path
-  # relative to the site's base. The Pirate Bay does exactly that, pointing at
-  # https://apibay.org/q.php. Concatenating it onto the base URL produced
-  # https://thepiratebay.org/https://apibay.org/q.php?... which the site
-  # answered with a redirect, surfacing to the operator as
-  # "Unexpected status: 302".
-  defp build_full_url(base_url, path) do
+  @doc """
+  Joins a rendered path onto a base URL, honouring an absolute path.
+
+  A Cardigann definition may put a full URL in `path:` rather than a path
+  relative to the site's base. Concatenating one produced
+  `https://thepiratebay.org/https://apibay.org/q.php?...`, which the site
+  answered with a redirect. The guard requires both a scheme and a host, so a
+  relative path containing a colon still joins correctly.
+  """
+  @spec build_full_url(String.t(), String.t()) :: String.t()
+  def build_full_url(base_url, path) do
     case URI.parse(path) do
       %URI{scheme: scheme, host: host} when is_binary(scheme) and is_binary(host) ->
         path

--- a/test/mydia/indexers/adapter/cardigann_test.exs
+++ b/test/mydia/indexers/adapter/cardigann_test.exs
@@ -491,6 +491,88 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
     end
   end
 
+  describe "on_promote credential scope" do
+    test "a legacy mirror that wins search failover does not become active_link when credentials are configured" do
+      # Mirrors the health check's "a legacy mirror that answers is not
+      # promoted" regression, but through the real search/2 path: the first
+      # candidate (an in-scope links entry) is unreachable, execute_search
+      # fails over to the second candidate (a legacylinks entry, out of
+      # scope), and on_promote fires for it. With a credential configured on
+      # the definition, that promotion must be withheld.
+      dead = Bypass.open()
+      Bypass.down(dead)
+
+      legacy = Bypass.open()
+
+      Bypass.stub(legacy, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("text/html")
+        |> Plug.Conn.resp(
+          200,
+          "<html><body><table class=\"results\"><tr><th>Header</th></tr></table></body></html>"
+        )
+      end)
+
+      dead_url = "http://localhost:#{dead.port}"
+      legacy_url = "http://localhost:#{legacy.port}"
+
+      yaml = """
+      id: legacy-promo
+      name: Legacy Promo
+      description: d
+      language: en-US
+      type: private
+      encoding: UTF-8
+      links:
+        - #{dead_url}
+      legacylinks:
+        - #{legacy_url}
+      caps:
+        categories:
+          2000: Movies
+      settings: []
+      search:
+        paths:
+          - path: /search
+        rows:
+          selector: tr
+        fields:
+          title:
+            selector: td.title
+          size:
+            selector: td.size
+          seeders:
+            selector: td.seeders
+          download:
+            selector: a
+            attribute: href
+      """
+
+      {:ok, definition} =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "legacy-promo",
+          name: "Legacy Promo",
+          type: "private",
+          links: %{"0" => dead_url},
+          capabilities: %{},
+          schema_version: "v11",
+          config: %{"username" => "me", "password" => "secret"},
+          definition: yaml,
+          enabled: true
+        })
+        |> Repo.insert()
+
+      config = %{type: :cardigann, name: "Legacy Promo", indexer_id: "legacy-promo"}
+
+      assert {:ok, _results} = Cardigann.search(config, "query")
+
+      reloaded = Repo.reload!(definition)
+      refute reloaded.active_link == legacy_url
+      assert reloaded.active_link == nil
+    end
+  end
+
   describe "get_capabilities/1" do
     test "returns capabilities from definition", %{definition: _definition} do
       config = %{

--- a/test/mydia/indexers/adapter/cardigann_test.exs
+++ b/test/mydia/indexers/adapter/cardigann_test.exs
@@ -306,6 +306,123 @@ defmodule Mydia.Indexers.Adapter.CardigannTest do
     end
   end
 
+  describe "operator config override reaches the login request" do
+    # Regression: get_or_create_session/3 built the credentials map passed to
+    # CardigannAuth.authenticate/3 from config.user_settings alone, never from
+    # definition.config. A login.path templated as {{ .Config.apiurl }} always
+    # rendered to the setting's schema default, so an operator's override was
+    # silently ignored and a login could be established against the wrong
+    # host while a search (which does read definition.config) used the right
+    # one. Two Bypasses stand in for "wrong host" (the setting default) and
+    # "right host" (the operator override); the test proves which one the
+    # login actually reached.
+    test "a login-path setting's operator override, not its schema default, receives the login" do
+      site = Bypass.open()
+      override = Bypass.open()
+      site_base_url = "http://localhost:#{site.port}"
+
+      yaml = """
+      id: login-override-indexer
+      name: Login Override Indexer
+      description: A private indexer whose login path is templated
+      language: en-US
+      type: private
+      encoding: UTF-8
+      links:
+        - #{site_base_url}
+      caps:
+        modes:
+          search: {search-type: q}
+        categories:
+          5000: TV
+      settings:
+        - name: apiurl
+          type: text
+          label: API URL
+          default: localhost:1
+      login:
+        path: http://{{ .Config.apiurl }}/login.php
+        method: form
+        inputs:
+          username: "{{ .Config.username }}"
+          password: "{{ .Config.password }}"
+        test:
+          selector: "a[href*=logout]"
+      search:
+        path: /search
+        rows:
+          selector: "table.results tr"
+          after: 1
+        fields:
+          title:
+            selector: "td.title a"
+          size:
+            selector: "td.size"
+          seeders:
+            selector: "td.seeders"
+      """
+
+      {:ok, _definition} =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "login-override-indexer",
+          name: "Login Override Indexer",
+          description: "A private indexer whose login path is templated",
+          language: "en-US",
+          type: "private",
+          encoding: "UTF-8",
+          links: %{"0" => site_base_url},
+          capabilities: %{modes: %{"search" => %{}}, categories: %{"5000" => "TV"}},
+          definition: yaml,
+          schema_version: "v11",
+          enabled: true,
+          # String keys, exactly as the database and the admin form supply
+          # them. apiurl deliberately does not match the setting's default
+          # (localhost:1), so the rendered login URL can only hit `override`
+          # if the adapter actually threads this map into the login render.
+          config: %{
+            "username" => "stringuser",
+            "password" => "stringpass",
+            "apiurl" => "localhost:#{override.port}"
+          },
+          last_synced_at: DateTime.utc_now()
+        })
+        |> Repo.insert()
+
+      test_pid = self()
+
+      Bypass.expect_once(override, "POST", "/login.php", fn conn ->
+        send(test_pid, :login_hit)
+
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "session=granted; Path=/")
+        |> Plug.Conn.resp(200, "<html><body><a href='/logout'>Logout</a></body></html>")
+      end)
+
+      Bypass.stub(site, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("text/html")
+        |> Plug.Conn.resp(
+          200,
+          "<html><body><table class=\"results\"><tr><th>Header</th></tr></table></body></html>"
+        )
+      end)
+
+      config = %{
+        type: :cardigann,
+        name: "Login Override Indexer",
+        indexer_id: "login-override-indexer"
+      }
+
+      # The point of this test is which host received the login, not what
+      # Cardigann.search/2 returns. If the login never reaches `override`,
+      # Bypass.expect_once fails the test on exit regardless of this result.
+      Cardigann.search(config, "query")
+
+      assert_receive :login_hit
+    end
+  end
+
   describe "search/3" do
     test "builds search options correctly", %{definition: _definition} do
       config = %{

--- a/test/mydia/indexers/cardigann/credential_scope_test.exs
+++ b/test/mydia/indexers/cardigann/credential_scope_test.exs
@@ -122,6 +122,41 @@ defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
       refute MapSet.member?(origins, "api.v3x.club:443")
     end
 
+    test "renders a path whose scheme, not just its host, comes from configuration" do
+      parsed =
+        definition(
+          settings: [%{name: "apiurl", type: "text", default: "https://api.example"}],
+          search: %{
+            paths: [%{path: "{{ .Config.apiurl }}/v1/search"}],
+            inputs: %{},
+            rows: %{},
+            fields: %{}
+          }
+        )
+
+      origins = CredentialScope.trusted_origins(parsed, %{})
+
+      assert MapSet.member?(origins, "api.example:443")
+    end
+
+    test "an operator override of a configured scheme wins over the default" do
+      parsed =
+        definition(
+          settings: [%{name: "apiurl", type: "text", default: "https://api.example"}],
+          search: %{
+            paths: [%{path: "{{ .Config.apiurl }}/v1/search"}],
+            inputs: %{},
+            rows: %{},
+            fields: %{}
+          }
+        )
+
+      origins = CredentialScope.trusted_origins(parsed, %{"apiurl" => "https://api.mine.example"})
+
+      assert MapSet.member?(origins, "api.mine.example:443")
+      refute MapSet.member?(origins, "api.example:443")
+    end
+
     test "includes the host of an absolute login path" do
       parsed = definition(login: %{method: "form", path: "https://auth.tracker.example/login"})
 

--- a/test/mydia/indexers/cardigann/credential_scope_test.exs
+++ b/test/mydia/indexers/cardigann/credential_scope_test.exs
@@ -1,0 +1,230 @@
+defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.Cardigann.CredentialScope
+  alias Mydia.Indexers.CardigannDefinition.Parsed
+  alias Mydia.Indexers.CardigannParser
+
+  @corpus Path.wildcard("test/fixtures/cardigann/**/*.yml")
+
+  defp absolute_urls(parsed) do
+    search =
+      case parsed.search do
+        %{} = s -> Map.get(s, :paths) || []
+        _ -> []
+      end
+
+    search_paths = Enum.map(search, fn p -> Map.get(p, :path) end)
+    login = if is_map(parsed.login), do: [Map.get(parsed.login, :path)], else: []
+
+    (login ++ search_paths)
+    |> Enum.filter(&is_binary/1)
+    |> Enum.filter(&String.match?(&1, ~r{^https?://}i))
+    |> Enum.flat_map(fn template ->
+      context = %{
+        keywords: "",
+        config: %{},
+        query: %{series: ""},
+        categories: [],
+        settings: parsed.settings
+      }
+
+      case Mydia.Indexers.CardigannTemplate.render(template, context, url_encode: false) do
+        {:ok, rendered} -> [rendered]
+        _ -> []
+      end
+    end)
+  end
+
+  defp definition(overrides \\ []) do
+    base = %Parsed{
+      id: "scope-test",
+      name: "Scope Test",
+      description: "",
+      language: "en-US",
+      type: "private",
+      encoding: "UTF-8",
+      links: ["https://tracker.example/", "https://mirror.example"],
+      legacylinks: ["https://old-tracker.example/"],
+      capabilities: %{modes: %{}},
+      search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+      login: nil,
+      download: nil,
+      settings: [],
+      request_delay: nil,
+      follow_redirect: true
+    }
+
+    struct!(base, overrides)
+  end
+
+  describe "trusted_hosts/2" do
+    test "includes every host in links" do
+      hosts = CredentialScope.trusted_hosts(definition(), %{})
+
+      assert MapSet.member?(hosts, "tracker.example")
+      assert MapSet.member?(hosts, "mirror.example")
+    end
+
+    test "excludes legacylinks" do
+      hosts = CredentialScope.trusted_hosts(definition(), %{})
+
+      refute MapSet.member?(hosts, "old-tracker.example")
+    end
+
+    test "includes the host of an absolute search path" do
+      parsed =
+        definition(
+          search: %{
+            paths: [%{path: "https://api.tracker.example/v1/search"}],
+            inputs: %{},
+            rows: %{},
+            fields: %{}
+          }
+        )
+
+      hosts = CredentialScope.trusted_hosts(parsed, %{})
+
+      assert MapSet.member?(hosts, "api.tracker.example")
+    end
+
+    test "renders a templated absolute path from a setting default" do
+      parsed =
+        definition(
+          settings: [%{name: "apiurl", type: "text", default: "api.v3x.club"}],
+          search: %{
+            paths: [%{path: "https://{{ .Config.apiurl }}/indexer/search"}],
+            inputs: %{},
+            rows: %{},
+            fields: %{}
+          }
+        )
+
+      hosts = CredentialScope.trusted_hosts(parsed, %{})
+
+      assert MapSet.member?(hosts, "api.v3x.club")
+    end
+
+    test "an operator override of the setting wins over the default" do
+      parsed =
+        definition(
+          settings: [%{name: "apiurl", type: "text", default: "api.v3x.club"}],
+          search: %{
+            paths: [%{path: "https://{{ .Config.apiurl }}/indexer/search"}],
+            inputs: %{},
+            rows: %{},
+            fields: %{}
+          }
+        )
+
+      hosts = CredentialScope.trusted_hosts(parsed, %{"apiurl" => "api.mine.example"})
+
+      assert MapSet.member?(hosts, "api.mine.example")
+      refute MapSet.member?(hosts, "api.v3x.club")
+    end
+
+    test "includes the host of an absolute login path" do
+      parsed = definition(login: %{method: "form", path: "https://auth.tracker.example/login"})
+
+      hosts = CredentialScope.trusted_hosts(parsed, %{})
+
+      assert MapSet.member?(hosts, "auth.tracker.example")
+    end
+
+    test "a relative path contributes no host" do
+      hosts = CredentialScope.trusted_hosts(definition(), %{})
+
+      assert MapSet.size(hosts) == 2
+    end
+  end
+
+  describe "allows?/2" do
+    setup do
+      %{hosts: CredentialScope.trusted_hosts(definition(), %{})}
+    end
+
+    test "allows an exact host match", %{hosts: hosts} do
+      assert CredentialScope.allows?(hosts, "https://tracker.example/search?q=x")
+    end
+
+    test "match is case insensitive", %{hosts: hosts} do
+      assert CredentialScope.allows?(hosts, "https://TRACKER.Example/search")
+    end
+
+    test "refuses a host outside the set", %{hosts: hosts} do
+      refute CredentialScope.allows?(hosts, "https://evil.example/search")
+    end
+
+    test "refuses a legacy host", %{hosts: hosts} do
+      refute CredentialScope.allows?(hosts, "https://old-tracker.example/search")
+    end
+
+    # limetorrents.proxyninja.net and extratorrent.ninjaproxy1.com are real
+    # shipped links entries on shared proxy services fronting many unrelated
+    # trackers. A subdomain-suffix rule would leak one tracker's session to a
+    # neighbour behind the same proxy.
+    test "refuses a subdomain of a trusted host", %{hosts: hosts} do
+      refute CredentialScope.allows?(hosts, "https://sub.tracker.example/search")
+    end
+
+    test "refuses a parent domain of a trusted host" do
+      hosts = CredentialScope.trusted_hosts(definition(links: ["https://a.proxy.example"]), %{})
+
+      refute CredentialScope.allows?(hosts, "https://proxy.example/search")
+    end
+
+    test "refuses a url with no host", %{hosts: hosts} do
+      refute CredentialScope.allows?(hosts, "/search")
+      refute CredentialScope.allows?(hosts, "magnet:?xt=urn:btih:abc")
+    end
+  end
+
+  describe "credentialed?/1" do
+    test "true for a non-empty cookie list" do
+      assert CredentialScope.credentialed?(%{cookies: ["session=abc"]})
+    end
+
+    test "true for a string-keyed username, as definition.config supplies" do
+      assert CredentialScope.credentialed?(%{"username" => "me", "password" => "secret"})
+    end
+
+    test "true for an api key under either spelling" do
+      assert CredentialScope.credentialed?(%{api_key: "k"})
+      assert CredentialScope.credentialed?(%{"apikey" => "k"})
+    end
+
+    test "false for blanks, which is how the admin form submits untouched fields" do
+      refute CredentialScope.credentialed?(%{"username" => "", cookies: [], password: nil})
+    end
+
+    test "false for a config holding only non-credential settings" do
+      refute CredentialScope.credentialed?(%{"apiurl" => "api.example", "sort" => "seeders"})
+    end
+  end
+
+  # A static guard that the policy never strips a legitimate shipped definition.
+  # Every absolute search or login path in the fixture corpus must resolve, with
+  # its own setting defaults, to a host that definition already trusts. If a
+  # future definition breaks this, the policy needs revisiting rather than the
+  # definition being silently searched anonymously.
+  describe "shipped definition corpus" do
+    test "every absolute path in the corpus lands inside its own trusted set" do
+      assert @corpus != [], "no cardigann fixtures found; check the wildcard"
+
+      # `{:ok, parsed} <- [...]` filters a parse failure out of the comprehension
+      # rather than raising, so one unparseable fixture cannot mask the guard.
+      offenders =
+        for file <- @corpus,
+            {:ok, parsed} <- [CardigannParser.parse_definition(File.read!(file))],
+            hosts = CredentialScope.trusted_hosts(parsed, %{}),
+            url <- absolute_urls(parsed),
+            not CredentialScope.allows?(hosts, url) do
+          {Path.basename(file), url}
+        end
+
+      assert offenders == [],
+             "these shipped definitions render an absolute path outside their own " <>
+               "trusted host set: #{inspect(offenders)}"
+    end
+  end
+end

--- a/test/mydia/indexers/cardigann/credential_scope_test.exs
+++ b/test/mydia/indexers/cardigann/credential_scope_test.exs
@@ -18,8 +18,7 @@ defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
     login = if is_map(parsed.login), do: [Map.get(parsed.login, :path)], else: []
 
     (login ++ search_paths)
-    |> Enum.filter(&is_binary/1)
-    |> Enum.filter(&String.match?(&1, ~r{^https?://}i))
+    |> Enum.filter(fn path -> is_binary(path) and String.match?(path, ~r{^https?://}i) end)
     |> Enum.flat_map(fn template ->
       context = %{
         keywords: "",
@@ -58,18 +57,18 @@ defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
     struct!(base, overrides)
   end
 
-  describe "trusted_hosts/2" do
+  describe "trusted_origins/2" do
     test "includes every host in links" do
-      hosts = CredentialScope.trusted_hosts(definition(), %{})
+      origins = CredentialScope.trusted_origins(definition(), %{})
 
-      assert MapSet.member?(hosts, "tracker.example")
-      assert MapSet.member?(hosts, "mirror.example")
+      assert MapSet.member?(origins, "tracker.example:443")
+      assert MapSet.member?(origins, "mirror.example:443")
     end
 
     test "excludes legacylinks" do
-      hosts = CredentialScope.trusted_hosts(definition(), %{})
+      origins = CredentialScope.trusted_origins(definition(), %{})
 
-      refute MapSet.member?(hosts, "old-tracker.example")
+      refute MapSet.member?(origins, "old-tracker.example:443")
     end
 
     test "includes the host of an absolute search path" do
@@ -83,9 +82,9 @@ defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
           }
         )
 
-      hosts = CredentialScope.trusted_hosts(parsed, %{})
+      origins = CredentialScope.trusted_origins(parsed, %{})
 
-      assert MapSet.member?(hosts, "api.tracker.example")
+      assert MapSet.member?(origins, "api.tracker.example:443")
     end
 
     test "renders a templated absolute path from a setting default" do
@@ -100,9 +99,9 @@ defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
           }
         )
 
-      hosts = CredentialScope.trusted_hosts(parsed, %{})
+      origins = CredentialScope.trusted_origins(parsed, %{})
 
-      assert MapSet.member?(hosts, "api.v3x.club")
+      assert MapSet.member?(origins, "api.v3x.club:443")
     end
 
     test "an operator override of the setting wins over the default" do
@@ -117,65 +116,80 @@ defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
           }
         )
 
-      hosts = CredentialScope.trusted_hosts(parsed, %{"apiurl" => "api.mine.example"})
+      origins = CredentialScope.trusted_origins(parsed, %{"apiurl" => "api.mine.example"})
 
-      assert MapSet.member?(hosts, "api.mine.example")
-      refute MapSet.member?(hosts, "api.v3x.club")
+      assert MapSet.member?(origins, "api.mine.example:443")
+      refute MapSet.member?(origins, "api.v3x.club:443")
     end
 
     test "includes the host of an absolute login path" do
       parsed = definition(login: %{method: "form", path: "https://auth.tracker.example/login"})
 
-      hosts = CredentialScope.trusted_hosts(parsed, %{})
+      origins = CredentialScope.trusted_origins(parsed, %{})
 
-      assert MapSet.member?(hosts, "auth.tracker.example")
+      assert MapSet.member?(origins, "auth.tracker.example:443")
     end
 
     test "a relative path contributes no host" do
-      hosts = CredentialScope.trusted_hosts(definition(), %{})
+      origins = CredentialScope.trusted_origins(definition(), %{})
 
-      assert MapSet.size(hosts) == 2
+      assert MapSet.size(origins) == 2
+    end
+
+    test "a different port on a trusted host is a different origin" do
+      origins = CredentialScope.trusted_origins(definition(links: ["http://127.0.0.1:3333"]), %{})
+
+      assert CredentialScope.allows?(origins, "http://127.0.0.1:3333/search")
+      refute CredentialScope.allows?(origins, "http://127.0.0.1:8080/search")
+    end
+
+    test "an explicit default port matches its implicit form" do
+      origins =
+        CredentialScope.trusted_origins(definition(links: ["https://tracker.example"]), %{})
+
+      assert CredentialScope.allows?(origins, "https://tracker.example:443/search")
     end
   end
 
   describe "allows?/2" do
     setup do
-      %{hosts: CredentialScope.trusted_hosts(definition(), %{})}
+      %{origins: CredentialScope.trusted_origins(definition(), %{})}
     end
 
-    test "allows an exact host match", %{hosts: hosts} do
-      assert CredentialScope.allows?(hosts, "https://tracker.example/search?q=x")
+    test "allows an exact host match", %{origins: origins} do
+      assert CredentialScope.allows?(origins, "https://tracker.example/search?q=x")
     end
 
-    test "match is case insensitive", %{hosts: hosts} do
-      assert CredentialScope.allows?(hosts, "https://TRACKER.Example/search")
+    test "match is case insensitive", %{origins: origins} do
+      assert CredentialScope.allows?(origins, "https://TRACKER.Example/search")
     end
 
-    test "refuses a host outside the set", %{hosts: hosts} do
-      refute CredentialScope.allows?(hosts, "https://evil.example/search")
+    test "refuses a host outside the set", %{origins: origins} do
+      refute CredentialScope.allows?(origins, "https://evil.example/search")
     end
 
-    test "refuses a legacy host", %{hosts: hosts} do
-      refute CredentialScope.allows?(hosts, "https://old-tracker.example/search")
+    test "refuses a legacy host", %{origins: origins} do
+      refute CredentialScope.allows?(origins, "https://old-tracker.example/search")
     end
 
     # limetorrents.proxyninja.net and extratorrent.ninjaproxy1.com are real
     # shipped links entries on shared proxy services fronting many unrelated
     # trackers. A subdomain-suffix rule would leak one tracker's session to a
     # neighbour behind the same proxy.
-    test "refuses a subdomain of a trusted host", %{hosts: hosts} do
-      refute CredentialScope.allows?(hosts, "https://sub.tracker.example/search")
+    test "refuses a subdomain of a trusted host", %{origins: origins} do
+      refute CredentialScope.allows?(origins, "https://sub.tracker.example/search")
     end
 
     test "refuses a parent domain of a trusted host" do
-      hosts = CredentialScope.trusted_hosts(definition(links: ["https://a.proxy.example"]), %{})
+      origins =
+        CredentialScope.trusted_origins(definition(links: ["https://a.proxy.example"]), %{})
 
-      refute CredentialScope.allows?(hosts, "https://proxy.example/search")
+      refute CredentialScope.allows?(origins, "https://proxy.example/search")
     end
 
-    test "refuses a url with no host", %{hosts: hosts} do
-      refute CredentialScope.allows?(hosts, "/search")
-      refute CredentialScope.allows?(hosts, "magnet:?xt=urn:btih:abc")
+    test "refuses a url with no host", %{origins: origins} do
+      refute CredentialScope.allows?(origins, "/search")
+      refute CredentialScope.allows?(origins, "magnet:?xt=urn:btih:abc")
     end
   end
 
@@ -216,9 +230,9 @@ defmodule Mydia.Indexers.Cardigann.CredentialScopeTest do
       offenders =
         for file <- @corpus,
             {:ok, parsed} <- [CardigannParser.parse_definition(File.read!(file))],
-            hosts = CredentialScope.trusted_hosts(parsed, %{}),
+            origins = CredentialScope.trusted_origins(parsed, %{}),
             url <- absolute_urls(parsed),
-            not CredentialScope.allows?(hosts, url) do
+            not CredentialScope.allows?(origins, url) do
           {Path.basename(file), url}
         end
 

--- a/test/mydia/indexers/cardigann_auth_test.exs
+++ b/test/mydia/indexers/cardigann_auth_test.exs
@@ -532,4 +532,65 @@ defmodule Mydia.Indexers.CardigannAuthTest do
       assert message =~ "No site link configured"
     end
   end
+
+  describe "form login credential scope" do
+    test "refuses to POST credentials over cleartext to a non-loopback host" do
+      parsed =
+        login_definition(%{
+          method: "form",
+          path: "/login.php",
+          inputs: %{
+            "username" => "{{ .Config.username }}",
+            "password" => "{{ .Config.password }}"
+          }
+        })
+
+      parsed = %{parsed | links: ["http://tracker.example"]}
+
+      assert {:error, error} =
+               CardigannAuth.authenticate(parsed, %{username: "me", password: "secret"})
+
+      assert error.message =~ "unencrypted"
+      assert error.message =~ "tracker.example"
+    end
+
+    test "allows a login on a host the definition names" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "POST", "/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "session=granted; Path=/")
+        |> Plug.Conn.resp(200, "<html>welcome</html>")
+      end)
+
+      parsed = %Parsed{
+        id: "login-scope-ok",
+        name: "Login Scope OK",
+        description: "",
+        language: "en-US",
+        type: "private",
+        encoding: "UTF-8",
+        links: ["http://localhost:#{bypass.port}"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+        login: %{
+          method: "form",
+          path: "/login",
+          inputs: %{
+            "username" => "{{ .Config.username }}",
+            "password" => "{{ .Config.password }}"
+          }
+        },
+        download: nil,
+        settings: [],
+        request_delay: nil,
+        follow_redirect: true
+      }
+
+      assert {:ok, %{cookies: cookies}} =
+               CardigannAuth.authenticate(parsed, %{username: "me", password: "secret"})
+
+      assert Enum.any?(cookies, &String.contains?(&1, "session=granted"))
+    end
+  end
 end

--- a/test/mydia/indexers/cardigann_auth_test.exs
+++ b/test/mydia/indexers/cardigann_auth_test.exs
@@ -6,6 +6,25 @@ defmodule Mydia.Indexers.CardigannAuthTest do
   alias Mydia.Indexers.CardigannSearchSession
   alias Mydia.Repo
 
+  defp login_definition(login, settings \\ []) do
+    %Parsed{
+      id: "login-url",
+      name: "Login URL",
+      description: "",
+      language: "en-US",
+      type: "private",
+      encoding: "UTF-8",
+      links: ["https://abn.lol/"],
+      capabilities: %{modes: %{}},
+      search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+      login: login,
+      download: nil,
+      settings: settings,
+      request_delay: nil,
+      follow_redirect: true
+    }
+  end
+
   describe "authenticate/3 with form login" do
     setup do
       definition = %Parsed{
@@ -151,6 +170,47 @@ defmodule Mydia.Indexers.CardigannAuthTest do
       assert stored_session != nil
       assert stored_session.cookies != nil
       assert stored_session.expires_at != nil
+    end
+
+    test "an operator override of a login-path setting reaches the login request" do
+      override = Bypass.open()
+
+      Bypass.expect_once(override, "POST", "/api/login", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "session=granted; Path=/")
+        |> Plug.Conn.resp(200, "<html>welcome</html>")
+      end)
+
+      parsed = %Parsed{
+        id: "login-override",
+        name: "Login Override",
+        description: "",
+        language: "en-US",
+        type: "private",
+        encoding: "UTF-8",
+        links: ["http://localhost:1/"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+        login: %{
+          method: "form",
+          path: "http://{{ .Config.apiurl }}/api/login",
+          inputs: %{
+            "username" => "{{ .Config.username }}",
+            "password" => "{{ .Config.password }}"
+          }
+        },
+        download: nil,
+        settings: [%{name: "apiurl", type: "text", default: "localhost:2"}],
+        request_delay: nil,
+        follow_redirect: true
+      }
+
+      assert {:ok, _session} =
+               CardigannAuth.authenticate(parsed, %{
+                 username: "me",
+                 password: "secret",
+                 config: %{"apiurl" => "localhost:#{override.port}"}
+               })
     end
   end
 
@@ -416,6 +476,60 @@ defmodule Mydia.Indexers.CardigannAuthTest do
       assert session.method == :none
       assert session.cookies == []
       assert session.expires_at == nil
+    end
+  end
+
+  describe "build_login_url/2" do
+    test "joins a relative login path onto the site link" do
+      parsed = login_definition(%{method: "form", path: "/login.php"})
+
+      assert {:ok, "https://abn.lol/login.php"} = CardigannAuth.build_login_url(parsed, %{})
+    end
+
+    test "an absolute login path is used as-is, not appended to the site link" do
+      parsed = login_definition(%{method: "form", path: "https://auth.abn.lol/api/login"})
+
+      assert {:ok, "https://auth.abn.lol/api/login"} = CardigannAuth.build_login_url(parsed, %{})
+    end
+
+    test "a templated login path is rendered before use" do
+      parsed =
+        login_definition(
+          %{method: "form", path: "https://{{ .Config.apiurl }}/api/Release/Search"},
+          [%{name: "apiurl", type: "text", default: "api.abn.lol"}]
+        )
+
+      assert {:ok, "https://api.abn.lol/api/Release/Search"} =
+               CardigannAuth.build_login_url(parsed, %{})
+    end
+
+    test "an operator override of the setting is honoured" do
+      parsed =
+        login_definition(
+          %{method: "form", path: "https://{{ .Config.apiurl }}/api"},
+          [%{name: "apiurl", type: "text", default: "api.abn.lol"}]
+        )
+
+      assert {:ok, "https://api.mine.example/api"} =
+               CardigannAuth.build_login_url(parsed, %{"apiurl" => "api.mine.example"})
+    end
+
+    test "a missing login path is an error" do
+      assert {:error, _} = CardigannAuth.build_login_url(login_definition(%{method: "form"}), %{})
+    end
+
+    test "a definition with no login block names the login path as the problem" do
+      parsed = login_definition(nil)
+
+      assert {:error, %{message: message}} = CardigannAuth.build_login_url(parsed, %{})
+      assert message =~ "Login path not configured"
+    end
+
+    test "a definition with no site link names the site link as the problem" do
+      parsed = %{login_definition(%{method: "form", path: "/login.php"}) | links: []}
+
+      assert {:error, %{message: message}} = CardigannAuth.build_login_url(parsed, %{})
+      assert message =~ "No site link configured"
     end
   end
 end

--- a/test/mydia/indexers/cardigann_download_resolution_test.exs
+++ b/test/mydia/indexers/cardigann_download_resolution_test.exs
@@ -3,6 +3,7 @@ defmodule Mydia.Indexers.CardigannDownloadResolutionTest do
 
   alias Mydia.Indexers
   alias Mydia.Indexers.CardigannDefinition
+  alias Mydia.Indexers.CardigannSearchSession
   alias Mydia.Repo
 
   @info_hash "d2e202a5d71ea60b26203f2a9003a1e569382096"
@@ -58,6 +59,99 @@ defmodule Mydia.Indexers.CardigannDownloadResolutionTest do
 
     test "returns :not_applicable when the indexer name is nil" do
       assert :not_applicable = Indexers.resolve_cardigann_download(nil, "https://example.test/x")
+    end
+  end
+
+  # resolve_cardigann_download/2 is the seam that plumbs a stored definition's
+  # operator config into CardigannDownload.resolve/3. A test that calls
+  # CardigannDownload.resolve/3 directly cannot catch a regression at that
+  # seam, e.g. indexers.ex passing the wrong field as :config: it would still
+  # compile, and every test aimed at CardigannDownload itself would still
+  # pass. This exercises resolve_cardigann_download/2 itself, with a real
+  # stored CardigannDefinition and a real stored CardigannSearchSession, so
+  # the cookies genuinely come from the database the way get_cardigann_auth_
+  # cookies/1 reads them, not from a user_config map built by the test.
+  describe "resolve_cardigann_download/2 threads the stored operator config" do
+    test "a download host named only by the operator's apiurl setting still receives the session" do
+      site = Bypass.open()
+      api = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(api, "GET", "/get.torrent", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "d8:announce")
+      end)
+
+      # The shipped default (`unused.invalid`) is not the api Bypass host, so
+      # only the operator's stored config below can land the api origin in
+      # the trusted set.
+      yaml = """
+      id: dl-scope-apiurl-db
+      name: DL Scope Apiurl DB
+      description: "Resolves a download host named only by the operator's apiurl setting"
+      language: en-US
+      type: private
+      encoding: UTF-8
+      links:
+        - http://localhost:#{site.port}/
+
+      caps:
+        modes:
+          search: [q]
+
+      settings:
+        - name: apiurl
+          type: text
+          default: unused.invalid
+
+      search:
+        paths:
+          - path: "http://{{ .Config.apiurl }}/search"
+        rows:
+          selector: tr
+        fields:
+          title:
+            selector: a
+          size:
+            text: 1
+          seeders:
+            text: 1
+
+      download:
+        selectors:
+          - selector: a.dl
+            attribute: href
+      """
+
+      definition =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "dl-scope-apiurl-db",
+          name: "DL Scope Apiurl DB",
+          type: "private",
+          links: %{"main" => "http://localhost:#{site.port}/"},
+          capabilities: %{},
+          definition: yaml,
+          schema_version: "1",
+          enabled: true,
+          config: %{"apiurl" => "localhost:#{api.port}"}
+        })
+        |> Repo.insert!()
+
+      %CardigannSearchSession{}
+      |> CardigannSearchSession.changeset(%{
+        cookies: ["session=secret"],
+        expires_at: DateTime.add(DateTime.utc_now(), 3600, :second),
+        cardigann_definition_id: definition.id
+      })
+      |> Repo.insert!()
+
+      Indexers.resolve_cardigann_download(
+        "DL Scope Apiurl DB",
+        "http://localhost:#{api.port}/get.torrent"
+      )
+
+      assert_receive {:cookie_header, ["session=secret"]}
     end
   end
 end

--- a/test/mydia/indexers/cardigann_download_test.exs
+++ b/test/mydia/indexers/cardigann_download_test.exs
@@ -308,4 +308,125 @@ defmodule Mydia.Indexers.CardigannDownloadTest do
       assert magnet =~ "VIALIVE"
     end
   end
+
+  describe "credential scope on downloads" do
+    test "a download url on a foreign host does not receive the session" do
+      site = Bypass.open()
+      foreign = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(foreign, "GET", "/get.torrent", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "d8:announce")
+      end)
+
+      definition = %Parsed{
+        id: "dl-scope",
+        name: "DL Scope",
+        description: "",
+        language: "en-US",
+        type: "private",
+        encoding: "UTF-8",
+        links: ["http://localhost:#{site.port}"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+        login: nil,
+        download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
+        settings: [],
+        request_delay: nil,
+        follow_redirect: false
+      }
+
+      CardigannDownload.resolve(definition, "http://localhost:#{foreign.port}/get.torrent", %{
+        cookies: ["session=secret"],
+        base_url: "http://localhost:#{site.port}",
+        config: %{}
+      })
+
+      assert_receive {:cookie_header, []}
+    end
+
+    test "a download url on the site host does receive the session" do
+      site = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(site, "GET", "/get.torrent", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "d8:announce")
+      end)
+
+      definition = %Parsed{
+        id: "dl-scope-ok",
+        name: "DL Scope OK",
+        description: "",
+        language: "en-US",
+        type: "private",
+        encoding: "UTF-8",
+        links: ["http://localhost:#{site.port}"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+        login: nil,
+        download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
+        settings: [],
+        request_delay: nil,
+        follow_redirect: false
+      }
+
+      CardigannDownload.resolve(definition, "/get.torrent", %{
+        cookies: ["session=secret"],
+        base_url: "http://localhost:#{site.port}",
+        config: %{}
+      })
+
+      assert_receive {:cookie_header, ["session=secret"]}
+    end
+
+    # The two tests above hold on with the interim `%{}` config Task 3 passed
+    # in: link-based scoping alone already decides them, so they cannot tell
+    # `scope_config/1` threading the operator's settings through from a
+    # regression that drops those settings back to `%{}`. This test can: the
+    # download host is named only by a templated `{{ .Config.apiurl }}`
+    # search path, resolvable exclusively from the operator's own config, not
+    # from the definition's shipped default.
+    test "a download url reachable only via the operator's configured api host receives the session" do
+      site = Bypass.open()
+      api = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(api, "GET", "/get.torrent", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "d8:announce")
+      end)
+
+      definition = %Parsed{
+        id: "dl-scope-apiurl",
+        name: "DL Scope Apiurl",
+        description: "",
+        language: "en-US",
+        type: "private",
+        encoding: "UTF-8",
+        links: ["http://localhost:#{site.port}"],
+        capabilities: %{modes: %{}},
+        search: %{
+          paths: [%{path: "https://{{ .Config.apiurl }}/search"}],
+          inputs: %{},
+          rows: %{},
+          fields: %{}
+        },
+        login: nil,
+        download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
+        settings: [%{name: "apiurl", type: "text", default: "unused.invalid"}],
+        request_delay: nil,
+        follow_redirect: false
+      }
+
+      CardigannDownload.resolve(definition, "http://localhost:#{api.port}/get.torrent", %{
+        cookies: ["session=secret"],
+        base_url: "http://localhost:#{site.port}",
+        config: %{"apiurl" => "localhost:#{api.port}"}
+      })
+
+      assert_receive {:cookie_header, ["session=secret"]}
+    end
+  end
 end

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -387,6 +387,56 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
     end
   end
 
+  defp promo_definition do
+    %Parsed{
+      id: "promo",
+      name: "Promo",
+      description: "",
+      language: "en-US",
+      type: "private",
+      encoding: "UTF-8",
+      links: ["https://tracker.example"],
+      legacylinks: ["https://old-tracker.example"],
+      capabilities: %{modes: %{}},
+      search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+      login: nil,
+      download: nil,
+      settings: [],
+      request_delay: nil,
+      follow_redirect: true
+    }
+  end
+
+  describe "promotable?/3" do
+    test "an in-scope host is promotable with credentials" do
+      assert CardigannHealthCheck.promotable?(
+               promo_definition(),
+               %{"username" => "me", "password" => "secret"},
+               "https://tracker.example"
+             )
+    end
+
+    test "a legacy host is not promotable when credentials are configured" do
+      refute CardigannHealthCheck.promotable?(
+               promo_definition(),
+               %{"username" => "me", "password" => "secret"},
+               "https://old-tracker.example"
+             )
+    end
+
+    test "a legacy host is promotable when there are no credentials to protect" do
+      assert CardigannHealthCheck.promotable?(
+               promo_definition(),
+               %{"sort" => "seeders"},
+               "https://old-tracker.example"
+             )
+    end
+
+    test "a nil candidate is never promotable" do
+      refute CardigannHealthCheck.promotable?(promo_definition(), %{}, nil)
+    end
+  end
+
   defp parsed_for(link, opts \\ []) do
     %Parsed{
       id: "probe-test",
@@ -681,6 +731,183 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       assert result.message =~ url_b
       refute result.message =~ url_a
       assert Mydia.Repo.reload!(definition).active_link == url_b
+    end
+
+    test "a legacy mirror that answers is not promoted when credentials are configured" do
+      # Same shape as "the persisted active_link..." above, but the only
+      # reachable candidate is a legacylinks entry, not a links entry, and the
+      # definition carries a credential. This exercises the store_link_state
+      # guard inside search_leg/6 end to end, not just promotable?/3 in
+      # isolation: with the guard removed this test writes legacy_url to
+      # active_link instead of leaving it nil.
+      dead = Bypass.open()
+      Bypass.down(dead)
+      legacy = Bypass.open()
+      Bypass.expect(legacy, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "ok") end)
+
+      Bypass.expect(legacy, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          ~s"""
+          <html><body><table class="results">
+          <tr><td class="title">Some Release</td>
+          <td class="download"><a href="/download/1">grab</a></td></tr>
+          </table></body></html>
+          """
+        )
+      end)
+
+      dead_url = "http://localhost:#{dead.port}"
+      legacy_url = "http://localhost:#{legacy.port}"
+
+      {:ok, definition} =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "probe-legacy-scope",
+          name: "Probe Legacy Scope",
+          type: "private",
+          links: %{"0" => dead_url},
+          capabilities: %{},
+          schema_version: "v11",
+          config: %{"username" => "me", "password" => "secret"},
+          definition: """
+          id: probe-legacy-scope
+          name: Probe Legacy Scope
+          description: d
+          language: en-US
+          type: private
+          encoding: UTF-8
+          links:
+            - #{dead_url}
+          legacylinks:
+            - #{legacy_url}
+          caps:
+            categories:
+              2000: Movies
+          settings: []
+          search:
+            paths:
+              - path: /search
+            rows:
+              selector: tr
+            fields:
+              title:
+                selector: td.title
+              size:
+                selector: td.size
+              seeders:
+                selector: td.seeders
+              download:
+                selector: a
+                attribute: href
+          """
+        })
+        |> Repo.insert()
+
+      assert {:ok, result} = CardigannHealthCheck.execute_health_check(definition)
+      assert result.success
+
+      reloaded = Repo.get!(CardigannDefinition, definition.id)
+      refute reloaded.active_link == legacy_url
+      assert reloaded.active_link == nil
+    end
+
+    test "a legacy mirror behind Cloudflare is not promoted when credentials are configured" do
+      # Regression: the {:cloudflare, message} branch of search_leg/6 called
+      # store_link_state(definition, active_link, link_status) with no
+      # promotable?/3 guard, unlike its two {:ok, ...} siblings. active_link
+      # here is whatever probe_candidates/2 picked at the homepage stage, so a
+      # legacylinks entry that only answers "/" can still ride this branch to
+      # active_link if its real search then hits a Cloudflare challenge.
+      #
+      # Both mirrors answer their search path with the same Cloudflare 403:
+      # execute_search's own failover (Task 5) is retryable on a Cloudflare
+      # response, so with only one mirror doing so the health check would
+      # fail over past it to the other candidate and this test would never
+      # observe the {:cloudflare, ...} outcome at all. Making both mirrors
+      # answer the same way keeps the final classification "cloudflare"
+      # regardless of which one failover lands on last, while only the
+      # legacylinks mirror's homepage succeeds, so it is still the one
+      # search_leg/6 receives as active_link.
+      in_scope = Bypass.open()
+      legacy = Bypass.open()
+
+      cloudflare_challenge = fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("server", "cloudflare")
+        |> Plug.Conn.resp(
+          403,
+          "<html><title>Just a moment...</title><body>Checking your browser before " <>
+            "accessing this site. cf-browser-verification. DDoS protection by Cloudflare." <>
+            "</body></html>"
+        )
+      end
+
+      # The in-scope link fails its homepage probe too (same Cloudflare
+      # response, any non-2xx/3xx status would do), so probe_candidates/2
+      # skips it and picks the legacylinks entry as active_link.
+      Bypass.stub(in_scope, "GET", "/", cloudflare_challenge)
+      Bypass.stub(in_scope, "GET", "/search", cloudflare_challenge)
+
+      Bypass.stub(legacy, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "ok") end)
+      Bypass.stub(legacy, "GET", "/search", cloudflare_challenge)
+
+      in_scope_url = "http://localhost:#{in_scope.port}"
+      legacy_url = "http://localhost:#{legacy.port}"
+
+      {:ok, definition} =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "probe-legacy-cloudflare",
+          name: "Probe Legacy Cloudflare",
+          type: "private",
+          active_link: nil,
+          links: %{"0" => in_scope_url},
+          capabilities: %{},
+          schema_version: "v11",
+          config: %{"username" => "me", "password" => "secret"},
+          definition: """
+          id: probe-legacy-cloudflare
+          name: Probe Legacy Cloudflare
+          description: d
+          language: en-US
+          type: private
+          encoding: UTF-8
+          links:
+            - #{in_scope_url}
+          legacylinks:
+            - #{legacy_url}
+          caps:
+            categories:
+              2000: Movies
+          settings: []
+          search:
+            paths:
+              - path: /search
+            rows:
+              selector: tr
+            fields:
+              title:
+                selector: td.title
+              size:
+                selector: td.size
+              seeders:
+                selector: td.seeders
+              download:
+                selector: a
+                attribute: href
+          """
+        })
+        |> Repo.insert()
+
+      assert {:ok, result} = CardigannHealthCheck.execute_health_check(definition)
+      assert result.success
+      assert result.status == "degraded"
+
+      reloaded = Repo.get!(CardigannDefinition, definition.id)
+      refute reloaded.active_link == legacy_url
+      assert reloaded.active_link == nil
     end
   end
 end

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -910,4 +910,89 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
       assert reloaded.active_link == nil
     end
   end
+
+  describe "connection test reports an anonymous search" do
+    test "a credentialed definition served by an out-of-scope host reports degraded" do
+      # Same shape as "a legacy mirror that answers is not promoted when
+      # credentials are configured" above: the only reachable candidate is a
+      # legacylinks entry outside the credential scope. That test only checks
+      # persistence; this one checks that the operator-facing message and
+      # status actually say why. The row includes a download link so this
+      # goes through the {:ok, count, served_by} branch, not the {:ok, 0, _}
+      # branch, which already reports "degraded" for an unrelated reason and
+      # would pass this assertion with or without the fix under test.
+      site = Bypass.open()
+      legacy = Bypass.open()
+      Bypass.down(site)
+
+      Bypass.stub(legacy, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html></html>") end)
+
+      Bypass.stub(legacy, "GET", "/search", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          ~s"""
+          <html><body><table class="results">
+          <tr><td class="title">A Movie</td>
+          <td class="download"><a href="/download/1">grab</a></td></tr>
+          </table></body></html>
+          """
+        )
+      end)
+
+      site_url = "http://localhost:#{site.port}"
+      legacy_url = "http://localhost:#{legacy.port}"
+
+      {:ok, definition} =
+        %CardigannDefinition{}
+        |> CardigannDefinition.changeset(%{
+          indexer_id: "degraded-scope",
+          name: "Degraded Scope",
+          type: "private",
+          links: %{"0" => site_url},
+          capabilities: %{},
+          schema_version: "v11",
+          config: %{"username" => "me", "password" => "secret"},
+          definition: """
+          id: degraded-scope
+          name: Degraded Scope
+          description: scope test
+          language: en-US
+          type: private
+          encoding: UTF-8
+          links:
+            - #{site_url}
+          legacylinks:
+            - #{legacy_url}
+          caps:
+            categories:
+              2000: Movies
+          settings: []
+          search:
+            paths:
+              - path: /search
+            rows:
+              selector: tr
+            fields:
+              title:
+                selector: td.title
+              size:
+                selector: td.size
+              seeders:
+                selector: td.seeders
+              download:
+                selector: a
+                attribute: href
+          """
+        })
+        |> Repo.insert()
+
+      assert {:ok, result} = CardigannHealthCheck.execute_health_check(definition)
+
+      assert result.success
+      assert result.status == "degraded"
+      assert result.message =~ "anonymously"
+      assert result.message =~ "#{legacy.port}"
+    end
+  end
 end

--- a/test/mydia/indexers/cardigann_search_engine_flaresolverr_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_flaresolverr_test.exs
@@ -1,0 +1,206 @@
+defmodule Mydia.Indexers.CardigannSearchEngineFlareSolverrTest do
+  # async: false: these tests inject FlareSolverr settings into the global
+  # :runtime_config application env (same as Mydia.Indexers.FlareSolverrTest),
+  # which is read across the app. Running them concurrently would race other
+  # tests reading the runtime config.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mydia.Indexers.CardigannSearchEngine
+  alias Mydia.Indexers.CardigannDefinition.Parsed
+
+  # Snapshot and restore the cached runtime config around every test so the
+  # per-test FlareSolverr config we inject never leaks into other tests.
+  setup do
+    original = Application.get_env(:mydia, :runtime_config)
+
+    on_exit(fn ->
+      if original do
+        Application.put_env(:mydia, :runtime_config, original)
+      else
+        Application.delete_env(:mydia, :runtime_config)
+      end
+    end)
+
+    :ok
+  end
+
+  defp scoped_definition(links, paths) do
+    %Parsed{
+      id: "scoped-flaresolverr",
+      name: "Scoped FlareSolverr",
+      description: "",
+      language: "en-US",
+      type: "private",
+      encoding: "UTF-8",
+      links: links,
+      capabilities: %{modes: %{}},
+      search: %{paths: paths, inputs: %{}, rows: %{selector: "tr"}, fields: %{}},
+      login: nil,
+      download: nil,
+      settings: [],
+      request_delay: nil,
+      follow_redirect: false
+    }
+  end
+
+  # FlareSolverr never dials `url` itself in these tests; it is a headless
+  # browser proxy, so only the JSON body posted to the mocked FlareSolverr
+  # endpoint is observed here. The solution's `response` field stands in for
+  # whatever the real target site would have returned.
+  defp flaresolverr_ok_response(conn, decoded) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(
+      200,
+      Jason.encode!(%{
+        "status" => "ok",
+        "solution" => %{
+          "url" => decoded["url"],
+          "status" => 200,
+          "response" => "<html></html>",
+          "cookies" => [],
+          "userAgent" => "test-agent"
+        },
+        "startTimestamp" => 1000,
+        "endTimestamp" => 1001
+      })
+    )
+  end
+
+  describe "execute_search/4 through FlareSolverr (should_use_flaresolverr? path)" do
+    test "a request to an out-of-scope origin does not carry the session cookie, and still goes out" do
+      site = Bypass.open()
+      evil = Bypass.open()
+      fs = Bypass.open()
+      test_pid = self()
+
+      put_flaresolverr_config(enabled: true, url: "http://localhost:#{fs.port}")
+
+      Bypass.expect_once(fs, "POST", "/v1", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+        send(test_pid, {:flaresolverr_body, decoded})
+        flaresolverr_ok_response(conn, decoded)
+      end)
+
+      definition = scoped_definition(["http://localhost:#{site.port}"], [%{path: "/search"}])
+
+      opts = [query: "test", base_url: "http://localhost:#{evil.port}"]
+      flaresolverr_opts = %{enabled: true, definition_id: "test-uuid"}
+      user_config = %{cookies: ["session=secret"]}
+
+      log =
+        capture_log(fn ->
+          assert {:ok, _response} =
+                   CardigannSearchEngine.execute_search(
+                     definition,
+                     opts,
+                     user_config,
+                     flaresolverr_opts
+                   )
+        end)
+
+      assert_receive {:flaresolverr_body, decoded}
+      assert decoded["url"] =~ "localhost:#{evil.port}"
+      refute Map.has_key?(decoded, "cookies")
+      assert log =~ "withholding session cookies"
+    end
+
+    test "a request to an in-scope origin does carry the session cookie" do
+      site = Bypass.open()
+      fs = Bypass.open()
+      test_pid = self()
+
+      put_flaresolverr_config(enabled: true, url: "http://localhost:#{fs.port}")
+
+      Bypass.expect_once(fs, "POST", "/v1", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+        send(test_pid, {:flaresolverr_body, decoded})
+        flaresolverr_ok_response(conn, decoded)
+      end)
+
+      definition = scoped_definition(["http://localhost:#{site.port}"], [%{path: "/search"}])
+
+      opts = [query: "test"]
+      flaresolverr_opts = %{enabled: true, definition_id: "test-uuid"}
+      user_config = %{cookies: ["session=secret"]}
+
+      assert {:ok, _response} =
+               CardigannSearchEngine.execute_search(
+                 definition,
+                 opts,
+                 user_config,
+                 flaresolverr_opts
+               )
+
+      assert_receive {:flaresolverr_body, decoded}
+      assert decoded["url"] =~ "localhost:#{site.port}"
+      assert decoded["cookies"] == [%{"name" => "session", "value" => "secret"}]
+    end
+  end
+
+  describe "execute_search/4 through the Cloudflare-challenge FlareSolverr retry" do
+    test "the retry withholds the session for the same out-of-scope url the direct request stripped it from" do
+      site = Bypass.open()
+      evil = Bypass.open()
+      fs = Bypass.open()
+      test_pid = self()
+
+      put_flaresolverr_config(enabled: true, url: "http://localhost:#{fs.port}")
+
+      Bypass.expect_once(evil, "GET", "/search", fn conn ->
+        Plug.Conn.resp(conn, 403, "<html><body>cf-browser-verification</body></html>")
+      end)
+
+      Bypass.expect_once(fs, "POST", "/v1", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        decoded = Jason.decode!(body)
+        send(test_pid, {:flaresolverr_body, decoded})
+        flaresolverr_ok_response(conn, decoded)
+      end)
+
+      definition = scoped_definition(["http://localhost:#{site.port}"], [%{path: "/search"}])
+
+      opts = [query: "test", base_url: "http://localhost:#{evil.port}"]
+      # FlareSolverr disabled per-indexer so the direct Req path runs first and
+      # hits the Cloudflare challenge branch, which is the second, previously
+      # unguarded, call site.
+      flaresolverr_opts = %{enabled: false, definition_id: "test-uuid"}
+      user_config = %{cookies: ["session=secret"]}
+
+      log =
+        capture_log(fn ->
+          assert {:ok, _response, _fs_meta} =
+                   CardigannSearchEngine.execute_search(
+                     definition,
+                     opts,
+                     user_config,
+                     flaresolverr_opts
+                   )
+        end)
+
+      assert_receive {:flaresolverr_body, decoded}
+      assert decoded["url"] =~ "localhost:#{evil.port}"
+      refute Map.has_key?(decoded, "cookies")
+      assert log =~ "withholding session cookies"
+    end
+  end
+
+  ## Helpers: inject FlareSolverr settings into the layered runtime config.
+  ## Mirrors Mydia.Indexers.FlareSolverrTest.
+
+  defp put_flaresolverr_config(attrs) do
+    fs = struct(Mydia.Config.Schema.FlareSolverr, attrs)
+    Application.put_env(:mydia, :runtime_config, %{current_runtime_config() | flaresolverr: fs})
+  end
+
+  defp current_runtime_config do
+    case Application.get_env(:mydia, :runtime_config) do
+      %Mydia.Config.Schema{} = config -> config
+      _ -> Mydia.Config.Schema.defaults()
+    end
+  end
+end

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -479,6 +479,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "https://httpbin.org/html",
                  params,
+                 %{},
                  %{}
                )
 
@@ -505,6 +506,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition_with_short_timeout,
                  "https://httpbin.org/delay/10",
                  params,
+                 %{},
                  %{}
                )
     end
@@ -528,7 +530,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "https://invalid-domain-for-testing.example",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
     end
   end
@@ -570,6 +573,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         definition,
         "https://invalid-domain.example",
         params,
+        %{},
         %{}
       )
 
@@ -807,7 +811,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "https://invalid-domain-for-testing.example",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
     end
 
@@ -827,7 +832,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "https://invalid-domain-for-testing.example",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
     end
 
@@ -845,7 +851,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "https://invalid-domain-for-testing.example",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
     end
 
@@ -858,6 +865,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         Plug.Conn.resp(conn, 200, "<html></html>")
       end)
 
+      definition = %{definition | links: ["http://localhost:#{bypass.port}"]}
       params = %{query_params: %{}, headers: [], method: :get}
       user_config = %{cookies: ["session=abc123", "token=xyz789"]}
 
@@ -866,7 +874,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "http://localhost:#{bypass.port}/search",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
 
       assert_receive {:cookie_header, ["session=abc123; token=xyz789"]}
@@ -883,6 +892,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         Plug.Conn.resp(conn, 200, "<html></html>")
       end)
 
+      definition = %{definition | links: ["http://localhost:#{bypass.port}"]}
       params = %{query_params: %{}, headers: [], method: :get}
 
       user_config = %{
@@ -897,7 +907,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "http://localhost:#{bypass.port}/search",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
 
       assert_receive {:cookie_header, ["cf_clearance=abc123; session=xyz789"]}
@@ -912,6 +923,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         Plug.Conn.resp(conn, 200, "<html></html>")
       end)
 
+      definition = %{definition | links: ["http://localhost:#{bypass.port}"]}
       params = %{query_params: %{}, headers: [], method: :get}
       # Decoded JSON can put a nested object or a number in either field, and
       # interpolating one would raise the error normalization exists to prevent.
@@ -930,7 +942,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "http://localhost:#{bypass.port}/search",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
 
       assert_receive {:cookie_header, []}
@@ -954,7 +967,12 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         Plug.Conn.resp(conn, 200, "ok")
       end)
 
-      definition = %{definition | follow_redirect: true}
+      definition = %{
+        definition
+        | follow_redirect: true,
+          links: ["http://localhost:#{origin.port}"]
+      }
+
       params = %{query_params: %{}, headers: [], method: :get}
       user_config = %{cookies: ["session=secret"]}
 
@@ -963,7 +981,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "http://localhost:#{origin.port}/search",
                  params,
-                 user_config
+                 user_config,
+                 %{}
                )
 
       assert response.status == 302
@@ -992,6 +1011,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
                  definition,
                  "http://localhost:#{origin.port}/search",
                  params,
+                 %{},
                  %{}
                )
 
@@ -1008,11 +1028,179 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
             definition,
             "http://invalid-domain-for-testing.example/search",
             params,
-            user_config
+            user_config,
+            %{}
           )
         end)
 
       assert log =~ "withholding session cookies"
+    end
+  end
+
+  defp scoped_definition(links, paths) do
+    %Parsed{
+      id: "scoped",
+      name: "Scoped",
+      description: "",
+      language: "en-US",
+      type: "private",
+      encoding: "UTF-8",
+      links: links,
+      capabilities: %{modes: %{}},
+      search: %{paths: paths, inputs: %{}, rows: %{selector: "tr"}, fields: %{}},
+      login: nil,
+      download: nil,
+      settings: [],
+      request_delay: nil,
+      follow_redirect: false
+    }
+  end
+
+  describe "credential scope" do
+    test "an absolute search path brings its own host into scope" do
+      site = Bypass.open()
+      api = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(api, "GET", "/q.php", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html></html>")
+      end)
+
+      definition =
+        scoped_definition(
+          ["http://localhost:#{site.port}"],
+          [%{path: "http://localhost:#{api.port}/q.php"}]
+        )
+
+      params = %{query_params: %{}, headers: [], method: :get}
+
+      assert {:ok, _response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{api.port}/q.php",
+                 params,
+                 %{cookies: ["session=secret"]},
+                 %{}
+               )
+
+      # The api host IS reachable through the definition's own absolute path, so
+      # it is in scope and does receive the session.
+      assert_receive {:cookie_header, ["session=secret"]}
+    end
+
+    test "cookies are withheld from a host the definition never names" do
+      site = Bypass.open()
+      evil = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(evil, "GET", "/steal", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html></html>")
+      end)
+
+      definition = scoped_definition(["http://localhost:#{site.port}"], [%{path: "/search"}])
+      params = %{query_params: %{}, headers: [], method: :get}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert {:ok, _response} =
+                   CardigannSearchEngine.execute_http_request(
+                     definition,
+                     "http://localhost:#{evil.port}/steal",
+                     params,
+                     %{cookies: ["session=secret"]},
+                     %{}
+                   )
+        end)
+
+      assert_receive {:cookie_header, []}
+      assert log =~ "withholding session cookies"
+    end
+
+    test "cookies are withheld from a legacylinks host but the request still goes out" do
+      site = Bypass.open()
+      legacy = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(legacy, "GET", "/search", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html><body>ok</body></html>")
+      end)
+
+      definition =
+        %{
+          scoped_definition(["http://localhost:#{site.port}"], [%{path: "/search"}])
+          | legacylinks: ["http://localhost:#{legacy.port}"]
+        }
+
+      params = %{query_params: %{}, headers: [], method: :get}
+
+      assert {:ok, response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{legacy.port}/search",
+                 params,
+                 %{cookies: ["session=secret"]},
+                 %{}
+               )
+
+      assert response.status == 200
+      assert_receive {:cookie_header, []}
+    end
+
+    test "cookies are sent to a links host" do
+      site = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(site, "GET", "/search", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html></html>")
+      end)
+
+      definition = scoped_definition(["http://localhost:#{site.port}"], [%{path: "/search"}])
+      params = %{query_params: %{}, headers: [], method: :get}
+
+      assert {:ok, _response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{site.port}/search",
+                 params,
+                 %{cookies: ["session=secret"]},
+                 %{}
+               )
+
+      assert_receive {:cookie_header, ["session=secret"]}
+    end
+
+    test "an operator-configured apiurl brings its host into scope" do
+      site = Bypass.open()
+      api = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(api, "GET", "/v1/search", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, "<html></html>")
+      end)
+
+      definition =
+        scoped_definition(
+          ["http://localhost:#{site.port}"],
+          [%{path: "http://{{ .Config.apiurl }}/v1/search"}]
+        )
+
+      params = %{query_params: %{}, headers: [], method: :get}
+
+      assert {:ok, _response} =
+               CardigannSearchEngine.execute_http_request(
+                 definition,
+                 "http://localhost:#{api.port}/v1/search",
+                 params,
+                 %{cookies: ["session=secret"]},
+                 %{"apiurl" => "localhost:#{api.port}"}
+               )
+
+      assert_receive {:cookie_header, ["session=secret"]}
     end
   end
 


### PR DESCRIPTION
Closes #602. Built on top of #601, which merged while this was in progress, so it targets master directly.

A Cardigann session cookie is a bearer credential for a tracker account. Until now it was attached to a request based only on the URL's scheme, never on which host the session belonged to. This scopes credentials to the origins a definition names as its own.

## The three paths that leaked

**Download URLs, the sharpest one.** `resolve_cardigann_download/2` passes cookie-bearing config into the HTTP layer, and `absolutize_download_url/3` accepts an absolute `http(s)://` URL verbatim. That URL is parsed out of the tracker's own search results, so a tracker, a hijacked mirror, or one poisoned result row could name any host and be handed the account session. No redirect required. This path is not in the issue text and is the only one where the host comes from remote content rather than shipped YAML.

**Mirror failover.** `try_candidates/7` walks `links` followed by `legacylinks`, and a session obtained against one host went to whichever host answered. Legacy links are by construction stale rotated domains: 149 of the 545 shipped v11 definitions carry a legacy host absent from their `links`, 95 of them private. A re-registered legacy domain was handed a live session.

**Absolute `search.paths` entries.** #601 added support for a definition whose `path:` is a full URL on another host. Nothing stopped the session going with it.

## The policy

New `Mydia.Indexers.Cardigann.CredentialScope` owns it. Trusted origins are the definition's `links` plus the origin of any `search.paths`/`login.path` that renders to an absolute URL, which covers operator-configured settings like `{{ .Config.apiurl }}`. `legacylinks` are excluded. Out of scope means withhold the cookie, log, and send the request anyway: an anonymous result beats a leaked login.

Matching is exact on host **and** port. No eTLD+1 and no subdomain-suffix rule, because `limetorrents.proxyninja.net` and `extratorrent.ninjaproxy1.com` are shipped `links` entries on shared proxy services fronting many unrelated trackers, so a suffix rule would leak one tracker's session to a neighbour. Ports matter because Mydia is self-hosted and several services behind one host on different ports is a normal deployment; `bitmagnet` ships exactly that shape.

The gate lives in `attach_cookies/4`, which every credential-bearing request reaches, and in a shared `cookie_disposition/2` that the FlareSolverr path also consults.

## What the corpus decided

All 545 Prowlarr v11 definitions were parsed rather than reasoned about. Two of the issue's premises did not survive.

An absolute `path:` almost never names a foreign host, and it is operator input rather than a definition constant: 7 exist, 6 render `{{ .Config.apiurl }}`, and every shipped default is a sibling subdomain of `links[0]`. All five such definitions use `login.method: get`, so none mint a session cookie.

Re-authenticating on a mirror switch, which two of the issue's three sketches proposed, is worse than replaying a cookie: `perform_form_login/3` POSTs the username and password. Handing a squatted domain the password beats handing it a cookie, so an allowlist is load-bearing either way.

## Corrections made during implementation

The plan's login gate compared the login URL's origin against the trusted set. That is tautological, since the set includes an absolute `login.path`'s own origin by construction, so it could never refuse. It was replaced with a transport check: credentials are refused over cleartext to a non-loopback host. That delivers the original intent, because cleartext is the one case where the cookie boundary genuinely refuses a login URL. Two shipped definitions (`3dtorrents`, `drugari`) currently POST a password in the clear, receive a session, and then have that session withheld by #601, so refusing costs no working functionality. The code carries a comment explaining why an origin check would be circular.

Operator setting overrides never reached the login render at all, because `credentials` is built from `config.user_settings` and never carried `definition.config`. Since the search leg sources it correctly, an override would mint the session against one host and use it on another.

## Also fixed

- `build_login_url/1` concatenated an absolute `login.path` onto `links[0]` without rendering it, producing `https://abn.lol/https://{{ .Config.apiurl }}/api` for five definitions. Same defect class #601 fixed for search, still live on the login leg.
- A legacy mirror could become the sticky `active_link`, quietly readmitting a host the scope excludes. Promotion is now guarded, but only when credentials are configured: 42 of the 81 public definitions ship legacylinks and depend on promoting them while having no session to protect.
- The connection test reports `degraded` and names the host when a search went out with its session withheld, instead of leaving an operator with an unexplained empty result.

## Testing

9647 tests, 0 failures. `mix format` and `mix credo --strict` clean.

Every gate test was verified differential by reverting the gate and confirming the test fails, because several first drafts passed whether or not the code under test existed. Withheld-cookie assertions distinguish a withheld cookie from a request that was never made. A corpus guard asserts that every absolute path in the fixture set still resolves inside its own definition's trusted origins, so the policy cannot silently strip a shipped definition.

## Known follow-ups

- `Mydia.Downloads.Queue.download_torrent_file/2` is a second download path this PR does not touch, with the same exposure: it sends indexer session cookies to a URL taken from a result row, and `download_direct/2` follows redirects before attaching them.
- `execute_login_request/3` passes `redirect: true`, so a 307 or 308 can move the credential POST off the checked host. Pre-existing. `redirect: false` would break every form login that redirects to a landing page, since `validate_login_success` matches a selector against the body, so it needs a scoped-redirect fix rather than a toggle.
- No operator-settable site URL exists, so a private tracker that genuinely moves to a legacy domain has no escape hatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session cookies and login credentials are now limited to trusted indexer hosts.
  * Configured API and login URLs, including templated absolute paths, are honored correctly.
  * Downloads through configured API endpoints retain authentication when appropriate.
  * Legacy or unrelated mirrors no longer receive credentials or become active when authentication is configured.
  * Searches served anonymously are reported with a degraded status.
* **Security**
  * Credentials are blocked over non-secure connections, except supported loopback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->