### PR TITLE
fix(media): stop the demote-to-extra button reading as a download

### DIFF
--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -883,15 +883,19 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                     >
                       <.icon name="hero-trash" class="w-5 h-5" />
                     </button>
+                    <%!-- Not a tray/arrow icon: `hero-arrow-down-tray` is the
+                          download icon everywhere else in the app, including the
+                          hero button on this same page. --%>
                     <button
                       id={"demote-#{file.id}"}
                       type="button"
                       class="btn btn-ghost btn-square sm:btn-sm"
+                      aria-label="Move this file to extras"
                       title="This is an extra, not a version"
                       phx-click="demote_to_extra"
                       phx-value-id={file.id}
                     >
-                      <.icon name="hero-arrow-down-tray" class="w-5 h-5" />
+                      <.icon name="hero-chevron-double-down" class="w-5 h-5" />
                     </button>
                   </div>
                 </div>
@@ -939,7 +943,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                     phx-click="promote_to_version"
                     phx-value-id={file.id}
                   >
-                    <.icon name="hero-arrow-up-tray" class="w-4 h-4" /> Version
+                    <.icon name="hero-chevron-double-up" class="w-4 h-4" /> Version
                   </button>
                 </div>
               </li>


### PR DESCRIPTION
`hero-arrow-down-tray` is the download icon everywhere in the app: the Downloads nav entry, every Download button, the `downloading` availability status, and the hero action on the media page itself (`show.html.heex:214`). The demote-to-extra control in the Media Files card reused it verbatim, so it read as "download this file" sitting one gap away from the delete button. Its mirror, promote-to-version, reused the upload icon for the same reason.

Both now use `hero-chevron-double-down` / `hero-chevron-double-up`, which read as a rank change and carry no transfer connotation. The demote button also gains the `aria-label` its icon-only siblings already have; it had only a sentence-shaped `title`.

Verified the two new classes reach the built stylesheet (`mix assets.build`, 8 matches in `priv/static/assets/css/app.css`) and `test/mydia_web/live/media_live/show_extras_test.exs` still passes (5 tests, 0 failures) — it keys on the button IDs, which are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated media file action icons to better distinguish moving files to extras from promoting extras to versions.
  * Added an accessible label to the “Move this file to extras” action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->