### PR TITLE
fix(media): make the Media Files card usable on mobile

### DIFF
--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -879,11 +879,14 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             </summary>
             <ul class="menu bg-base-100 rounded-box p-0 mt-2">
               <li :for={file <- @extras} id={"extra-#{file.id}"}>
-                <div class="flex items-center justify-between gap-4 p-4 rounded-none">
-                  <div class="flex-1 min-w-0 flex flex-col gap-1">
-                    <p class="text-sm font-mono break-all">
-                      {Mydia.Library.MediaFile.display_path(file) ||
-                        Mydia.Library.MediaFile.display_name(file)}
+                <div class="flex flex-col gap-2 p-4 rounded-none sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+                  <div class="min-w-0 sm:flex-1 flex flex-col gap-1">
+                    <p
+                      id={"extra-name-#{file.id}"}
+                      class="text-sm font-mono truncate"
+                      title={Mydia.Library.MediaFile.display_path(file)}
+                    >
+                      {Mydia.Library.MediaFile.display_name(file)}
                     </p>
                     <div class="flex flex-wrap gap-2 text-xs text-base-content/60">
                       <span class="badge badge-ghost badge-sm">{file.extra_kind}</span>
@@ -896,7 +899,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   <button
                     id={"promote-#{file.id}"}
                     type="button"
-                    class="btn btn-ghost btn-sm"
+                    class="btn btn-ghost btn-sm self-end sm:self-auto"
                     title="This is a version, not an extra"
                     phx-click="promote_to_version"
                     phx-value-id={file.id}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -726,9 +726,9 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           <ul class="menu bg-base-100 rounded-box p-0">
             <li :for={file <- @versions} id={"version-#{file.id}"}>
               <div class="flex flex-col gap-3 p-4 hover:bg-base-200 rounded-none transition-colors">
-                <div class="flex items-start justify-between gap-4">
+                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
                   <%!-- Left side: File info --%>
-                  <div class="flex-1 min-w-0 flex flex-col gap-2">
+                  <div class="min-w-0 sm:flex-1 flex flex-col gap-2">
                     <%!-- File name. The full path lives on the title attribute
                           and in the file details modal. Rendered here it left
                           about 90px of column beside the button strip on a
@@ -769,13 +769,13 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                     />
                   </div>
                   <%!-- Right side: Icon-only action buttons --%>
-                  <div class="flex items-center gap-1 flex-shrink-0">
+                  <div class="flex items-center justify-end gap-1 flex-shrink-0">
                     <button
                       id={"subtitle-open-file-#{file.id}"}
                       type="button"
                       phx-click="open_subtitle_manage"
                       phx-value-media-file-id={file.id}
-                      class="btn btn-ghost btn-sm btn-square"
+                      class="btn btn-ghost btn-square sm:btn-sm"
                       aria-label="Manage subtitles"
                       title="Subtitles"
                     >
@@ -791,7 +791,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                         <div
                           tabindex="0"
                           role="button"
-                          class="btn btn-ghost btn-sm btn-square"
+                          class="btn btn-ghost btn-square sm:btn-sm"
                           title="Pre-transcode"
                         >
                           <.icon name="hero-wrench" class="w-5 h-5" />
@@ -817,7 +817,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="show_file_details"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-sm btn-square"
+                      class="btn btn-ghost btn-square sm:btn-sm"
                       aria-label="View file details"
                       title="View file details"
                     >
@@ -827,7 +827,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="mark_file_preferred"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-sm btn-square"
+                      class="btn btn-ghost btn-square sm:btn-sm"
                       aria-label="Mark this file as preferred"
                       title="Mark as preferred"
                     >
@@ -837,7 +837,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="show_file_delete_confirm"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-sm btn-square text-error hover:bg-error hover:text-error-content"
+                      class="btn btn-ghost btn-square sm:btn-sm text-error hover:bg-error hover:text-error-content"
                       aria-label="Delete this file"
                       title="Delete file"
                     >
@@ -846,7 +846,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                     <button
                       id={"demote-#{file.id}"}
                       type="button"
-                      class="btn btn-ghost btn-sm btn-square"
+                      class="btn btn-ghost btn-square sm:btn-sm"
                       title="This is an extra, not a version"
                       phx-click="demote_to_extra"
                       phx-value-id={file.id}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -722,11 +722,42 @@ defmodule MydiaWeb.MediaLive.Show.Components do
       <div id="media-files-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
         <div class="card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">Media Files</h2>
-          <%!-- DaisyUI list component --%>
-          <ul class="menu bg-base-100 rounded-box p-0">
-            <li :for={file <- @versions} id={"version-#{file.id}"}>
-              <div class="flex flex-col gap-3 p-4 hover:bg-base-200 rounded-none transition-colors">
-                <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+          <%!-- DaisyUI list component.
+
+                w-full and flex-nowrap on the <ul>, flex-nowrap on the <li>, and
+                items-stretch on the row div all override defaults that
+                DaisyUI's `.menu` component ships for its own reasons and that
+                fight the fixed-width row this card needs:
+
+                - `.menu` itself is `width: fit-content` and `flex-flow: column
+                  wrap` (so a plain sidebar menu hugs its content and can spill
+                  into extra columns rather than stretch full width). With an
+                  82-char unbroken basename below in a `truncate` label, that
+                  let the whole <ul> grow to the label's max-content width
+                  (measured 712px against a 351px card) instead of the
+                  available column width, so `truncate` had nothing to clip
+                  against and the page scrolled horizontally. w-full pins the
+                  <ul> to the card's width; flex-nowrap stops it from opening
+                  a second content-sized column instead of shrinking.
+                - `.menu li` inherits the same `flex-flow: column wrap`, so
+                  without its own flex-nowrap the <li> repeats the same
+                  content-sized-column trick one level down.
+                - DaisyUI's `:where(li > :not(ul,menu,details,.menu-title,.btn))`
+                  selector sets `align-items: center` on any plain <div> child
+                  of <li> (styling meant for a menu item's icon+label row),
+                  which stops that div from stretching its own child to the
+                  row's width. items-stretch overrides it back to the default
+                  so the info block underneath can actually be squeezed down
+                  to a fixed width and truncate the filename.
+
+                Measured before/after at 375px: row width 712.5px -> 319px
+                (card clientWidth 351px), label no longer forced wide,
+                `label.scrollWidth > label.clientWidth` false -> true (it now
+                genuinely clips), no more horizontal document scroll. --%>
+          <ul class="menu w-full flex-nowrap bg-base-100 rounded-box p-0">
+            <li :for={file <- @versions} id={"version-#{file.id}"} class="min-w-0 flex-nowrap">
+              <div class="min-w-0 items-stretch flex flex-col gap-3 p-4 hover:bg-base-200 rounded-none transition-colors">
+                <div class="min-w-0 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
                   <%!-- Left side: File info --%>
                   <div class="min-w-0 sm:flex-1 flex flex-col gap-2">
                     <%!-- File name. The full path lives on the title attribute
@@ -877,9 +908,13 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             <summary class="cursor-pointer text-sm font-medium text-base-content/70 hover:text-base-content">
               Extras ({length(@extras)})
             </summary>
-            <ul class="menu bg-base-100 rounded-box p-0 mt-2">
-              <li :for={file <- @extras} id={"extra-#{file.id}"}>
-                <div class="flex flex-col gap-2 p-4 rounded-none sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+            <%!-- Same w-full/flex-nowrap/items-stretch overrides as the versions
+                  <ul> above, and for the same reason: without them this list
+                  grows to its longest unbroken filename instead of the card's
+                  width. --%>
+            <ul class="menu w-full flex-nowrap bg-base-100 rounded-box p-0 mt-2">
+              <li :for={file <- @extras} id={"extra-#{file.id}"} class="min-w-0 flex-nowrap">
+                <div class="min-w-0 items-stretch flex flex-col gap-2 p-4 rounded-none sm:flex-row sm:items-center sm:justify-between sm:gap-4">
                   <div class="min-w-0 sm:flex-1 flex flex-col gap-1">
                     <p
                       id={"extra-name-#{file.id}"}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -934,7 +934,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   <button
                     id={"promote-#{file.id}"}
                     type="button"
-                    class="btn btn-ghost btn-sm self-end sm:self-auto"
+                    class="btn btn-ghost self-end sm:self-auto sm:btn-sm"
                     title="This is a version, not an extra"
                     phx-click="promote_to_version"
                     phx-value-id={file.id}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -729,15 +729,20 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                 <div class="flex items-start justify-between gap-4">
                   <%!-- Left side: File info --%>
                   <div class="flex-1 min-w-0 flex flex-col gap-2">
-                    <%!-- File path --%>
+                    <%!-- File name. The full path lives on the title attribute
+                          and in the file details modal. Rendered here it left
+                          about 90px of column beside the button strip on a
+                          375px phone, and break-all shredded it into a tall
+                          narrow stack of characters rather than clipping. --%>
                     <% file_path = Mydia.Library.MediaFile.display_path(file) %>
                     <p
-                      class="text-sm font-mono text-base-content break-all leading-relaxed"
+                      id={"file-name-#{file.id}"}
+                      class="text-sm font-mono text-base-content truncate leading-relaxed"
                       title={file_path}
                     >
                       <%!-- display_name/1 is the "Unknown file" label when there is no path,
                             so an orphaned row reads the same here as everywhere else. --%>
-                      {file_path || Mydia.Library.MediaFile.display_name(file)}
+                      {Mydia.Library.MediaFile.display_name(file)}
                     </p>
                     <%!-- Technical details with quality badge --%>
                     <div class="flex flex-wrap gap-4 text-xs text-base-content/70 items-center">

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -744,18 +744,27 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                             so an orphaned row reads the same here as everywhere else. --%>
                       {Mydia.Library.MediaFile.display_name(file)}
                     </p>
-                    <%!-- Technical details with quality badge --%>
-                    <div class="flex flex-wrap gap-4 text-xs text-base-content/70 items-center">
+                    <%!-- Technical details with quality badge. gap-x-3 rather
+                          than gap-4: four short badges do not need 16px of
+                          separation, and on a phone that gap forces a ragged
+                          wrap. Codec names run through shorten_codec/1, the
+                          same helper episode_file_row/1 uses. --%>
+                    <div
+                      id={"file-meta-#{file.id}"}
+                      class="flex flex-wrap gap-x-3 gap-y-1.5 text-xs text-base-content/70 items-center"
+                    >
                       <span class="badge badge-primary badge-sm">
                         {file.resolution || "Unknown"}
                       </span>
                       <div class="flex items-center gap-1.5">
                         <.icon name="hero-film" class="w-3.5 h-3.5" />
-                        <span>{file.codec || "Unknown"}</span>
+                        <span title={file.codec}>{shorten_codec(file.codec) || "Unknown"}</span>
                       </div>
                       <div class="flex items-center gap-1.5">
                         <.icon name="hero-speaker-wave" class="w-3.5 h-3.5" />
-                        <span>{file.audio_codec || "Unknown"}</span>
+                        <span title={file.audio_codec}>
+                          {shorten_codec(file.audio_codec) || "Unknown"}
+                        </span>
                       </div>
                       <div class="flex items-center gap-1.5">
                         <.icon name="hero-circle-stack" class="w-3.5 h-3.5" />

--- a/lib/mydia_web/live/media_live/show/modals.ex
+++ b/lib/mydia_web/live/media_live/show/modals.ex
@@ -250,8 +250,12 @@ defmodule MydiaWeb.MediaLive.Show.Modals do
           <%!-- File Path --%>
           <div>
             <h4 class="text-sm font-semibold text-base-content/70 mb-2">File Path</h4>
+            <%!-- display_path/1 returns nil for a fully orphaned row, which
+                  rendered an empty box. This modal is the only surface showing
+                  a full path now that the card labels rows by basename. --%>
             <p class="text-sm font-mono bg-base-200 p-3 rounded-box break-all">
-              {Mydia.Library.MediaFile.absolute_path(@file_details)}
+              {Mydia.Library.MediaFile.display_path(@file_details) ||
+                Mydia.Library.MediaFile.display_name(@file_details)}
             </p>
           </div>
           <%!-- Quality Information --%>

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -52,6 +52,24 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
     }
   end
 
+  # The full path is on the label's title attribute, so `html =~ path` passes
+  # even when the visible text is wrong. Query the element and read its text.
+  defp element_text(html, id) do
+    html
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("##{id}")
+    |> LazyHTML.text()
+    |> String.trim()
+  end
+
+  defp element_title(html, id) do
+    html
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("##{id}")
+    |> LazyHTML.attribute("title")
+    |> List.first()
+  end
+
   describe "media_files_section/1" do
     test "renders a movie's own files" do
       media_item = %{
@@ -63,6 +81,40 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
 
       assert html =~ "The.Matrix.1999.1080p.mkv"
       assert html =~ ~s|phx-value-file-id="mf-1"|
+    end
+
+    test "labels a version with its basename, not its full path" do
+      media_item = %{
+        media_files: [file("mf-1", "The Matrix (1999)/The.Matrix.1999.1080p.mkv")],
+        episodes: []
+      }
+
+      html = section_html(media_item)
+
+      assert element_text(html, "file-name-mf-1") == "The.Matrix.1999.1080p.mkv"
+    end
+
+    test "carries a version's full path on the label's title attribute" do
+      media_item = %{
+        media_files: [file("mf-1", "The Matrix (1999)/The.Matrix.1999.1080p.mkv")],
+        episodes: []
+      }
+
+      html = section_html(media_item)
+
+      assert element_title(html, "file-name-mf-1") ==
+               "/media/The Matrix (1999)/The.Matrix.1999.1080p.mkv"
+    end
+
+    test "does not render a version's directory as visible text" do
+      media_item = %{
+        media_files: [file("mf-1", "The Matrix (1999)/The.Matrix.1999.1080p.mkv")],
+        episodes: []
+      }
+
+      html = section_html(media_item)
+
+      refute element_text(html, "file-name-mf-1") =~ "The Matrix (1999)/"
     end
 
     # This card shows the item's *own* files. An episode's file already renders

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -209,6 +209,26 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
 
       assert meta =~ "Unknown"
     end
+
+    test "labels an extra with its basename and keeps the path on title" do
+      extra = %{
+        file("mf-x", "The Matrix (1999)/Featurettes/Making.Of.mkv")
+        | extra_kind: :featurette,
+          extra_source: :filename
+      }
+
+      # Both are Ecto.Enum fields, so production rows hold atoms. A bare struct
+      # does not validate, so string values would render fine here and hide the
+      # mismatch. Valid extra_kind values come from MediaFile.extra_kinds/0;
+      # extra_source is one of :folder, :filename, :duration, :operator.
+
+      html = section_html(%{media_files: [extra], episodes: []})
+
+      assert element_text(html, "extra-name-mf-x") == "Making.Of.mkv"
+
+      assert element_title(html, "extra-name-mf-x") ==
+               "/media/The Matrix (1999)/Featurettes/Making.Of.mkv"
+    end
   end
 
   describe "refresh_all_file_metadata/2" do

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -184,6 +184,31 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
       assert html =~ "Unknown file"
       assert html =~ ~s|phx-value-file-id="mf-broken"|
     end
+
+    test "shortens long codec names in the metadata row" do
+      long_codec = %{
+        file("mf-1", "Movie (2020)/movie.mkv")
+        | codec: "hevc (Main 10)",
+          audio_codec: "Dolby Digital Plus"
+      }
+
+      meta =
+        element_text(section_html(%{media_files: [long_codec], episodes: []}), "file-meta-mf-1")
+
+      assert meta =~ "DD+"
+      assert meta =~ "hevc"
+      refute meta =~ "Dolby Digital Plus"
+      refute meta =~ "Main 10"
+    end
+
+    test "still labels a missing codec Unknown" do
+      no_codec = %{file("mf-1", "Movie (2020)/movie.mkv") | codec: nil, audio_codec: nil}
+
+      meta =
+        element_text(section_html(%{media_files: [no_codec], episodes: []}), "file-meta-mf-1")
+
+      assert meta =~ "Unknown"
+    end
   end
 
   describe "refresh_all_file_metadata/2" do

--- a/test/mydia_web/live/media_live/show/modals_test.exs
+++ b/test/mydia_web/live/media_live/show/modals_test.exs
@@ -87,6 +87,42 @@ defmodule MydiaWeb.MediaLive.Show.ModalsTest do
     end
   end
 
+  describe "file_details_modal/1 file path" do
+    test "names an orphaned file instead of rendering a blank path" do
+      orphaned = %MediaFile{
+        id: "mf-orphan",
+        path: nil,
+        relative_path: nil,
+        library_path: nil,
+        resolution: nil,
+        codec: nil,
+        audio_codec: nil,
+        size: nil
+      }
+
+      html = render_component(&Modals.file_details_modal/1, file_details: orphaned)
+
+      assert html =~ "Unknown file"
+    end
+
+    test "renders the absolute path of a resolvable file" do
+      resolvable = %MediaFile{
+        id: "mf-ok",
+        path: nil,
+        relative_path: "Movie (2020)/movie.mkv",
+        library_path: %LibraryPath{path: "/movies"},
+        resolution: "1080p",
+        codec: "hevc",
+        audio_codec: "eac3",
+        size: 1_000
+      }
+
+      html = render_component(&Modals.file_details_modal/1, file_details: resolvable)
+
+      assert html =~ "/movies/Movie (2020)/movie.mkv"
+    end
+  end
+
   describe "reidentify_modal/1" do
     test "renders candidates with selectable buttons wired to the select event" do
       html =


### PR DESCRIPTION
The Media Files card on a movie page rendered each file's full absolute path in `font-mono break-all` inside a flex row next to a fixed ~200px strip of six icon buttons, at every viewport width. On a 375px phone that left the path roughly 90px of column, where `break-all` shredded it into a tall stack of single characters beside 32px buttons too small to hit.

Rows now show the basename with `truncate`, carrying the full path on a `title` attribute. The full path is still rendered in the file details modal that every row already links to. Below the `sm:` breakpoint the button strip drops to its own full-width line and the icon buttons grow from 32px to daisyUI's default 40px.

Also here: the metadata row's `gap-4` becomes `gap-x-3`, codec names run through the existing `shorten_codec/1` helper so "Dolby Digital Plus" renders as "DD+", the extras list gets the same treatment, and the details modal falls back to "Unknown file" instead of rendering a blank path box for an orphaned row.

## A regression that only measurement caught

The first five commits introduced a worse bug than the one being fixed, and it took driving a real browser to see it. `truncate` sets `white-space: nowrap`, which only clips against a width-constrained ancestor. daisyUI's `.menu` ships `width: fit-content; flex-flow: column wrap`, so an unbreakable 82-character basename inflated the row to 712px against a 351px card and gave the whole page a horizontal scrollbar on mobile. The original `break-all` was ugly, but it wrapped, so it never overflowed.

Every other non-popover `.menu` list in this codebase already carries `w-full`; these two lists were the anomaly. The last commit adds that, plus `flex-nowrap` and `items-stretch` to defeat the inherited wrap and a daisyUI selector forcing `align-items: center`.

## Measured in headless Chromium

375x812, versions row, on a file with an 82-character basename:

| | before | after five commits | shipped |
|---|---|---|---|
| label height (line height 22.75) | 386.75 (~17 lines) | 22.75 (1 line) | 22.75 (1 line) |
| label actually clips | no, wraps | **no, inflates** | **yes** |
| row width vs card clientWidth 351 | 319 | **712.5** | 319 |
| document scrolls horizontally | no | **yes** | no |
| icon buttons | 32x32 | 40x40 | 40x40 |

Extras row: 569.7 to 319 against the same 351px card.

1440x900 desktop: row still side-by-side, buttons back to 32x32, row 728 vs card 776, no scroll.

The probe was falsified before being trusted: run against the pre-change markup it throws its "target missing" error, and an adapted probe reproduces the old 17-line, 32px, no-scroll numbers.

## Tests

31 component tests across `media_files_section_test.exs` and `modals_test.exs`; 462 tests green across `test/mydia_web/live/media_live/`. The new tests query the label element and read its text and `title` separately, because a whole-document substring assert is satisfied by the `title` attribute alone and would pass even when the visible text is wrong.

`episode_file_row/1` is deliberately untouched: it already renders a truncated basename and degrades correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Media file lists now fit within their cards without expanding for long filenames.
  - Filenames display compactly, with the full path available on hover.
  - Codec information is shortened for readability, with “Unknown” shown when unavailable.
  - File action buttons and technical details have improved responsive spacing and alignment.
  - File details show the full path when available and clearly identify orphaned files.

- **Tests**
  - Added coverage for filename display, paths, codec labels, extra files, and orphaned media files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->