### PR TITLE
fix(player): drop the AndroidOptions parameter flutter_secure_storage 11 removed

### DIFF
--- a/player/lib/core/storage/secure_storage_options.dart
+++ b/player/lib/core/storage/secure_storage_options.dart
@@ -6,10 +6,15 @@ library;
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-/// Android: use the EncryptedSharedPreferences backend.
-const kAndroidSecureStorageOptions = AndroidOptions(
-  encryptedSharedPreferences: true,
-);
+/// Android: the package's default backend.
+///
+/// This used to pass `encryptedSharedPreferences: true`, selecting the Jetpack
+/// Security backend. `flutter_secure_storage` 11.0.0 removed that backend and
+/// the parameter with it: v10 migrated any data it held into the custom cipher
+/// storage that is now the only Android implementation, so there is nothing
+/// left to opt into and no replacement to pass. The constant stays so both call
+/// sites keep a single place to change if Android ever needs an option again.
+const kAndroidSecureStorageOptions = AndroidOptions();
 
 /// macOS: use the legacy file-based login keychain, not the data-protection
 /// keychain.


### PR DESCRIPTION
## What broke

`master`'s Docker image has been failing since 2026-08-29, both the `sqlite` and `postgres` variants, in the Flutter stage:

```
Target dart2js failed: ProcessException: Process exited abnormally with exit code 1:
Error: No named parameter with the name 'encryptedSharedPreferences'.
```

`flutter_secure_storage` 11.0.0 removed `AndroidOptions.encryptedSharedPreferences` along with the Jetpack Security backend it selected. `secure_storage_options.dart` still passed it. This is a Dart front-end error on every target, not a web-only one.

## The fix

Drop the argument. There is no replacement parameter and nothing to migrate:

- v10 already moved any data the Jetpack backend held into the custom cipher storage that is now the only Android implementation.
- `v0.14.0-beta.1` and `v0.14.0-beta.3` both shipped 10.3.1, so every recent install has already been through that migration.

The constant stays rather than being inlined, so `auth_storage_native.dart` and `update_service.dart` keep one place to change if Android needs an option again.

Also checked, no changes needed: `sharedPreferencesName`, `KeyCipherAlgorithm.RSA_ECB_PKCS1Padding` and `StorageCipherAlgorithm.AES_CBC_PKCS7Padding` (v11's other removals) are unused, and `minSdk = flutter.minSdkVersion` already satisfies v11's raise to API 24.

## Verification

Local build with the Dockerfile's own flags:

```
flutter build web --release --base-href /player/ --tree-shake-icons --pwa-strategy=none
✓ Built build/web
```

`flutter analyze` reports no errors or warnings (55 pre-existing `info` lints), and the `dart analyze` pre-commit hook passes.

## How it got in

This arrived in dependabot PR #613, which merged with **seven** red checks: `Build / Web`, `Test / Player`, `Build / Android`, `Build / Linux`, `Build / Windows`, `Build / macOS` and `Flatpak / Build`. None of them is a required context on the Master ruleset, and `gh pr merge --auto` waits on required checks only, so auto-merge saw six greens and merged.

That gap is real but out of scope here. This PR only unbreaks `master`.

Separately worth knowing when reading Docker history: `ci-docker.yml` sets `cancel-in-progress: true` on a ref-keyed group, so the master runs for #577, #612 and #613 were all cancelled and the first surviving red run was #611's, which had nothing to do with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Android secure storage configuration to remain compatible with the latest storage package.
  - Securely stored data now uses the package’s supported default backend without requiring the removed encryption option.

- **Documentation**
  - Clarified the Android secure storage configuration and documented the removal of the retired option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->