### PR TITLE
fix(import): create episodes the metadata provider is missing

### DIFF
--- a/lib/mydia/jobs/apply_import_groups.ex
+++ b/lib/mydia/jobs/apply_import_groups.ex
@@ -61,7 +61,7 @@ defmodule Mydia.Jobs.ApplyImportGroups do
       library_path_id
       |> accepted_groups()
       |> Enum.map(&apply_group(&1, page))
-      |> Enum.reject(&(&1 == :applied))
+      |> Enum.reject(&(&1 in [:applied, :vanished]))
 
     broadcast(library_path_id)
 
@@ -83,7 +83,7 @@ defmodule Mydia.Jobs.ApplyImportGroups do
     |> Repo.all()
   end
 
-  @spec apply_group(ImportGroup.t(), pos_integer()) :: :applied | :stuck
+  @spec apply_group(ImportGroup.t(), pos_integer()) :: :applied | :stuck | :vanished
   defp apply_group(%ImportGroup{} = group, page) do
     remaining = drain(group, ImportGroups.member_count(group.id), page)
     now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -92,9 +92,31 @@ defmodule Mydia.Jobs.ApplyImportGroups do
 
     group
     |> Ecto.Changeset.change(unresolved_count: remaining, status: status, updated_at: now)
-    |> Repo.update!()
+    |> Repo.update(stale_error_field: :id, stale_error_message: "vanished")
+    |> case do
+      {:ok, _group} ->
+        if status == "applied", do: :applied, else: :stuck
 
-    if status == "applied", do: :applied, else: :stuck
+      # The row went away while we were draining it, which
+      # `ImportGroups.clear_for_library/1` can do: its guard only refuses while
+      # an ImportRun is active, and this worker is not one. A deleted group has
+      # no work left, so reporting it stuck would burn the retry budget
+      # re-applying something that no longer exists.
+      {:error, %Ecto.Changeset{errors: [{:id, {"vanished", _}}]}} ->
+        Logger.info("Import group vanished mid-drain, nothing to apply",
+          import_group_id: group.id
+        )
+
+        :vanished
+
+      {:error, changeset} ->
+        Logger.error("Could not record an import group's outcome",
+          import_group_id: group.id,
+          errors: inspect(changeset.errors)
+        )
+
+        :stuck
+    end
   rescue
     error ->
       Logger.error("Applying an import group failed, leaving it accepted for retry",

--- a/lib/mydia/library/episode_minter.ex
+++ b/lib/mydia/library/episode_minter.ex
@@ -1,0 +1,126 @@
+defmodule Mydia.Library.EpisodeMinter do
+  @moduledoc """
+  Creates the episode rows a metadata provider is missing.
+
+  Mydia builds episodes from provider metadata, so a provider that has not yet
+  published a season leaves every file for it with no parent and on no surface.
+  TVDB 447978 sat five weeks behind its own broadcaster and stranded sixteen
+  files exactly that way.
+
+  Whether minting is allowed at all is not decided here. `FileIngest` owns that
+  through its policy: an accepted import run is `:create_items` and may mint, a
+  scheduled scan is `:local_only` and never does. This module decides only
+  whether a coordinate is *plausible* for this show.
+
+  ## The anchor
+
+  A misparse must not be able to invent an episode. Given `{max_season,
+  max_episode}` from `Media.episode_bounds/1`, minting requires:
+
+    * `season_number >= 1`, because season 0 specials are too ragged to guess at
+    * `season_number <= max_season + 1`, so season 4 on a show ending at 3
+      passes while a misparsed S99 does not
+    * `episode_number >= 1 and episode_number <= max(max_episode + 10, 30)`
+
+  The floor of 30 covers a show whose provider returned no episodes at all,
+  where a bare `max_episode + 10` would be a ceiling of 10 and would refuse a
+  legitimate 22 episode first season.
+
+  There is deliberately no per-group cap. The anchor already bounds the damage,
+  because a group of absurd files fails file by file.
+
+  The season ceiling is read fresh on every call, so importing seasons 4 and 5
+  together cascades: the season 4 rows land first and raise the ceiling for
+  season 5. Out of order, the season 5 files stay outstanding and the next pass
+  takes them, because `Jobs.ApplyImportGroups.drain/3` retries while it makes
+  progress.
+
+  ## Why the row is untagged
+
+  A minted row carries `provider_episode_id: nil`. `Media.fallback_by_number/2`
+  adopts an untagged row at matching coordinates when the provider later
+  publishes an episode carrying an id, so `Media.upsert_episodes_from_season/3`
+  updates these rows in place with the real title, air date and id rather than
+  inserting a second one. The file link, watch history and monitored flag ride
+  along.
+  """
+
+  require Logger
+
+  alias Mydia.Library.ReleaseParser.EpisodeTitle
+  alias Mydia.Media
+  alias Mydia.Media.{Episode, MediaItem}
+
+  @episode_margin 10
+  @episode_floor 30
+
+  @doc """
+  Whether `season_number`/`episode_number` is a plausible coordinate for this show.
+  """
+  @spec mintable?(MediaItem.t(), term(), term()) :: boolean()
+  def mintable?(%MediaItem{} = media_item, season_number, episode_number)
+      when is_integer(season_number) and is_integer(episode_number) do
+    {max_season, max_episode} = Media.episode_bounds(media_item.id)
+
+    season_number >= 1 and
+      season_number <= max_season + 1 and
+      episode_number >= 1 and
+      episode_number <= max(max_episode + @episode_margin, @episode_floor)
+  end
+
+  def mintable?(_media_item, _season_number, _episode_number), do: false
+
+  @doc """
+  Creates the episode when the coordinate is plausible.
+
+  Returns the existing row when one is already there, so a retried import does
+  not fight the `(media_item_id, season_number, episode_number)` unique index.
+  """
+  @spec mint(MediaItem.t(), term(), term(), String.t() | nil) ::
+          {:ok, Episode.t()} | {:error, :implausible} | {:error, Ecto.Changeset.t()}
+  def mint(%MediaItem{} = media_item, season_number, episode_number, filename) do
+    if mintable?(media_item, season_number, episode_number) do
+      case Media.get_episode_by_number(media_item.id, season_number, episode_number) do
+        nil -> create(media_item, season_number, episode_number, filename)
+        existing -> {:ok, existing}
+      end
+    else
+      Logger.info("Refusing to create an implausible episode",
+        media_item_id: media_item.id,
+        season: inspect(season_number),
+        episode: inspect(episode_number)
+      )
+
+      {:error, :implausible}
+    end
+  end
+
+  defp create(media_item, season_number, episode_number, filename) do
+    attrs = %{
+      media_item_id: media_item.id,
+      season_number: season_number,
+      episode_number: episode_number,
+      provider_episode_id: nil,
+      title: EpisodeTitle.extract(filename),
+      monitored: Media.should_monitor_new_episode?(media_item, season_number)
+    }
+
+    case Media.create_episode(attrs) do
+      {:ok, episode} ->
+        Logger.info("Created an episode the metadata provider is missing",
+          media_item_id: media_item.id,
+          season: season_number,
+          episode: episode_number
+        )
+
+        {:ok, episode}
+
+      {:error, changeset} ->
+        # A concurrent minter won the unique index. Its row is the answer.
+        case Media.get_episode_by_number(media_item.id, season_number, episode_number) do
+          nil -> {:error, changeset}
+          existing -> {:ok, existing}
+        end
+    end
+  end
+end

--- a/lib/mydia/library/episode_minter.ex
+++ b/lib/mydia/library/episode_minter.ex
@@ -15,7 +15,8 @@ defmodule Mydia.Library.EpisodeMinter do
   ## The anchor
 
   A misparse must not be able to invent an episode. Given `{max_season,
-  max_episode}` from `Media.episode_bounds/1`, minting requires:
+  max_episode}` from `Media.episode_bounds/1`, which excludes season 0 so a
+  special's episode number can never inflate the ceiling, minting requires:
 
     * `season_number >= 1`, because season 0 specials are too ragged to guess at
     * `season_number <= max_season + 1`, so season 4 on a show ending at 3

--- a/lib/mydia/library/file_ingest.ex
+++ b/lib/mydia/library/file_ingest.ex
@@ -165,8 +165,18 @@ defmodule Mydia.Library.FileIngest do
 
   defp link(media_file, match_result, opts) do
     config = Keyword.get(opts, :config) || Metadata.default_relay_config()
+    policy = Keyword.fetch!(opts, :policy)
 
-    case MetadataEnricher.enrich(match_result, config: config, media_file_id: media_file.id) do
+    enrich_opts = [
+      config: config,
+      media_file_id: media_file.id,
+      # The policy is the consent signal. `:create_items` means a user accepted
+      # this import, which is what authorises creating an episode the provider
+      # does not have. A scheduled scan is `:local_only` and never mints.
+      allow_episode_creation: policy == :create_items
+    ]
+
+    case MetadataEnricher.enrich(match_result, enrich_opts) do
       {:ok, media_item} ->
         confirm_association(media_file, media_item, match_result)
 

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -11,6 +11,7 @@ defmodule Mydia.Library.MetadataEnricher do
 
   require Logger
   alias Mydia.{Media, Metadata, Repo, Settings}
+  alias Mydia.Library.EpisodeMinter
   alias Mydia.Media.ExternalIds
   alias Mydia.Metadata.LanguageCode
   alias Mydia.Metadata.NfoWriter
@@ -39,6 +40,7 @@ defmodule Mydia.Library.MetadataEnricher do
       when not is_nil(provider_id) and not is_nil(provider_type) do
     config = Keyword.get(opts, :config, Metadata.default_relay_config())
     media_file_id = Keyword.get(opts, :media_file_id)
+    allow_episode_creation = Keyword.get(opts, :allow_episode_creation, false)
 
     media_type = determine_media_type(match_result)
 
@@ -89,9 +91,19 @@ defmodule Mydia.Library.MetadataEnricher do
                 title: media_item.title
               )
 
-              associate_file_with_target_episodes(media_item, match_result_with_file_id)
+              associate_file_with_target_episodes(
+                media_item,
+                match_result_with_file_id,
+                allow_episode_creation
+              )
             else
-              enrich_episodes(media_item, provider_id, config, match_result_with_file_id)
+              enrich_episodes(
+                media_item,
+                provider_id,
+                config,
+                match_result_with_file_id,
+                allow_episode_creation
+              )
             end
           end
 
@@ -421,7 +433,13 @@ defmodule Mydia.Library.MetadataEnricher do
       {:error, error}
   end
 
-  defp enrich_episodes(media_item, provider_id, config, match_result) do
+  defp enrich_episodes(
+         media_item,
+         provider_id,
+         config,
+         match_result,
+         allow_episode_creation
+       ) do
     Logger.debug("Fetching episodes for TV show",
       media_item_id: media_item.id,
       title: media_item.title
@@ -458,7 +476,7 @@ defmodule Mydia.Library.MetadataEnricher do
       end)
 
       # After all episodes are created, directly associate the file with the target episode(s)
-      associate_file_with_target_episodes(media_item, match_result)
+      associate_file_with_target_episodes(media_item, match_result, allow_episode_creation)
     else
       Logger.warning("No season information available",
         media_item_id: media_item.id
@@ -497,9 +515,10 @@ defmodule Mydia.Library.MetadataEnricher do
   defp associate_file_with_target_episodes(
          media_item,
          %{
-           parsed_info: %{season: season, episodes: episode_numbers},
+           parsed_info: %{season: season, episodes: episode_numbers} = parsed,
            media_file_id: media_file_id
-         }
+         },
+         allow_episode_creation
        )
        when is_binary(media_file_id) and is_list(episode_numbers) do
     Logger.debug("Associating file with target episodes via direct lookup",
@@ -514,10 +533,13 @@ defmodule Mydia.Library.MetadataEnricher do
     Enum.each(episode_numbers, fn episode_number ->
       case Media.get_episode_by_number(media_item.id, season, episode_number) do
         nil ->
-          Logger.warning("Target episode not found for file association",
-            media_item_id: media_item.id,
-            season: season,
-            episode: episode_number
+          maybe_mint_and_associate(
+            media_item,
+            season,
+            episode_number,
+            media_file_id,
+            Map.get(parsed, :original_filename),
+            allow_episode_creation
           )
 
         episode ->
@@ -526,7 +548,7 @@ defmodule Mydia.Library.MetadataEnricher do
     end)
   end
 
-  defp associate_file_with_target_episodes(_media_item, match_result) do
+  defp associate_file_with_target_episodes(_media_item, match_result, _allow) do
     # No media_file_id or parsed_info - nothing to associate
     Logger.debug("Skipping file association - no media_file_id or parsed episode info",
       has_media_file_id: Map.has_key?(match_result, :media_file_id),
@@ -534,6 +556,49 @@ defmodule Mydia.Library.MetadataEnricher do
     )
 
     :ok
+  end
+
+  # The provider does not have this episode. Creating it is allowed only on a
+  # user-accepted import (`FileIngest`'s `:create_items` policy), and only for a
+  # coordinate `EpisodeMinter` considers plausible for this show. Anything else
+  # keeps the old behaviour exactly: warn, leave the file orphaned, and let
+  # `FileIngest.confirm_association/3` write the reason onto the rank-0
+  # candidate so the inbox can show it.
+  defp maybe_mint_and_associate(
+         media_item,
+         season,
+         episode_number,
+         media_file_id,
+         filename,
+         true
+       ) do
+    case EpisodeMinter.mint(media_item, season, episode_number, filename) do
+      {:ok, episode} ->
+        associate_media_file_with_episode(episode, media_file_id)
+
+      {:error, reason} ->
+        Logger.warning("Could not create the missing episode for file association",
+          media_item_id: media_item.id,
+          season: season,
+          episode: episode_number,
+          reason: inspect(reason)
+        )
+    end
+  end
+
+  defp maybe_mint_and_associate(
+         media_item,
+         season,
+         episode_number,
+         _media_file_id,
+         _filename,
+         false
+       ) do
+    Logger.warning("Target episode not found for file association",
+      media_item_id: media_item.id,
+      season: season,
+      episode: episode_number
+    )
   end
 
   defp associate_media_file_with_episode(episode, media_file_id) do

--- a/lib/mydia/library/release_parser/episode_title.ex
+++ b/lib/mydia/library/release_parser/episode_title.ex
@@ -1,0 +1,76 @@
+defmodule Mydia.Library.ReleaseParser.EpisodeTitle do
+  @moduledoc """
+  Recovers the episode title that follows the `SxxEyy` marker in a filename.
+
+  `TitleAssembler.assemble/2` is not reusable here. It renders tokens whose
+  byte offset falls *before* a boundary, because it exists to recover the show
+  title preceding the episode marker. The episode title is on the other side of
+  that anchor.
+
+  The rule is the classifier's own output. In the metadata zone a token
+  receives candidates only when an anchor or the vocabulary recognised it, so
+  resolution, source, codec and release-group tokens carry candidates while
+  ordinary title words carry none. The unclassified run immediately after the
+  marker is therefore exactly the episode title, and a scene release with no
+  title yields nothing at all.
+
+  Kept deliberately separate from `TitleAssembler`: the show-title path is
+  covered by the corpus and parity gates, and widening it to serve a second
+  caller would put those gates at risk for no gain.
+  """
+
+  alias Mydia.Library.ReleaseParser.{Classifier, Token, Tokenizer}
+
+  @marker_labels [:episode_marker, :season_marker]
+
+  # `-` is not a tokenizer delimiter, so a dash-separated name leaves a bare
+  # `-` token at either end of the title run.
+  @leading_junk ~r/\A[\s\-_.,:;!?'"]+/u
+  @trailing_junk ~r/[\s\-_.,:;!?'"]+\z/u
+
+  @doc """
+  The episode title in `filename`, or `nil` when there is none to recover.
+  """
+  @spec extract(String.t() | nil) :: String.t() | nil
+  def extract(nil), do: nil
+
+  def extract(filename) when is_binary(filename) do
+    anchors = Tokenizer.anchor_positions(filename)
+
+    filename
+    |> Tokenizer.tokenize()
+    |> Classifier.classify(anchors)
+    |> after_episode_marker()
+    |> Enum.take_while(&unclassified?/1)
+    |> render()
+  end
+
+  # Drops everything up to and including the marker. `S04` and `E01` can arrive
+  # as two adjacent tokens, hence the second drop_while rather than one split.
+  defp after_episode_marker(tokens) do
+    case Enum.split_while(tokens, &(not marker?(&1))) do
+      {_before, []} -> []
+      {_before, [_marker | rest]} -> Enum.drop_while(rest, &marker?/1)
+    end
+  end
+
+  defp marker?(%Token{candidates: candidates}) do
+    Enum.any?(candidates, &(&1.label in @marker_labels))
+  end
+
+  defp unclassified?(%Token{candidates: []}), do: true
+  defp unclassified?(%Token{}), do: false
+
+  defp render([]), do: nil
+
+  defp render(tokens) do
+    tokens
+    |> Enum.map_join(" ", & &1.value)
+    |> String.replace(@leading_junk, "")
+    |> String.replace(@trailing_junk, "")
+    |> nil_if_empty()
+  end
+
+  defp nil_if_empty(""), do: nil
+  defp nil_if_empty(value), do: value
+end

--- a/lib/mydia/library/release_parser/episode_title.ex
+++ b/lib/mydia/library/release_parser/episode_title.ex
@@ -21,12 +21,35 @@ defmodule Mydia.Library.ReleaseParser.EpisodeTitle do
 
   alias Mydia.Library.ReleaseParser.{Classifier, Token, Tokenizer}
 
+  # `:season_marker` is part of `Candidate.label()`'s type, but
+  # `Classifier.classify/2` never emits it on this path — only anchor
+  # tagging (`:year` / `:resolution` / `:episode_marker`) and vocabulary
+  # lookups produce candidates here, and neither ever yields
+  # `:season_marker`. `Resolver`, a later stage this module never calls,
+  # is the only place that label appears. Kept in the list defensively.
   @marker_labels [:episode_marker, :season_marker]
 
+  # A single `SxxEyy` match can span more than one token: the tokenizer's
+  # marker regex allows `[-\s.]?` between `S` and `E` (and between a
+  # multi-episode tail like `.E06`), so a delimiter inside the match splits
+  # it across tokens. `Tokenizer.anchor_positions/1` records only the
+  # match's *starting* byte offset, and `Classifier.anchor_label_for/6`
+  # tags only the one token whose byte range contains that offset — so
+  # `S04.E01` tags `S04` and leaves `E01` with `candidates: []`,
+  # indistinguishable from a title word. After dropping the tagged marker
+  # token, also drop any immediately following bare season/episode
+  # fragments before treating the rest as title. This can also eat a
+  # genuine title that opens with a bare number directly adjacent to the
+  # marker (no separator token in between); that trade-off is accepted
+  # because the delimiter-split case is the common one.
+  @marker_fragment ~r/\A[SE]?\d{1,4}\z/i
+
   # `-` is not a tokenizer delimiter, so a dash-separated name leaves a bare
-  # `-` token at either end of the title run.
-  @leading_junk ~r/\A[\s\-_.,:;!?'"]+/u
-  @trailing_junk ~r/[\s\-_.,:;!?'"]+\z/u
+  # `-` token at either end of the title run. Dropped at the token level —
+  # never by trimming the joined string — so real punctuation that lives
+  # inside a token's value (a trailing `!` or `?`, neither a delimiter) is
+  # never touched.
+  @bare_punctuation ~r/\A[\s\-_.,:;!?'"]+\z/u
 
   @doc """
   The episode title in `filename`, or `nil` when there is none to recover.
@@ -45,12 +68,18 @@ defmodule Mydia.Library.ReleaseParser.EpisodeTitle do
     |> render()
   end
 
-  # Drops everything up to and including the marker. `S04` and `E01` can arrive
-  # as two adjacent tokens, hence the second drop_while rather than one split.
+  # Drops everything up to and including the classifier-tagged marker
+  # token, then any residual marker-fragment tokens left over when the
+  # tokenizer split a single `SxxEyy` match across more than one token.
   defp after_episode_marker(tokens) do
     case Enum.split_while(tokens, &(not marker?(&1))) do
-      {_before, []} -> []
-      {_before, [_marker | rest]} -> Enum.drop_while(rest, &marker?/1)
+      {_before, []} ->
+        []
+
+      {_before, [_marker | rest]} ->
+        rest
+        |> Enum.drop_while(&marker?/1)
+        |> Enum.drop_while(&marker_fragment?/1)
     end
   end
 
@@ -58,18 +87,29 @@ defmodule Mydia.Library.ReleaseParser.EpisodeTitle do
     Enum.any?(candidates, &(&1.label in @marker_labels))
   end
 
+  defp marker_fragment?(%Token{value: value}), do: String.match?(value, @marker_fragment)
+
   defp unclassified?(%Token{candidates: []}), do: true
   defp unclassified?(%Token{}), do: false
 
   defp render([]), do: nil
 
   defp render(tokens) do
-    tokens
-    |> Enum.map_join(" ", & &1.value)
-    |> String.replace(@leading_junk, "")
-    |> String.replace(@trailing_junk, "")
-    |> nil_if_empty()
+    case trim_bare_punctuation(tokens) do
+      [] -> nil
+      trimmed -> trimmed |> Enum.map_join(" ", & &1.value) |> nil_if_empty()
+    end
   end
+
+  defp trim_bare_punctuation(tokens) do
+    tokens
+    |> Enum.drop_while(&bare_punctuation?/1)
+    |> Enum.reverse()
+    |> Enum.drop_while(&bare_punctuation?/1)
+    |> Enum.reverse()
+  end
+
+  defp bare_punctuation?(%Token{value: value}), do: String.match?(value, @bare_punctuation)
 
   defp nil_if_empty(""), do: nil
   defp nil_if_empty(value), do: value

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -906,17 +906,24 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  The highest season and episode numbers recorded for a show.
+  The highest regular-season and episode numbers recorded for a show.
 
-  Returns `{0, 0}` for a show with no episodes so callers can treat the result
-  as a numeric ceiling with no nil branch. `max/1` over an integer column
-  behaves identically on SQLite and PostgreSQL.
+  Season 0 (specials) is excluded from the aggregate. This function exists to
+  bound plausible *regular-season* coordinates for `EpisodeMinter`, and
+  specials routinely carry episode numbers far outside that range -- a
+  special's episode number must never raise the ceiling used to judge a
+  regular-season file.
+
+  Returns `{0, 0}` for a show with no regular-season episodes so callers can
+  treat the result as a numeric ceiling with no nil branch. `max/1` over an
+  integer column behaves identically on SQLite and PostgreSQL.
   """
   @spec episode_bounds(binary()) :: {non_neg_integer(), non_neg_integer()}
   def episode_bounds(media_item_id) do
     {season, episode} =
       Episode
       |> where([e], e.media_item_id == ^media_item_id)
+      |> where([e], e.season_number > 0)
       |> select([e], {max(e.season_number), max(e.episode_number)})
       |> Repo.one() || {nil, nil}
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -906,6 +906,24 @@ defmodule Mydia.Media do
   end
 
   @doc """
+  The highest season and episode numbers recorded for a show.
+
+  Returns `{0, 0}` for a show with no episodes so callers can treat the result
+  as a numeric ceiling with no nil branch. `max/1` over an integer column
+  behaves identically on SQLite and PostgreSQL.
+  """
+  @spec episode_bounds(binary()) :: {non_neg_integer(), non_neg_integer()}
+  def episode_bounds(media_item_id) do
+    {season, episode} =
+      Episode
+      |> where([e], e.media_item_id == ^media_item_id)
+      |> select([e], {max(e.season_number), max(e.episode_number)})
+      |> Repo.one() || {nil, nil}
+
+    {season || 0, episode || 0}
+  end
+
+  @doc """
   Gets the next episode for the given episode.
   Returns the next episode in the same season if available,
   otherwise returns the first episode of the next season.

--- a/test/mydia/jobs/apply_import_groups_test.exs
+++ b/test/mydia/jobs/apply_import_groups_test.exs
@@ -478,4 +478,30 @@ defmodule Mydia.Jobs.ApplyImportGroupsTest do
 
     refute Repo.reload!(stuck_file).episode_id
   end
+
+  test "a group deleted mid-drain does not raise and is not reported as stuck", %{
+    library_path: lp
+  } do
+    scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{band: :ready})
+    {:ok, 1} = ImportGroups.accept(scope)
+
+    group_id = Repo.one!(ImportGroup).id
+
+    block_ref = MetadataStubProvider.block_next_season_fetch(self())
+    on_exit(fn -> MetadataStubProvider.clear_season_fetch_block(block_ref) end)
+
+    task =
+      Task.async(fn ->
+        perform_job(ApplyImportGroups, %{"library_path_id" => lp.id})
+      end)
+
+    assert_receive {:metadata_season_fetch_started, ^block_ref, fetch_pid}, 5_000
+
+    # What ImportGroups.clear_for_library/1 does while a drain is in flight.
+    Repo.delete_all(from(g in ImportGroup, where: g.id == ^group_id))
+
+    send(fetch_pid, {:release_metadata_season_fetch, block_ref})
+
+    assert :ok = Task.await(task, 5_000)
+  end
 end

--- a/test/mydia/library/episode_minter_test.exs
+++ b/test/mydia/library/episode_minter_test.exs
@@ -66,6 +66,15 @@ defmodule Mydia.Library.EpisodeMinterTest do
       refute EpisodeMinter.mintable?(show, 1, 31)
       refute EpisodeMinter.mintable?(show, 2, 1)
     end
+
+    test "a high-numbered special does not inflate the ceiling for a regular season" do
+      show = show_with_episodes([{1, 21}, {2, 21}, {3, 16}, {0, 187}])
+
+      # Without excluding season 0 from Media.episode_bounds/1, max_episode
+      # would be 187 and the ceiling max(187 + 10, 30) = 197 would accept
+      # this misparsed coordinate.
+      refute EpisodeMinter.mintable?(show, 4, 190)
+    end
   end
 
   describe "mint/4" do

--- a/test/mydia/library/episode_minter_test.exs
+++ b/test/mydia/library/episode_minter_test.exs
@@ -1,0 +1,105 @@
+defmodule Mydia.Library.EpisodeMinterTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Library.EpisodeMinter
+  alias Mydia.Media
+
+  defp show_with_episodes(coords) do
+    show = media_item_fixture(%{type: "tv_show", title: "Minter Show"})
+
+    for {season, episode} <- coords do
+      {:ok, _} =
+        Media.create_episode(%{
+          media_item_id: show.id,
+          season_number: season,
+          episode_number: episode
+        })
+    end
+
+    Media.get_media_item!(show.id)
+  end
+
+  describe "mintable?/3" do
+    setup do
+      %{show: show_with_episodes([{1, 21}, {2, 21}, {3, 16}])}
+    end
+
+    test "accepts the season after the last known one", %{show: show} do
+      assert EpisodeMinter.mintable?(show, 4, 1)
+    end
+
+    test "accepts an episode at the ceiling", %{show: show} do
+      assert EpisodeMinter.mintable?(show, 4, 31)
+    end
+
+    test "refuses a season two beyond the last known one", %{show: show} do
+      refute EpisodeMinter.mintable?(show, 5, 1)
+    end
+
+    test "refuses season zero", %{show: show} do
+      refute EpisodeMinter.mintable?(show, 0, 1)
+    end
+
+    test "refuses a negative season", %{show: show} do
+      refute EpisodeMinter.mintable?(show, -1, 1)
+    end
+
+    test "refuses an episode past the ceiling", %{show: show} do
+      refute EpisodeMinter.mintable?(show, 4, 32)
+    end
+
+    test "refuses episode zero", %{show: show} do
+      refute EpisodeMinter.mintable?(show, 4, 0)
+    end
+
+    test "refuses non-integer coordinates", %{show: show} do
+      refute EpisodeMinter.mintable?(show, nil, 1)
+      refute EpisodeMinter.mintable?(show, 4, nil)
+    end
+
+    test "a show with no episodes still accepts a full first season" do
+      show = show_with_episodes([])
+
+      assert EpisodeMinter.mintable?(show, 1, 22)
+      refute EpisodeMinter.mintable?(show, 1, 31)
+      refute EpisodeMinter.mintable?(show, 2, 1)
+    end
+  end
+
+  describe "mint/4" do
+    setup do
+      %{show: show_with_episodes([{1, 21}, {2, 21}, {3, 16}])}
+    end
+
+    test "creates an untagged episode carrying the filename title", %{show: show} do
+      assert {:ok, episode} =
+               EpisodeMinter.mint(show, 4, 1, "Show (2022) - S04E01 - La soirée pyjama.mkv")
+
+      assert episode.season_number == 4
+      assert episode.episode_number == 1
+      assert episode.title == "La soirée pyjama"
+      assert is_nil(episode.provider_episode_id)
+    end
+
+    test "creates a titleless episode for a scene release", %{show: show} do
+      assert {:ok, episode} =
+               EpisodeMinter.mint(show, 4, 2, "Show.S04E02.1080p.WEB-DL.x264-GRP.mkv")
+
+      assert is_nil(episode.title)
+    end
+
+    test "refuses an implausible coordinate without writing", %{show: show} do
+      assert {:error, :implausible} = EpisodeMinter.mint(show, 99, 1, "Show - S99E01.mkv")
+      assert is_nil(Media.get_episode_by_number(show.id, 99, 1))
+    end
+
+    test "returns the existing row when one is already there", %{show: show} do
+      {:ok, first} = EpisodeMinter.mint(show, 4, 3, "Show - S04E03 - La chorale.mkv")
+      assert {:ok, second} = EpisodeMinter.mint(show, 4, 3, "Show - S04E03 - La chorale.mkv")
+
+      assert first.id == second.id
+    end
+  end
+end

--- a/test/mydia/library/episode_minting_test.exs
+++ b/test/mydia/library/episode_minting_test.exs
@@ -69,4 +69,71 @@ defmodule Mydia.Library.EpisodeMintingTest do
 
     assert [%{rank: 0}] = Library.list_match_candidates(ctx.media_file.id)
   end
+
+  test "an accepted import takes the fast path when episodes already exist and still mints",
+       ctx do
+    title = MetadataStubProvider.series_title()
+
+    # Bootstrap the show through an ordinary first import, so it already has
+    # episodes before the S01E03 file below is ever ingested -- this is the
+    # production trigger: TVDB 447978 already had three published seasons
+    # when the season 4 files landed. `MetadataEnricher.enrich/2` only takes
+    # the fast path (`associate_file_with_target_episodes/3` directly) when
+    # `episodes_exist_for_show?/1` is already true at that moment, which the
+    # two other tests in this file never exercise -- both start from a show
+    # with no episodes at all and so only ever take the slow path
+    # (`enrich_episodes/5`).
+    bootstrap_filename = "#{title} - S01E01 - Pilot.mkv"
+
+    bootstrap_file =
+      orphaned_media_file_fixture(%{
+        library_path_id: ctx.library_path.id,
+        relative_path: "#{title}/Season 01/#{bootstrap_filename}"
+      })
+
+    bootstrap_match = %{
+      ctx.match
+      | parsed_info: %{
+          type: :tv_show,
+          season: 1,
+          episodes: [1],
+          original_filename: bootstrap_filename
+        }
+    }
+
+    assert {:linked, show} =
+             FileIngest.ingest(bootstrap_file, bootstrap_match, policy: :create_items)
+
+    # The stub's catalog carries two seasons, so the bootstrap's slow-path
+    # `enrich_episodes/5` fetched and upserted both: max season 2, max
+    # episode 2. This also confirms the S01E03 coordinate below is a
+    # plausible mint target: season 1 <= max_season(2) + 1, episode 3 <=
+    # max(2 + 10, 30).
+    assert Media.episode_bounds(show.id) == {2, 2}
+
+    # Poison the bootstrapped S01E01 row with a title the SLOW path's
+    # `upsert_episodes_from_season/3` would overwrite on its way through --
+    # it always writes `title: episode.name`, and the stub always answers
+    # "Stub Episode One" for season 1 episode 1 -- but that the FAST path's
+    # direct `Media.get_episode_by_number/3` lookup in
+    # `associate_file_with_target_episodes/3` never touches. Its survival
+    # below is the proof this test actually took the fast path rather than
+    # merely reaching the same end state by a different route.
+    s1e1 = Media.get_episode_by_number(show.id, 1, 1)
+    {:ok, _} = Media.update_episode(s1e1, %{title: "FAST-PATH-MARKER"})
+
+    assert {:linked, item} = FileIngest.ingest(ctx.media_file, ctx.match, policy: :create_items)
+    assert item.id == show.id
+
+    # The marker survived: enrich_episodes/5 (and its season re-fetch/upsert)
+    # never ran for this second ingest.
+    assert Media.get_episode_by_number(show.id, 1, 1).title == "FAST-PATH-MARKER"
+
+    episode = Media.get_episode_by_number(item.id, 1, 3)
+    refute is_nil(episode)
+    assert episode.title == "La chorale"
+    assert is_nil(episode.provider_episode_id)
+
+    assert Library.get_media_file!(ctx.media_file.id).episode_id == episode.id
+  end
 end

--- a/test/mydia/library/episode_minting_test.exs
+++ b/test/mydia/library/episode_minting_test.exs
@@ -1,0 +1,72 @@
+defmodule Mydia.Library.EpisodeMintingTest do
+  @moduledoc """
+  End-to-end cover for creating episodes the provider is missing.
+
+  Goes through `FileIngest.ingest/3` rather than calling the enricher directly,
+  because the policy is what authorises minting and `FileIngest` owns it.
+  """
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.MetadataStub
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library
+  alias Mydia.Library.FileIngest
+  alias Mydia.{Media, MetadataStubProvider, Repo}
+
+  setup :setup_metadata_stub
+
+  setup do
+    lp = library_path_fixture(%{type: "series", path: "/media/Series"})
+    title = MetadataStubProvider.series_title()
+    filename = "#{title} - S01E03 - La chorale.mkv"
+
+    file =
+      orphaned_media_file_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "#{title}/Season 01/#{filename}"
+      })
+
+    match = %{
+      provider_id: to_string(MetadataStubProvider.series_tvdb_id()),
+      provider_type: :tvdb,
+      title: title,
+      year: nil,
+      match_confidence: 1.0,
+      from_local_db: true,
+      parsed_info: %{
+        type: :tv_show,
+        season: 1,
+        episodes: [3],
+        original_filename: filename
+      }
+    }
+
+    {:ok, library_path: lp, media_file: Repo.preload(file, :library_path), match: match}
+  end
+
+  test "an accepted import creates the missing episode and links the file", ctx do
+    assert {:linked, item} = FileIngest.ingest(ctx.media_file, ctx.match, policy: :create_items)
+
+    episode = Media.get_episode_by_number(item.id, 1, 3)
+    refute is_nil(episode)
+    assert episode.title == "La chorale"
+    assert is_nil(episode.provider_episode_id)
+
+    assert Library.get_media_file!(ctx.media_file.id).episode_id == episode.id
+  end
+
+  test "a scheduled scan leaves the file orphaned with a reason", ctx do
+    assert {:error, {:not_associated, message}} =
+             FileIngest.ingest(ctx.media_file, ctx.match, policy: :local_only)
+
+    assert message =~ "season 1 episode 3 does not exist"
+
+    reloaded = Library.get_media_file!(ctx.media_file.id)
+    assert is_nil(reloaded.episode_id)
+    assert is_nil(reloaded.media_item_id)
+
+    assert [%{rank: 0}] = Library.list_match_candidates(ctx.media_file.id)
+  end
+end

--- a/test/mydia/library/release_parser/episode_title_test.exs
+++ b/test/mydia/library/release_parser/episode_title_test.exs
@@ -1,0 +1,39 @@
+defmodule Mydia.Library.ReleaseParser.EpisodeTitleTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.ReleaseParser.EpisodeTitle
+
+  describe "extract/1" do
+    test "recovers a dash-separated episode title" do
+      assert EpisodeTitle.extract(
+               "On joue! avec Biscuit et Cassonade (2022) - S04E03 - La chorale.mkv"
+             ) == "La chorale"
+    end
+
+    test "keeps accented multi-word titles intact" do
+      assert EpisodeTitle.extract("Show (2022) - S04E01 - La soirée pyjama.mkv") ==
+               "La soirée pyjama"
+    end
+
+    test "returns nil for a scene release carrying no title" do
+      assert EpisodeTitle.extract("Show.S04E01.1080p.WEB-DL.x264-GROUP.mkv") == nil
+    end
+
+    test "stops at the first release-metadata token" do
+      assert EpisodeTitle.extract("Show - S04E01 - La chorale - 1080p.WEB-DL.mkv") ==
+               "La chorale"
+    end
+
+    test "returns nil when nothing follows the marker" do
+      assert EpisodeTitle.extract("Show - S04E01.mkv") == nil
+    end
+
+    test "returns nil when there is no episode marker" do
+      assert EpisodeTitle.extract("Some Movie (2019) 1080p.mkv") == nil
+    end
+
+    test "returns nil for nil input" do
+      assert EpisodeTitle.extract(nil) == nil
+    end
+  end
+end

--- a/test/mydia/library/release_parser/episode_title_test.exs
+++ b/test/mydia/library/release_parser/episode_title_test.exs
@@ -35,5 +35,29 @@ defmodule Mydia.Library.ReleaseParser.EpisodeTitleTest do
     test "returns nil for nil input" do
       assert EpisodeTitle.extract(nil) == nil
     end
+
+    test "drops a residual episode fragment when '.' splits the marker" do
+      assert EpisodeTitle.extract("Show.S04.E01.Title.mkv") == "Title"
+    end
+
+    test "drops a residual episode fragment when whitespace splits the marker" do
+      assert EpisodeTitle.extract("Show S04 E01 - Title.mkv") == "Title"
+    end
+
+    test "drops a residual fragment from a multi-episode marker" do
+      assert EpisodeTitle.extract("Show.S02E05.E06.Title.mkv") == "Title"
+    end
+
+    test "keeps a trailing exclamation mark that belongs to the title" do
+      assert EpisodeTitle.extract("Show - S04E01 - Surprise!.mkv") == "Surprise!"
+    end
+
+    test "keeps a trailing question mark that belongs to the title" do
+      assert EpisodeTitle.extract("Show - S04E01 - Who Are You?.mkv") == "Who Are You?"
+    end
+
+    test "returns nil when only punctuation follows the marker" do
+      assert EpisodeTitle.extract("Show - S04E01 - !!!.mkv") == nil
+    end
   end
 end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -589,6 +589,75 @@ defmodule Mydia.MediaTest do
     end
   end
 
+  describe "upsert_episodes_from_season/3 adopts a minted episode" do
+    import Mydia.MediaFixtures
+
+    test "a provider catch-up adopts the minted row instead of duplicating it" do
+      # This is the load-bearing claim behind EpisodeMinter: a minted row
+      # carries `provider_episode_id: nil` precisely so that when the
+      # provider later publishes the season, the (season_number,
+      # episode_number) fallback in `fallback_by_number/2` adopts it in
+      # place instead of colliding with the unique index and leaving the
+      # file link stranded on a duplicate row. If this ever breaks, users
+      # get permanent duplicate episodes and the file link goes stale.
+      show = media_item_fixture(%{type: "tv_show", title: "Catch-Up"})
+
+      # Give the show a season the provider already has, so season 4 below
+      # is a plausible next season for the minter rather than a misparse.
+      episode_fixture(%{media_item_id: show.id, season_number: 3, episode_number: 8})
+
+      assert {:ok, minted} =
+               Mydia.Library.EpisodeMinter.mint(
+                 show,
+                 4,
+                 1,
+                 "Catch-Up - S04E01 - New Season Begins.mkv"
+               )
+
+      assert is_nil(minted.provider_episode_id)
+      assert minted.title == "New Season Begins"
+
+      # Attach a file to the minted row so its survival through the adoption
+      # can be proven, not just assumed.
+      media_file = media_file_fixture(%{episode_id: minted.id})
+
+      # The provider has now caught up and published season 4 with a real id.
+      season_data = %Mydia.Metadata.Structs.SeasonData{
+        season_number: 4,
+        episodes: [
+          %Mydia.Metadata.Structs.EpisodeData{
+            season_number: 4,
+            episode_number: 1,
+            provider_episode_id: "778899",
+            name: "New Season Begins (Official)"
+          }
+        ]
+      }
+
+      assert {:ok, 1} =
+               Media.upsert_episodes_from_season(show, season_data, monitor_new?: true)
+
+      # Exactly one row at these coordinates -- not two. A broken adoption
+      # would hit the unique index and get swallowed by
+      # `upsert_episodes_from_season/3`'s per-episode error handling,
+      # returning {:ok, 0} instead, or (if the unique index were somehow
+      # bypassed) would leave two rows here.
+      matching =
+        show.id
+        |> Media.list_episodes()
+        |> Enum.filter(&(&1.season_number == 4 and &1.episode_number == 1))
+
+      assert [adopted] = matching
+      assert adopted.id == minted.id
+      assert adopted.provider_episode_id == "778899"
+      assert adopted.title == "New Season Begins (Official)"
+
+      # The file link, made before the provider ever knew about this
+      # episode, survives the adoption untouched.
+      assert Mydia.Repo.get!(Mydia.Library.MediaFile, media_file.id).episode_id == adopted.id
+    end
+  end
+
   describe "episodes" do
     alias Mydia.Media.Episode
 

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -3201,5 +3201,27 @@ defmodule Mydia.MediaTest do
 
       assert Mydia.Media.episode_bounds(show.id) == {0, 0}
     end
+
+    test "a high-numbered special does not raise the regular-season ceiling" do
+      show = media_item_fixture(%{type: "tv_show", title: "Special-Heavy Show"})
+
+      for {season, episode} <- [{1, 1}, {2, 10}] do
+        {:ok, _} =
+          Mydia.Media.create_episode(%{
+            media_item_id: show.id,
+            season_number: season,
+            episode_number: episode
+          })
+      end
+
+      {:ok, _} =
+        Mydia.Media.create_episode(%{
+          media_item_id: show.id,
+          season_number: 0,
+          episode_number: 187
+        })
+
+      assert Mydia.Media.episode_bounds(show.id) == {2, 10}
+    end
   end
 end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -3108,4 +3108,29 @@ defmodule Mydia.MediaTest do
       assert id == show.id
     end
   end
+
+  describe "episode_bounds/1" do
+    import Mydia.MediaFixtures
+
+    test "returns the highest season and episode numbers" do
+      show = media_item_fixture(%{type: "tv_show", title: "Bounds Show"})
+
+      for {season, episode} <- [{1, 1}, {1, 21}, {2, 5}, {3, 16}] do
+        {:ok, _} =
+          Mydia.Media.create_episode(%{
+            media_item_id: show.id,
+            season_number: season,
+            episode_number: episode
+          })
+      end
+
+      assert Mydia.Media.episode_bounds(show.id) == {3, 21}
+    end
+
+    test "returns zeroes for a show with no episodes" do
+      show = media_item_fixture(%{type: "tv_show", title: "Empty Show"})
+
+      assert Mydia.Media.episode_bounds(show.id) == {0, 0}
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Mydia creates episode rows only from provider metadata. When TVDB lags a broadcaster, files for a season it has not published yet match the show fine but find no episode row to attach to. They end up in `media_files` with `episode_id` **and** `media_item_id` both NULL, which puts them on no surface at all: not the episode list, not the show page's Media Files card (it renders files with `media_item_id` set and `episode_id` nil), and not the import inbox.

Found on production. A user imported 16 files for season 4 of *On joue! avec Biscuit et Cassonade* and got silence. TVDB series 447978 lists official seasons 0-3, last touched 2026-01-03; the files are genuine episodes published 2026-02-11, carrying the same Télé-Québec Brightcove account as seasons 1-3 and an unbroken run of sequential video ids following season 3's block. The provider was simply five weeks behind.

The scan reproduced it exactly, sixteen times:

```
Matched On joue! avec Biscuit et Cassonade but season 4 episode 1
does not exist on it, so nothing was added.
```

## What this does

**Lets a user-accepted import create the missing episode rows.** Authorisation rides `FileIngest`'s existing policy rather than a new flag: `:create_items` may mint, `:local_only` never does. `policy_for/2` fails closed, so a scan of a library the user has not opted into cannot invent data behind them.

A new `EpisodeMinter` owns the decision and the write. Its plausibility anchor refuses a misparse: season must be at least 1 and no more than `max_season + 1`, episode no more than `max(max_episode + 10, 30)`. A show ending at season 3 accepts season 4; a misparsed S99 or a group claiming E400 does not. The floor of 30 covers a show whose provider returned nothing, where a bare margin would refuse a legitimate 22 episode first season.

A new `EpisodeTitle` recovers the episode name from the filename using the release parser's existing tokenizer and classifier, kept separate from `TitleAssembler` so the corpus and parity gates are not put at risk. No title recovered means nil, and the UI already renders "Episode N".

**Minted rows carry `provider_episode_id: nil`, and that is load-bearing.** `Media.fallback_by_number/2` adopts an untagged row at matching coordinates, so when TVDB does publish season 4, `upsert_episodes_from_season/3` updates these rows in place with the real title, air date and id instead of inserting duplicates. The file link, watch history and monitored flag ride along.

**Fixes a second defect that hid the first.** `ApplyImportGroups.apply_group/2` called `Repo.update!` on a group struct read before its drain, so a row deleted meanwhile raised `Ecto.StaleEntryError`, marked the group stuck, and burned Oban retries on a group that no longer existed. `ImportGroups.clear_for_library/1` can perform exactly that deletion, since its guard only refuses while an `ImportRun` is active and this worker is not one. Now the stale case is a value, not a raise, and a vanished group is not counted as stuck.

This is what erased every trace of those 16 files on production: the import group was built and accepted, the apply job crashed, and groups, runs and candidates were all gone afterwards.

## Behaviour when minting is refused

Unchanged from before. The file stays orphaned and the rank-0 `MatchCandidate` carries the existing message naming the season and episode, so the inbox can still show it.

## Notes

No migration; no schema changed. Already-orphaned rows are unaffected and re-match through the normal path on the next scan, which rebuilds the group so accepting it mints the episodes.

A scheduled scan of a library carrying `auto_import: true` also mints. That is deliberate: the flag is itself a per-library opt-in meaning "create items from what you find", and the anchor still bounds it.

## Testing

Full suite green: 9722 tests, 0 failures. Credo `--strict` clean.

New coverage includes the two paths the design rests on: that a minted row is adopted rather than duplicated when the provider catches up, and that minting works on the enricher's fast path, which is the route the production incident actually took since the show already had seasons 1-3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accepted imports can create missing episodes when provider data is unavailable.
  * Newly created episodes retain titles extracted from filenames and can be monitored automatically.
  * Later provider updates adopt previously created episodes without creating duplicates.

* **Bug Fixes**
  * Imports no longer retry or report groups that disappear during processing.
  * Local-only scans continue to avoid creating episodes.
  * Specials no longer affect regular-season episode matching limits.

* **Improvements**
  * Episode matching now supports plausible season and episode coordinates more reliably.
  * Episode titles are extracted more accurately from release filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->