### PR TITLE
ci(docker): give every master commit its own concurrency group

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -8,8 +8,19 @@ on:
   push:
     branches: [master, main]
 
+# Keyed to the commit, not the ref. A concurrency group holds at most one
+# PENDING run and cancels the previous one when a new run enters, so a burst of
+# master merges silently discards its own queue: on 2026-08-29 the runs for
+# #577, #612 and #613 were all superseded and never executed, and #613 was the
+# commit that broke the image. Per-SHA groups mean nothing supersedes anything
+# and every commit gets a real verdict. Re-runs of the same SHA still dedupe,
+# which is the only thing the ref-keyed group was buying.
+#
+# cancel-in-progress stays as an expression rather than a literal false: it is
+# always false today (this workflow is push-only), but the expression keeps the
+# right behaviour if a pull_request trigger is ever added back.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:


### PR DESCRIPTION
A concurrency group holds at most one *pending* run and cancels the previously pending one when a new run enters it. Docker image builds take over twenty minutes, so a burst of master merges discards its own queue.

That is not hypothetical. On 2026-08-29 the merges of #577, #612 and #613 all queued behind #610's build and superseded each other. `gh run list --workflow=ci-docker.yml --limit 30` has no entry at all for any of the three. #613 was the commit that broke the image (it bumped `flutter_secure_storage` to 11.0.0, removing an `AndroidOptions` parameter the app still passed), and it never got a Docker verdict. The first red run belonged to #611, whose diff was a test-suite relay guard that cannot affect Flutter.

Note what this is *not*: `cancel-in-progress` already reads `${{ github.event_name == 'pull_request' }}`, and this workflow is push-only on master, so that expression is always `false`. Setting it to a literal `false` would change nothing. The ref-keyed group is the problem, not the cancel flag, and the flag stays an expression here so the behaviour stays right if a `pull_request` trigger is ever added back.

Keying the group to `github.sha` gives each commit its own group. Nothing supersedes anything, every master commit gets a real verdict, and re-runs of the same SHA still dedupe — which is the only thing the ref-keyed group was buying.

The cost is that a burst of merges now runs concurrent image builds instead of serialising them. That is the price of per-commit attribution, and it is the point of the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI run handling so different commits are processed independently.
  * Repeated runs for the same commit are automatically deduplicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->