### PR TITLE
docs(ci): correct why the dependabot gate left check_suite

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,16 +8,26 @@ name: Dependabot auto-merge
 # PR #613 auto-merged with seven red checks and broke the master Docker image.
 # This workflow waits on the whole rollup instead.
 #
-# check_suite would have been the natural event and was tried first. It cannot
-# work here: "this event does not trigger workflows if the check suite was
-# created by GitHub Actions or if the check suite's head SHA is associated with
-# GitHub Actions." Every check suite on a pull request here is Actions-created,
-# so the trigger never fired at all.
+# check_suite was the natural event and was tried first, in the revision this
+# one replaces. It fires here, but not usefully, and the distinction is worth
+# recording because the docs invite the wrong conclusion in both directions.
 #
-# workflow_run has no such restriction. It is listed against every workflow that
-# runs on pull requests, so the gate re-evaluates as each one finishes and the
-# last to complete sees a terminal rollup. Missing one from this list only costs
-# a re-evaluation point, not correctness, because the gate always re-reads the
+# GitHub says the event "does not trigger workflows if the check suite was
+# created by GitHub Actions or if the check suite's head SHA is associated with
+# GitHub Actions." Read literally that suggests it never fires on this
+# repository. It does: runs on this workflow with event `check_suite` are in the
+# history for 2026-08-30, and they executed the gate correctly. The restriction
+# evidently applies per check suite, so suites from other apps still trigger it.
+#
+# That is precisely the problem. The suites that DO fire are the ones Actions did
+# not create, and they finish on their own schedule -- CodeRabbit typically well
+# before CI does. The gate would evaluate early, log WAIT, and never be woken
+# again when the last Actions workflow finally completed. Firing at the wrong
+# moment is worse than not firing, because it looks like it is working.
+#
+# workflow_run fires exactly when a listed workflow completes, so the last one
+# to finish sees a terminal rollup. Missing an entry from the list below costs a
+# re-evaluation point, not correctness, because the gate always re-reads the
 # full rollup rather than trusting the triggering event.
 #
 # A workflow_run workflow runs in default-branch context, so it does not carry


### PR DESCRIPTION
Comment only. No behaviour change.

The comment that arrived with the `workflow_run` switch in #622 claimed `check_suite` "never fired at all" on this repository. That is false, and the evidence was already in the history when it was written: several runs of this workflow on 2026-08-30 carry event `check_suite` and executed the gate correctly, logging `No open dependabot pull request at <sha>. Nothing to do.`

GitHub's documented restriction is real — the event *"does not trigger workflows if the check suite was created by GitHub Actions or if the check suite's head SHA is associated with GitHub Actions"* — but it evidently applies **per check suite**, not as a repository-wide switch. Suites created by other apps still trigger it.

Leaving `check_suite` was still the right call, for a sharper reason than the one the comment gave. The suites that *do* fire are the ones Actions did not create, and they conclude on their own schedule — CodeRabbit typically finishes well before CI does. The gate would evaluate early, log `WAIT`, and never be woken again once the last Actions workflow completed. **Firing at the wrong moment is worse than not firing, because it looks like it works.**

`workflow_run` fires exactly when a listed workflow completes, so the last one to finish sees a terminal rollup.

This PR is also a canary for the ruleset change made just before it: `Build / Web` and `Test / Player` are now required contexts. It touches neither player code nor anything under the paths `ci-player.yml` watches, so both must report `pass` in a few seconds with every step skipped. If they instead sit unreported, the promotion was premature and should be rolled back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments describing when automatic merge checks are triggered.
  * Documented how external check suites and workflow completion events affect gate evaluation.
  * Confirmed that no functional or configuration behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->