### PR TITLE
test: refuse outbound HTTP in the test suite (#530)

### DIFF
--- a/test/mydia/crash_reporter/queue_test.exs
+++ b/test/mydia/crash_reporter/queue_test.exs
@@ -11,6 +11,26 @@ defmodule Mydia.CrashReporter.QueueTest do
       _ -> :ok
     end
 
+    # Point Sender.send_report/1 at a local Bypass server rather than the
+    # live relay. Unlike report_resilience_test.exs and tower_reporter_test.exs,
+    # which point METADATA_RELAY_URL at an unreachable loopback address
+    # (127.0.0.1:1) because they only care that a report got *enqueued*, this
+    # module's tests exercise the queue's actual send-and-retry behaviour, so
+    # the request needs a real round trip and a real HTTP response — just not
+    # one that leaves the machine (#530). Bypass replies 400, matching the
+    # "no API key configured" failure these tests were written against when
+    # they still hit the real relay, so every retry/entry-shape assertion
+    # below keeps exercising the same failure path it always did.
+    bypass = Bypass.open()
+    previous_metadata_relay_url = Application.get_env(:mydia, :metadata_relay_url)
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+    Bypass.stub(bypass, "POST", "/crashes/report", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(400, Jason.encode!(%{"error" => "no_api_key_configured"}))
+    end)
+
     # Configure for testing with reasonable defaults
     Application.put_env(:mydia, Queue,
       initial_retry_delay: 1_000,
@@ -23,8 +43,16 @@ defmodule Mydia.CrashReporter.QueueTest do
     )
 
     on_exit(fn ->
+      # Clear pending entries before restoring the relay url, so a scheduled
+      # retry timer that fires after teardown finds nothing to send rather
+      # than reaching for a url that no longer points at this test's Bypass.
       Queue.clear_all()
       Application.delete_env(:mydia, Queue)
+
+      case previous_metadata_relay_url do
+        nil -> Application.delete_env(:mydia, :metadata_relay_url)
+        value -> Application.put_env(:mydia, :metadata_relay_url, value)
+      end
     end)
 
     # Give the queue time to settle

--- a/test/mydia/downloads/client/nzbget_test.exs
+++ b/test/mydia/downloads/client/nzbget_test.exs
@@ -46,7 +46,7 @@ defmodule Mydia.Downloads.Client.NzbgetTest do
       unreachable_config = %{@config | host: "nonexistent.invalid", port: 9999}
       timeout_config = put_in(unreachable_config, [:options, :connect_timeout], 100)
 
-      nzb_url = "https://example.com/test.nzb"
+      nzb_url = "https://nonexistent.invalid/test.nzb"
 
       {:error, error} = Nzbget.add_torrent(timeout_config, {:url, nzb_url})
       # URL download will fail first before reaching NZBGet

--- a/test/mydia/indexers/cardigann_health_check_test.exs
+++ b/test/mydia/indexers/cardigann_health_check_test.exs
@@ -368,9 +368,22 @@ defmodule Mydia.Indexers.CardigannHealthCheckTest do
 
   describe "check_all_enabled/0" do
     test "checks all enabled indexers" do
+      # See the comment on "tests connection for valid public indexer" above:
+      # an enabled fixture's definition now parses cleanly, so each one here
+      # gets its own Bypass rather than reaching the fixture's
+      # https://example.com default for real.
+      bypass1 = Bypass.open()
+      Bypass.stub(bypass1, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+      Bypass.stub(bypass1, "GET", "/search", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+      bypass2 = Bypass.open()
+      Bypass.stub(bypass2, "GET", "/", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+      Bypass.stub(bypass2, "GET", "/search", fn conn -> Plug.Conn.resp(conn, 200, "<html/>") end)
+
       # Create mix of enabled and disabled
-      _enabled1 = cardigann_definition_fixture(%{enabled: true, name: "Enabled 1"})
-      _enabled2 = cardigann_definition_fixture(%{enabled: true, name: "Enabled 2"})
+      enabled1 = cardigann_definition_fixture(%{enabled: true, name: "Enabled 1"})
+      put_link(enabled1, "http://localhost:#{bypass1.port}")
+      enabled2 = cardigann_definition_fixture(%{enabled: true, name: "Enabled 2"})
+      put_link(enabled2, "http://localhost:#{bypass2.port}")
       _disabled = cardigann_definition_fixture(%{enabled: false, name: "Disabled 1"})
 
       assert {:ok, results} = CardigannHealthCheck.check_all_enabled()

--- a/test/mydia/indexers/cardigann_search_engine_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_test.exs
@@ -591,7 +591,12 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         language: "en-US",
         type: "public",
         encoding: "UTF-8",
-        links: ["https://example.com"],
+        # .test is an RFC 2606 reserved TLD that never resolves, same as
+        # "invalid-domain.example" a few tests up in this same file — unlike
+        # example.com, which resolves to a real server, so Mydia.RelayGuard
+        # correctly refuses it and this test loosely asserts {:error, _}
+        # regardless of which failure it is (#530).
+        links: ["https://cardigann-search.test"],
         capabilities: %{modes: %{}},
         search: %{
           paths: [%{path: "/search/{{ .Keywords }}"}],
@@ -605,8 +610,8 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         follow_redirect: false
       }
 
-      # This will fail to connect since example.com doesn't have our endpoint,
-      # but it tests the flow up to the HTTP request
+      # This will fail to connect since the host doesn't resolve, but it
+      # tests the flow up to the HTTP request.
       assert {:error, _} = CardigannSearchEngine.execute_search(definition, query: "Ubuntu")
     end
 
@@ -618,7 +623,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         language: "en-US",
         type: "public",
         encoding: "UTF-8",
-        links: ["https://example.com"],
+        links: ["https://cardigann-search.test"],
         capabilities: %{modes: %{}},
         search: %{
           paths: [%{path: "/search/{{ .Keywords }}"}],
@@ -646,7 +651,10 @@ defmodule Mydia.Indexers.CardigannSearchEngineTest do
         language: "en-US",
         type: "public",
         encoding: "UTF-8",
-        links: ["https://example.com"],
+        # .test never resolves (RFC 2606), unlike example.com, so
+        # Mydia.RelayGuard correctly refuses it rather than letting it
+        # through as if it were safe (#530).
+        links: ["https://cardigann-search.test"],
         capabilities: %{modes: %{}},
         search: %{
           paths: [%{path: "/search/{{ .Keywords }}"}],

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -699,7 +699,7 @@ defmodule Mydia.IndexersTest do
       # the config conversion doesn't crash
       config = %{
         type: :prowlarr,
-        base_url: "https://prowlarr.example.com:9696",
+        base_url: "https://prowlarr.nonexistent.invalid:9696",
         api_key: "test-api-key"
       }
 

--- a/test/mydia/jobs/library_scanner_extras_test.exs
+++ b/test/mydia/jobs/library_scanner_extras_test.exs
@@ -6,6 +6,25 @@ defmodule Mydia.Jobs.LibraryScannerExtrasTest do
   alias Mydia.Library.MediaFile
 
   import Mydia.SettingsFixtures
+  import Mydia.MetadataCacheHelpers
+
+  # Every "Ratatouille (2007)" file the scanner cannot match locally sends
+  # MetadataMatcher.search_external_movie/3 to the live relay — one search
+  # per file, all for the same title+year, so warming it once covers however
+  # many files a given test scans (#530). A non-empty, matching result is
+  # required: an empty match triggers search_external_movie/3's own
+  # retry-without-year fallback, which is a different, separately-cached
+  # search that would escape all over again.
+  defp warm_ratatouille_search do
+    warm_movie_search_cache("Ratatouille", [year: 2007], [
+      %{
+        "id" => unique_provider_id(),
+        "title" => "Ratatouille",
+        "release_date" => "2007-06-22",
+        "popularity" => 50.0
+      }
+    ])
+  end
 
   defp scan(library_path) do
     LibraryScanner.perform(%Oban.Job{args: %{"library_path_id" => library_path.id}})
@@ -29,6 +48,8 @@ defmodule Mydia.Jobs.LibraryScannerExtrasTest do
     File.write!(Path.join(movie_dir, "Ratatouille.2007.1080p.BluRay.mkv"), "feature")
     File.write!(Path.join(movie_dir, "gusteau-featurette.mkv"), "extra")
     File.write!(Path.join(movie_dir, "ratatouille-trailer.mkv"), "trailer")
+
+    warm_ratatouille_search()
 
     library_path = library_path_fixture(%{path: tmp_dir, type: "movies"})
     scan(library_path)
@@ -66,6 +87,8 @@ defmodule Mydia.Jobs.LibraryScannerExtrasTest do
     File.mkdir_p!(movie_dir)
     File.write!(Path.join(movie_dir, "Ratatouille.2007.1080p.BluRay.mkv"), "feature")
     File.write!(Path.join(movie_dir, "gusteau-featurette.mkv"), "extra")
+
+    warm_ratatouille_search()
 
     library_path = library_path_fixture(%{path: tmp_dir, type: "movies"})
     scan(library_path)

--- a/test/mydia/jobs/metadata_refresh_test.exs
+++ b/test/mydia/jobs/metadata_refresh_test.exs
@@ -16,6 +16,33 @@ defmodule Mydia.Jobs.MetadataRefreshTest do
     end
 
     test "returns missing_provider_id when nothing resolves and recovery fails" do
+      # perform/1 takes no config option (job args are the only input Oban's
+      # perform_job/2 can drive), so Media.Refresh.run/2 falls back to
+      # Metadata.default_relay_config/0. The recovery search this test means
+      # to exercise must actually happen and come back empty, not be skipped,
+      # so point the relay at a Bypass server that legitimately answers "no
+      # results" instead of letting Metadata.search/3 (uncached, unlike the
+      # mount-time detail-page lookups) reach the live relay (#530).
+      bypass = Bypass.open()
+      previous_metadata_relay_url = Application.get_env(:mydia, :metadata_relay_url)
+      Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+      on_exit(fn ->
+        case previous_metadata_relay_url do
+          nil -> Application.delete_env(:mydia, :metadata_relay_url)
+          value -> Application.put_env(:mydia, :metadata_relay_url, value)
+        end
+      end)
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{"page" => 1, "total_pages" => 1, "total_results" => 0, "results" => []})
+        )
+      end)
+
       media_item =
         media_item_fixture(%{
           type: "movie",

--- a/test/mydia/media/metadata_type_test.exs
+++ b/test/mydia/media/metadata_type_test.exs
@@ -271,20 +271,27 @@ defmodule Mydia.Media.MetadataTypeTest do
     end
 
     test "external_ids survive a database round trip" do
+      # skip_episode_refresh: true — this test is only about metadata JSON
+      # round-tripping, not episodes. Without it, the real tvdb_id here sends
+      # refresh_episodes_for_tv_show/2 to the live relay for the series'
+      # extended details (#530).
       {:ok, media_item} =
-        Media.create_media_item(%{
-          type: "tv_show",
-          title: "Game of Thrones",
-          year: 2011,
-          tvdb_id: 121_361,
-          metadata: %{
-            "provider_id" => "121361",
-            "provider" => "tvdb",
-            "media_type" => "tv_show",
-            "title" => "Game of Thrones",
-            "external_ids" => %{"tmdb" => 1399, "tvdb" => nil, "imdb" => "tt0944947"}
-          }
-        })
+        Media.create_media_item(
+          %{
+            type: "tv_show",
+            title: "Game of Thrones",
+            year: 2011,
+            tvdb_id: 121_361,
+            metadata: %{
+              "provider_id" => "121361",
+              "provider" => "tvdb",
+              "media_type" => "tv_show",
+              "title" => "Game of Thrones",
+              "external_ids" => %{"tmdb" => 1399, "tvdb" => nil, "imdb" => "tt0944947"}
+            }
+          },
+          skip_episode_refresh: true
+        )
 
       reloaded = Media.get_media_item!(media_item.id)
 

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -3043,19 +3043,29 @@ defmodule Mydia.MediaTest do
       # not guarantee LIMIT 1 returns insertion order, and since the crawl now
       # repeats daily a nondeterministic pick could flip the stored mapping
       # between runs.
+      # skip_episode_refresh: true — this test is only about imdb_id
+      # duplicate-ordering, not episodes. Without it, a tv_show with no
+      # tmdb_id/tvdb_id sends refresh_episodes_for_tv_show/2 straight to the
+      # live relay trying to recover one by title (#530).
       {:ok, older} =
-        Media.create_media_item(%{
-          title: "Older Duplicate",
-          type: "tv_show",
-          imdb_id: "tt-dup-order"
-        })
+        Media.create_media_item(
+          %{
+            title: "Older Duplicate",
+            type: "tv_show",
+            imdb_id: "tt-dup-order"
+          },
+          skip_episode_refresh: true
+        )
 
       {:ok, _newer} =
-        Media.create_media_item(%{
-          title: "Newer Duplicate",
-          type: "tv_show",
-          imdb_id: "tt-dup-order"
-        })
+        Media.create_media_item(
+          %{
+            title: "Newer Duplicate",
+            type: "tv_show",
+            imdb_id: "tt-dup-order"
+          },
+          skip_episode_refresh: true
+        )
 
       assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt-dup-order"})
       assert id == older.id

--- a/test/mydia/relay_guard/escapes_test.exs
+++ b/test/mydia/relay_guard/escapes_test.exs
@@ -115,6 +115,43 @@ defmodule Mydia.RelayGuard.EscapesTest do
            ) == "warm_movie_details_cache(900000123)"
   end
 
+  test "suggests the trending helper for movies and tv" do
+    assert Escapes.suggest("/tmdb/movies/trending", nil) ==
+             "warm_trending_cache(:movie, results)"
+
+    assert Escapes.suggest("/tmdb/tv/trending", nil) ==
+             "warm_trending_cache(:tv_show, results)"
+  end
+
+  test "suggests the genre helper for movies and tv" do
+    assert Escapes.suggest("/tmdb/genre/movie", nil) ==
+             "warm_genre_cache(:movie, genres)"
+
+    assert Escapes.suggest("/tmdb/genre/tv", nil) ==
+             "warm_genre_cache(:tv_show, genres)"
+  end
+
+  test "suggests the movie search helper, carrying the query and year through" do
+    assert Escapes.suggest(
+             "/tmdb/movies/search",
+             "query=Ratatouille&language=en-US&include_adult=false&page=1&year=2007"
+           ) == "warm_movie_search_cache(\"Ratatouille\", [year: 2007], results)"
+  end
+
+  test "suggests the movie search helper with no year when none was searched" do
+    assert Escapes.suggest("/tmdb/movies/search", "query=Ratatouille&language=en-US") ==
+             "warm_movie_search_cache(\"Ratatouille\", [], results)"
+  end
+
+  test "suggests nothing for a movie search path with no parseable query" do
+    refute Escapes.suggest("/tmdb/movies/search", nil)
+    refute Escapes.suggest("/tmdb/movies/search", "language=en-US")
+  end
+
+  test "suggests nothing for a tvdb search path (uncached, no safe suggestion)" do
+    refute Escapes.suggest("/tvdb/search", "query=Test&type=series")
+  end
+
   test "suggests nothing for an unrecognised path" do
     refute Escapes.suggest("/some/other/path", nil)
   end

--- a/test/mydia/relay_guard/escapes_test.exs
+++ b/test/mydia/relay_guard/escapes_test.exs
@@ -1,61 +1,93 @@
 defmodule Mydia.RelayGuard.EscapesTest do
-  # The escape table is global, named and public. async: false modules run
-  # alone, which keeps these assertions from seeing another test's escapes.
+  # The escape table is global, named and public, and shared with the rest of
+  # the suite, which runs with the guard armed from test_helper.exs and reads
+  # Escapes.all() at the end expecting a complete account of what was
+  # blocked. This module must not call Escapes.reset/0: it used to, in both
+  # setup and on_exit, which wiped every escape the rest of the suite had
+  # recorded before this module happened to run — the actual cause of the
+  # end-of-suite report under-counting real escapes (#530). async: false
+  # keeps another MODULE from interleaving with this one; a unique id per
+  # test below is what keeps this module's own tests, and the rest of the
+  # suite, from polluting each other's counts.
   use ExUnit.Case, async: false
 
   alias Mydia.RelayGuard.Escapes
 
   setup do
     Escapes.setup()
-    Escapes.reset()
-    on_exit(&Escapes.reset/0)
     :ok
   end
 
   defp request(url), do: Req.new(url: url)
 
-  test "records a blocked request" do
-    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000123"))
+  defp unique_id, do: System.unique_integer([:positive])
 
-    assert [{_key, 1, url, _frames}] = Escapes.all()
-    assert url == "https://relay.mydia.dev/tmdb/movies/900000123"
+  # Registers on_exit cleanup for a url a test is about to record, so the row
+  # does not linger in the shared table once the test is done — otherwise the
+  # end-of-suite report would flag it as if it were a real, unwarmed
+  # application escape rather than this module's own test fixture.
+  defp track(url) do
+    on_exit(fn -> Escapes.delete(url) end)
+    url
+  end
+
+  defp rows_for(urls) when is_list(urls) do
+    Enum.filter(Escapes.all(), fn {_key, _count, url, _frames} -> url in urls end)
+  end
+
+  defp rows_for(url), do: rows_for([url])
+
+  test "records a blocked request" do
+    url = track("https://relay.mydia.dev/tmdb/movies/#{unique_id()}")
+
+    Escapes.record(request(url))
+
+    assert [{_key, 1, recorded_url, _frames}] = rows_for(url)
+    assert recorded_url == url
   end
 
   test "deduplicates repeats of the same request into one counted row" do
-    req = request("https://relay.mydia.dev/tmdb/movies/900000123")
+    url = track("https://relay.mydia.dev/tmdb/movies/#{unique_id()}")
+    req = request(url)
 
     Escapes.record(req)
     Escapes.record(req)
     Escapes.record(req)
 
-    assert [{_key, 3, _url, _frames}] = Escapes.all()
+    assert [{_key, 3, _url, _frames}] = rows_for(url)
   end
 
   test "records distinct paths separately" do
-    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000123"))
-    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000456"))
+    url1 = track("https://relay.mydia.dev/tmdb/movies/#{unique_id()}")
+    url2 = track("https://relay.mydia.dev/tmdb/movies/#{unique_id()}")
 
-    assert length(Escapes.all()) == 2
+    Escapes.record(request(url1))
+    Escapes.record(request(url2))
+
+    assert length(rows_for([url1, url2])) == 2
   end
 
   test "records two requests for the same movie id with different append_to_response queries as two rows" do
-    Escapes.record(
-      request("https://relay.mydia.dev/tmdb/movies/900000123?append_to_response=recommendations")
-    )
+    id = unique_id()
+    url1 = track("https://relay.mydia.dev/tmdb/movies/#{id}?append_to_response=recommendations")
 
-    Escapes.record(
-      request(
-        "https://relay.mydia.dev/tmdb/movies/900000123?append_to_response=credits,alternative_titles,videos,external_ids"
+    url2 =
+      track(
+        "https://relay.mydia.dev/tmdb/movies/#{id}?append_to_response=credits,alternative_titles,videos,external_ids"
       )
-    )
 
-    assert length(Escapes.all()) == 2
+    Escapes.record(request(url1))
+    Escapes.record(request(url2))
+
+    assert length(rows_for([url1, url2])) == 2
   end
 
   test "the recorded frames exclude the guard's own modules" do
-    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000123"))
+    url = track("https://relay.mydia.dev/tmdb/movies/#{unique_id()}")
 
-    assert [{_key, _count, _url, frames}] = Escapes.all()
+    Escapes.record(request(url))
+
+    assert [{_key, _count, _url, frames}] = rows_for(url)
 
     refute Enum.any?(frames, fn {mod, _fun, _arity, _loc} ->
              mod == Mydia.RelayGuard or
@@ -88,12 +120,15 @@ defmodule Mydia.RelayGuard.EscapesTest do
   end
 
   test "the report names the url and the fix" do
-    Escapes.record(request("https://relay.mydia.dev/tmdb/collections/900000123"))
+    id = unique_id()
+    url = track("https://relay.mydia.dev/tmdb/collections/#{id}")
 
-    report = Escapes.format(Escapes.all())
+    Escapes.record(request(url))
 
-    assert report =~ "https://relay.mydia.dev/tmdb/collections/900000123"
-    assert report =~ "warm_collection_cache(900000123, parts)"
+    report = Escapes.format(rows_for(url))
+
+    assert report =~ url
+    assert report =~ "warm_collection_cache(#{id}, parts)"
     assert report =~ "escaped to the network"
   end
 end

--- a/test/mydia/relay_guard/escapes_test.exs
+++ b/test/mydia/relay_guard/escapes_test.exs
@@ -52,6 +52,17 @@ defmodule Mydia.RelayGuard.EscapesTest do
     assert length(Escapes.all()) == 2
   end
 
+  test "the recorded frames exclude the guard's own modules" do
+    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000123"))
+
+    assert [{_key, _count, _url, frames}] = Escapes.all()
+
+    refute Enum.any?(frames, fn {mod, _fun, _arity, _loc} ->
+             mod == Mydia.RelayGuard or
+               mod |> Atom.to_string() |> String.starts_with?("Elixir.Mydia.RelayGuard.")
+           end)
+  end
+
   test "suggests the collection helper for a collection path" do
     assert Escapes.suggest("/tmdb/collections/900000123", nil) ==
              "warm_collection_cache(900000123, parts)"

--- a/test/mydia/relay_guard/escapes_test.exs
+++ b/test/mydia/relay_guard/escapes_test.exs
@@ -38,27 +38,42 @@ defmodule Mydia.RelayGuard.EscapesTest do
     assert length(Escapes.all()) == 2
   end
 
+  test "records two requests for the same movie id with different append_to_response queries as two rows" do
+    Escapes.record(
+      request("https://relay.mydia.dev/tmdb/movies/900000123?append_to_response=recommendations")
+    )
+
+    Escapes.record(
+      request(
+        "https://relay.mydia.dev/tmdb/movies/900000123?append_to_response=credits,alternative_titles,videos,external_ids"
+      )
+    )
+
+    assert length(Escapes.all()) == 2
+  end
+
   test "suggests the collection helper for a collection path" do
-    assert Escapes.suggest("/tmdb/collections/900000123", []) ==
+    assert Escapes.suggest("/tmdb/collections/900000123", nil) ==
              "warm_collection_cache(900000123, parts)"
   end
 
   test "suggests the recommendations helper for a tv path" do
-    assert Escapes.suggest("/tmdb/tv/shows/900000123", []) ==
+    assert Escapes.suggest("/tmdb/tv/shows/900000123", nil) ==
              "warm_recommendations_cache(900000123, :tv_show, results)"
   end
 
-  test "disambiguates a movie path by the calling module" do
-    assert Escapes.suggest("/tmdb/movies/900000123", [Mydia.Media.Recommendations]) ==
+  test "disambiguates a movie path by the append_to_response query" do
+    assert Escapes.suggest("/tmdb/movies/900000123", "append_to_response=recommendations") ==
              "warm_recommendations_cache(900000123, :movie, results)"
 
-    assert Escapes.suggest("/tmdb/movies/900000123", [Mydia.Media.Franchises]) ==
-             "warm_movie_details_cache(900000123)"
+    assert Escapes.suggest(
+             "/tmdb/movies/900000123",
+             "append_to_response=credits,alternative_titles,videos,external_ids"
+           ) == "warm_movie_details_cache(900000123)"
   end
 
-  test "suggests nothing when the path or caller is unrecognised" do
-    refute Escapes.suggest("/tmdb/movies/900000123", [])
-    refute Escapes.suggest("/some/other/path", [Mydia.Media.Franchises])
+  test "suggests nothing for an unrecognised path" do
+    refute Escapes.suggest("/some/other/path", nil)
   end
 
   test "the report names the url and the fix" do

--- a/test/mydia/relay_guard/escapes_test.exs
+++ b/test/mydia/relay_guard/escapes_test.exs
@@ -1,0 +1,73 @@
+defmodule Mydia.RelayGuard.EscapesTest do
+  # The escape table is global, named and public. async: false modules run
+  # alone, which keeps these assertions from seeing another test's escapes.
+  use ExUnit.Case, async: false
+
+  alias Mydia.RelayGuard.Escapes
+
+  setup do
+    Escapes.setup()
+    Escapes.reset()
+    on_exit(&Escapes.reset/0)
+    :ok
+  end
+
+  defp request(url), do: Req.new(url: url)
+
+  test "records a blocked request" do
+    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000123"))
+
+    assert [{_key, 1, url, _frames}] = Escapes.all()
+    assert url == "https://relay.mydia.dev/tmdb/movies/900000123"
+  end
+
+  test "deduplicates repeats of the same request into one counted row" do
+    req = request("https://relay.mydia.dev/tmdb/movies/900000123")
+
+    Escapes.record(req)
+    Escapes.record(req)
+    Escapes.record(req)
+
+    assert [{_key, 3, _url, _frames}] = Escapes.all()
+  end
+
+  test "records distinct paths separately" do
+    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000123"))
+    Escapes.record(request("https://relay.mydia.dev/tmdb/movies/900000456"))
+
+    assert length(Escapes.all()) == 2
+  end
+
+  test "suggests the collection helper for a collection path" do
+    assert Escapes.suggest("/tmdb/collections/900000123", []) ==
+             "warm_collection_cache(900000123, parts)"
+  end
+
+  test "suggests the recommendations helper for a tv path" do
+    assert Escapes.suggest("/tmdb/tv/shows/900000123", []) ==
+             "warm_recommendations_cache(900000123, :tv_show, results)"
+  end
+
+  test "disambiguates a movie path by the calling module" do
+    assert Escapes.suggest("/tmdb/movies/900000123", [Mydia.Media.Recommendations]) ==
+             "warm_recommendations_cache(900000123, :movie, results)"
+
+    assert Escapes.suggest("/tmdb/movies/900000123", [Mydia.Media.Franchises]) ==
+             "warm_movie_details_cache(900000123)"
+  end
+
+  test "suggests nothing when the path or caller is unrecognised" do
+    refute Escapes.suggest("/tmdb/movies/900000123", [])
+    refute Escapes.suggest("/some/other/path", [Mydia.Media.Franchises])
+  end
+
+  test "the report names the url and the fix" do
+    Escapes.record(request("https://relay.mydia.dev/tmdb/collections/900000123"))
+
+    report = Escapes.format(Escapes.all())
+
+    assert report =~ "https://relay.mydia.dev/tmdb/collections/900000123"
+    assert report =~ "warm_collection_cache(900000123, parts)"
+    assert report =~ "escaped to the network"
+  end
+end

--- a/test/mydia/relay_guard_test.exs
+++ b/test/mydia/relay_guard_test.exs
@@ -85,13 +85,33 @@ defmodule Mydia.RelayGuardTest do
     assert [{_key, 1, ^url, _frames}] = rows_for(url)
   end
 
-  test "the error message points at the warming helpers" do
+  test "the error message names every current cache-warming helper" do
+    # A plain substring match on "Mydia.MetadataCacheHelpers" would not catch
+    # the message text drifting out of sync with the helpers module — it
+    # already had, once: fix round 2 added three helpers here and to
+    # Escapes.suggest/2 but never updated this message (#530). Introspecting
+    # the module's own exports instead means this only breaks when a warm_*
+    # helper is genuinely missing from the message, not whenever one is
+    # added: naming a new helper here in the same change keeps this green.
     {:error, error} = Req.request(Req.new(url: blocked_url(), adapter: RelayGuard))
 
     message = Exception.message(error)
 
     assert message =~ "relay.mydia.dev"
     assert message =~ "Mydia.MetadataCacheHelpers"
+
+    warm_helpers =
+      Mydia.MetadataCacheHelpers.__info__(:functions)
+      |> Enum.filter(fn {name, _arity} ->
+        name |> Atom.to_string() |> String.starts_with?("warm_")
+      end)
+
+    assert warm_helpers != [], "expected Mydia.MetadataCacheHelpers to export warm_* helpers"
+
+    Enum.each(warm_helpers, fn {name, arity} ->
+      assert message =~ "#{name}/#{arity}",
+             "BlockedError's message should name #{name}/#{arity}"
+    end)
   end
 
   test "loopback?/1 recognises this machine and nothing else" do

--- a/test/mydia/relay_guard_test.exs
+++ b/test/mydia/relay_guard_test.exs
@@ -1,22 +1,42 @@
 defmodule Mydia.RelayGuardTest do
-  # Shares the global escape table with Mydia.RelayGuard.EscapesTest.
+  # Shares the global escape table with Mydia.RelayGuard.EscapesTest, and with
+  # the rest of the suite, which runs with the guard armed from
+  # test_helper.exs and relies on Escapes.all() at the end to be a complete
+  # account of what was blocked. This module must not call Escapes.reset/0:
+  # it used to, in both setup and on_exit, which wiped every escape the rest
+  # of the suite had recorded before this module happened to run — the actual
+  # cause of the end-of-suite report under-counting real escapes (#530).
+  # Isolation instead comes from giving each test its own, never-repeated
+  # movie id and filtering `Escapes.all()` down to just the rows it created.
   use ExUnit.Case, async: false
 
   alias Mydia.RelayGuard
   alias Mydia.RelayGuard.BlockedError
   alias Mydia.RelayGuard.Escapes
 
-  @blocked_url "https://relay.mydia.dev/tmdb/movies/900000123"
-
   setup do
     Escapes.setup()
-    Escapes.reset()
-    on_exit(&Escapes.reset/0)
     :ok
   end
 
+  # Registers its own on_exit cleanup: a test here deliberately triggers a
+  # real guard block as its own assertion, and that row must not linger in
+  # the shared table once the test is done, or it would show up in the
+  # end-of-suite report as if it were a real, unwarmed application escape.
+  defp blocked_url do
+    url = "https://relay.mydia.dev/tmdb/movies/#{System.unique_integer([:positive])}"
+    on_exit(fn -> Escapes.delete(url) end)
+    url
+  end
+
+  defp rows_for(urls) when is_list(urls) do
+    Enum.filter(Escapes.all(), fn {_key, _count, url, _frames} -> url in urls end)
+  end
+
+  defp rows_for(url), do: rows_for([url])
+
   test "refuses a request to a host that is not this machine" do
-    req = Req.new(url: @blocked_url, adapter: RelayGuard)
+    req = Req.new(url: blocked_url(), adapter: RelayGuard)
 
     assert {:error, %BlockedError{}} = Req.request(req)
   end
@@ -39,9 +59,11 @@ defmodule Mydia.RelayGuardTest do
     # with roughly 0.95s + 1.97s + 3.87s of backoff, which is past the 5s
     # render_async budget the detail-page tests use (#530). BlockedError is a
     # plain exception precisely so transient?/1 returns false for it.
+    url = blocked_url()
+
     req =
       Req.new(
-        url: @blocked_url,
+        url: url,
         adapter: RelayGuard,
         retry: :transient,
         max_retries: 3
@@ -52,22 +74,19 @@ defmodule Mydia.RelayGuardTest do
     # The escape store counts hits per request, so the count IS the call
     # count. A retried request would reach the adapter 4 times (the attempt
     # plus max_retries: 3) and record 4.
-    assert [{_key, 1, @blocked_url, _frames}] =
-             Enum.filter(Escapes.all(), fn {_key, _count, url, _frames} ->
-               url == @blocked_url
-             end)
+    assert [{_key, 1, ^url, _frames}] = rows_for(url)
   end
 
   test "records the refused request" do
-    Req.request(Req.new(url: @blocked_url, adapter: RelayGuard))
+    url = blocked_url()
 
-    assert Enum.any?(Escapes.all(), fn {_key, _count, url, _frames} ->
-             url == @blocked_url
-           end)
+    Req.request(Req.new(url: url, adapter: RelayGuard))
+
+    assert [{_key, 1, ^url, _frames}] = rows_for(url)
   end
 
   test "the error message points at the warming helpers" do
-    {:error, error} = Req.request(Req.new(url: @blocked_url, adapter: RelayGuard))
+    {:error, error} = Req.request(Req.new(url: blocked_url(), adapter: RelayGuard))
 
     message = Exception.message(error)
 
@@ -81,5 +100,25 @@ defmodule Mydia.RelayGuardTest do
     assert RelayGuard.loopback?("::1")
     refute RelayGuard.loopback?("relay.mydia.dev")
     refute RelayGuard.loopback?(nil)
+  end
+
+  describe "reserved?/1" do
+    test "recognises RFC 2606 reserved TLDs on the final label only" do
+      assert RelayGuard.reserved?("nonexistent.invalid")
+      assert RelayGuard.reserved?("host.test")
+      assert RelayGuard.reserved?("site.example")
+      refute RelayGuard.reserved?("example.com")
+      refute RelayGuard.reserved?("example.net")
+      refute RelayGuard.reserved?("example.org")
+      refute RelayGuard.reserved?("relay.mydia.dev")
+    end
+
+    test "recognises RFC 5737 documentation ranges" do
+      assert RelayGuard.reserved?("203.0.113.1")
+      assert RelayGuard.reserved?("192.0.2.1")
+      assert RelayGuard.reserved?("198.51.100.1")
+      refute RelayGuard.reserved?("8.8.8.8")
+      refute RelayGuard.reserved?(nil)
+    end
   end
 end

--- a/test/mydia/relay_guard_test.exs
+++ b/test/mydia/relay_guard_test.exs
@@ -1,0 +1,85 @@
+defmodule Mydia.RelayGuardTest do
+  # Shares the global escape table with Mydia.RelayGuard.EscapesTest.
+  use ExUnit.Case, async: false
+
+  alias Mydia.RelayGuard
+  alias Mydia.RelayGuard.BlockedError
+  alias Mydia.RelayGuard.Escapes
+
+  @blocked_url "https://relay.mydia.dev/tmdb/movies/900000123"
+
+  setup do
+    Escapes.setup()
+    Escapes.reset()
+    on_exit(&Escapes.reset/0)
+    :ok
+  end
+
+  test "refuses a request to a host that is not this machine" do
+    req = Req.new(url: @blocked_url, adapter: RelayGuard)
+
+    assert {:error, %BlockedError{}} = Req.request(req)
+  end
+
+  test "hands a loopback request to the real adapter" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/ok", fn conn ->
+      Plug.Conn.resp(conn, 200, "fine")
+    end)
+
+    req = Req.new(url: "http://localhost:#{bypass.port}/ok", adapter: RelayGuard)
+
+    assert {:ok, %Req.Response{status: 200, body: "fine"}} = Req.request(req)
+  end
+
+  test "a refused request is not retried" do
+    # These are exactly the options Mydia.Metadata.Provider.HTTP.new_request/1
+    # sets. A Req.TransportError here would be classified transient and retried
+    # with roughly 0.95s + 1.97s + 3.87s of backoff, which is past the 5s
+    # render_async budget the detail-page tests use (#530). BlockedError is a
+    # plain exception precisely so transient?/1 returns false for it.
+    req =
+      Req.new(
+        url: @blocked_url,
+        adapter: RelayGuard,
+        retry: :transient,
+        max_retries: 3
+      )
+
+    assert {:error, %BlockedError{}} = Req.request(req)
+
+    # The escape store counts hits per request, so the count IS the call
+    # count. A retried request would reach the adapter 4 times (the attempt
+    # plus max_retries: 3) and record 4.
+    assert [{_key, 1, @blocked_url, _frames}] =
+             Enum.filter(Escapes.all(), fn {_key, _count, url, _frames} ->
+               url == @blocked_url
+             end)
+  end
+
+  test "records the refused request" do
+    Req.request(Req.new(url: @blocked_url, adapter: RelayGuard))
+
+    assert Enum.any?(Escapes.all(), fn {_key, _count, url, _frames} ->
+             url == @blocked_url
+           end)
+  end
+
+  test "the error message points at the warming helpers" do
+    {:error, error} = Req.request(Req.new(url: @blocked_url, adapter: RelayGuard))
+
+    message = Exception.message(error)
+
+    assert message =~ "relay.mydia.dev"
+    assert message =~ "Mydia.MetadataCacheHelpers"
+  end
+
+  test "loopback?/1 recognises this machine and nothing else" do
+    assert RelayGuard.loopback?("localhost")
+    assert RelayGuard.loopback?("127.0.0.1")
+    assert RelayGuard.loopback?("::1")
+    refute RelayGuard.loopback?("relay.mydia.dev")
+    refute RelayGuard.loopback?(nil)
+  end
+end

--- a/test/mydia/remote_access/direct_url_refresher_test.exs
+++ b/test/mydia/remote_access/direct_url_refresher_test.exs
@@ -13,10 +13,15 @@ defmodule Mydia.RemoteAccess.DirectUrlRefresherTest do
     # Save original config
     original_direct_urls_config = Application.get_env(:mydia, :direct_urls, [])
 
-    # Set test data directory and external port
+    # Set test data directory and external port. public_ip_enabled defaults
+    # to true, and every test below calls detect_all/0 directly, so without
+    # this every test here reaches ifconfig.me/icanhazip.com/api.ipify.org
+    # for real — none of them assert anything that depends on a
+    # public-IP-derived URL specifically being present (#530).
     Application.put_env(:mydia, :direct_urls,
       data_dir: @test_data_dir,
-      external_port: 4000
+      external_port: 4000,
+      public_ip_enabled: false
     )
 
     on_exit(fn ->
@@ -110,7 +115,8 @@ defmodule Mydia.RemoteAccess.DirectUrlRefresherTest do
       Application.put_env(:mydia, :direct_urls,
         data_dir: @test_data_dir,
         external_port: 4000,
-        external_url: "https://mydia.example.com:443"
+        external_url: "https://mydia.example.com:443",
+        public_ip_enabled: false
       )
 
       # Initialize remote access config
@@ -131,7 +137,8 @@ defmodule Mydia.RemoteAccess.DirectUrlRefresherTest do
         additional_direct_urls: [
           "https://vpn.mydia.local:4000",
           "https://tailscale.mydia.local:4000"
-        ]
+        ],
+        public_ip_enabled: false
       )
 
       # Initialize remote access config
@@ -155,7 +162,8 @@ defmodule Mydia.RemoteAccess.DirectUrlRefresherTest do
           # Duplicate
           "https://mydia.example.com:443",
           "https://vpn.mydia.local:4000"
-        ]
+        ],
+        public_ip_enabled: false
       )
 
       # Initialize remote access config

--- a/test/mydia/remote_access/direct_urls_test.exs
+++ b/test/mydia/remote_access/direct_urls_test.exs
@@ -185,6 +185,11 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
       %{original_config: original_config}
     end
 
+    # Genuinely reaches the public internet (ifconfig.me/icanhazip.com/
+    # api.ipify.org) rather than a stub, so it stays out of the default run
+    # like every other :external test — Mydia.RelayGuard refuses it
+    # otherwise (#530).
+    @tag :external
     test "returns {:ok, ip} when successful" do
       # Enable public IP detection
       Application.put_env(:mydia, :direct_urls, public_ip_enabled: true)

--- a/test/mydia/remote_access/direct_urls_test.exs
+++ b/test/mydia/remote_access/direct_urls_test.exs
@@ -80,8 +80,15 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
       %{original_config: original_config}
     end
 
+    # public_ip_enabled defaults to true (DirectUrls.detect_public_ip/0), and
+    # detect_all/0 always calls it regardless of what these tests actually
+    # configure, so every test in this describe block needs it turned off
+    # explicitly or it reaches ifconfig.me/icanhazip.com/api.ipify.org for
+    # real — none of them assert anything about the public-IP-derived URL
+    # detect_all/0 would otherwise prepend (#530).
+
     test "includes local URLs" do
-      Application.put_env(:mydia, :direct_urls, external_port: 4000)
+      Application.put_env(:mydia, :direct_urls, external_port: 4000, public_ip_enabled: false)
 
       urls = DirectUrls.detect_all()
 
@@ -92,7 +99,8 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
     test "includes external URL when configured" do
       Application.put_env(:mydia, :direct_urls,
         external_port: 4000,
-        external_url: "https://example.com:443"
+        external_url: "https://example.com:443",
+        public_ip_enabled: false
       )
 
       urls = DirectUrls.detect_all()
@@ -106,7 +114,8 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
         additional_direct_urls: [
           "https://custom1.example.com:443",
           "https://custom2.example.com:443"
-        ]
+        ],
+        public_ip_enabled: false
       )
 
       urls = DirectUrls.detect_all()
@@ -124,7 +133,8 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
           # Duplicate of external_url
           "https://example.com:443",
           "https://custom.example.com:443"
-        ]
+        ],
+        public_ip_enabled: false
       )
 
       urls = DirectUrls.detect_all()
@@ -144,7 +154,8 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
       Application.put_env(:mydia, :direct_urls,
         external_port: 4000,
         external_url: nil,
-        additional_direct_urls: []
+        additional_direct_urls: [],
+        public_ip_enabled: false
       )
 
       urls = DirectUrls.detect_all()
@@ -159,7 +170,8 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
       Application.put_env(:mydia, :direct_urls,
         external_port: 4000,
         external_url: nil,
-        additional_direct_urls: []
+        additional_direct_urls: [],
+        public_ip_enabled: false
       )
 
       urls = DirectUrls.detect_all()
@@ -214,6 +226,9 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
       assert {:error, :disabled} = DirectUrls.detect_public_ip()
     end
 
+    # Genuinely reaches the public internet, same as "returns {:ok, ip} when
+    # successful" above (#530).
+    @tag :external
     test "caches successful results" do
       Application.put_env(:mydia, :direct_urls, public_ip_enabled: true)
 
@@ -240,6 +255,9 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
       %{original_config: original_config}
     end
 
+    # Genuinely reaches the public internet: detect_public_url/0 calls
+    # detect_public_ip/0 internally (#530).
+    @tag :external
     test "returns sslip.io URL on success" do
       Application.put_env(:mydia, :direct_urls, public_ip_enabled: true, http_port: 4443)
 
@@ -257,6 +275,9 @@ defmodule Mydia.RemoteAccess.DirectUrlsTest do
       end
     end
 
+    # Genuinely reaches the public internet, same as "returns sslip.io URL on
+    # success" above (#530).
+    @tag :external
     test "uses http_port from config" do
       Application.put_env(:mydia, :direct_urls,
         public_ip_enabled: true,

--- a/test/mydia_web/controllers/api/playback_controller_test.exs
+++ b/test/mydia_web/controllers/api/playback_controller_test.exs
@@ -402,14 +402,24 @@ defmodule MydiaWeb.Api.PlaybackControllerTest do
   end
 
   # Helper functions for test setup
+  #
+  # skip_episode_refresh: true — these tests only need a persisted media item
+  # to exercise the playback controller's own validation (not found, wrong
+  # type), not a real episode list. Without it, a "tv_show" item with a fake
+  # tmdb_id sends refresh_episodes_for_tv_show/2 to the live relay for both a
+  # details fetch and a TVDB title-search recovery, neither of which is
+  # cached the way the mount-time detail-page lookups are (#530).
   defp create_media_item(type) do
-    Media.create_media_item(%{
-      title: "Test #{type} #{System.unique_integer([:positive])}",
-      tmdb_id: System.unique_integer([:positive]),
-      type: type,
-      year: 2024,
-      monitored: true
-    })
+    Media.create_media_item(
+      %{
+        title: "Test #{type} #{System.unique_integer([:positive])}",
+        tmdb_id: System.unique_integer([:positive]),
+        type: type,
+        year: 2024,
+        monitored: true
+      },
+      skip_episode_refresh: true
+    )
   end
 
   defp create_episode do

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -246,7 +246,11 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
     end
 
     test "env-sourced config shows an ENV badge on the row", %{conn: conn} do
-      System.put_env("FLARESOLVERR_URL", "http://env-flaresolverr:8191")
+      # .test is an RFC 2606 reserved TLD Mydia.RelayGuard already lets
+      # through: a container hostname like "flaresolverr" would resolve to
+      # something real elsewhere, so the guard cannot allowlist it, but this
+      # fixture only needs to look like one, not resolve as one (#530).
+      System.put_env("FLARESOLVERR_URL", "http://env-flaresolverr.test:8191")
 
       {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
 
@@ -270,11 +274,15 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
 
       view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
 
+      # Saving with enabled: true makes maybe_load_flaresolverr_status/1 fire a
+      # real health-check request at this url immediately, so it has to be a
+      # host Mydia.RelayGuard already lets through (.test, RFC 2606) rather
+      # than a container hostname the guard cannot safely allowlist (#530).
       view
       |> form("#flaresolverr-form",
         flaresolverr: %{
           enabled: "true",
-          url: "http://flaresolverr:8191",
+          url: "http://flaresolverr.test:8191",
           timeout: "60000",
           max_timeout: "120000"
         }
@@ -282,7 +290,7 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       |> render_submit()
 
       url = Settings.get_config_setting_by_key("flaresolverr.url")
-      assert url.value == "http://flaresolverr:8191"
+      assert url.value == "http://flaresolverr.test:8191"
       assert url.category == :flaresolverr
       assert Settings.get_config_setting_by_key("flaresolverr.timeout").value == "60000"
       refute has_element?(view, "#flaresolverr-form")
@@ -291,7 +299,7 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       # restart — FlareSolverr now reads enabled/url from the merged config.
       config = Mydia.Indexers.FlareSolverr.config()
       assert config.enabled == true
-      assert config.url == "http://flaresolverr:8191"
+      assert config.url == "http://flaresolverr.test:8191"
     end
 
     test "invalid timeout shows a validation error and writes no setting", %{conn: conn} do
@@ -357,7 +365,10 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
 
     test "enabling is allowed and the env URL is never persisted when the URL is env-sourced",
          %{conn: conn} do
-      System.put_env("FLARESOLVERR_URL", "http://env-flaresolverr:8191")
+      # Same reason as "saving the modal form upserts the settings" above:
+      # enabled: true fires a real health check at whatever url is
+      # effective, so it must resolve nowhere rather than be allowlisted.
+      System.put_env("FLARESOLVERR_URL", "http://env-flaresolverr.test:8191")
 
       {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
 
@@ -378,7 +389,7 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       # The effective config still reflects the env URL plus the saved enabled flag.
       config = Mydia.Indexers.FlareSolverr.config()
       assert config.enabled == true
-      assert config.url == "http://env-flaresolverr:8191"
+      assert config.url == "http://env-flaresolverr.test:8191"
     end
 
     test "Cancel closes the modal without writing a setting", %{conn: conn} do

--- a/test/mydia_web/live/admin_remote_access_live_test.exs
+++ b/test/mydia_web/live/admin_remote_access_live_test.exs
@@ -6,6 +6,19 @@ defmodule MydiaWeb.AdminRemoteAccessLiveTest do
   alias Mydia.RemoteAccess
 
   setup do
+    # AdminRemoteAccessLive.Components renders Mydia.RemoteAccess.DirectUrls
+    # .detect_public_urls/0 unconditionally, and public_ip_enabled defaults
+    # to true, so every test that mounts this page reaches
+    # ifconfig.me/icanhazip.com/api.ipify.org for real unless told not to.
+    # None of the tests below assert anything about the public-IP-derived
+    # URL (#530).
+    original_direct_urls_config = Application.get_env(:mydia, :direct_urls, [])
+    Application.put_env(:mydia, :direct_urls, public_ip_enabled: false)
+
+    on_exit(fn ->
+      Application.put_env(:mydia, :direct_urls, original_direct_urls_config)
+    end)
+
     unique_id = System.unique_integer([:positive])
 
     {:ok, user} =

--- a/test/mydia_web/live/admin_settings_live_feedback_test.exs
+++ b/test/mydia_web/live/admin_settings_live_feedback_test.exs
@@ -2,6 +2,7 @@ defmodule MydiaWeb.AdminSettingsLiveFeedbackTest do
   use MydiaWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Mydia.MetadataCacheHelpers
 
   alias Mydia.{Accounts, Settings}
 
@@ -96,6 +97,11 @@ defmodule MydiaWeb.AdminSettingsLiveFeedbackTest do
         value: "false",
         category: :feedback
       })
+
+    # DashboardLive.Index unconditionally loads both trending rails on
+    # connected mount (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
 
     {:ok, _view, html} = live(conn, ~p"/")
 

--- a/test/mydia_web/live/changelog_banner_test.exs
+++ b/test/mydia_web/live/changelog_banner_test.exs
@@ -2,11 +2,17 @@ defmodule MydiaWeb.ChangelogBannerTest do
   use MydiaWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Mydia.MetadataCacheHelpers
 
   alias Mydia.Accounts
   alias Mydia.Changelog
 
   setup %{conn: conn} do
+    # Every test here mounts "/", and DashboardLive.Index unconditionally
+    # loads both trending rails on connected mount (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+
     unique_id = System.unique_integer([:positive])
 
     {:ok, user} =

--- a/test/mydia_web/live/dashboard_live/recently_added_test.exs
+++ b/test/mydia_web/live/dashboard_live/recently_added_test.exs
@@ -11,9 +11,15 @@ defmodule MydiaWeb.DashboardLive.RecentlyAddedTest do
   import Phoenix.LiveViewTest
   import Mydia.MediaFixtures
   import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
   import MydiaWeb.AuthHelpers
 
   setup %{conn: conn} do
+    # Every test here mounts "/", and DashboardLive.Index unconditionally
+    # loads both trending rails on connected mount (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+
     %{conn: log_in_user(conn, admin_user_fixture())}
   end
 

--- a/test/mydia_web/live/dashboard_live/stat_tiles_test.exs
+++ b/test/mydia_web/live/dashboard_live/stat_tiles_test.exs
@@ -11,7 +11,16 @@ defmodule MydiaWeb.DashboardLive.StatTilesTest do
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
   import MydiaWeb.AuthHelpers
+
+  setup do
+    # Every test here mounts "/", and DashboardLive.Index unconditionally
+    # loads both trending rails on connected mount (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+    :ok
+  end
 
   test "the library and downloads tiles link for a regular user", %{conn: conn} do
     conn = log_in_user(conn, user_fixture())

--- a/test/mydia_web/live/feedback_modal_test.exs
+++ b/test/mydia_web/live/feedback_modal_test.exs
@@ -2,11 +2,21 @@ defmodule MydiaWeb.FeedbackModalTest do
   use MydiaWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Mydia.MetadataCacheHelpers
 
   alias Mydia.Accounts
   alias Mydia.Settings
 
   setup %{conn: conn} do
+    # Every test here mounts "/", and DashboardLive.Index unconditionally
+    # loads both trending rails on connected mount. stub_dashboard_requests/1
+    # below additionally covers the 3 tests that override metadata_relay_url
+    # for their own Bypass, but warming the cache here protects every test in
+    # the file regardless of which relay url happens to be configured at
+    # mount time — a cache hit never reaches the network at all (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+
     unique_id = System.unique_integer([:positive])
 
     {:ok, user} =

--- a/test/mydia_web/live/grid_density_test.exs
+++ b/test/mydia_web/live/grid_density_test.exs
@@ -11,12 +11,18 @@ defmodule MydiaWeb.GridDensityTest do
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
   import MydiaWeb.AuthHelpers
 
   alias Mydia.Accounts
   alias Mydia.Accounts.UserPreference
 
   setup %{conn: conn} do
+    # DiscoverLive.Index unconditionally loads the movie genre list and its
+    # default (trending) category on connected mount (#530).
+    warm_genre_cache(:movie, [])
+    warm_trending_cache(:movie, [])
+
     user = admin_user_fixture()
     %{conn: log_in_user(conn, user), user: user}
   end

--- a/test/mydia_web/live/media_live/show/franchise_section_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_section_test.exs
@@ -14,13 +14,20 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseSectionTest do
   end
 
   test "a TV show page never renders the franchise section", %{conn: conn} do
+    show_tmdb_id = unique_provider_id()
+
     show =
       media_item_fixture(%{
         type: "tv_show",
         title: "A Show",
         year: 2010,
-        tmdb_id: unique_provider_id()
+        tmdb_id: show_tmdb_id
       })
+
+    # The page starts a recommendations lookup on any connected mount with an
+    # integer tmdb_id, franchise strip or not. Unwarmed it leaves the VM for
+    # the production relay.
+    warm_recommendations_cache(show_tmdb_id, :tv_show, [])
 
     {:ok, view, _html} = live(conn, ~p"/media/#{show.id}")
 
@@ -53,6 +60,8 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseSectionTest do
       %{"id" => owned_tmdb_id, "title" => "First", "release_date" => "2001-01-01"},
       %{"id" => missing_tmdb_id, "title" => "Second", "release_date" => "2004-01-01"}
     ])
+
+    warm_recommendations_cache(owned_tmdb_id, :movie, [])
 
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
     render_async(view, 5000)

--- a/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
+++ b/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
@@ -226,8 +226,24 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
     # succeeds instead of reaching the live relay. Mirrors the fixture body in
     # `test/mydia_web/features/library_picker_test.exs`'s "/tmdb/movies/900001"
     # stub, which is the same call site.
+    #
+    # Blocks the response until `release_added_movie_details/1` is called.
+    # `Add.from_provider/4` runs inside a `start_async/3` task the picker
+    # click starts, and every test below asserts the card is still showing
+    # "Adding..." immediately after that click — proof that the
+    # recommendations (or franchise) rail, not the other one, registered the
+    # in-flight add. Before this branch's guard existed, that call was a
+    # real round trip to relay.mydia.dev, and the round-trip latency is what
+    # accidentally kept the in-flight window open long enough to observe: it
+    # won locally and lost on a slower CI runner (#530 fix round 6). Blocking
+    # here makes the window deterministic instead of relying on how fast a
+    # network call happens not to resolve.
     defp stub_added_movie_details(bypass, tmdb_id, title) do
+      {:ok, gate} = Agent.start_link(fn -> false end)
+
       Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        await_release(gate)
+
         body = %{
           "id" => tmdb_id,
           "title" => title,
@@ -241,6 +257,22 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
         |> Plug.Conn.put_resp_content_type("application/json")
         |> Plug.Conn.resp(200, Jason.encode!(body))
       end)
+
+      gate
+    end
+
+    defp release_added_movie_details(gate), do: Agent.update(gate, fn _ -> true end)
+
+    # Runs in the Bypass connection process, not the test process, so this
+    # sleep only delays that one HTTP response — it has no effect on how
+    # fast the test process's own assertions run.
+    defp await_release(gate) do
+      if Agent.get(gate, & &1) do
+        :ok
+      else
+        Process.sleep(5)
+        await_release(gate)
+      end
     end
 
     test "a recommendation-only title routes the add to the recommendations rail",
@@ -249,7 +281,7 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
       library_path_fixture(%{path: "/media/host-b", type: "movies"})
 
       {movie, recommended_tmdb_id} = movie_with_recommendation()
-      stub_added_movie_details(bypass, recommended_tmdb_id, "The Eternal Daughter")
+      gate = stub_added_movie_details(bypass, recommended_tmdb_id, "The Eternal Daughter")
 
       {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
       render_async(view, 5000)
@@ -266,9 +298,14 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
 
       # Proof of routing: the recommendations rail registered the in-flight
       # add (its card now shows the spinner) and there is no franchise strip
-      # at all to have wrongly claimed it.
+      # at all to have wrongly claimed it. The added title's own details
+      # fetch is still blocked at this point (see stub_added_movie_details/3),
+      # so this in-flight window is guaranteed rather than raced.
       assert has_element?(view, "#recommendations-rail-item-#{recommended_tmdb_id}", "Adding...")
       refute has_element?(view, "#franchise-section")
+
+      release_added_movie_details(gate)
+      render_async(view, 5000)
     end
 
     test "a movie that is a franchise entry routes the add to the franchise rail",
@@ -277,7 +314,7 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
       library_path_fixture(%{path: "/media/host-b", type: "movies"})
 
       {movie, missing_tmdb_id} = movie_with_franchise_entry()
-      stub_added_movie_details(bypass, missing_tmdb_id, "Aliens")
+      gate = stub_added_movie_details(bypass, missing_tmdb_id, "Aliens")
 
       {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
       render_async(view, 5000)
@@ -290,7 +327,12 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
       |> element("#library-picker-dialog [data-test='library-picker-option']", "host-a")
       |> render_click()
 
+      # Same deterministic-in-flight-window reasoning as the recommendation
+      # test above: the added title's details fetch is still blocked here.
       assert has_element?(view, "#franchise-section-item-#{missing_tmdb_id}", "Adding...")
+
+      release_added_movie_details(gate)
+      render_async(view, 5000)
     end
 
     test "a title in both rails (#460) routes to the franchise rail even when the click " <>
@@ -300,7 +342,7 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
       library_path_fixture(%{path: "/media/host-b", type: "movies"})
 
       {movie, overlap_tmdb_id} = movie_with_overlapping_entry()
-      stub_added_movie_details(bypass, overlap_tmdb_id, "Aliens")
+      gate = stub_added_movie_details(bypass, overlap_tmdb_id, "Aliens")
 
       {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
       render_async(view, 5000)
@@ -318,8 +360,13 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
       |> element("#library-picker-dialog [data-test='library-picker-option']", "host-a")
       |> render_click()
 
+      # Same deterministic-in-flight-window reasoning as the two tests above:
+      # the added title's details fetch is still blocked here.
       assert has_element?(view, "#franchise-section-item-#{overlap_tmdb_id}", "Adding...")
       refute has_element?(view, "#recommendations-rail-item-#{overlap_tmdb_id}", "Adding...")
+
+      release_added_movie_details(gate)
+      render_async(view, 5000)
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
+++ b/test/mydia_web/live/media_live/show/rail_picker_host_test.exs
@@ -194,12 +194,62 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
   end
 
   describe "add_from_library_picker/2 routing" do
+    # `add_from_library_picker/2` dispatches to `FranchiseEvents.perform_add/4`
+    # or `RecommendationEvents.perform_add/4`, both of which call
+    # `Mydia.Media.Add.from_provider/4` for the card's tmdb_id — the one being
+    # added, not the mounted movie's own. `from_provider/4` fetches that
+    # movie's full TMDB details through `Metadata.fetch_by_id/3` directly,
+    # which is uncached (unlike the mount-time franchise/recommendations
+    # lookups `Mydia.MetadataCacheHelpers` warms), so cache-warming it does
+    # nothing: the request still leaves for the live relay every time
+    # (confirmed by reading `Mydia.Media.Add.resolve_movie_attrs/4` and
+    # `Mydia.Metadata.fetch_by_id/3` — neither touches `Mydia.Metadata.Cache`).
+    # `test/mydia_web/features/library_picker_test.exs` hits this exact call
+    # and already documents the fix: point `metadata_relay_url` at a Bypass
+    # server for the duration of the test, matching the pattern here.
+    setup do
+      bypass = Bypass.open()
+      previous_metadata_relay_url = Application.get_env(:mydia, :metadata_relay_url)
+      Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+      on_exit(fn ->
+        case previous_metadata_relay_url do
+          nil -> Application.delete_env(:mydia, :metadata_relay_url)
+          value -> Application.put_env(:mydia, :metadata_relay_url, value)
+        end
+      end)
+
+      %{bypass: bypass}
+    end
+
+    # Stubs the added title's own TMDB details lookup so `Add.from_provider/4`
+    # succeeds instead of reaching the live relay. Mirrors the fixture body in
+    # `test/mydia_web/features/library_picker_test.exs`'s "/tmdb/movies/900001"
+    # stub, which is the same call site.
+    defp stub_added_movie_details(bypass, tmdb_id, title) do
+      Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        body = %{
+          "id" => tmdb_id,
+          "title" => title,
+          "release_date" => "2024-01-01",
+          "overview" => "",
+          "credits" => %{"cast" => [], "crew" => []},
+          "genres" => []
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+    end
+
     test "a recommendation-only title routes the add to the recommendations rail",
-         %{conn: conn} do
+         %{conn: conn, bypass: bypass} do
       library_path_fixture(%{path: "/media/host-a", type: "movies"})
       library_path_fixture(%{path: "/media/host-b", type: "movies"})
 
       {movie, recommended_tmdb_id} = movie_with_recommendation()
+      stub_added_movie_details(bypass, recommended_tmdb_id, "The Eternal Daughter")
 
       {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
       render_async(view, 5000)
@@ -222,11 +272,12 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
     end
 
     test "a movie that is a franchise entry routes the add to the franchise rail",
-         %{conn: conn} do
+         %{conn: conn, bypass: bypass} do
       library_path_fixture(%{path: "/media/host-a", type: "movies"})
       library_path_fixture(%{path: "/media/host-b", type: "movies"})
 
       {movie, missing_tmdb_id} = movie_with_franchise_entry()
+      stub_added_movie_details(bypass, missing_tmdb_id, "Aliens")
 
       {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
       render_async(view, 5000)
@@ -244,11 +295,12 @@ defmodule MydiaWeb.MediaLive.Show.RailPickerHostTest do
 
     test "a title in both rails (#460) routes to the franchise rail even when the click " <>
            "starts from the recommendations card",
-         %{conn: conn} do
+         %{conn: conn, bypass: bypass} do
       library_path_fixture(%{path: "/media/host-a", type: "movies"})
       library_path_fixture(%{path: "/media/host-b", type: "movies"})
 
       {movie, overlap_tmdb_id} = movie_with_overlapping_entry()
+      stub_added_movie_details(bypass, overlap_tmdb_id, "Aliens")
 
       {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
       render_async(view, 5000)

--- a/test/mydia_web/live/media_live/show/recommendations_rail_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendations_rail_test.exs
@@ -7,9 +7,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
   import Mydia.MediaFixtures
   import Mydia.AccountsFixtures
   import MydiaWeb.AuthHelpers
-
-  alias Mydia.Metadata
-  alias Mydia.Metadata.Cache
+  import Mydia.MetadataCacheHelpers
 
   setup %{conn: conn} do
     # The app disables Oban in test (engine: false), so Oban.insert cannot run
@@ -22,8 +20,8 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
   end
 
   test "a movie with recommendations renders the rail", %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
-    recommended_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -42,6 +40,8 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
       }
     ])
 
+    warm_movie_details_cache(source_tmdb_id)
+
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
     render_async(view, 5000)
 
@@ -50,7 +50,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
   end
 
   test "a movie with no recommendations renders no rail", %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -61,6 +61,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
       })
 
     warm_recommendations_cache(source_tmdb_id, :movie, [])
+    warm_movie_details_cache(source_tmdb_id)
 
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
     render_async(view, 5000)
@@ -70,8 +71,8 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
 
   test "an owned recommendation links to its page instead of offering an add",
        %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
-    owned_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
+    owned_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -93,6 +94,8 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
       %{"id" => owned_tmdb_id, "title" => "Already Here", "release_date" => "2013-01-01"}
     ])
 
+    warm_movie_details_cache(source_tmdb_id)
+
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
     render_async(view, 5000)
 
@@ -100,8 +103,8 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
   end
 
   test "a tv show starts collapsed and the header toggles it", %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
-    recommended_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
 
     show =
       media_item_fixture(%{
@@ -137,7 +140,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
   end
 
   test "a movie rail is not collapsible", %{conn: conn} do
-    source_tmdb_id = System.unique_integer([:positive])
+    source_tmdb_id = unique_provider_id()
 
     movie =
       media_item_fixture(%{
@@ -148,55 +151,15 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationsRailTest do
       })
 
     warm_recommendations_cache(source_tmdb_id, :movie, [
-      %{"id" => System.unique_integer([:positive]), "title" => "The Eternal Daughter"}
+      %{"id" => unique_provider_id(), "title" => "The Eternal Daughter"}
     ])
+
+    warm_movie_details_cache(source_tmdb_id)
 
     {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
     render_async(view, 5000)
 
     assert has_element?(view, "#recommendations-rail")
     refute has_element?(view, "#recommendations-rail-toggle")
-  end
-
-  # Populates the shared metadata cache through the real fetch path, with the
-  # relay response coming from Bypass. `fetch_recommendations_cached/3` keys on
-  # the provider type, id, media type and language but NOT the base URL, so the
-  # LiveView's own default config reads this entry back without any outbound
-  # request.
-  defp warm_recommendations_cache(tmdb_id, media_type, results) do
-    bypass = Bypass.open()
-    relay = Metadata.default_relay_config()
-    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
-
-    on_exit(fn ->
-      Cache.delete(
-        "recommendations:#{relay.type}:#{tmdb_id}:#{media_type}:#{relay.options.language}"
-      )
-    end)
-
-    path =
-      if media_type == :tv_show, do: "/tmdb/tv/shows/#{tmdb_id}", else: "/tmdb/movies/#{tmdb_id}"
-
-    Bypass.expect_once(bypass, "GET", path, fn conn ->
-      body = %{
-        "id" => tmdb_id,
-        "title" => "Source",
-        "recommendations" => %{
-          "page" => 1,
-          "results" => results,
-          "total_pages" => 1,
-          "total_results" => length(results)
-        }
-      }
-
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(body))
-    end)
-
-    {:ok, _results} =
-      Metadata.fetch_recommendations_cached(config, to_string(tmdb_id), media_type: media_type)
-
-    :ok
   end
 end

--- a/test/mydia_web/route_authorization_test.exs
+++ b/test/mydia_web/route_authorization_test.exs
@@ -15,6 +15,16 @@ defmodule MydiaWeb.RouteAuthorizationTest do
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
+
+  setup do
+    # "/" is DashboardLive.Index, which unconditionally loads both trending
+    # rails on connected mount, reached here by every role in both describe
+    # blocks below (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+    :ok
+  end
 
   # live_session :authenticated — guarded only by :ensure_authenticated
   @authenticated_routes ["/", "/movies", "/downloads", "/calendar"]

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -119,6 +119,24 @@ defmodule MydiaWeb.FeatureCase do
   end
 
   setup tags do
+    # Every :feature test module sets `async: false` (SQLite can't take
+    # concurrent writes), so exactly one of these setups runs at a time —
+    # the Application.put_env swap warm_trending_cache/2 does internally is
+    # safe here for that reason alone. DashboardLive.Index unconditionally
+    # loads both trending rails on connected mount, and many feature tests
+    # land there via the post-login redirect even when the test itself is
+    # about something else entirely, so this is warmed for every feature
+    # test rather than per file (#530). Empty results are fine: no feature
+    # test asserts on trending content, confirmed by grep across
+    # test/mydia_web/features/ before relying on it.
+    #
+    # library_picker_test.exs manages its own separate Bypass, its own
+    # metadata_relay_url, and its own Cache.clear() afterwards; its `setup`
+    # runs after this one (declared later in that file) and simply
+    # overwrites what this warms, so there is no conflict between the two.
+    Mydia.MetadataCacheHelpers.warm_trending_cache(:movie, [])
+    Mydia.MetadataCacheHelpers.warm_trending_cache(:tv_show, [])
+
     pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Mydia.Repo, shared: not tags[:async])
 
     on_exit(fn ->

--- a/test/support/metadata_cache_helpers.ex
+++ b/test/support/metadata_cache_helpers.ex
@@ -140,4 +140,146 @@ defmodule Mydia.MetadataCacheHelpers do
 
     :ok
   end
+
+  @doc """
+  Populates both cached entry points to the TMDB trending list for
+  `media_type` (`:movie` or `:tv_show`) with `results`.
+
+  `Mydia.Metadata.trending_movies/0`/`trending_tv_shows/0` (used by
+  `DashboardLive`) and `Mydia.Metadata.fetch_curated_list/2` called with
+  `:trending` (used by `DiscoverLive`'s default category) build the exact
+  same `/tmdb/movies|tv/trending` request but land in two different cache
+  keys, so both need warming or one of the two LiveViews still escapes.
+
+  Unlike `fetch_by_id_cached/3` and friends, neither cached function accepts
+  a config override, so this swaps `metadata_relay_url` for the duration of
+  the call instead of building a throwaway config struct.
+  """
+  def warm_trending_cache(media_type, results) do
+    bypass = Bypass.open()
+    previous_metadata_relay_url = Application.get_env(:mydia, :metadata_relay_url)
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+    trending_key = if media_type == :tv_show, do: "trending_tv_shows", else: "trending_movies"
+    curated_key = "curated:trending:#{media_type}:1"
+
+    on_exit(fn ->
+      Cache.delete(trending_key)
+      Cache.delete(curated_key)
+    end)
+
+    path = if media_type == :tv_show, do: "/tmdb/tv/trending", else: "/tmdb/movies/trending"
+
+    Bypass.expect(bypass, "GET", path, fn conn ->
+      body = %{
+        "page" => 1,
+        "total_pages" => 1,
+        "total_results" => length(results),
+        "results" => results
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    {:ok, _results} =
+      if media_type == :tv_show do
+        Metadata.trending_tv_shows()
+      else
+        Metadata.trending_movies()
+      end
+
+    {:ok, _curated} = Metadata.fetch_curated_list(:trending, media_type: media_type, page: 1)
+
+    case previous_metadata_relay_url do
+      nil -> Application.delete_env(:mydia, :metadata_relay_url)
+      value -> Application.put_env(:mydia, :metadata_relay_url, value)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Populates the TMDB genre-list cache for `media_type` (`:movie` or
+  `:tv_show`) with `genres` (raw TMDB genre maps, e.g.
+  `%{"id" => 28, "name" => "Action"}`).
+
+  `Mydia.Metadata.genres/1` (used by `DiscoverLive`) does not accept a config
+  override, so this swaps `metadata_relay_url` for the duration of the call,
+  same as `warm_trending_cache/2`.
+  """
+  def warm_genre_cache(media_type, genres) do
+    bypass = Bypass.open()
+    previous_metadata_relay_url = Application.get_env(:mydia, :metadata_relay_url)
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn -> Cache.delete("genres:#{media_type}") end)
+
+    path = if media_type == :tv_show, do: "/tmdb/genre/tv", else: "/tmdb/genre/movie"
+
+    Bypass.expect(bypass, "GET", path, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(%{"genres" => genres}))
+    end)
+
+    {:ok, _genres} = Metadata.genres(media_type)
+
+    case previous_metadata_relay_url do
+      nil -> Application.delete_env(:mydia, :metadata_relay_url)
+      value -> Application.put_env(:mydia, :metadata_relay_url, value)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Populates the movie search cache for `query` with `results`.
+
+  `results` are raw TMDB result maps with string keys, matching
+  `warm_recommendations_cache/3`. `opts` accepts `:year`, since both
+  `Mydia.Library.MetadataMatcher.search_external_movie/3` (the library
+  scanner) and callers of `Mydia.Metadata.search_cached/3` in general search
+  with the parsed release year when one is known, and the year rides in the
+  cache key.
+
+  Unlike `fetch_recommendations_cached/3`, `search_cached/3` takes a
+  `config` argument directly, so this follows the throwaway-config shape the
+  other helpers above use rather than the env-swap `warm_trending_cache/2`
+  and `warm_genre_cache/2` need.
+  """
+  def warm_movie_search_cache(query, opts, results) do
+    bypass = Bypass.open()
+    relay = Metadata.default_relay_config()
+    config = %{relay | base_url: "http://localhost:#{bypass.port}"}
+
+    year = Keyword.get(opts, :year)
+
+    # Mirrors the key search_cached/3 builds for these opts: no :provider or
+    # :language override, so provider defaults to the config type and
+    # language to the config's own.
+    on_exit(fn ->
+      Cache.delete("search:#{relay.type}:#{query}:movie:#{year}:#{relay.options.language}:1")
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/tmdb/movies/search", fn conn ->
+      body = %{
+        "page" => 1,
+        "total_pages" => 1,
+        "total_results" => length(results),
+        "results" => results
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+
+    search_opts = if year, do: [media_type: :movie, year: year], else: [media_type: :movie]
+
+    {:ok, _results} = Metadata.search_cached(config, query, search_opts)
+
+    :ok
+  end
 end

--- a/test/support/metadata_cache_helpers.ex
+++ b/test/support/metadata_cache_helpers.ex
@@ -170,31 +170,39 @@ defmodule Mydia.MetadataCacheHelpers do
 
     path = if media_type == :tv_show, do: "/tmdb/tv/trending", else: "/tmdb/movies/trending"
 
-    Bypass.expect(bypass, "GET", path, fn conn ->
-      body = %{
-        "page" => 1,
-        "total_pages" => 1,
-        "total_results" => length(results),
-        "results" => results
-      }
+    # try/after: a raise anywhere between the swap above and the restore
+    # below (Bypass.expect/4, or either fetch call) must not skip the
+    # restore, or the global metadata_relay_url is left pointing at a
+    # Bypass server that is about to close, and later unrelated tests read
+    # a dead URL from global config — precisely the cross-test pollution
+    # this whole branch exists to eliminate.
+    try do
+      Bypass.expect(bypass, "GET", path, fn conn ->
+        body = %{
+          "page" => 1,
+          "total_pages" => 1,
+          "total_results" => length(results),
+          "results" => results
+        }
 
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(body))
-    end)
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
 
-    {:ok, _results} =
-      if media_type == :tv_show do
-        Metadata.trending_tv_shows()
-      else
-        Metadata.trending_movies()
+      {:ok, _results} =
+        if media_type == :tv_show do
+          Metadata.trending_tv_shows()
+        else
+          Metadata.trending_movies()
+        end
+
+      {:ok, _curated} = Metadata.fetch_curated_list(:trending, media_type: media_type, page: 1)
+    after
+      case previous_metadata_relay_url do
+        nil -> Application.delete_env(:mydia, :metadata_relay_url)
+        value -> Application.put_env(:mydia, :metadata_relay_url, value)
       end
-
-    {:ok, _curated} = Metadata.fetch_curated_list(:trending, media_type: media_type, page: 1)
-
-    case previous_metadata_relay_url do
-      nil -> Application.delete_env(:mydia, :metadata_relay_url)
-      value -> Application.put_env(:mydia, :metadata_relay_url, value)
     end
 
     :ok
@@ -218,17 +226,21 @@ defmodule Mydia.MetadataCacheHelpers do
 
     path = if media_type == :tv_show, do: "/tmdb/genre/tv", else: "/tmdb/genre/movie"
 
-    Bypass.expect(bypass, "GET", path, fn conn ->
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(200, Jason.encode!(%{"genres" => genres}))
-    end)
+    # try/after: see the identical comment in warm_trending_cache/2 above —
+    # a raise between the swap and the restore must not skip the restore.
+    try do
+      Bypass.expect(bypass, "GET", path, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"genres" => genres}))
+      end)
 
-    {:ok, _genres} = Metadata.genres(media_type)
-
-    case previous_metadata_relay_url do
-      nil -> Application.delete_env(:mydia, :metadata_relay_url)
-      value -> Application.put_env(:mydia, :metadata_relay_url, value)
+      {:ok, _genres} = Metadata.genres(media_type)
+    after
+      case previous_metadata_relay_url do
+        nil -> Application.delete_env(:mydia, :metadata_relay_url)
+        value -> Application.put_env(:mydia, :metadata_relay_url, value)
+      end
     end
 
     :ok

--- a/test/support/relay_guard.ex
+++ b/test/support/relay_guard.ex
@@ -1,0 +1,40 @@
+defmodule Mydia.RelayGuard do
+  @moduledoc """
+  A Req adapter that refuses any request leaving this machine.
+
+  Installed globally from `test/test_helper.exs` with
+  `Req.default_options(adapter: __MODULE__)`. `Req.new/2` merges
+  `default_options()` before splitting `:adapter` out into the request struct,
+  so this reaches every `Req.new/1` call site with no change to `lib/`.
+
+  Loopback traffic goes to the real `Req.Finch` adapter, which is what keeps
+  Bypass working and leaves every `Mydia.MetadataCacheHelpers` warm call
+  untouched. Everything else is recorded and refused.
+
+  This exists because nothing else stopped it. `Mydia.Metadata.default_relay_config/0`
+  falls back to `https://relay.mydia.dev` in test, and the cache warming that
+  protects detail-page tests is opt-in and silent when forgotten (#530).
+  `Mydia.MetadataStub` does not help: it swaps the provider in
+  `Mydia.Metadata.Provider.Registry`, and these lookups call
+  `Metadata.fetch_*_cached` against a config map directly.
+  """
+
+  alias Mydia.RelayGuard.BlockedError
+  alias Mydia.RelayGuard.Escapes
+
+  @loopback_hosts ~w(localhost 127.0.0.1 ::1)
+
+  @doc "The Req adapter callback."
+  def run(%Req.Request{} = req) do
+    if loopback?(req.url.host) do
+      Req.Finch.run(req)
+    else
+      Escapes.record(req)
+      {req, %BlockedError{url: req.url}}
+    end
+  end
+
+  @doc "Whether `host` names this machine."
+  def loopback?(host) when host in @loopback_hosts, do: true
+  def loopback?(_host), do: false
+end

--- a/test/support/relay_guard.ex
+++ b/test/support/relay_guard.ex
@@ -24,9 +24,34 @@ defmodule Mydia.RelayGuard do
 
   @loopback_hosts ~w(localhost 127.0.0.1 ::1)
 
-  @doc "The Req adapter callback."
+  # RFC 2606 permanently reserves these TLDs for documentation and testing:
+  # no registry will ever delegate them, so a request to a host under one can
+  # never reach a real service. `example.com`/`.net`/`.org` are reserved
+  # *names* under the ordinary `.com`/`.net`/`.org` TLDs and DO resolve to
+  # real, internet-hosted servers today, so they are deliberately left off
+  # this list — matching them here would let real traffic out.
+  @reserved_tlds ~w(invalid test example)
+
+  # RFC 5737 reserves these three /24s for documentation. They are guaranteed
+  # non-routable, so a request to a literal address in one of them can never
+  # reach a real service — the connection black-holes or is refused locally.
+  # `Mydia.Plugins.Net.Gate.pin_url/2` rewrites a granted hostname to its
+  # resolved IP before building the request, so a test that resolves into one
+  # of these ranges (see `gate_test.exs`'s connect-timeout test) reaches this
+  # guard as the bare IP, never the hostname.
+  @reserved_ipv4_prefixes [{192, 0, 2}, {198, 51, 100}, {203, 0, 113}]
+
+  @doc """
+  The Req adapter callback.
+
+  A reserved host (see `reserved?/1`) is handed to the real adapter alongside
+  loopback traffic, on purpose: download-client and connect-timeout tests
+  point at these hosts specifically to exercise real connection-error
+  classification, and a genuine transport error is the whole point — which is
+  exactly what `BlockedError` is designed not to be.
+  """
   def run(%Req.Request{} = req) do
-    if loopback?(req.url.host) do
+    if loopback?(req.url.host) or reserved?(req.url.host) do
       Req.Finch.run(req)
     else
       Escapes.record(req)
@@ -37,4 +62,32 @@ defmodule Mydia.RelayGuard do
   @doc "Whether `host` names this machine."
   def loopback?(host) when host in @loopback_hosts, do: true
   def loopback?(_host), do: false
+
+  @doc """
+  Whether `host` is a reserved, non-routable placeholder rather than a real
+  destination: an RFC 2606 TLD (`.invalid`, `.test`, `.example`) or a literal
+  address in an RFC 5737 documentation range.
+  """
+  def reserved?(host) when is_binary(host) do
+    reserved_tld?(host) or reserved_ipv4?(host)
+  end
+
+  def reserved?(_host), do: false
+
+  # Matches on the final dot-separated label so `.test` matches `host.test`
+  # but not, say, "test.example.com" (whose final label is "com") or a host
+  # that merely contains the word "test" somewhere else.
+  defp reserved_tld?(host) do
+    host
+    |> String.split(".")
+    |> List.last()
+    |> then(&(&1 in @reserved_tlds))
+  end
+
+  defp reserved_ipv4?(host) do
+    case :inet.parse_ipv4_address(String.to_charlist(host)) do
+      {:ok, {a, b, c, _d}} -> {a, b, c} in @reserved_ipv4_prefixes
+      {:error, _reason} -> false
+    end
+  end
 end

--- a/test/support/relay_guard/blocked_error.ex
+++ b/test/support/relay_guard/blocked_error.ex
@@ -1,0 +1,27 @@
+defmodule Mydia.RelayGuard.BlockedError do
+  @moduledoc """
+  The value `Mydia.RelayGuard` returns when it refuses an outbound request.
+
+  Deliberately not a `Req.TransportError` or `Req.HTTPError`. Those are the two
+  shapes `Req.Steps.transient?/1` retries, and
+  `Mydia.Metadata.Provider.HTTP.new_request/1` sets `retry: :transient,
+  max_retries: 3`. A retried refusal would burn about 6.8 seconds of backoff and
+  blow the 5s `render_async` budget instead of failing immediately.
+  """
+
+  defexception [:url]
+
+  @impl true
+  def message(%__MODULE__{url: url}) do
+    """
+    Mydia.RelayGuard refused an outbound HTTP request to #{url.host}:
+
+        #{URI.to_string(url)}
+
+    Tests must not reach the network. Warm the metadata cache with
+    Mydia.MetadataCacheHelpers (warm_recommendations_cache/3,
+    warm_movie_details_cache/1, warm_collection_cache/2), or serve the response
+    from Bypass on localhost.
+    """
+  end
+end

--- a/test/support/relay_guard/blocked_error.ex
+++ b/test/support/relay_guard/blocked_error.ex
@@ -20,8 +20,9 @@ defmodule Mydia.RelayGuard.BlockedError do
 
     Tests must not reach the network. Warm the metadata cache with
     Mydia.MetadataCacheHelpers (warm_recommendations_cache/3,
-    warm_movie_details_cache/1, warm_collection_cache/2), or serve the response
-    from Bypass on localhost.
+    warm_movie_details_cache/1, warm_collection_cache/2, warm_trending_cache/2,
+    warm_genre_cache/2, warm_movie_search_cache/3), or serve the response from
+    Bypass on localhost.
     """
   end
 end

--- a/test/support/relay_guard/escapes.ex
+++ b/test/support/relay_guard/escapes.ex
@@ -77,6 +77,28 @@ defmodule Mydia.RelayGuard.Escapes do
   end
 
   @doc """
+  Removes every recorded row for `url`.
+
+  For a test that intentionally triggers a guard block as one of its own
+  assertions (`Mydia.RelayGuardTest`, `Mydia.RelayGuard.EscapesTest`): the row
+  it created is real, in the sense that the guard genuinely recorded it, but
+  it is not a real *application* escape, so it must not linger in the shared
+  table for the end-of-suite report to flag alongside genuinely unwarmed
+  lookups. Mirrors the `on_exit(fn -> Cache.delete(key) end)` convention
+  `Mydia.MetadataCacheHelpers` already uses for the cache it warms — clean up
+  only the row you wrote, never the whole table (that is what made the report
+  under-count real escapes in the first place, see `reset/0`'s callers before
+  #530's fix round 1).
+  """
+  def delete(url) when is_binary(url) do
+    if :ets.whereis(@table) != :undefined do
+      :ets.match_delete(@table, {:_, :_, url, :_})
+    end
+
+    :ok
+  end
+
+  @doc """
   The `Mydia.MetadataCacheHelpers` call that would have prevented this escape,
   or nil.
 

--- a/test/support/relay_guard/escapes.ex
+++ b/test/support/relay_guard/escapes.ex
@@ -22,6 +22,7 @@ defmodule Mydia.RelayGuard.Escapes do
   @tv_path ~r{^/tmdb/tv/shows/(?<id>\d+)}
 
   @app_prefixes ["Elixir.Mydia.", "Elixir.MydiaWeb."]
+  @self_prefix "Elixir.Mydia.RelayGuard."
 
   @doc "Creates the escape table. Idempotent."
   def setup do
@@ -44,7 +45,7 @@ defmodule Mydia.RelayGuard.Escapes do
   def record(%Req.Request{} = req) do
     if :ets.whereis(@table) != :undefined do
       frames = app_frames()
-      key = {req.method, req.url.host, req.url.path, List.first(frames)}
+      key = {req.method, req.url.host, req.url.path, req.url.query}
       default = {key, 0, URI.to_string(req.url), frames}
 
       :ets.update_counter(@table, key, {2, 1}, default)
@@ -79,11 +80,13 @@ defmodule Mydia.RelayGuard.Escapes do
   The `Mydia.MetadataCacheHelpers` call that would have prevented this escape,
   or nil.
 
-  `/tmdb/movies/:id` is reachable from two different lookups, so the calling
-  modules disambiguate it. Anything unrecognised returns nil: a wrong suggestion
-  is worse than none.
+  `/tmdb/movies/:id` is reachable from two different lookups, so the
+  `append_to_response` query parameter disambiguates them: an exact
+  `append_to_response=recommendations` value is the recommendations lookup,
+  anything else is the details lookup. Anything unrecognised returns nil: a
+  wrong suggestion is worse than none.
   """
-  def suggest(path, modules) when is_binary(path) and is_list(modules) do
+  def suggest(path, query) when is_binary(path) and (is_nil(query) or is_binary(query)) do
     cond do
       caps = Regex.named_captures(@collection_path, path) ->
         "warm_collection_cache(#{caps["id"]}, parts)"
@@ -92,14 +95,18 @@ defmodule Mydia.RelayGuard.Escapes do
         "warm_recommendations_cache(#{caps["id"]}, :tv_show, results)"
 
       caps = Regex.named_captures(@movie_path, path) ->
-        movie_suggestion(caps["id"], modules)
+        if recommendations_query?(query) do
+          "warm_recommendations_cache(#{caps["id"]}, :movie, results)"
+        else
+          "warm_movie_details_cache(#{caps["id"]})"
+        end
 
       true ->
         nil
     end
   end
 
-  def suggest(_path, _modules), do: nil
+  def suggest(_path, _query), do: nil
 
   @doc "The end-of-suite report."
   def format(escapes) do
@@ -117,24 +124,20 @@ defmodule Mydia.RelayGuard.Escapes do
     """
   end
 
-  defp movie_suggestion(id, modules) do
-    cond do
-      Mydia.Media.Recommendations in modules ->
-        "warm_recommendations_cache(#{id}, :movie, results)"
+  defp recommendations_query?(nil), do: false
 
-      Mydia.Media.Franchises in modules ->
-        "warm_movie_details_cache(#{id})"
-
-      true ->
-        nil
+  defp recommendations_query?(query) when is_binary(query) do
+    case URI.decode_query(query) do
+      %{"append_to_response" => "recommendations"} -> true
+      _other -> false
     end
   end
 
-  defp format_one({{method, _host, path, _frame}, count, url, frames}) do
-    modules = Enum.map(frames, fn {mod, _fun, _arity, _loc} -> mod end)
+  defp format_one({{method, _host, path, _query}, count, url, frames}) do
+    query = URI.parse(url).query
 
     fix =
-      case suggest(path, modules) do
+      case suggest(path, query) do
         nil -> ""
         call -> "\n      fix: #{call}\n"
       end
@@ -159,7 +162,7 @@ defmodule Mydia.RelayGuard.Escapes do
 
     frames
     |> Enum.filter(fn
-      {mod, _fun, _arity, _loc} -> app_module?(mod)
+      {mod, _fun, _arity, _loc} -> app_module?(mod) and not self_module?(mod)
       _other -> false
     end)
     |> Enum.take(5)
@@ -170,4 +173,10 @@ defmodule Mydia.RelayGuard.Escapes do
   end
 
   defp app_module?(_mod), do: false
+
+  defp self_module?(mod) when is_atom(mod) do
+    mod |> Atom.to_string() |> String.starts_with?(@self_prefix)
+  end
+
+  defp self_module?(_mod), do: false
 end

--- a/test/support/relay_guard/escapes.ex
+++ b/test/support/relay_guard/escapes.ex
@@ -1,0 +1,173 @@
+defmodule Mydia.RelayGuard.Escapes do
+  @moduledoc """
+  Records the outbound HTTP requests `Mydia.RelayGuard` refused, and formats the
+  end-of-suite report.
+
+  The table is public and named because an escape is recorded from whatever
+  process made the request, which for a detail-page lookup is a LiveView
+  `start_async` task rather than the test process. `test_helper.exs` sets
+  `max_cases` to `System.schedulers_online()` on PostgreSQL, so those writes are
+  genuinely concurrent.
+
+  The report names the *lookup*, not the test. A LiveView process in a connected
+  `Phoenix.LiveViewTest` mount is not a `$callers` descendant of the test
+  process, so there is no reliable way to attribute an escape to a test. The
+  app-only stack frames plus the nine-digit provider id are enough to find it.
+  """
+
+  @table :mydia_relay_guard_escapes
+
+  @collection_path ~r{^/tmdb/collections/(?<id>\d+)}
+  @movie_path ~r{^/tmdb/movies/(?<id>\d+)}
+  @tv_path ~r{^/tmdb/tv/shows/(?<id>\d+)}
+
+  @app_prefixes ["Elixir.Mydia.", "Elixir.MydiaWeb."]
+
+  @doc "Creates the escape table. Idempotent."
+  def setup do
+    case :ets.whereis(@table) do
+      :undefined ->
+        :ets.new(@table, [:set, :public, :named_table, write_concurrency: true])
+        :ok
+
+      _tid ->
+        :ok
+    end
+  end
+
+  @doc """
+  Records one refused request.
+
+  A no-op when the table does not exist, so `Mydia.RelayGuard` can be exercised
+  in isolation without suite-level setup.
+  """
+  def record(%Req.Request{} = req) do
+    if :ets.whereis(@table) != :undefined do
+      frames = app_frames()
+      key = {req.method, req.url.host, req.url.path, List.first(frames)}
+      default = {key, 0, URI.to_string(req.url), frames}
+
+      :ets.update_counter(@table, key, {2, 1}, default)
+    end
+
+    :ok
+  end
+
+  @doc "Every recorded escape, most frequent first."
+  def all do
+    case :ets.whereis(@table) do
+      :undefined ->
+        []
+
+      _tid ->
+        @table
+        |> :ets.tab2list()
+        |> Enum.sort_by(fn {_key, count, _url, _frames} -> -count end)
+    end
+  end
+
+  @doc "Empties the table."
+  def reset do
+    if :ets.whereis(@table) != :undefined do
+      :ets.delete_all_objects(@table)
+    end
+
+    :ok
+  end
+
+  @doc """
+  The `Mydia.MetadataCacheHelpers` call that would have prevented this escape,
+  or nil.
+
+  `/tmdb/movies/:id` is reachable from two different lookups, so the calling
+  modules disambiguate it. Anything unrecognised returns nil: a wrong suggestion
+  is worse than none.
+  """
+  def suggest(path, modules) when is_binary(path) and is_list(modules) do
+    cond do
+      caps = Regex.named_captures(@collection_path, path) ->
+        "warm_collection_cache(#{caps["id"]}, parts)"
+
+      caps = Regex.named_captures(@tv_path, path) ->
+        "warm_recommendations_cache(#{caps["id"]}, :tv_show, results)"
+
+      caps = Regex.named_captures(@movie_path, path) ->
+        movie_suggestion(caps["id"], modules)
+
+      true ->
+        nil
+    end
+  end
+
+  def suggest(_path, _modules), do: nil
+
+  @doc "The end-of-suite report."
+  def format(escapes) do
+    entries = Enum.map_join(escapes, "\n", &format_one/1)
+
+    """
+
+    ================================================================================
+    #{length(escapes)} outbound HTTP request(s) escaped to the network during this run.
+
+    Tests must not depend on the network. Warm the metadata cache with
+    Mydia.MetadataCacheHelpers, or serve the response from Bypass on localhost.
+    #{entries}
+    ================================================================================
+    """
+  end
+
+  defp movie_suggestion(id, modules) do
+    cond do
+      Mydia.Media.Recommendations in modules ->
+        "warm_recommendations_cache(#{id}, :movie, results)"
+
+      Mydia.Media.Franchises in modules ->
+        "warm_movie_details_cache(#{id})"
+
+      true ->
+        nil
+    end
+  end
+
+  defp format_one({{method, _host, path, _frame}, count, url, frames}) do
+    modules = Enum.map(frames, fn {mod, _fun, _arity, _loc} -> mod end)
+
+    fix =
+      case suggest(path, modules) do
+        nil -> ""
+        call -> "\n      fix: #{call}\n"
+      end
+
+    trace =
+      Enum.map_join(frames, "\n", fn {mod, fun, arity, loc} ->
+        file = Keyword.get(loc, :file, ~c"")
+        line = Keyword.get(loc, :line, 0)
+        "        #{inspect(mod)}.#{fun}/#{arity} #{file}:#{line}"
+      end)
+
+    """
+
+      #{method |> to_string() |> String.upcase()} #{url} (#{count}x)
+    #{fix}
+    #{trace}
+    """
+  end
+
+  defp app_frames do
+    {:current_stacktrace, frames} = Process.info(self(), :current_stacktrace)
+
+    frames
+    |> Enum.filter(fn
+      {mod, _fun, _arity, _loc} -> app_module?(mod)
+      _other -> false
+    end)
+    |> Enum.take(5)
+  end
+
+  defp app_module?(mod) when is_atom(mod) do
+    mod |> Atom.to_string() |> String.starts_with?(@app_prefixes)
+  end
+
+  defp app_module?(_mod), do: false
+end

--- a/test/support/relay_guard/escapes.ex
+++ b/test/support/relay_guard/escapes.ex
@@ -20,6 +20,9 @@ defmodule Mydia.RelayGuard.Escapes do
   @collection_path ~r{^/tmdb/collections/(?<id>\d+)}
   @movie_path ~r{^/tmdb/movies/(?<id>\d+)}
   @tv_path ~r{^/tmdb/tv/shows/(?<id>\d+)}
+  @trending_path ~r{^/tmdb/(?<kind>movies|tv)/trending$}
+  @genre_path ~r{^/tmdb/genre/(?<kind>movie|tv)$}
+  @movie_search_path ~r{^/tmdb/movies/search$}
 
   @app_prefixes ["Elixir.Mydia.", "Elixir.MydiaWeb."]
   @self_prefix "Elixir.Mydia.RelayGuard."
@@ -123,6 +126,15 @@ defmodule Mydia.RelayGuard.Escapes do
           "warm_movie_details_cache(#{caps["id"]})"
         end
 
+      caps = Regex.named_captures(@trending_path, path) ->
+        "warm_trending_cache(#{inspect(trending_media_type(caps["kind"]))}, results)"
+
+      caps = Regex.named_captures(@genre_path, path) ->
+        "warm_genre_cache(#{inspect(trending_media_type(caps["kind"]))}, genres)"
+
+      Regex.match?(@movie_search_path, path) ->
+        movie_search_suggestion(query)
+
       true ->
         nil
     end
@@ -144,6 +156,29 @@ defmodule Mydia.RelayGuard.Escapes do
     #{entries}
     ================================================================================
     """
+  end
+
+  # "tv" (trending) and "tv" (genre) both name the same media type; "movies"
+  # (trending, plural) and "movie" (genre, singular) both name the other.
+  # Neither regex's capture is ever anything else, so this has no fallback.
+  defp trending_media_type("tv"), do: :tv_show
+  defp trending_media_type(_movies_or_movie), do: :movie
+
+  # Unlike the by-id paths above, a movie search's cache key includes the
+  # query and the release year, both of which only exist in the query
+  # string, so there is no fixed suggestion — build one from what is there,
+  # or say nothing at all when the query cannot be parsed.
+  defp movie_search_suggestion(nil), do: nil
+
+  defp movie_search_suggestion(query) do
+    case URI.decode_query(query) do
+      %{"query" => q} = params when is_binary(q) ->
+        opts = if params["year"], do: "year: #{params["year"]}", else: ""
+        "warm_movie_search_cache(#{inspect(q)}, [#{opts}], results)"
+
+      _other ->
+        nil
+    end
   end
 
   defp recommendations_query?(nil), do: false

--- a/test/support/relay_guard/escapes.ex
+++ b/test/support/relay_guard/escapes.ex
@@ -174,6 +174,8 @@ defmodule Mydia.RelayGuard.Escapes do
 
   defp app_module?(_mod), do: false
 
+  defp self_module?(Mydia.RelayGuard), do: true
+
   defp self_module?(mod) when is_atom(mod) do
     mod |> Atom.to_string() |> String.starts_with?(@self_prefix)
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -15,6 +15,46 @@ max_cases =
 ExUnit.start(max_cases: max_cases, exclude: [:external, :feature, :requires_relay])
 Ecto.Adapters.SQL.Sandbox.mode(Mydia.Repo, :manual)
 
+# Refuse outbound HTTP. Nothing else stops a test reaching the production
+# metadata relay: Mydia.Metadata.default_relay_config/0 falls back to
+# relay.mydia.dev in test, and the cache warming that protects detail-page
+# tests is opt-in and silent when forgotten (#530).
+#
+# Skipped when the run explicitly opts into relay-touching tests, which are
+# excluded by default above. This disarms the guard for the whole run rather
+# than for the tagged tests alone: a per-test allowance would have to resolve
+# the current test from inside an arbitrary spawned process, and a LiveView
+# async task is not a $callers descendant of its test.
+relay_tags = [:external, :requires_relay]
+
+relay_tags_included? =
+  ExUnit.configuration()
+  |> Keyword.get(:include, [])
+  |> Enum.any?(fn
+    tag when is_atom(tag) -> tag in relay_tags
+    {tag, _value} -> tag in relay_tags
+    _other -> false
+  end)
+
+unless relay_tags_included? do
+  Mydia.RelayGuard.Escapes.setup()
+  Req.default_options(adapter: Mydia.RelayGuard)
+
+  ExUnit.after_suite(fn _results ->
+    case Mydia.RelayGuard.Escapes.all() do
+      [] ->
+        :ok
+
+      escapes ->
+        IO.puts(Mydia.RelayGuard.Escapes.format(escapes))
+
+        # ExUnit discards after_suite return values and exposes no hook to fail
+        # a run, so force the exit status here.
+        System.at_exit(fn _status -> exit({:shutdown, 1}) end)
+    end
+  end)
+end
+
 # Clear runtime config indexers, download clients, and media servers so tests
 # never accidentally hit real external services (e.g. Prowlarr from Docker env vars).
 # Tests that need indexers should create their own via Bypass + Settings.create_indexer_config.

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -27,16 +27,18 @@ Ecto.Adapters.SQL.Sandbox.mode(Mydia.Repo, :manual)
 # async task is not a $callers descendant of its test.
 relay_tags = [:external, :requires_relay]
 
-relay_tags_included? =
+included_tags =
   ExUnit.configuration()
   |> Keyword.get(:include, [])
-  |> Enum.any?(fn
-    tag when is_atom(tag) -> tag in relay_tags
-    {tag, _value} -> tag in relay_tags
-    _other -> false
+  |> Enum.map(fn
+    tag when is_atom(tag) -> tag
+    {tag, _value} -> tag
+    _other -> nil
   end)
 
-unless relay_tags_included? do
+relay_tags_included = Enum.filter(relay_tags, &(&1 in included_tags))
+
+if relay_tags_included == [] do
   Mydia.RelayGuard.Escapes.setup()
   Req.default_options(adapter: Mydia.RelayGuard)
 
@@ -53,6 +55,13 @@ unless relay_tags_included? do
         System.at_exit(fn _status -> exit({:shutdown, 1}) end)
     end
   end)
+else
+  # Defense in depth: this disarm is exactly the "silent when forgotten"
+  # failure mode the whole guard exists to close, so make the one deliberate
+  # case that reintroduces it loud instead (#530).
+  IO.puts(
+    "Mydia.RelayGuard is disarmed for this run: --include #{Enum.map_join(relay_tags_included, ", ", &inspect/1)} opted into relay-touching tests."
+  )
 end
 
 # Clear runtime config indexers, download clients, and media servers so tests


### PR DESCRIPTION
Closes #530.

## Why

`Mydia.Metadata.default_relay_config/0` falls back to `https://relay.mydia.dev` in the test environment, and nothing stopped a test from actually calling it. The protection that existed was opt-in and silent when forgotten: a test rendering a media detail page had to remember to warm the metadata cache, and forgetting produced no error, no warning and no failed assertion, just a network call whose latency landed inside a `render_async` budget.

That is #530, which failed on one CI job and passed on a rerun at an identical SHA.

`test/test_helper.exs` already cleared runtime-config indexers, download clients and media servers so that "tests never accidentally hit real external services". The metadata relay was left out of that net. This closes it.

## What

`Mydia.RelayGuard`, a test-only Req adapter installed globally from `test/test_helper.exs`:

```elixir
Req.default_options(adapter: Mydia.RelayGuard)
```

`Req.new/2` merges `default_options()` before splitting `:adapter` into the request struct, so this reaches every `Req.new/1` call site with **no changes to `lib/`**. Loopback and RFC-reserved hosts are delegated to the real `Req.Finch` adapter, so Bypass keeps working. Everything else is refused, recorded, and printed in an end-of-suite report that fails the run.

Two details that are load-bearing rather than incidental:

- **The refusal is a plain exception, deliberately not a `Req.TransportError`.** `Mydia.Metadata.Provider.HTTP.new_request/1` sets `retry: :transient, max_retries: 3`, and Req classifies transport errors as retryable. A retried refusal would burn roughly 6.8s of backoff and blow the same 5s `render_async` budget this fix exists to protect. The test for this asserts on the recorded hit count rather than elapsed time, so it cannot pass for the wrong reason.
- **The allowlist is a trust boundary and fails closed.** Only loopback, RFC 2606 reserved TLDs (`.invalid`, `.test`, `.example`) and RFC 5737 documentation ranges pass. `example.com`/`.net`/`.org` are deliberately excluded: they are reserved names but they resolve to real servers. Every malformed or ambiguous input falls toward blocking.

## What it found

Arming the guard surfaced real outbound traffic in the suite, all fixed here at the root rather than allowlisted:

- the crash-reporter queue POSTing telemetry to the production relay 18 times per run
- public-IP detection reaching `ifconfig.me` / `icanhazip.com` / `api.ipify.org`
- FlareSolverr health checks to container hostnames
- genuinely unwarmed relay lookups (trending, genre, searches), now warmed through new `MetadataCacheHelpers` helpers with matching `Escapes.suggest/2` patterns
- test fixtures using `example.com` as a placeholder

It also fixed the two files from the original issue, plus `RailPickerHostTest`, which had the same exposure.

## Verification

Full suite run on both adapters, checking the process exit code rather than the failure count:

| | exit | tests | failures | escape report |
|---|---|---|---|---|
| SQLite | 0 | 9673 | 0 | none |
| PostgreSQL | 0 | 9674 | 0 | none |

The guard was also verified to actually fire, by removing a warm call and confirming the run named the exact URL with the right `fix:` suggestion and exited non-zero. A guard never observed to fire is not a verified guard.

## Known residual risk

`Req.default_options/1` **replaces** rather than merges the global option list. Nothing calls it twice today, so the guard is safe, but future test-support code calling it for an unrelated reason would silently disarm the adapter for the rest of the run with no error. Worth knowing about, since a guard that degrades quietly is worse than no guard.

Running with `--include external` or `--include requires_relay` disarms the guard for the whole run by design; it now prints a line saying so instead of doing it silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by isolating external network interactions and using local responses where appropriate.
  * Added safeguards that detect unintended outbound requests during standard test runs.
  * Expanded coverage for request safety, blocked destinations, error handling, metadata caching, remote access, indexers, playback, and LiveView screens.
  * Reduced flaky behavior by warming required test data and disabling unnecessary public-service lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->