### PR TITLE
ci(dependabot): merge on a fully green rollup, comment when blocked

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -47,8 +47,9 @@ on:
     types: [completed]
 
 permissions:
-  contents: read
-  pull-requests: read
+  contents: write
+  pull-requests: write
+  checks: read
 
 jobs:
   gate:
@@ -82,7 +83,83 @@ jobs:
             exit 0
           fi
 
+          marker='<!-- dependabot-gate -->'
+
+          # mergeStateStatus is computed lazily and returns UNKNOWN until GitHub
+          # catches up. Poll rather than treating UNKNOWN as an answer either way.
+          merge_state() {
+            local pr="$1" state i
+            for i in 1 2 3 4 5; do
+              state="$(gh pr view "$pr" --json mergeStateStatus --jq .mergeStateStatus)"
+              if [ "$state" != "UNKNOWN" ]; then
+                echo "$state"
+                return 0
+              fi
+              sleep 5
+            done
+            echo UNKNOWN
+          }
+
+          # One comment per pull request, edited in place. Appending a new
+          # comment on every completed check suite would bury the pull request.
+          upsert_comment() {
+            local pr="$1" body="$2" id
+            id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \
+                   --jq "[.[] | select(.body | startswith(\"$marker\"))] | last | .id // empty")"
+            if [ -n "$id" ]; then
+              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" \
+                -f body="$body" > /dev/null
+            else
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" \
+                -f body="$body" > /dev/null
+            fi
+          }
+
           for pr in $prs; do
-            verdict="$(./scripts/dependabot-gate.sh verdict --pr "$pr")"
+            # A failure evaluating one pull request must not abort the whole
+            # step and leave every later pull request in this run unevaluated.
+            gate_status=0
+            line="$(./scripts/dependabot-gate.sh verdict --pr "$pr")" || gate_status=$?
+            if [ "$gate_status" -ne 0 ]; then
+              echo "PR #$pr: dependabot-gate.sh failed (exit $gate_status). Skipping this pull request." >&2
+              continue
+            fi
+
+            verdict="$(printf '%s' "$line" | cut -f1)"
             echo "PR #$pr: $verdict"
+
+            case "$verdict" in
+              WAIT)
+                echo "  Checks still running. Nothing to do."
+                ;;
+              BLOCKED)
+                contexts="$(printf '%s' "$line" | cut -f2- | tr '\t' '\n' | sed 's/^/- `/; s/=/` — /')"
+                upsert_comment "$pr" "$marker
+          This pull request is not being merged automatically. Every check has finished and these did not pass:
+
+          $contexts
+
+          Re-run them if you believe they are flaky, or fix the incompatibility. This comment is rewritten in place as the checks change."
+                echo "  Blocked. Comment updated."
+                ;;
+              MERGE)
+                state="$(merge_state "$pr")"
+                case "$state" in
+                  CLEAN|HAS_HOOKS)
+                    # --merge is the only strategy this repository allows: both
+                    # allow_squash_merge and allow_rebase_merge are false, and
+                    # the other forms fail outright.
+                    gh pr merge --merge "$pr"
+                    echo "  Merged."
+                    ;;
+                  *)
+                    echo "  All checks green but mergeStateStatus is $state. Not merging."
+                    ;;
+                esac
+                ;;
+              *)
+                echo "  Unrecognised verdict '$verdict'. Not merging." >&2
+                exit 1
+                ;;
+            esac
           done

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -90,6 +90,14 @@ jobs:
           merge_state() {
             local pr="$1" state i
             for i in 1 2 3 4 5; do
+              # bash does not inherit errexit into a command-substitution
+              # subshell (that needs `shopt -s inherit_errexit`, unset here),
+              # so a failing `gh` call below does not abort or retry -- it
+              # just yields an empty string for $state. Empty is not
+              # "UNKNOWN", so the loop stops immediately and the empty value
+              # falls through to the caller's inner `*` branch, which does
+              # not merge. It fails safe, but it is not the retry the loop
+              # otherwise looks like it provides.
               state="$(gh pr view "$pr" --json mergeStateStatus --jq .mergeStateStatus)"
               if [ "$state" != "UNKNOWN" ]; then
                 echo "$state"
@@ -134,13 +142,18 @@ jobs:
                 ;;
               BLOCKED)
                 contexts="$(printf '%s' "$line" | cut -f2- | tr '\t' '\n' | sed 's/^/- `/; s/=/` — /')"
+                comment_status=0
                 upsert_comment "$pr" "$marker
           This pull request is not being merged automatically. Every check has finished and these did not pass:
 
           $contexts
 
-          Re-run them if you believe they are flaky, or fix the incompatibility. This comment is rewritten in place as the checks change."
-                echo "  Blocked. Comment updated."
+          Re-run them if you believe they are flaky, or fix the incompatibility. This comment is rewritten in place as the checks change." || comment_status=$?
+                if [ "$comment_status" -ne 0 ]; then
+                  echo "  PR #$pr is blocked, but the comment could not be posted (exit $comment_status)." >&2
+                else
+                  echo "  Blocked. Comment updated."
+                fi
                 ;;
               MERGE)
                 state="$(merge_state "$pr")"
@@ -149,8 +162,13 @@ jobs:
                     # --merge is the only strategy this repository allows: both
                     # allow_squash_merge and allow_rebase_merge are false, and
                     # the other forms fail outright.
-                    gh pr merge --merge "$pr"
-                    echo "  Merged."
+                    merge_status=0
+                    gh pr merge --merge "$pr" || merge_status=$?
+                    if [ "$merge_status" -ne 0 ]; then
+                      echo "  gh pr merge failed (exit $merge_status). Leaving PR #$pr open." >&2
+                    else
+                      echo "  Merged."
+                    fi
                     ;;
                   *)
                     echo "  All checks green but mergeStateStatus is $state. Not merging."

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -88,17 +88,23 @@ jobs:
           # mergeStateStatus is computed lazily and returns UNKNOWN until GitHub
           # catches up. Poll rather than treating UNKNOWN as an answer either way.
           merge_state() {
-            local pr="$1" state i
+            local pr="$1" state i read_status
             for i in 1 2 3 4 5; do
               # bash does not inherit errexit into a command-substitution
               # subshell (that needs `shopt -s inherit_errexit`, unset here),
-              # so a failing `gh` call below does not abort or retry -- it
-              # just yields an empty string for $state. Empty is not
-              # "UNKNOWN", so the loop stops immediately and the empty value
-              # falls through to the caller's inner `*` branch, which does
-              # not merge. It fails safe, but it is not the retry the loop
-              # otherwise looks like it provides.
-              state="$(gh pr view "$pr" --json mergeStateStatus --jq .mergeStateStatus)"
+              # so a failing `gh` call below would not abort this function on
+              # its own -- its exit status has to be captured explicitly to
+              # tell a failed read apart from a successful one that
+              # legitimately returned UNKNOWN. A failed read is retried like
+              # any other UNKNOWN; only a successful non-UNKNOWN read returns
+              # early.
+              read_status=0
+              state="$(gh pr view "$pr" --json mergeStateStatus --jq .mergeStateStatus)" || read_status=$?
+              if [ "$read_status" -ne 0 ]; then
+                echo "  gh pr view failed while polling mergeStateStatus for PR #$pr (exit $read_status); retrying." >&2
+                sleep 5
+                continue
+              fi
               if [ "$state" != "UNKNOWN" ]; then
                 echo "$state"
                 return 0
@@ -111,9 +117,13 @@ jobs:
           # One comment per pull request, edited in place. Appending a new
           # comment on every completed check suite would bury the pull request.
           upsert_comment() {
-            local pr="$1" body="$2" id
+            local pr="$1" body="$2" id read_status=0
             id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" --paginate \
-                   --jq "[.[] | select(.body | startswith(\"$marker\"))] | last | .id // empty")"
+                   --jq "[.[] | select(.body | startswith(\"$marker\"))] | last | .id // empty")" || read_status=$?
+            if [ "$read_status" -ne 0 ]; then
+              echo "  Could not read existing comments on PR #$pr (exit $read_status); not posting to avoid a duplicate." >&2
+              return 1
+            fi
             if [ -n "$id" ]; then
               gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" \
                 -f body="$body" > /dev/null


### PR DESCRIPTION
The last piece of the merge gate. The workflow has been logging its verdict since #620; now it acts on it.

## What it does

For each open dependabot pull request at the triggering run's head SHA:

- **`MERGE`** — every context concluded in `SUCCESS`, `SKIPPED` or `NEUTRAL`, *and* `mergeStateStatus` is `CLEAN` or `HAS_HOOKS`. Merges with `gh pr merge --merge`, the only strategy this repository allows.
- **`WAIT`** — something is still running. No action, no comment.
- **`BLOCKED`** — everything concluded and something failed. Upserts a single comment naming the blocking contexts, found by an HTML marker and rewritten in place rather than appended.

## The one state that must never merge

`UNSTABLE` means "mergeable with non-required checks failing". That is *literally* the state PR #613 was in when native auto-merge landed it with seven red checks and broke the master Docker image. It is excluded explicitly — only `CLEAN` and `HAS_HOOKS` reach the merge call.

`mergeStateStatus` is polled rather than read once, because GitHub computes it lazily and returns `UNKNOWN` at first. That is not a theoretical concern; it was observed on live pull requests while building this.

## Failing one pull request must not strand the rest

Every fallible operation in the loop is guarded with `cmd || status=$?` and logs to stderr before continuing:

- the gate script itself,
- `gh pr merge` — a 409 is realistic if someone merges by hand between the verdict and the call,
- both `gh api` calls behind the blocked-comment upsert.

Without this, one 409 under `set -euo pipefail` would abort the step and leave every later dependabot pull request in the run unevaluated.

An unrecognised verdict still exits non-zero deliberately. That means the gate script's output contract is broken, which is categorically different from operational flakiness and should fail loudly rather than be papered over.

## Deliberately not done

Permissions are `contents: write`, `pull-requests: write`, `checks: read` — not widened further. Whether `pull-requests: write` alone suffices for the comment API, or whether it needs `issues: write`, is answerable only from a live run. The comment call is guarded, so a 403 there logs and continues rather than taking the step down; we can learn the answer without granting scope speculatively.

`merge_state()` carries a comment recording that bash does not inherit `errexit` into command-substitution subshells, so a failing `gh` call there yields an empty string rather than retrying — which falls through and does not merge. It fails safe, but the retry loop reads as though it covers that case, and it does not.

## Expected on merge

Dependabot pull requests #624, #625, #626 and #627 are currently green, and running the gate script against each returns `MERGE`. They should merge shortly after this lands. That is the intended behaviour, not a surprise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated dependency update handling by waiting for all required checks to complete before evaluating merge readiness.
  * Added clearer status reporting for blocked, ready, and unexpected outcomes.
  * Prevented issues with one update from interrupting processing of others.
  * Ensured merges occur only when the update is in an approved, conflict-free state.
  * Improved reliability when checking update status, including retries for temporarily unavailable results.
  * Updated status comments in place to reduce duplicate notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->