### PR TITLE
docs(ci): bring the CI notes in line with the merge gate

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -97,12 +97,88 @@ the last run that was not a startup_failure, then
 change. Reaching `queued` instead of dying within a second is the signal the graph
 validates.
 
+## Dependabot merges through a gate, not GitHub's auto-merge
+
+`dependabot-auto-merge.yml` no longer calls `gh pr merge --auto`. That waited on
+**required** checks only, with no flag to widen it, so PR #613 merged 2026-08-29
+with seven red advisory checks and broke the master Docker image. Supplementing it
+would not have helped either: `--auto` fires the moment the required checks go
+green and beats any custom gate.
+
+The workflow now runs `scripts/dependabot-gate.sh`, which reads a PR's whole
+`statusCheckRollup` and prints one line:
+
+- `MERGE` -- every context concluded `SUCCESS`, `SKIPPED` or `NEUTRAL`. Merges,
+  but only when `mergeStateStatus` is `CLEAN` or `HAS_HOOKS`. `UNSTABLE` means
+  "mergeable with non-required checks failing", which is literally the state #613
+  merged in, and never merges.
+- `WAIT` -- something is still running, or no checks are registered yet. No
+  action, no comment.
+- `BLOCKED` -- everything concluded and something failed. Upserts one comment
+  naming the blocking contexts, rewritten in place rather than appended.
+
+Three details the data forces, each with a test fixture in
+`scripts/tests/fixtures/`: a rollup mixes `CheckRun` entries (`name`/`status`/
+`conclusion`) with `StatusContext` entries (`context`/`state`, no `status` field
+at all -- CodeRabbit posts one of these, and reading only `.status` waits
+forever); `SKIPPED` and `NEUTRAL` are normal and must count as passing; and an
+empty or null rollup means `WAIT`, never `MERGE`.
+
+### It cannot merge PRs that touch `.github/workflows/`
+
+This is structural, not a bug. `GITHUB_TOKEN` is a GitHub App token, and GitHub
+refuses to let an App land workflow-file changes without `workflows` permission:
+
+```text
+GraphQL: refusing to allow a GitHub App to create or update workflow
+`.github/workflows/<file>.yml` without `workflows` permission (mergePullRequest)
+```
+
+In practice that is dependabot's **actions group**. Confirmed 2026-08-31 on #627:
+the gate logged `PR #627: MERGE`, the merge failed, and the run continued. Merge
+that class by hand.
+
+Granting `permissions: workflows: write` would fix it and was deliberately not
+done -- it would let an auto-merging bot land changes to CI configuration itself,
+which is a materially larger privilege than merging dependency bumps. Treat it as
+a maintainer decision, not a papercut.
+
+### The trigger, and why not `check_suite`
+
+`workflow_run` over the nine workflows that run on pull requests. `check_suite`
+was tried first and reverted. GitHub documents that it "does not trigger workflows
+if the check suite was created by GitHub Actions", which reads as though it never
+fires here -- but it does, for suites created by *other* apps. That is worse than
+not firing: those suites conclude on their own schedule, typically well before CI,
+so the gate would evaluate early, log `WAIT`, and never be woken when the last
+Actions workflow finished.
+
+Missing a workflow from the list costs a re-evaluation point, not correctness,
+because the gate always re-reads the full rollup rather than trusting the event.
+
+### It is edge-triggered, so a green backlog sits
+
+The gate only evaluates a PR when one of those workflows *completes*. A PR that
+was already green before the gate existed has no event to fire for it and stays
+open indefinitely. Re-running any one of its workflows is enough to trigger a
+verdict. New dependabot PRs are unaffected.
+
+### Every fallible call in the loop is guarded
+
+The gate script call, `gh pr merge`, and the comment API calls all use
+`cmd || status=$?`, log to stderr, and continue. Under `set -euo pipefail` an
+unguarded failure -- a 409 because someone merged by hand, or the workflow-file
+refusal above -- would abort the step and leave every later dependabot PR in that
+run unevaluated. Do not remove those guards.
+
 ## Dependabot: a stale base blocks a green PR forever
 
 The Master ruleset requires `Load lanes (ios)`, `Load lanes (android)`,
-`Site build`, `Test`, `Test / PostgreSQL` and `Test / E2E Browser`. Several of
-those workflows were originally `paths:`-filtered, and `20f0db5e2` (2026-08-26)
-removed the filters precisely so they report on every PR.
+`Site build`, `Test`, `Test / PostgreSQL`, `Test / E2E Browser`, and -- since
+2026-08-31 -- `Build / Web` and `Test / Player`. Several of those workflows were
+originally `paths:`-filtered, and `20f0db5e2` (2026-08-26) removed the filters
+precisely so they report on every PR. `ci-player.yml` got the same treatment
+differently: its filter moved into a `changes` job, so its jobs always report.
 
 A PR branched from a master older than that commit still carries the
 path-filtered workflow files, so those jobs never run and the required contexts

--- a/.github/README.md
+++ b/.github/README.md
@@ -138,10 +138,15 @@ In practice that is dependabot's **actions group**. Confirmed 2026-08-31 on #627
 the gate logged `PR #627: MERGE`, the merge failed, and the run continued. Merge
 that class by hand.
 
-Granting `permissions: workflows: write` would fix it and was deliberately not
-done -- it would let an auto-merging bot land changes to CI configuration itself,
-which is a materially larger privilege than merging dependency bumps. Treat it as
-a maintainer decision, not a papercut.
+There is no workflow-level escape hatch: `workflows` is not a valid key in a
+`permissions:` block, so this cannot be fixed by widening the job's permissions.
+It would take a GitHub App installation token or PAT carrying the repository's
+Workflows permission, wired in as a secret in place of `GITHUB_TOKEN`.
+
+That is deliberately not done. It would hand an auto-merging bot a credential
+that can land changes to CI configuration itself, which is a materially larger
+privilege than merging dependency bumps, and it would sit in a workflow that
+merges without human review. Merging that class by hand is the cheaper trade.
 
 ### The trigger, and why not `check_suite`
 
@@ -153,8 +158,14 @@ not firing: those suites conclude on their own schedule, typically well before C
 so the gate would evaluate early, log `WAIT`, and never be woken when the last
 Actions workflow finished.
 
-Missing a workflow from the list costs a re-evaluation point, not correctness,
-because the gate always re-reads the full rollup rather than trusting the event.
+Missing a workflow from the list cannot cause a wrong merge -- the gate re-reads
+the full rollup rather than trusting the event, so an unlisted workflow still
+counts toward the verdict. What it can cause is a stuck PR. If the omitted
+workflow is the last to finish, every listed one has already fired, the gate has
+already logged `WAIT`, and nothing wakes it again. The PR sits green and open
+until someone re-runs a listed workflow. Keep the list complete, and when a
+green dependabot PR is not merging, check whether a workflow it runs is absent
+from it.
 
 ### It is edge-triggered, so a green backlog sits
 

--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -64,51 +64,79 @@ Also note `cancel-in-progress: true` in that workflow's concurrency group: pushi
 a new commit cancels the in-flight run, so a `gh pr checks --watch` started on the
 old head exits with a truncated view. Re-watch after each push.
 
-## Only six checks are required
+## Eight checks are required, and most are still advisory
 
 The Master ruleset (`gh api repos/getmydia/mydia/rulesets/9740184`) requires
-exactly six status checks:
+eight status checks:
 
 ```text
 Test, Test / PostgreSQL, Test / E2E Browser, Site build,
-Load lanes (ios), Load lanes (android)
+Load lanes (ios), Load lanes (android), Build / Web, Test / Player
 ```
 
-Everything else is advisory, including `Test / Player`, `Build / Web`,
-`Build / Android`, `Build / Linux`, `Build / macOS`, `Build / Windows`,
-`Flatpak / Build`, `Rust`, every `Check / *`, and the lockfile scanners.
+Everything else is still advisory, including `Build / Android`, `Build / Linux`,
+`Build / macOS`, `Build / Windows`, `Flatpak / Build`, `Rust`, every `Check / *`,
+and the lockfile scanners. A break visible only to those still merges.
 
-GitHub required-status-checks block forever on a context that never reports, and
-those workflows are path-filtered at the workflow level (`ci-player.yml`'s
-`on.pull_request.paths`), so a PR touching no `player/**` file would hang on an
-Expected check. The short list is the workaround, and `dependabot-auto-merge.yml`'s
-own comment says so.
+`Build / Web` and `Test / Player` were promoted 2026-08-31, and the two jobs with
+catalogued hang and network-block modes -- `Build / Linux` and `Flatpak / Build`
+-- were deliberately left out. Requiring either would trade a merge hole for a
+merge deadlock.
+
+### Why the list was short, and what changed
+
+GitHub required-status-checks block forever on a context that never reports.
+`ci-player.yml` used to filter on paths at the *workflow* level, so on a PR
+touching no `player/**` file the workflow never started and `Build / Web` never
+registered. The short required list was the workaround.
+
+The filter now lives in a `changes` job inside the workflow, so every job always
+reports -- concluding in a few seconds with its steps skipped when nothing
+relevant changed. That is what made the two contexts requirable. The gating
+conditions are **step-level, never job-level**: a job-level `if:` concludes the
+job `skipped`, and whether a ruleset counts a skipped required check as satisfied
+is configuration-dependent. `grep -n "^    if:" .github/workflows/ci-player.yml`
+must return nothing; that is the whole safety net.
+
+Measured behaviour on real PRs: on one touching `native/`, `Build / Web` ran
+4m17s and `Test / Player` 12m57s. On one touching only `site/`, they reported
+`pass` in 2s and 4s.
+
+### The failure that prompted all of this
 
 `gh pr merge --auto` waits on required checks only, with no flag to consider
-advisory ones, so a dependabot PR can merge with a wall of red. PR #613
-(`flutter_secure_storage` 10.3.1 to 11.0.0) merged 2026-08-29 with seven red checks
-(Build/Web, Test/Player, Build/Android, Build/Linux, Build/Windows, Build/macOS,
-Flatpak/Build) and broke the master Docker image, because v11 removed
-`AndroidOptions.encryptedSharedPreferences`.
+advisory ones. PR #613 (`flutter_secure_storage` 10.3.1 to 11.0.0) merged
+2026-08-29 with seven red checks (Build/Web, Test/Player, Build/Android,
+Build/Linux, Build/Windows, Build/macOS, Flatpak/Build) and broke the master
+Docker image, because v11 removed `AndroidOptions.encryptedSharedPreferences`.
 
 Do not describe a break like that as "the PR gate missed it". The gate fired
 loudly and nothing was listening. When triaging a merged-but-broken commit, check
 the PR's full check list rather than whether it merged green.
 
-Making a path-filtered job requirable needs a shim: move the path filter into a
-`changes` job and gate downstream work with a step-level `if:`, never job-level. A
-job-level `if:` concludes `skipped`, and a skipped required check is ambiguous to
-rulesets.
+`--auto` is no longer used for dependabot. See the merge gate in
+`.github/README.md`.
 
-## CI / Docker cancels its own master runs
+## CI / Docker used to cancel its own master runs
 
-`ci-docker.yml` sets `cancel-in-progress: true` on a ref-keyed group and is
-push-only on master, so consecutive merges cancel each other's image builds. On
-2026-08-29 the runs for #577, #612 and #613 were all cancelled, and the first to
-survive was #611's, which inherited a break introduced by #613.
+**Fixed 2026-08-31.** `ci-docker.yml` now keys its concurrency group to
+`github.sha`, so every master commit gets its own run and nothing supersedes
+anything. Re-runs of the same SHA still dedupe. The cost is that a burst of
+merges runs concurrent image builds instead of serialising them, which is the
+point.
 
-Before bisecting a Docker failure, list the runs and note which SHAs have no
-completed run at all:
+The history matters for reading anything older than that, and the mechanism is
+worth knowing because it is easy to misdiagnose. The group was keyed to the ref,
+and `cancel-in-progress` read `${{ github.event_name == 'pull_request' }}` --
+always `false` here, since the workflow is push-only. Setting it to a literal
+`false` would have changed nothing; that was never the bug. A concurrency group
+holds at most **one pending run** and cancels the previously pending one when a
+new run enters, so a burst of merges discarded its own queue. On 2026-08-29 the
+runs for #577, #612 and #613 never executed at all, and the first to survive was
+#611's, which inherited a break introduced by #613.
+
+Before bisecting a Docker failure on older history, list the runs and note which
+SHAs have no completed run at all:
 
 ```bash
 gh run list --workflow=ci-docker.yml --branch=master --json headSha,conclusion,createdAt
@@ -284,6 +312,31 @@ Postgres, so the Postgres job runs modules concurrently and is where order- and
 config-leak-sensitive tests surface. Any change that shifts suite timing, even one
 extra query per LiveView mount, can expose a latent one without being its cause.
 
+### Both adapters at once
+
+The green-SQLite / red-Postgres split is the usual shape, so a test failing on
+**both** jobs in the same run reads as a real regression. One known case is not.
+
+**`Mydia.Library.CandidatePromotionTest`, "separate database connections
+serialize competing promotions at ownership"**
+(`test/mydia/library/candidate_promotion_test.exs`). Seen 2026-08-31 on PR #631,
+1 failure of 9773 on `Test` and 1 of 9774 on `Test / PostgreSQL` simultaneously.
+
+It is not adapter-related because the test deliberately escapes the sandbox: it
+wraps setup in `Ecto.Adapters.SQL.Sandbox.unboxed_run/2` and races real
+connections to prove promotion serialises at the ownership boundary. Real
+connections on a loaded runner are timing-sensitive by construction, and the
+SQLite log carries `(Exqlite.Error) database is locked` and
+`DBConnection.OwnershipError: cannot find ownership process` alongside it.
+
+Triage as usual: #631's diff was a single workflow YAML file, which cannot reach
+Elixir code, and master's `ci.yml` was green on the three preceding commits. The
+test is young, added with the import-pipeline work, so treat timing-shaped
+failures in that file as flake-first once master is confirmed green.
+
+Note its `on_exit` deletes rows through another `unboxed_run`, so a failed run
+can leave real rows behind in the shared SQLite test database.
+
 ### Postgres job
 
 **`CrashReporter.TowerReporterTest`**, high rate, roughly 3 in 5 runs. Fails
@@ -345,17 +398,29 @@ files, all under `player/`, zero Elixir, and the same job had passed on the
 immediately preceding commit with an identical Elixir tree.
 
 **`Media.MediaTest`**, "a duplicate match deterministically picks the earliest
-inserted row". Fails `assert id == older.id` with two different UUIDs. This one has
-a real root cause: `external_id_match/2` (`lib/mydia/media.ex`) does
+inserted row". **FIXED 2026-08-31 in #632.** Kept here because it was the
+highest-frequency flake in this file for months and old runs still show it.
+
+`external_id_match/2` (`lib/mydia/media.ex`) ordered only by
 `order_by([m], asc: m.inserted_at) |> limit(1)`, while `MediaItem` declares
 `timestamps(type: :utc_datetime)`, second precision. Two rows inserted in the same
-second are an exact tie, so PostgreSQL may return either while SQLite happens to be
-stable. The test asserts a determinism the query does not provide, and the real fix
-is a tie-break: `order_by([m], asc: m.inserted_at, asc: m.id)`. Until then it is a
-coin flip on a fast runner, and the production risk the test was written to catch,
-the daily crawl flipping a stored mapping between runs, is still live. Reconfirmed
-2026-08-29 on PR #615 (`f44cc0b0a`), a single failure in 9797, on a
+second were an exact tie, so PostgreSQL could return either while SQLite happened
+to be stable. The test created its two rows back to back -- which share a second
+-- so it was asserting a determinism the query did not provide, and was itself a
+coin flip. Reconfirmed 2026-08-29 on PR #615, a single failure in 9797, on a
 collections-only diff.
+
+The fix adds `asc: m.id` as a secondary sort. Note what that buys, because the
+obvious reading is wrong: `id` is a random v4 UUID
+(`@primary_key {:id, :binary_id, autogenerate: true}`), not a sequence, so among
+rows sharing a second the winner is arbitrary but **stable**. Stability is the
+property that prevents the production risk -- the daily crawl flipping a stored
+mapping between runs. "Oldest wins" holds only at second granularity.
+
+The test was split in two: one backdates the older row so "earliest" is a real
+comparison, and one forces three rows onto a single timestamp and asserts the
+lowest id wins. The second fails whenever the tie-break is absent; asserting only
+that repeated calls agree would pass by luck on an unordered query.
 
 That same test has a second, unrelated mode: a 60s `ExUnit.TimeoutError` whose
 stack ends in `Mint.Core.Transport.SSL.recv/3` via Finch, a real outbound HTTPS

--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -320,7 +320,10 @@ The green-SQLite / red-Postgres split is the usual shape, so a test failing on
 **`Mydia.Library.CandidatePromotionTest`, "separate database connections
 serialize competing promotions at ownership"**
 (`test/mydia/library/candidate_promotion_test.exs`). Seen 2026-08-31 on PR #631,
-1 failure of 9773 on `Test` and 1 of 9774 on `Test / PostgreSQL` simultaneously.
+1 failure of 9773 on `Test` and 1 of 9774 on `Test / PostgreSQL` simultaneously,
+and again hours later on #634 (1 of 9774 on `Test`) whose diff was **this file
+and `.github/README.md` only**. Two sightings the same day on diffs that cannot
+reach Elixir code, so budget a re-run for it rather than investigating.
 
 It is not adapter-related because the test deliberately escapes the sandbox: it
 wraps setup in `Ecto.Adapters.SQL.Sandbox.unboxed_run/2` and races real

--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -320,10 +320,11 @@ The green-SQLite / red-Postgres split is the usual shape, so a test failing on
 **`Mydia.Library.CandidatePromotionTest`, "separate database connections
 serialize competing promotions at ownership"**
 (`test/mydia/library/candidate_promotion_test.exs`). Seen 2026-08-31 on PR #631,
-1 failure of 9773 on `Test` and 1 of 9774 on `Test / PostgreSQL` simultaneously,
-and again hours later on #634 (1 of 9774 on `Test`) whose diff was **this file
-and `.github/README.md` only**. Two sightings the same day on diffs that cannot
-reach Elixir code, so budget a re-run for it rather than investigating.
+failing on `Test` (1 failure out of 9773) and `Test / PostgreSQL` (1 out of 9774)
+in the same run, and again hours later on #634 (1 out of 9774 on `Test`) whose
+diff was **this file and `.github/README.md` only**. Two sightings the same day
+on diffs that cannot reach Elixir code, so budget a re-run rather than
+investigating.
 
 It is not adapter-related because the test deliberately escapes the sandbox: it
 wraps setup in `Ecto.Adapters.SQL.Sandbox.unboxed_run/2` and races real


### PR DESCRIPTION
Docs only. Nine PRs landed over 2026-08-30 and 08-31 and left `.github/README.md` and `.github/ci-flakes.md` describing the world before them.

## Statements that were current and are now false

- **"Only six checks are required."** Eight are. `Build / Web` and `Test / Player` were promoted 2026-08-31.
- **`ci-player.yml` filters on paths "at the workflow level".** It doesn't — the filter moved into a `changes` job, which is precisely what made those two contexts requirable.
- **`gh pr merge --auto` is how dependabot merges.** It isn't; a full-rollup gate replaced it.
- **"CI / Docker cancels its own master runs."** Fixed by keying the concurrency group to `github.sha`. The old mechanism is kept in the doc because it is genuinely easy to misdiagnose: `cancel-in-progress` was *already* effectively `false`, so the obvious fix was a no-op. The real cause is that a concurrency group holds one *pending* run and cancels the previous one.
- **`Media.MediaTest`'s tie-break is an open root cause.** Fixed in #632.

## Added

**How the gate decides**, and the three shapes in a `statusCheckRollup` that force that design — `StatusContext` entries carry no `status` field at all (CodeRabbit posts one, and reading only `.status` waits forever); `SKIPPED`/`NEUTRAL` are normal outcomes; an empty or null rollup means `WAIT`, never `MERGE`.

**That the gate structurally cannot merge PRs touching `.github/workflows/`.** GitHub refuses App-token merges of workflow files without `workflows` permission, which in practice means dependabot's actions group. Confirmed on #627. Granting that permission is written up as a maintainer decision rather than a fix, since it would let an auto-merging bot land changes to CI configuration itself.

**Why `check_suite` was tried and reverted.** It *does* fire, contrary to the obvious reading of GitHub's docs — but only for non-Actions suites, which conclude before CI does. The gate would evaluate early, log `WAIT`, and never be woken again. Firing at the wrong moment is worse than not firing.

**That the gate is edge-triggered**, so a PR already green when it went live has no event to fire for it and sits until one of its workflows is re-run.

**A both-adapters flake entry** for `CandidatePromotionTest`. A test failing on SQLite and Postgres in the same run normally reads as a regression — this one escapes the sandbox via `unboxed_run` and races real connections, so it isn't adapter-related at all.

On the `Media.MediaTest` fix, the note is careful about what it buys: `id` is a random v4 UUID, not a sequence, so the pick among same-second rows is **stable, not oldest** — and stability is the property that prevents the production risk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the automated dependency merge gate, including verdicts, required checks, workflow limitations, trigger behavior, and failure handling.
  * Updated CI documentation with current required checks, path filtering, concurrency history, and known flaky test guidance.
  * Documented an additional flaky test occurrence and the recommended re-run-first triage approach.
  * Recorded the fixed media tie-break behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->