### PR TITLE
fix(media): break the external-id duplicate tie on id, not just inserted_at

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -259,20 +259,36 @@ defmodule Mydia.Media do
 
   defp parse_external_id(_id), do: nil
 
-  # `limit(1)` rather than a bare `Repo.one/1`: imdb_id carries no unique index,
-  # so a duplicate would raise Ecto.MultipleResultsError partway through a crawl
-  # and abort every remaining item. `order_by` makes the pick among duplicates
-  # deterministic (oldest first) rather than left to whatever order the
-  # database happens to return, which on PostgreSQL is not guaranteed to be
-  # insertion order -- and the crawl now repeats daily, so a nondeterministic
-  # pick could flip the stored mapping between runs.
-  defp external_id_match(query, nil),
-    do: query |> order_by([m], asc: m.inserted_at) |> limit(1) |> Repo.one()
+  defp external_id_match(query, nil), do: oldest_match(query)
 
   defp external_id_match(query, type) do
     query
     |> where([m], m.type == ^type)
-    |> order_by([m], asc: m.inserted_at)
+    |> oldest_match()
+  end
+
+  # `limit(1)` rather than a bare `Repo.one/1`: imdb_id carries no unique index,
+  # so a duplicate would raise Ecto.MultipleResultsError partway through a crawl
+  # and abort every remaining item. The ordering makes the pick among duplicates
+  # deterministic rather than left to whatever order the database happens to
+  # return, which on PostgreSQL is not guaranteed to be insertion order -- and
+  # the crawl repeats daily, so a nondeterministic pick could flip the stored
+  # mapping between runs.
+  #
+  # The `id` tie-break is load-bearing, not decoration. `MediaItem` declares
+  # `timestamps(type: :utc_datetime)`, which is SECOND precision, so two rows
+  # written in the same second carry identical `inserted_at` and ordering by it
+  # alone leaves them an exact tie -- which PostgreSQL may break either way on
+  # successive queries. That is the flip this function exists to prevent, and it
+  # is reachable in production: the crawl inserts in bursts.
+  #
+  # Note what the tie-break does and does not buy. `id` is a random v4 UUID
+  # (`@primary_key {:id, :binary_id, autogenerate: true}`), not a sequence, so
+  # among rows sharing a second the winner is arbitrary -- but STABLE, which is
+  # the property that matters. "Oldest wins" holds only at second granularity.
+  defp oldest_match(query) do
+    query
+    |> order_by([m], asc: m.inserted_at, asc: m.id)
     |> limit(1)
     |> Repo.one()
   end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -3276,8 +3276,67 @@ defmodule Mydia.MediaTest do
           skip_episode_refresh: true
         )
 
+      # `timestamps(type: :utc_datetime)` is SECOND precision, so two rows
+      # created back to back share an `inserted_at` and this assertion would be
+      # a coin flip on PostgreSQL -- which is exactly why this test flaked for
+      # months. Backdate the older row so "earliest" is a real comparison
+      # rather than a tie that some unrelated tie-break happens to resolve.
+      # The tie itself is covered by the next test, deliberately separately.
+      {1, _} =
+        Repo.update_all(
+          from(m in Mydia.Media.MediaItem, where: m.id == ^older.id),
+          set: [
+            inserted_at:
+              DateTime.utc_now() |> DateTime.add(-60, :second) |> DateTime.truncate(:second)
+          ]
+        )
+
       assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt-dup-order"})
       assert id == older.id
+    end
+
+    test "a duplicate match resolves an identical-timestamp tie the same way every call" do
+      # The tie production actually has to survive. `MediaItem` uses
+      # `timestamps(type: :utc_datetime)`, so a burst of inserts landing in one
+      # second is an exact tie on `inserted_at`, and PostgreSQL may break such a
+      # tie either way on successive queries. That flip is the whole reason
+      # find_by_external_ids/2 orders at all, and the crawl inserts in bursts,
+      # so it is reachable rather than theoretical.
+      for title <- ["Tie A", "Tie B", "Tie C"] do
+        {:ok, _} =
+          Media.create_media_item(
+            %{title: title, type: "tv_show", imdb_id: "tt-dup-tie"},
+            skip_episode_refresh: true
+          )
+      end
+
+      # Force the tie rather than hoping the three inserts land in one second.
+      shared = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {3, _} =
+        Repo.update_all(
+          from(m in Mydia.Media.MediaItem, where: m.imdb_id == "tt-dup-tie"),
+          set: [inserted_at: shared]
+        )
+
+      # Assert the specific row the tie-break selects, not merely that repeated
+      # calls agree. Agreement alone can pass by luck on an unordered query
+      # within a single run; pinning it to the lowest id fails whenever the
+      # tie-break is absent. `id` is a random v4 UUID, so which row that is
+      # carries no meaning -- only that it is always the same one.
+      lowest_id =
+        Mydia.Media.MediaItem
+        |> where([m], m.imdb_id == "tt-dup-tie")
+        |> order_by([m], asc: m.id)
+        |> limit(1)
+        |> Repo.one()
+
+      assert %{id: id} = Media.find_by_external_ids(%{imdb: "tt-dup-tie"})
+      assert id == lowest_id.id
+
+      for _ <- 1..5 do
+        assert Media.find_by_external_ids(%{imdb: "tt-dup-tie"}).id == id
+      end
     end
 
     test "a non-numeric tvdb id falls through to tmdb instead of raising" do


### PR DESCRIPTION
Fixes the repository's most-hit CI flake, which also has a live production consequence.

## The bug

`find_by_external_ids/2` orders duplicate matches by `inserted_at` and takes the first, so the pick among duplicates stays stable across crawl runs. But `MediaItem` declares `timestamps(type: :utc_datetime)` — **second** precision. Two rows written in the same second carry an identical `inserted_at`, so the ordering leaves them an exact tie, and PostgreSQL may break that tie either way on successive queries.

That is precisely the mapping flip the ordering exists to prevent. It is reachable rather than theoretical: the crawl inserts in bursts, and it repeats daily.

## The fix

`id` becomes a secondary sort.

Worth being precise about what that buys, because the obvious reading is wrong: `id` is a random v4 UUID (`@primary_key {:id, :binary_id, autogenerate: true}`), not a sequence. So among rows sharing a second the winner is **arbitrary — but stable**, and stable is the property that actually matters here. "Oldest wins" holds only at second granularity. The comment now says that instead of claiming more than the code delivers.

The two clauses had the ordering copy-pasted; they now share one private `oldest_match/1`.

## The test was flaking for the same reason it was testing

`"a duplicate match deterministically picks the earliest inserted row"` created two rows back to back — which share a second — so its own assertion was a coin flip on PostgreSQL. It has cost re-runs on unrelated PRs for months and is the top entry in our flake notes.

It now backdates the older row, so "earliest" is a real comparison rather than a tie resolved by luck.

A second test covers the tie production actually has to survive: three rows forced onto one timestamp, asserting the query returns the **lowest id**. That assertion fails whenever the tie-break is absent. Asserting only that repeated calls agree would have been weaker — an unordered query can return the same row repeatedly within a single run and pass by accident.

## Verification

SQLite: `172 tests, 0 failures` in `test/mydia/media_test.exs`.

The PostgreSQL leg is left to CI. The local devenv daemon would not start in this worktree, and `Test / PostgreSQL` runs on every pull request — which is also the adapter where the tie actually bites, so that job is the meaningful check on this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media matching when duplicate records share the same timestamp.
  * Matching now consistently selects the oldest record, producing predictable results across repeated lookups.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->