### PR TITLE
fix(ci): trigger dependabot gate on workflow_run, not check_suite

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,16 +1,39 @@
 name: Dependabot auto-merge
 
-# check_suite rather than pull_request_target. GitHub's native auto-merge
-# (`gh pr merge --auto`, which this file used to call) waits on REQUIRED checks
-# only, and there is no flag to widen it. The Master ruleset requires six of
-# roughly twenty-six contexts, so on 2026-08-29 PR #613 auto-merged with seven
-# red checks and broke the master Docker image. This workflow waits on the whole
-# rollup instead.
+# workflow_run rather than check_suite, and neither of them pull_request_target.
 #
-# A check_suite workflow runs in default-branch context, so it does not carry the
-# pull_request_target hazard the previous revision of this file reasoned about.
+# GitHub's native auto-merge (`gh pr merge --auto`, which this file used to
+# call) waits on REQUIRED checks only, and there is no flag to widen it. The
+# Master ruleset requires six of roughly twenty-six contexts, so on 2026-08-29
+# PR #613 auto-merged with seven red checks and broke the master Docker image.
+# This workflow waits on the whole rollup instead.
+#
+# check_suite would have been the natural event and was tried first. It cannot
+# work here: "this event does not trigger workflows if the check suite was
+# created by GitHub Actions or if the check suite's head SHA is associated with
+# GitHub Actions." Every check suite on a pull request here is Actions-created,
+# so the trigger never fired at all.
+#
+# workflow_run has no such restriction. It is listed against every workflow that
+# runs on pull requests, so the gate re-evaluates as each one finishes and the
+# last to complete sees a terminal rollup. Missing one from this list only costs
+# a re-evaluation point, not correctness, because the gate always re-reads the
+# full rollup rather than trusting the triggering event.
+#
+# A workflow_run workflow runs in default-branch context, so it does not carry
+# the pull_request_target hazard an earlier revision of this file reasoned about.
 on:
-  check_suite:
+  workflow_run:
+    workflows:
+      - CI
+      - CI / Documentation
+      - CI / Fastlane
+      - CI / Nix
+      - CI / Player Desktop
+      - CI / Relay
+      - CI / Security
+      - CI / Site
+      - CI Server
     types: [completed]
 
 permissions:
@@ -28,16 +51,15 @@ jobs:
         with:
           persist-credentials: false
 
-      # The check_suite payload does carry a pull_requests array, but it is
-      # empty in some cases. Matching open dependabot pull requests on the
-      # suite's head SHA is unconditional and needs no payload archaeology.
+      # Matching open dependabot pull requests on the triggering run's head SHA
+      # is unconditional and needs no payload archaeology.
       #
       # Note the author spelling: `gh pr list --author` wants `app/dependabot`,
       # while the webhook payload spells the same account `dependabot[bot]`.
       - name: Decide
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## What was broken

The dependabot merge gate added an hour ago (#620) triggers on `check_suite: [completed]`. GitHub's documentation is explicit about why that never runs here:

> To prevent recursive workflows, this event does not trigger workflows if the check suite was created by GitHub Actions or if the check suite's head SHA is associated with GitHub Actions.

Every check suite on this repo's pull requests is created by GitHub Actions, so the trigger has never fired once.

## Why it matters right now

The same PR that added this gate also removed `gh pr merge --auto` (GitHub's native auto-merge only honors REQUIRED checks, which is how PR #613 auto-merged with seven red checks and broke the master Docker image). Between that removal and this fix, dependabot pull requests have no auto-merge path at all and will sit open indefinitely.

## The fix

Switch the trigger to `workflow_run`, the documented fallback with no such restriction, listed against every workflow that runs on pull requests. `HEAD_SHA` now reads `github.event.workflow_run.head_sha` instead of `github.event.check_suite.head_sha`. The gate script call, job body, and permissions are untouched.

This workflow remains log-only — it still merges nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated dependency update handling by triggering merge checks after pull-request CI workflows complete.
  * Ensured merge decisions evaluate the correct commit associated with each completed workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->