### PR TITLE
fix(search): stop a 1080p profile grabbing a 360p rip

### DIFF
--- a/lib/mydia/indexers/quality_parser.ex
+++ b/lib/mydia/indexers/quality_parser.ex
@@ -177,6 +177,50 @@ defmodule Mydia.Indexers.QualityParser do
     end)
   end
 
+  # A release title with no resolution token is SD in practice: the tag is
+  # omitted precisely when there is nothing to boast about. `XviD-AFG` and
+  # friends are 360p rips.
+  @assumed_resolution "360p"
+
+  @doc """
+  The resolution to *judge* a release by, with an untagged one assumed to be
+  #{@assumed_resolution}.
+
+  `parse/1` and `extract_resolution/1` stay honest and return `nil` when the
+  title carries no resolution token, because that output also feeds file
+  renaming (`Mydia.Jobs.MediaImport.generate_filename/4` → `FileNamer`), where
+  an invented resolution would be written into the filename on disk.
+
+  This function is the search-side reading of the same `nil`. Scoring an
+  untagged release as "unknown" gave it a neutral 50 from
+  `QualityProfile.score_media_file/2` and no range violation at all, which put
+  it *above* an honestly-labelled out-of-range release scoring 25. A 360p XviD
+  beat a 720p x265 that way. Call this at the point a release is measured
+  against a profile; never when recording what a file actually is.
+
+  ## Examples
+
+      iex> QualityParser.effective_resolution(QualityParser.parse("Movie.1080p.BluRay"))
+      "1080p"
+
+      iex> QualityParser.effective_resolution(QualityParser.parse("Movie.XviD-AFG"))
+      "360p"
+
+      iex> QualityParser.effective_resolution(nil)
+      "360p"
+  """
+  @spec effective_resolution(Quality.t() | nil) :: String.t()
+  def effective_resolution(%Quality{resolution: resolution}) when is_binary(resolution),
+    do: resolution
+
+  def effective_resolution(_quality), do: @assumed_resolution
+
+  @doc """
+  The resolution assumed for a release title that carries no resolution token.
+  """
+  @spec assumed_resolution() :: String.t()
+  def assumed_resolution, do: @assumed_resolution
+
   @doc """
   Extracts the source from a release title.
 

--- a/lib/mydia/indexers/release_ranker.ex
+++ b/lib/mydia/indexers/release_ranker.ex
@@ -47,12 +47,18 @@ defmodule Mydia.Indexers.ReleaseRanker do
     as a hard removal (default: `true`). The automatic search jobs leave this at the default.
     Manual search deliberately passes `false`: per spec R8, manual search and manual grab are the
     operator's explicit escape hatch and must not silently drop a release the profile excludes.
+  - `:apply_resolution_floor` - Whether `:quality_profile`'s `:min_resolution` is enforced as a
+    hard removal (default: `true`). A release below the floor is dropped rather than down-scored,
+    because there is no minimum-score threshold before grabbing, so the top of an all-below-floor
+    list is grabbed regardless. A release with no resolution token counts as
+    `QualityParser.assumed_resolution/0`. Manual search passes `false`, for the same R8 reason as
+    `:apply_source_exclusion`.
   """
 
   require Logger
 
   alias Mydia.Downloads.ReleaseValidator
-  alias Mydia.Indexers.{SearchResult, SearchScorer}
+  alias Mydia.Indexers.{QualityParser, SearchResult, SearchScorer}
   alias Mydia.Indexers.Structs.{RankedResult, ScoreBreakdown}
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.Structs.ParsedFileInfo
@@ -79,6 +85,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
           min_post_age_minutes: non_neg_integer() | nil,
           now: DateTime.t() | nil,
           apply_source_exclusion: boolean() | nil,
+          apply_resolution_floor: boolean() | nil,
           custom_formats: [map()]
         ]
 
@@ -150,6 +157,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
       |> reject_invalid_releases()
       |> filter_acceptable(opts)
       |> reject_excluded_sources(opts)
+      |> reject_below_min_resolution(opts)
       |> reject_title_mismatches(expected_title)
       |> Enum.map(fn result ->
         breakdown = calculate_score_breakdown(result, opts)
@@ -287,6 +295,62 @@ defmodule Mydia.Indexers.ReleaseRanker do
   defp result_source(%SearchResult{quality: %{source: source}}) when is_binary(source), do: source
   defp result_source(%SearchResult{title: title}) when is_binary(title), do: Sources.detect(title)
   defp result_source(_), do: nil
+
+  # Drops releases below the profile's :min_resolution. A hard removal for the
+  # same reason excluded_sources is: there is no minimum-score threshold before
+  # grabbing, so the top of an all-bad list is grabbed regardless of how far it
+  # sits below the floor. A 1080p profile took a 360p XviD this way.
+  #
+  # A release with no resolution token counts as
+  # `QualityParser.assumed_resolution/0`, so an untagged SD rip cannot slip
+  # under the floor by being unreadable.
+  #
+  # An absent profile, an absent :min_resolution, or a resolution outside the
+  # canonical vocabulary all mean "no floor". Only :min_resolution gates;
+  # :max_resolution stays a scoring signal, since grabbing above the ceiling
+  # wastes disk but still yields a watchable file.
+  defp reject_below_min_resolution(results, opts) do
+    order = QualityProfile.valid_resolutions()
+
+    case min_resolution_floor(opts, order) do
+      nil ->
+        results
+
+      floor_index ->
+        Enum.filter(results, fn result ->
+          resolution = QualityParser.effective_resolution(result.quality)
+
+          case Enum.find_index(order, &(&1 == resolution)) do
+            index when is_integer(index) and index < floor_index ->
+              Logger.info(
+                "[ReleaseRanker] Filtered out (resolution #{resolution} below profile minimum " <>
+                  "#{Enum.at(order, floor_index)}): #{result.title}"
+              )
+
+              false
+
+            _ ->
+              true
+          end
+        end)
+    end
+  end
+
+  # Resolves the floor's index in the canonical ascending vocabulary, or nil
+  # for "no floor". Reads :apply_resolution_floor (default true) *before*
+  # looking at the profile, mirroring excluded_sources/1: the opt-out is a
+  # positive flag the caller sets. Manual search passes false so the operator
+  # keeps their deliberate escape hatch (R8).
+  defp min_resolution_floor(opts, order) do
+    with true <- Keyword.get(opts, :apply_resolution_floor, true),
+         %{quality_standards: standards} when is_map(standards) <-
+           Keyword.get(opts, :quality_profile),
+         min_resolution when is_binary(min_resolution) <- Map.get(standards, :min_resolution) do
+      Enum.find_index(order, &(&1 == min_resolution))
+    else
+      _ -> nil
+    end
+  end
 
   ## Private Functions - Filtering
 
@@ -612,10 +676,6 @@ defmodule Mydia.Indexers.ReleaseRanker do
     end)
   end
 
-  defp quality_preference_index(%SearchResult{quality: nil}, _preferred_qualities) do
-    999
-  end
-
   defp quality_preference_index(_result, nil) do
     # No preferred qualities set, return 0 so all results sort by score only
     0
@@ -626,16 +686,16 @@ defmodule Mydia.Indexers.ReleaseRanker do
     0
   end
 
+  # An untagged release resolves to QualityParser.assumed_resolution/0 rather
+  # than sorting into the 999 bucket, so it takes its real place in the
+  # preference order instead of tying with every other unrecognized release
+  # and winning the tie-break on raw score.
   defp quality_preference_index(%SearchResult{quality: quality}, preferred_qualities) do
-    case quality.resolution do
-      nil ->
-        999
+    resolution = QualityParser.effective_resolution(quality)
 
-      resolution ->
-        case Enum.find_index(preferred_qualities, &(&1 == resolution)) do
-          nil -> 999
-          index -> index
-        end
+    case Enum.find_index(preferred_qualities, &(&1 == resolution)) do
+      nil -> 999
+      index -> index
     end
   end
 
@@ -670,6 +730,7 @@ defmodule Mydia.Indexers.ReleaseRanker do
     blocked_tags = Keyword.get(opts, :blocked_tags, [])
     custom_formats = Keyword.get(opts, :custom_formats, [])
     expected_title = Keyword.get(opts, :expected_title)
+    floor_index = min_resolution_floor(opts, QualityProfile.valid_resolutions())
 
     results
     |> Enum.map(fn result ->
@@ -691,7 +752,8 @@ defmodule Mydia.Indexers.ReleaseRanker do
              blocked_tags,
              expected_title,
              excluded_sources(opts),
-             custom_formats
+             custom_formats,
+             floor_index
            ) do
         nil ->
           # Accepted — record the full breakdown (including penalties) so the
@@ -805,11 +867,20 @@ defmodule Mydia.Indexers.ReleaseRanker do
 
   defp maybe_put_penalties(row, _), do: row
 
-  # Returns a rejection reason string or nil if acceptable. The only hard
-  # removals are invalid releases (validator), blocked tags, and wrong-show
-  # title mismatches. Size/seeders/ratio are no longer rejection reasons — they
-  # are soft penalties on accepted results.
-  defp get_rejection_reason(result, blocked_tags, expected_title, excluded, custom_formats) do
+  # Returns a rejection reason string or nil if acceptable. The hard removals
+  # are invalid releases (validator), blocked tags, excluded sources, rejecting
+  # custom formats, sub-floor resolutions, and wrong-show title mismatches.
+  # Size/seeders/ratio are no longer rejection reasons — they are soft
+  # penalties on accepted results. The clause order mirrors the rank_all/2
+  # pipeline so the Activity stats and the actual ranking agree.
+  defp get_rejection_reason(
+         result,
+         blocked_tags,
+         expected_title,
+         excluded,
+         custom_formats,
+         floor_index
+       ) do
     cond do
       invalid_reason = invalid_release_reason(result) ->
         "invalid: #{invalid_reason}"
@@ -823,10 +894,33 @@ defmodule Mydia.Indexers.ReleaseRanker do
       rejecting = rejecting_format(result, custom_formats) ->
         "custom_format: #{rejecting}"
 
+      below = below_min_resolution_reason(result, floor_index) ->
+        below
+
       expected_title_mismatch?(result, expected_title) ->
         "title_mismatch"
 
       true ->
+        nil
+    end
+  end
+
+  # Mirrors reject_below_min_resolution/2. Names the assumed resolution
+  # explicitly when the title carried no token, so an operator reading the
+  # Activity view is not left wondering why a `resolution: null` row was cut.
+  defp below_min_resolution_reason(_result, nil), do: nil
+
+  defp below_min_resolution_reason(%SearchResult{quality: quality}, floor_index) do
+    order = QualityProfile.valid_resolutions()
+    resolution = QualityParser.effective_resolution(quality)
+    assumed? = is_nil(quality) or is_nil(quality.resolution)
+
+    case Enum.find_index(order, &(&1 == resolution)) do
+      index when is_integer(index) and index < floor_index ->
+        assumed_note = if assumed?, do: " (assumed, no resolution in title)", else: ""
+        "resolution_below_minimum: #{resolution}#{assumed_note} < #{Enum.at(order, floor_index)}"
+
+      _ ->
         nil
     end
   end

--- a/lib/mydia/indexers/search_scorer.ex
+++ b/lib/mydia/indexers/search_scorer.ex
@@ -24,6 +24,7 @@ defmodule Mydia.Indexers.SearchScorer do
       SearchScorer.score_result_with_breakdown(result, quality_profile: profile, media_type: :movie, search_query: "...")
   """
 
+  alias Mydia.Indexers.QualityParser
   alias Mydia.Indexers.SearchResult
   alias Mydia.Library.Hdr
   alias Mydia.Settings.QualityProfile
@@ -304,12 +305,19 @@ defmodule Mydia.Indexers.SearchScorer do
   end
 
   # Convert SearchResult to the media_attrs format expected by QualityProfile.score_media_file/2
+  #
+  # `:resolution` goes through QualityParser.effective_resolution/1, so an
+  # untagged release is measured as 360p rather than as "unknown". A nil here
+  # scored a neutral 50 and produced no range violation, ranking it above an
+  # honestly-labelled out-of-range release at 25. The assumption belongs at
+  # this seam and not inside score_media_file/2, which Mydia.Upgrades.Comparator
+  # also calls for real files, where a nil resolution means "not analyzed yet".
   defp search_result_to_media_attrs(%SearchResult{quality: nil} = result, media_type) do
     # No quality info available
     file_size_mb = if result.size, do: result.size / (1024 * 1024), else: nil
 
     %{
-      resolution: nil,
+      resolution: QualityParser.effective_resolution(nil),
       source: nil,
       video_codec: nil,
       audio_codec: nil,
@@ -327,7 +335,7 @@ defmodule Mydia.Indexers.SearchScorer do
     file_size_mb = if result.size, do: result.size / (1024 * 1024), else: nil
 
     base_attrs = %{
-      resolution: quality.resolution,
+      resolution: QualityParser.effective_resolution(quality),
       source: quality.source,
       video_codec: video_codec,
       audio_codec: audio_codec,

--- a/lib/mydia/library/release_parser.ex
+++ b/lib/mydia/library/release_parser.ex
@@ -142,7 +142,7 @@ defmodule Mydia.Library.ReleaseParser do
   # Only an *unambiguous* boundary is stripped, in three forms:
   #
   #   (a) bracketed          `[ www.Torrenting.org ] Movie...`
-  #   (b) separator glyph    `www.UIndex.org    -    Dark Matter...`
+  #   (b) separator glyph    `www.SiteName.org    -    Example Show...`
   #   (c) bare `www.host.tld` then whitespace   `www.Torrenting.org Movie...`
   #
   # A greedy `(?:\.[\w-]+)*` label run with a mere "next char is a delimiter"

--- a/lib/mydia/library/release_parser.ex
+++ b/lib/mydia/library/release_parser.ex
@@ -80,6 +80,7 @@ defmodule Mydia.Library.ReleaseParser do
 
     result =
       basename
+      |> strip_site_prefix()
       |> tokenize_classify_resolve(target)
       |> build_parsed_file_info(filename, opts)
       |> maybe_merge_folder_context(folder_context)
@@ -125,6 +126,36 @@ defmodule Mydia.Library.ReleaseParser do
   end
 
   # ---- Internals ----
+
+  # Leading indexer site-branding, e.g. `www.UIndex.org    -    `,
+  # `[ www.Torrenting.org ] `, `www.1TamilMV.world - `. Several trackers
+  # stamp their domain onto every title they publish. Left in place the
+  # tokenizer reads it as part of the show name ("Www Uindex Org Dark
+  # Matter"), which sinks the Jaro comparison in
+  # `ReleaseRanker.reject_title_mismatches/2` below its 0.7 threshold and
+  # hard-rejects an otherwise perfect release.
+  #
+  # Anchored to a literal `www.` plus dot-separated labels, so it cannot bite
+  # a real title: no show or film is named "www.something". Only the leading
+  # occurrence is removed; trailing site tags in brackets are already handled
+  # by @release_group_re.
+  #
+  # The lookahead is what keeps this safe. The domain run is greedy, so
+  # without it a fully dot-separated name like
+  # `www.Site.org.Movie.Name.2020.1080p` would have its title eaten as extra
+  # domain labels. Requiring a delimiter (whitespace, closing bracket, or a
+  # separator glyph) immediately after the domain means such a run-on simply
+  # does not match and is left untouched, which is the safe failure: a title
+  # we decline to clean, never a title we destroy.
+  @site_prefix_re ~r/^\s*(?:[\[\(\{]\s*)?www\.[\w-]+(?:\.[\w-]+)*(?=[\s\]\)\}:|–—-])\s*(?:[\]\)\}]\s*)?(?:[-–—:|]+\s*)?/i
+
+  defp strip_site_prefix(filename) do
+    stripped = Regex.replace(@site_prefix_re, filename, "", global: false)
+
+    # A name that is *nothing but* a site tag has no release information to
+    # recover, so keep the original rather than handing the tokenizer "".
+    if String.trim(stripped) == "", do: filename, else: stripped
+  end
 
   defp tokenize_classify_resolve(filename, target) do
     # Pre-pass: detect a trailing release-group separator (`-GROUP`)

--- a/lib/mydia/library/release_parser.ex
+++ b/lib/mydia/library/release_parser.ex
@@ -135,19 +135,34 @@ defmodule Mydia.Library.ReleaseParser do
   # `ReleaseRanker.reject_title_mismatches/2` below its 0.7 threshold and
   # hard-rejects an otherwise perfect release.
   #
-  # Anchored to a literal `www.` plus dot-separated labels, so it cannot bite
-  # a real title: no show or film is named "www.something". Only the leading
-  # occurrence is removed; trailing site tags in brackets are already handled
-  # by @release_group_re.
+  # Anchored to a literal `www.` so it cannot bite a real title: no show or
+  # film is named "www.something". Only the leading occurrence is removed;
+  # trailing site tags in brackets are already handled by @release_group_re.
   #
-  # The lookahead is what keeps this safe. The domain run is greedy, so
-  # without it a fully dot-separated name like
-  # `www.Site.org.Movie.Name.2020.1080p` would have its title eaten as extra
-  # domain labels. Requiring a delimiter (whitespace, closing bracket, or a
-  # separator glyph) immediately after the domain means such a run-on simply
-  # does not match and is left untouched, which is the safe failure: a title
-  # we decline to clean, never a title we destroy.
-  @site_prefix_re ~r/^\s*(?:[\[\(\{]\s*)?www\.[\w-]+(?:\.[\w-]+)*(?=[\s\]\)\}:|–—-])\s*(?:[\]\)\}]\s*)?(?:[-–—:|]+\s*)?/i
+  # Only an *unambiguous* boundary is stripped, in three forms:
+  #
+  #   (a) bracketed          `[ www.Torrenting.org ] Movie...`
+  #   (b) separator glyph    `www.UIndex.org    -    Dark Matter...`
+  #   (c) bare `www.host.tld` then whitespace   `www.Torrenting.org Movie...`
+  #
+  # A greedy `(?:\.[\w-]+)*` label run with a mere "next char is a delimiter"
+  # check is NOT safe: in `www.example.com.The Matrix.1999`, `.The` matches as
+  # another label and the space after it satisfies the check, so the title
+  # parses as "Matrix". Hence (c) permits exactly one TLD label, and (a)/(b)
+  # require a bracket or separator that a title word would not be followed by.
+  # Anything else, such as a fully run-on `www.Site.org.Movie.Name.2020`, does
+  # not match and is left untouched. That is the safe failure: a title we
+  # decline to clean, never a title we destroy.
+  @site_prefix_re ~r/
+    ^\s*
+    (?:
+        [\[\(\{]\s*www\.[\w.-]+\s*[\]\)\}]\s*      # (a) bracketed host
+      |
+        www\.[\w-]+(?:\.[\w-]+)*\s*[-–—:|]+\s*     # (b) host then separator
+      |
+        www\.[\w-]+\.[a-z]{2,6}\s+                 # (c) host then whitespace
+    )
+  /ix
 
   defp strip_site_prefix(filename) do
     stripped = Regex.replace(@site_prefix_re, filename, "", global: false)

--- a/lib/mydia_web/live/media_live/show/search_helpers.ex
+++ b/lib/mydia_web/live/media_live/show/search_helpers.ex
@@ -286,10 +286,11 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
 
   For the `:quality` sort mode this routes through `ReleaseRanker.rank_all/2`,
   so the manual top result equals what automatic search would select (R2),
-  with one deliberate exception: `quality_sort_via_ranker/2` passes
-  `apply_source_exclusion: false`, so a profile's `:excluded_sources` list is
-  NOT enforced here. Per spec R8, manual search and manual grab are the
-  operator's explicit escape hatch and must stay unaffected by exclusion the
+  with two deliberate exceptions: `quality_sort_via_ranker/2` passes
+  `apply_source_exclusion: false` and `apply_resolution_floor: false`, so
+  neither a profile's `:excluded_sources` list nor its `:min_resolution` floor
+  is enforced here. Per spec R8, manual search and manual grab are the
+  operator's explicit escape hatch and must stay unaffected by removals the
   automatic path applies — silently dropping a release from the manual
   dialog, recoverable only by switching sort mode, would remove that escape
   hatch. Penalized releases (size/seeder/identity) remain visible, sorted to
@@ -312,11 +313,12 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
   # order. When no quality profile is set, fall back to a seeders sort (matching
   # the legacy no-profile behavior).
   #
-  # apply_source_exclusion: false is load-bearing (R8): this is the manual
-  # search dialog, and manual search/grab must never silently drop a release
-  # because of a profile's :excluded_sources list, even though a resolved
-  # profile IS passed through for scoring/sorting. The opt-out is an explicit
-  # flag rather than "no profile present" so it can't be defeated by the
+  # apply_source_exclusion: false and apply_resolution_floor: false are both
+  # load-bearing (R8): this is the manual search dialog, and manual search/grab
+  # must never silently drop a release because of a profile's
+  # :excluded_sources list or its :min_resolution floor, even though a resolved
+  # profile IS passed through for scoring/sorting. The opt-outs are explicit
+  # flags rather than "no profile present" so they can't be defeated by the
   # profile the manual dialog legitimately does pass.
   defp quality_sort_via_ranker(results, ranking_opts) do
     case Keyword.get(ranking_opts, :quality_profile) do
@@ -324,8 +326,13 @@ defmodule MydiaWeb.MediaLive.Show.SearchHelpers do
         Enum.sort_by(results, & &1.seeders, :desc)
 
       _profile ->
+        opts =
+          ranking_opts
+          |> Keyword.put(:apply_source_exclusion, false)
+          |> Keyword.put(:apply_resolution_floor, false)
+
         results
-        |> ReleaseRanker.rank_all(Keyword.put(ranking_opts, :apply_source_exclusion, false))
+        |> ReleaseRanker.rank_all(opts)
         |> Enum.map(& &1.result)
     end
   end

--- a/test/mydia/indexers/quality_parser_test.exs
+++ b/test/mydia/indexers/quality_parser_test.exs
@@ -97,8 +97,9 @@ defmodule Mydia.Indexers.QualityParserTest do
     test "assumes 360p when the title carries no resolution token" do
       # An untagged release is SD in practice. Scoring it as "unknown" made it
       # rank above an honestly-labelled 720p, which is how a 360p XviD beat a
-      # 720p x265 for Dark Matter S02E01.
-      quality = QualityParser.parse("Dark.Matter.2024.S02E01.A.Quiet.Life.XviD-AFG[EZTVx.to].avi")
+      # 720p x265 for a monitored episode.
+      quality =
+        QualityParser.parse("Example.Show.2024.S02E01.Episode.Title.XviD-GRP[site.to].avi")
 
       assert quality.resolution == nil, "parse/1 must stay honest about what it detected"
       assert QualityParser.effective_resolution(quality) == "360p"

--- a/test/mydia/indexers/quality_parser_test.exs
+++ b/test/mydia/indexers/quality_parser_test.exs
@@ -88,6 +88,33 @@ defmodule Mydia.Indexers.QualityParserTest do
     end
   end
 
+  describe "effective_resolution/1" do
+    test "returns the detected resolution when the title carries one" do
+      assert QualityParser.effective_resolution(QualityParser.parse("Movie.1080p.BluRay")) ==
+               "1080p"
+    end
+
+    test "assumes 360p when the title carries no resolution token" do
+      # An untagged release is SD in practice. Scoring it as "unknown" made it
+      # rank above an honestly-labelled 720p, which is how a 360p XviD beat a
+      # 720p x265 for Dark Matter S02E01.
+      quality = QualityParser.parse("Dark.Matter.2024.S02E01.A.Quiet.Life.XviD-AFG[EZTVx.to].avi")
+
+      assert quality.resolution == nil, "parse/1 must stay honest about what it detected"
+      assert QualityParser.effective_resolution(quality) == "360p"
+    end
+
+    test "assumes 360p for a nil quality" do
+      assert QualityParser.effective_resolution(nil) == "360p"
+    end
+
+    test "parse/1 is left untouched so renamed files never get a false 360p tag" do
+      # media_import.ex feeds parse/1 into FileNamer. A resolution invented
+      # here would be written into the filename on disk.
+      assert QualityParser.parse("Movie.BluRay.x264").resolution == nil
+    end
+  end
+
   describe "extract_source/1" do
     test "extracts BluRay source" do
       assert QualityParser.extract_source("Movie.1080p.BluRay.x264") == "BluRay"

--- a/test/mydia/indexers/release_ranker_resolution_floor_test.exs
+++ b/test/mydia/indexers/release_ranker_resolution_floor_test.exs
@@ -5,8 +5,11 @@ defmodule Mydia.Indexers.ReleaseRankerResolutionFloorTest do
   Before this, `min_resolution` fed scoring and the upgrade-violation list but
   gated nothing, and there is no minimum score to grab, so the top of a bad
   list was taken regardless. Paired with an untagged release scoring a neutral
-  50 (better than an honestly-labelled out-of-range one at 25), that is how
-  Dark Matter S02E01 landed a 360p XviD on a 1080p-floor profile.
+  50 (better than an honestly-labelled out-of-range one at 25), that is how a
+  monitored episode landed a 360p XviD on a 1080p-floor profile.
+
+  Release names are anonymised; the shapes are what matter, and they are taken
+  from a real `search.completed` event.
   """
   use ExUnit.Case, async: true
 
@@ -51,19 +54,19 @@ defmodule Mydia.Indexers.ReleaseRankerResolutionFloorTest do
   end
 
   defp xvid_360p do
-    result("Dark.Matter.2024.S02E01.A.Quiet.Life.XviD-AFG[EZTVx.to].avi", 459.2, 0, "xvid")
+    result("Example.Show.2024.S02E01.Episode.Title.XviD-GRP[site.to].avi", 459.2, 0, "xvid")
   end
 
   defp x265_720p do
-    result("Dark.Matter.2024.S02E01.720p.10bit.WEBRip.2CH.x265.HEVC-PSA.mkv", 269.8, 11, "psa")
+    result("Example.Show.2024.S02E01.720p.10bit.WEBRip.2CH.x265.HEVC-GRP.mkv", 269.8, 11, "psa")
   end
 
   defp web_dl_1080p do
     result(
-      "www.UIndex.org    -    Dark Matter 2024 S02E01 A Quiet Life 1080p ATVP WEB-DL DDP5 1 Atmos H 264-Kitsune",
+      "www.SiteName.org    -    Example Show 2024 S02E01 Episode Title 1080p ATVP WEB-DL DDP5 1 Atmos H 264-GRP",
       4117.8,
       1,
-      "kitsune-1080p"
+      "webdl-1080p"
     )
   end
 
@@ -74,8 +77,8 @@ defmodule Mydia.Indexers.ReleaseRankerResolutionFloorTest do
         quality_profile: profile,
         preferred_qualities: ["1080p"],
         size_range: {1024, 7680},
-        search_query: "Dark Matter (2024) S02E01",
-        expected_title: "Dark Matter (2024)",
+        search_query: "Example Show (2024) S02E01",
+        expected_title: "Example Show (2024)",
         expected_season: 2,
         expected_episode: 1,
         custom_formats: []
@@ -100,7 +103,7 @@ defmodule Mydia.Indexers.ReleaseRankerResolutionFloorTest do
     end
 
     test "an at-floor release survives" do
-      assert %{result: %SearchResult{guid: "kitsune-1080p"}} =
+      assert %{result: %SearchResult{guid: "webdl-1080p"}} =
                ReleaseRanker.select_best_result(
                  [xvid_360p(), x265_720p(), web_dl_1080p()],
                  opts(hd_1080p())

--- a/test/mydia/indexers/release_ranker_resolution_floor_test.exs
+++ b/test/mydia/indexers/release_ranker_resolution_floor_test.exs
@@ -1,0 +1,159 @@
+defmodule Mydia.Indexers.ReleaseRankerResolutionFloorTest do
+  @moduledoc """
+  A profile's `:min_resolution` is a hard floor on the automatic path.
+
+  Before this, `min_resolution` fed scoring and the upgrade-violation list but
+  gated nothing, and there is no minimum score to grab, so the top of a bad
+  list was taken regardless. Paired with an untagged release scoring a neutral
+  50 (better than an honestly-labelled out-of-range one at 25), that is how
+  Dark Matter S02E01 landed a 360p XviD on a 1080p-floor profile.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.{QualityParser, ReleaseRanker, SearchResult}
+  alias Mydia.Settings.QualityProfile
+
+  defp hd_1080p do
+    %QualityProfile{
+      name: "HD-1080p",
+      quality_standards: %{
+        episode_max_size_mb: 7680,
+        episode_min_size_mb: 1024,
+        excluded_sources: ["CAM", "Telesync", "Telecine", "Screener", "Workprint"],
+        max_resolution: "1080p",
+        min_resolution: "1080p",
+        preferred_resolutions: ["1080p"],
+        preferred_sources: ["BluRay", "WEB-DL"]
+      }
+    }
+  end
+
+  defp no_floor do
+    %QualityProfile{
+      name: "Any",
+      quality_standards: %{
+        preferred_resolutions: ["360p", "480p", "576p", "720p", "1080p", "2160p"]
+      }
+    }
+  end
+
+  defp result(title, size_mb, seeders, guid) do
+    SearchResult.new(
+      title: title,
+      size: round(size_mb * 1_048_576),
+      seeders: seeders,
+      leechers: 0,
+      download_url: "magnet:?xt=urn:btih:#{guid}",
+      indexer: "Prowlarr",
+      guid: guid,
+      quality: QualityParser.parse(title)
+    )
+  end
+
+  defp xvid_360p do
+    result("Dark.Matter.2024.S02E01.A.Quiet.Life.XviD-AFG[EZTVx.to].avi", 459.2, 0, "xvid")
+  end
+
+  defp x265_720p do
+    result("Dark.Matter.2024.S02E01.720p.10bit.WEBRip.2CH.x265.HEVC-PSA.mkv", 269.8, 11, "psa")
+  end
+
+  defp web_dl_1080p do
+    result(
+      "www.UIndex.org    -    Dark Matter 2024 S02E01 A Quiet Life 1080p ATVP WEB-DL DDP5 1 Atmos H 264-Kitsune",
+      4117.8,
+      1,
+      "kitsune-1080p"
+    )
+  end
+
+  defp opts(profile, extra \\ []) do
+    Keyword.merge(
+      [
+        media_type: :episode,
+        quality_profile: profile,
+        preferred_qualities: ["1080p"],
+        size_range: {1024, 7680},
+        search_query: "Dark Matter (2024) S02E01",
+        expected_title: "Dark Matter (2024)",
+        expected_season: 2,
+        expected_episode: 1,
+        custom_formats: []
+      ],
+      extra
+    )
+  end
+
+  describe "min_resolution is a hard floor on the automatic path" do
+    test "a below-floor release is dropped even when it is the ONLY candidate" do
+      # The item must stay wanted rather than take a 360p rip.
+      assert ReleaseRanker.select_best_result([xvid_360p()], opts(hd_1080p())) == nil
+    end
+
+    test "an untagged release is treated as 360p and dropped by a 1080p floor" do
+      assert xvid_360p().quality.resolution == nil
+      assert ReleaseRanker.rank_all([xvid_360p()], opts(hd_1080p())) == []
+    end
+
+    test "every below-floor candidate is dropped, leaving nothing to grab" do
+      assert ReleaseRanker.rank_all([xvid_360p(), x265_720p()], opts(hd_1080p())) == []
+    end
+
+    test "an at-floor release survives" do
+      assert %{result: %SearchResult{guid: "kitsune-1080p"}} =
+               ReleaseRanker.select_best_result(
+                 [xvid_360p(), x265_720p(), web_dl_1080p()],
+                 opts(hd_1080p())
+               )
+    end
+
+    test "a profile with no min_resolution keeps everything" do
+      ranked = ReleaseRanker.rank_all([xvid_360p(), x265_720p()], opts(no_floor()))
+      assert length(ranked) == 2
+    end
+
+    test "a nil profile keeps everything" do
+      ranked =
+        ReleaseRanker.rank_all(
+          [xvid_360p(), x265_720p()],
+          opts(nil) |> Keyword.delete(:quality_profile)
+        )
+
+      assert length(ranked) == 2
+    end
+  end
+
+  describe "apply_resolution_floor opt-out (manual search is the escape hatch)" do
+    test "apply_resolution_floor: false keeps a below-floor release" do
+      ranked =
+        ReleaseRanker.rank_all([xvid_360p()], opts(hd_1080p(), apply_resolution_floor: false))
+
+      assert length(ranked) == 1
+    end
+
+    test "the floor defaults to on, so the automatic path keeps filtering" do
+      assert ReleaseRanker.rank_all([xvid_360p()], opts(hd_1080p())) == []
+    end
+  end
+
+  describe "an untagged release no longer outranks a labelled one" do
+    test "the 720p beats the untagged XviD once the floor is lifted" do
+      # Both are below a 1080p floor, so this is the no-floor profile. The
+      # XviD used to win on a neutral 50 for "unknown" against the 720p's 25.
+      [%{result: best} | _] =
+        ReleaseRanker.rank_all([xvid_360p(), x265_720p()], opts(no_floor()))
+
+      assert best.guid == "psa"
+    end
+
+    test "an untagged release sorts as 360p in the preference order" do
+      ranked =
+        ReleaseRanker.rank_all(
+          [xvid_360p(), x265_720p()],
+          opts(no_floor(), preferred_qualities: ["2160p", "1080p", "720p", "480p", "360p"])
+        )
+
+      assert Enum.map(ranked, & &1.result.guid) == ["psa", "xvid"]
+    end
+  end
+end

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -662,7 +662,7 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       # penalties let weak releases sink rather than vanish. In practice
       # nothing sits below them: there is no minimum score to grab, so the top
       # of an all-sub-floor list is still taken. That is how a 1080p-floor
-      # profile grabbed a 360p XviD of Dark Matter S02E01. :min_resolution is
+      # profile grabbed a 360p XviD of a monitored episode. :min_resolution is
       # now a floor, matching :excluded_sources.
       profile =
         build_quality_profile(%{

--- a/test/mydia/indexers/release_ranker_test.exs
+++ b/test/mydia/indexers/release_ranker_test.exs
@@ -656,7 +656,14 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
       assert length(ranked) == 1
     end
 
-    test "a min/max resolution violation zeroes the quality component but does not hard-reject the release" do
+    test "a min_resolution violation zeroes the quality component AND hard-rejects the release" do
+      # This assertion was inverted deliberately. It used to assert that a
+      # sub-floor release was merely down-scored, on the reasoning that soft
+      # penalties let weak releases sink rather than vanish. In practice
+      # nothing sits below them: there is no minimum score to grab, so the top
+      # of an all-sub-floor list is still taken. That is how a 1080p-floor
+      # profile grabbed a 360p XviD of Dark Matter S02E01. :min_resolution is
+      # now a floor, matching :excluded_sources.
       profile =
         build_quality_profile(%{
           quality_standards: %{
@@ -674,13 +681,39 @@ defmodule Mydia.Indexers.ReleaseRankerTest do
         })
 
       breakdown = ReleaseRanker.calculate_score_breakdown(result, quality_profile: profile)
-      # QualityProfile.score_media_file/2 still detects the violation and zeroes
-      # the quality sub-score; that's real. What it no longer does is prevent
-      # the release from being ranked and selected.
       assert breakdown.quality == 0.0
 
-      ranked = ReleaseRanker.rank_all([result], quality_profile: profile)
-      assert length(ranked) == 1
+      assert ReleaseRanker.rank_all([result], quality_profile: profile) == []
+
+      # The operator's manual escape hatch still surfaces it.
+      assert length(
+               ReleaseRanker.rank_all([result],
+                 quality_profile: profile,
+                 apply_resolution_floor: false
+               )
+             ) == 1
+    end
+
+    test "max_resolution stays a scoring signal and does not hard-reject" do
+      # Only the floor gates. Grabbing above the ceiling wastes disk but still
+      # yields a watchable file, so it remains a penalty.
+      profile =
+        build_quality_profile(%{
+          quality_standards: %{
+            preferred_resolutions: ["720p"],
+            min_resolution: "720p",
+            max_resolution: "1080p"
+          }
+        })
+
+      result =
+        build_result(%{
+          title: "Test.Movie.2024.2160p.BluRay.x265-GROUP",
+          seeders: 100,
+          quality: QualityParser.parse("Test.Movie.2024.2160p.BluRay.x265-GROUP")
+        })
+
+      assert length(ReleaseRanker.rank_all([result], quality_profile: profile)) == 1
     end
 
     test "a profile without quality_standards zeroes the quality component" do

--- a/test/mydia/library/release_parser_test.exs
+++ b/test/mydia/library/release_parser_test.exs
@@ -218,19 +218,19 @@ defmodule Mydia.Library.ReleaseParserTest do
 
   describe "parse/1 - indexer site-branding prefixes" do
     test "strips a `www.<host> - ` prefix from a TV release" do
-      # Regression: this exact title was returned by a live search for
-      # Dark Matter S02E01. The prefix was folded into the show title as
-      # "Www Uindex Org Dark Matter", whose Jaro distance to the expected
-      # "Dark Matter (2024)" was 0.40, below ReleaseRanker's 0.7 threshold.
-      # Every 1080p and 2160p candidate was hard-rejected as a title
-      # mismatch and a 360p XviD was grabbed instead.
+      # Regression: a title of this exact shape was returned by a live search.
+      # The prefix was folded into the show title as "Www Sitename Org Example
+      # Show", whose Jaro distance to the expected title was 0.40, below
+      # ReleaseRanker's 0.7 threshold. Every 1080p and 2160p candidate was
+      # hard-rejected as a title mismatch and a 360p XviD was grabbed instead.
+      # Names are anonymised; the shape is what matters.
       result =
         ReleaseParser.parse(
-          "www.UIndex.org    -    Dark Matter 2024 S02E01 A Quiet Life 1080p ATVP WEB-DL DDP5 1 Atmos H 264-Kitsune"
+          "www.SiteName.org    -    Example Show 2024 S02E01 Episode Title 1080p ATVP WEB-DL DDP5 1 Atmos H 264-GRP"
         )
 
       assert result.type == :tv_show
-      assert result.title == "Dark Matter"
+      assert result.title == "Example Show"
       assert result.year == 2024
       assert result.season == 2
       assert result.episodes == [1]
@@ -239,10 +239,10 @@ defmodule Mydia.Library.ReleaseParserTest do
     test "strips the prefix from the 2160p variant of the same release" do
       result =
         ReleaseParser.parse(
-          "www.UIndex.org    -    Dark Matter 2024 S02E01 A Quiet Life 2160p ATVP WEB-DL DDP5 1 Atmos DV HDR10Plus H 265-Kitsune"
+          "www.SiteName.org    -    Example Show 2024 S02E01 Episode Title 2160p ATVP WEB-DL DDP5 1 Atmos DV HDR10Plus H 265-GRP"
         )
 
-      assert result.title == "Dark Matter"
+      assert result.title == "Example Show"
       assert result.season == 2
       assert result.episodes == [1]
     end
@@ -279,11 +279,14 @@ defmodule Mydia.Library.ReleaseParserTest do
       # Only an unambiguous boundary (a bracket, a separator glyph, or a bare
       # www.domain.tld before whitespace) may be stripped.
       for title <- [
-            "www.example.com.The Matrix.1999.1080p",
-            "www.example.com.The Matrix 1999 1080p BluRay x264"
+            "www.example.com.The Sample Film.1999.1080p",
+            "www.example.com.The Sample Film 1999 1080p BluRay x264"
           ] do
         result = ReleaseParser.parse(title)
-        assert result.title =~ "The Matrix", "expected 'The Matrix' in #{inspect(result.title)}"
+
+        assert result.title =~ "The Sample",
+               "leading article was eaten: #{inspect(result.title)}"
+
         assert result.year == 1999
       end
     end

--- a/test/mydia/library/release_parser_test.exs
+++ b/test/mydia/library/release_parser_test.exs
@@ -273,6 +273,21 @@ defmodule Mydia.Library.ReleaseParserTest do
       refute result.title == ""
     end
 
+    test "does not eat a title word that follows the host on a dot" do
+      # The domain-label run is greedy, so `.The` looked like another label and
+      # the space after it satisfied the boundary check, leaving "Matrix".
+      # Only an unambiguous boundary (a bracket, a separator glyph, or a bare
+      # www.domain.tld before whitespace) may be stripped.
+      for title <- [
+            "www.example.com.The Matrix.1999.1080p",
+            "www.example.com.The Matrix 1999 1080p BluRay x264"
+          ] do
+        result = ReleaseParser.parse(title)
+        assert result.title =~ "The Matrix", "expected 'The Matrix' in #{inspect(result.title)}"
+        assert result.year == 1999
+      end
+    end
+
     test "leaves a run-on dotted domain alone rather than eating the title" do
       # No delimiter separates the domain from the release, so the labels are
       # indistinguishable from title words. Declining to strip is the safe

--- a/test/mydia/library/release_parser_test.exs
+++ b/test/mydia/library/release_parser_test.exs
@@ -215,4 +215,79 @@ defmodule Mydia.Library.ReleaseParserTest do
       assert result.year == 2020
     end
   end
+
+  describe "parse/1 - indexer site-branding prefixes" do
+    test "strips a `www.<host> - ` prefix from a TV release" do
+      # Regression: this exact title was returned by a live search for
+      # Dark Matter S02E01. The prefix was folded into the show title as
+      # "Www Uindex Org Dark Matter", whose Jaro distance to the expected
+      # "Dark Matter (2024)" was 0.40, below ReleaseRanker's 0.7 threshold.
+      # Every 1080p and 2160p candidate was hard-rejected as a title
+      # mismatch and a 360p XviD was grabbed instead.
+      result =
+        ReleaseParser.parse(
+          "www.UIndex.org    -    Dark Matter 2024 S02E01 A Quiet Life 1080p ATVP WEB-DL DDP5 1 Atmos H 264-Kitsune"
+        )
+
+      assert result.type == :tv_show
+      assert result.title == "Dark Matter"
+      assert result.year == 2024
+      assert result.season == 2
+      assert result.episodes == [1]
+    end
+
+    test "strips the prefix from the 2160p variant of the same release" do
+      result =
+        ReleaseParser.parse(
+          "www.UIndex.org    -    Dark Matter 2024 S02E01 A Quiet Life 2160p ATVP WEB-DL DDP5 1 Atmos DV HDR10Plus H 265-Kitsune"
+        )
+
+      assert result.title == "Dark Matter"
+      assert result.season == 2
+      assert result.episodes == [1]
+    end
+
+    test "strips a bracketed site prefix" do
+      result = ReleaseParser.parse("[ www.Torrenting.org ] Movie.Name.2020.1080p.BluRay.x264-GRP")
+
+      assert result.type == :movie
+      assert result.title == "Movie Name"
+      assert result.year == 2020
+    end
+
+    test "strips a dotted site prefix with no separator" do
+      result = ReleaseParser.parse("www.1TamilMV.world - Movie.Name.2020.1080p.BluRay.x264")
+
+      assert result.title == "Movie Name"
+      assert result.year == 2020
+    end
+
+    test "leaves a title that merely contains www alone" do
+      # Only a leading site prefix is stripped. A title is never emptied.
+      result = ReleaseParser.parse("Movie.Name.2020.1080p.BluRay.x264-GRP")
+      assert result.title == "Movie Name"
+    end
+
+    test "does not empty the title when the name is nothing but a site tag" do
+      result = ReleaseParser.parse("www.UIndex.org")
+      refute result.title == ""
+    end
+
+    test "leaves a run-on dotted domain alone rather than eating the title" do
+      # No delimiter separates the domain from the release, so the labels are
+      # indistinguishable from title words. Declining to strip is the safe
+      # failure: the title survives intact, just uncleaned.
+      result = ReleaseParser.parse("www.Site.org.Movie.Name.2020.1080p.BluRay.x264")
+
+      assert result.title =~ "Movie Name"
+      assert result.year == 2020
+    end
+
+    test "strips a prefix separated only by whitespace" do
+      result = ReleaseParser.parse("www.Torrenting.org Movie.Name.2020.1080p.BluRay.x264")
+
+      assert result.title == "Movie Name"
+      assert result.year == 2020
+    end
+  end
 end


### PR DESCRIPTION
An automatic episode search returned a perfectly good 1080p WEB-DL and grabbed a 360p XviD instead, on a profile whose floor is 1080p. Three defects lined up. Diagnosed from the recorded `search.completed` event on a live instance, which captured all six results.

Release names below are anonymised; the shapes are what matter.

| Release | Res | Size | Was | Now |
| --- | --- | --- | --- | --- |
| `www.SiteName.org - Example Show 2024 S02E01 ... 1080p ATVP WEB-DL DDP5 1 Atmos H 264-GRP` | 1080p | 4118 MB | rejected: title_mismatch | **selected** |
| (duplicate) | 1080p | 4096 MB | rejected: title_mismatch | accepted |
| `www.SiteName.org - ... 2160p ATVP WEB-DL DV HDR10Plus H 265-GRP` | 2160p | 9523 MB | rejected: title_mismatch | accepted, outscored |
| `www.SiteName.org - ... 720p ATVP WEB-DL DDP5 1 H 264-GRP` | 720p | 1331 MB | rejected: title_mismatch | rejected: below floor |
| `Example.Show.2024.S02E01.720p.10bit.WEBRip.2CH.x265.HEVC-GRP.mkv` | 720p | 270 MB | accepted, 3.85 | rejected: below floor |
| `Example.Show.2024.S02E01.XviD-GRP[site.to].avi` | null | 459 MB | **grabbed, 18.83** | rejected: below floor |

## 1. Site-branding prefix eats the show title

Some indexers stamp their domain onto every title they publish, and `ReleaseParser` folded that into the show name. A title of the form `www.SiteName.org - Example Show 2024 S02E01 ...` parsed as `"Www Sitename Org Example Show"`, whose Jaro distance to the expected title was **0.40**, under the 0.7 threshold in `reject_title_mismatches/2`. Every 1080p and 2160p candidate was hard-rejected before any scoring ran.

`strip_site_prefix/1` removes a leading `www.<host>` before tokenizing, at one of three unambiguous boundaries: a bracketed host, a host followed by a separator glyph, or a bare `www.host.tld` followed by whitespace. Anything ambiguous, such as a fully run-on `www.Site.org.Movie.Name.2020.1080p`, is left untouched. That is the safe failure: a title we decline to clean, never one we destroy.

## 2. An unknown resolution outranked a known-bad one

`QualityParser` returns `nil` for a title with no resolution token (`XviD` is a codec, not a resolution). Scored against the profile, `nil` got a neutral **50** and produced no range violation, while an honestly-labelled 720p got **25** plus a violation. So the untagged XviD (quality 59.3, 0 seeders) beat the 720p x265 (quality 0.0, 11 seeders) by 18.83 to 3.85.

`QualityParser.effective_resolution/1` reads an untagged release as 360p, applied at the search boundary. `parse/1` deliberately stays honest and still returns `nil`, because it also feeds file renaming (`media_import.ex` → `FileNamer`), where an invented resolution would be written into a filename on disk, and `score_media_file/2` is shared with `Upgrades.Comparator`, where `nil` means "not analyzed yet" rather than SD.

## 3. `min_resolution` gated nothing

It fed scoring and the upgrade-violation list but never removed anything, and there is no minimum score before grabbing, so the top of an all-sub-floor list is taken regardless. `reject_below_min_resolution/2` makes it a hard removal gated on `:apply_resolution_floor` (default true), mirroring `:excluded_sources`. Manual search passes `false` so the operator keeps their escape hatch per R8. `max_resolution` stays a scoring signal: grabbing above the ceiling wastes disk but still yields a watchable file.

## Verification

- `mix precommit`: **9796 tests, 0 failures**, all stages green.
- Replaying all six recorded releases now selects the 1080p WEB-DL.
- New `release_ranker_resolution_floor_test.exs` plus cases in the parser and quality-parser suites.

## Note for review

One existing assertion is deliberately inverted: `"a min/max resolution violation ... does not hard-reject the release"` now asserts the opposite. That test encoded the old soft-penalty intent, which is precisely the behaviour that let this happen.

A consequence worth naming: a genuine 1080p release whose title omits the resolution token is now read as 360p and dropped by a 1080p floor. Rare in scene naming, and manual search still surfaces it, but it is a real trade-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added minimum-resolution filtering for automatic release selection.
  * Untagged releases now use a 360p fallback for ranking and search results.
  * Added an option to disable resolution filtering during manual searches.
  * Improved parsing of release names with indexer site-branding prefixes.

* **Bug Fixes**
  * Releases below the configured minimum resolution are now excluded rather than merely down-ranked.
  * Improved ordering of releases without explicit resolution labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->