### PR TITLE
ci: auto-merge Dependabot pull requests with a merge commit

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,7 +27,12 @@ jobs:
       # Those gates report on every pull request rather than being
       # path-filtered, precisely so this wait means something.
       #
-      # Rebase because squash merge is disabled on this repository.
+      # --merge because it is the only strategy this repository allows.
+      # Both allow_squash_merge and allow_rebase_merge are false, so
+      # `gh pr merge --rebase` fails outright with "Rebase merges are not
+      # allowed on this repository" and no auto-merge is ever queued. The
+      # failure is invisible on a green pull request: the merge simply never
+      # happens.
       #
       # dependabot/fetch-metadata is deliberately absent. It is the right way
       # to read what a Dependabot pull request changed, but nothing here needs
@@ -35,7 +40,7 @@ jobs:
       # branch on. Leaving it out keeps a job holding contents: write on
       # pull_request_target free of third-party actions entirely.
       - name: Enable auto-merge
-        run: gh pr merge --auto --rebase "$PR_URL"
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

`dependabot-auto-merge.yml` has never enabled auto-merge on a single pull request. The step runs:

```
gh pr merge --auto --rebase "$PR_URL"
```

but this repository allows **only merge commits**:

```
allow_merge_commit:  true
allow_rebase_merge:  false
allow_squash_merge:  false
```

so the command fails outright. Confirmed on the live run against #582:

```
GraphQL: Merge method rebase merging is not allowed on this repository (enablePullRequestAutoMerge)
##[error]Process completed with exit code 1.
```

The failure is easy to miss, because it looks like nothing at all: the Dependabot pull request stays green, auto-merge is simply never queued, and the pull request sits open indefinitely. Five of them are open right now.

The existing comment justified `--rebase` by pointing at the squash setting alone, which is how the rebase setting went unchecked.

## Fix

Use `--merge`, the one strategy the repository permits, and record both settings in the comment so the next reader does not have to rediscover this.

## Verification

- `yaml.safe_load` parses the workflow.
- The failing run above is the direct evidence for the diagnosis; `allow_rebase_merge: false` is confirmed against the repository API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency pull requests to use the repository’s permitted merge method.
  * Clarified the workflow’s merge configuration and dependency metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->