### PR TITLE
fix(downloads): match season packs at show level and add titles from the match dialog

### DIFF
--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -273,14 +273,10 @@ defmodule MydiaWeb.DownloadsLive.Components do
             id={"match-dialog-add-#{result.provider_id}"}
             type="button"
             class="btn btn-sm btn-ghost justify-start"
-            disabled={@dialog.adding == to_string(result.provider_id)}
             phx-click="match_modal_add_external"
             phx-value-provider_id={result.provider_id}
+            phx-disable-with="Adding..."
           >
-            <span
-              :if={@dialog.adding == to_string(result.provider_id)}
-              class="loading loading-spinner loading-xs"
-            ></span>
             <span class="font-medium">{result.title}</span>
             <span :if={result.year} class="text-base-content/60">({result.year})</span>
             <span class="badge badge-xs badge-outline">Add to library</span>

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -144,6 +144,135 @@ defmodule MydiaWeb.DownloadsLive.Components do
     """
   end
 
+  @doc """
+  The match / re-match dialog.
+
+  One list holds library rows and, once Task 6 lands, provider rows. TV rows
+  behave differently per mode, which the dialog states in words rather than
+  leaving the operator to discover by clicking.
+  """
+  attr :dialog, :map, required: true
+
+  def match_modal(assigns) do
+    ~H"""
+    <.modal id="match-modal" show={true} on_cancel="close_match_modal">
+      <:title>
+        {if @dialog.mode == :inflight, do: "Change match", else: "Re-match download"}
+      </:title>
+
+      <%= if @dialog.selected do %>
+        <p class="text-sm text-base-content/80">
+          Choose the episode for <span class="font-medium">{@dialog.selected.title}</span>:
+        </p>
+        <p :if={@dialog.mode == :postimport} class="text-xs text-base-content/50 mt-1">
+          This download imported one file, so it maps to a single episode.
+        </p>
+        <div :if={@dialog.episodes == []} class="text-sm text-base-content/50 mt-2">
+          No episodes found for this show.
+        </div>
+        <div class="mt-2 max-h-64 overflow-y-auto flex flex-col gap-1">
+          <button
+            :for={ep <- @dialog.episodes}
+            id={"match-dialog-episode-#{ep.id}"}
+            type="button"
+            class="btn btn-sm btn-ghost justify-start"
+            phx-click="match_modal_pick_episode"
+            phx-value-episode_id={ep.id}
+          >
+            S{String.pad_leading("#{ep.season_number}", 2, "0")}E{String.pad_leading(
+              "#{ep.episode_number}",
+              2,
+              "0"
+            )}
+            <span :if={ep.title} class="text-base-content/60">- {ep.title}</span>
+          </button>
+        </div>
+      <% else %>
+        <div class="filter mb-3">
+          <input
+            id="match-dialog-type-tv"
+            class="btn btn-sm"
+            type="checkbox"
+            name="match_type"
+            aria-label="TV"
+            checked={@dialog.type == :tv_show}
+            phx-click="match_modal_set_type"
+            phx-value-type="tv_show"
+          />
+          <input
+            id="match-dialog-type-movie"
+            class="btn btn-sm"
+            type="checkbox"
+            name="match_type"
+            aria-label="Movie"
+            checked={@dialog.type == :movie}
+            phx-click="match_modal_set_type"
+            phx-value-type="movie"
+          />
+        </div>
+
+        <form id="match-modal-search-form" phx-change="match_modal_search">
+          <input
+            type="text"
+            name="q"
+            value={@dialog.query}
+            class="input input-bordered w-full"
+            phx-debounce="300"
+            autocomplete="off"
+            placeholder="Search your library or add a new title..."
+          />
+        </form>
+
+        <p :if={@dialog.search_warning} id="match-dialog-warning" class="text-warning text-xs mt-2">
+          {@dialog.search_warning}
+        </p>
+
+        <p :if={@dialog.error} id="match-dialog-error" class="alert alert-error mt-3 text-sm">
+          {@dialog.error}
+        </p>
+
+        <div class="mt-2 max-h-64 overflow-y-auto flex flex-col gap-1">
+          <div
+            :for={item <- @dialog.library_results}
+            class="flex items-center gap-1"
+          >
+            <button
+              id={"match-dialog-result-#{item.id}"}
+              type="button"
+              class="btn btn-sm btn-ghost justify-start grow"
+              phx-click="match_modal_pick_item"
+              phx-value-media_item_id={item.id}
+            >
+              <span class="font-medium">{item.title}</span>
+              <span :if={item.year} class="text-base-content/60">({item.year})</span>
+              <span class="badge badge-xs badge-outline">
+                {if item.type == "tv_show", do: "TV", else: "Movie"}
+              </span>
+            </button>
+            <button
+              :if={item.type == "tv_show" and @dialog.mode == :inflight}
+              id={"match-dialog-pick-episode-#{item.id}"}
+              type="button"
+              class="btn btn-xs btn-ghost"
+              phx-click="match_modal_show_episodes"
+              phx-value-media_item_id={item.id}
+              title="Match a single episode instead of the whole show"
+            >
+              Pick episode
+            </button>
+          </div>
+        </div>
+      <% end %>
+
+      <:actions>
+        <button type="button" class="btn btn-ghost" phx-click="close_match_modal">
+          Cancel
+        </button>
+      </:actions>
+    </.modal>
+    """
+  end
+
   # Whether the modal's candidates can target a movie destination, an episode,
   # or neither. Deliberately keyed off `download.media_item.type` (authoritative)
   # rather than `episodes == []` — an ordinary TV show whose episodes haven't

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -147,9 +147,9 @@ defmodule MydiaWeb.DownloadsLive.Components do
   @doc """
   The match / re-match dialog.
 
-  One list holds library rows and, once Task 6 lands, provider rows. TV rows
-  behave differently per mode, which the dialog states in words rather than
-  leaving the operator to discover by clicking.
+  One panel holds library rows, then provider rows for titles not yet in the
+  library. TV rows behave differently per mode, which the dialog states in
+  words rather than leaving the operator to discover by clicking.
   """
   attr :dialog, :map, required: true
 
@@ -261,6 +261,30 @@ defmodule MydiaWeb.DownloadsLive.Components do
               Pick episode
             </button>
           </div>
+        </div>
+
+        <div :if={@dialog.external_results != []} class="divider text-xs my-1">
+          Not in your library
+        </div>
+
+        <div class="max-h-64 overflow-y-auto flex flex-col gap-1">
+          <button
+            :for={result <- @dialog.external_results}
+            id={"match-dialog-add-#{result.provider_id}"}
+            type="button"
+            class="btn btn-sm btn-ghost justify-start"
+            disabled={@dialog.adding == to_string(result.provider_id)}
+            phx-click="match_modal_add_external"
+            phx-value-provider_id={result.provider_id}
+          >
+            <span
+              :if={@dialog.adding == to_string(result.provider_id)}
+              class="loading loading-spinner loading-xs"
+            ></span>
+            <span class="font-medium">{result.title}</span>
+            <span :if={result.year} class="text-base-content/60">({result.year})</span>
+            <span class="badge badge-xs badge-outline">Add to library</span>
+          </button>
         </div>
       <% end %>
 

--- a/lib/mydia_web/live/downloads_live/components.ex
+++ b/lib/mydia_web/live/downloads_live/components.ex
@@ -170,6 +170,9 @@ defmodule MydiaWeb.DownloadsLive.Components do
         <div :if={@dialog.episodes == []} class="text-sm text-base-content/50 mt-2">
           No episodes found for this show.
         </div>
+        <p :if={@dialog.error} id="match-dialog-error" class="alert alert-error mt-3 text-sm">
+          {@dialog.error}
+        </p>
         <div class="mt-2 max-h-64 overflow-y-auto flex flex-col gap-1">
           <button
             :for={ep <- @dialog.episodes}

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -673,11 +673,11 @@ defmodule MydiaWeb.DownloadsLive.Index do
 
   def handle_event("match_modal_add_external", %{"provider_id" => provider_id}, socket) do
     with :ok <- Authorization.authorize_create_media(socket) do
-      dialog = %{socket.assigns.match_modal | adding: to_string(provider_id), error: nil}
+      dialog = %{socket.assigns.match_modal | error: nil}
 
       case MatchDialog.add_external(dialog, provider_id) do
         {:added, item} ->
-          case MatchDialog.select(%{dialog | adding: nil}, item.id) do
+          case MatchDialog.select(dialog, item.id) do
             {:submit, {item_id, episode_id}} -> submit_match(socket, item_id, episode_id)
             {:episodes, updated} -> {:noreply, assign(socket, :match_modal, updated)}
           end

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -671,6 +671,25 @@ defmodule MydiaWeb.DownloadsLive.Index do
     {:noreply, update(socket, :match_modal, &MatchDialog.show_episodes(&1, media_item_id))}
   end
 
+  def handle_event("match_modal_add_external", %{"provider_id" => provider_id}, socket) do
+    with :ok <- Authorization.authorize_create_media(socket) do
+      dialog = %{socket.assigns.match_modal | adding: to_string(provider_id), error: nil}
+
+      case MatchDialog.add_external(dialog, provider_id) do
+        {:added, item} ->
+          case MatchDialog.select(%{dialog | adding: nil}, item.id) do
+            {:submit, {item_id, episode_id}} -> submit_match(socket, item_id, episode_id)
+            {:episodes, updated} -> {:noreply, assign(socket, :match_modal, updated)}
+          end
+
+        {:error, updated} ->
+          {:noreply, assign(socket, :match_modal, updated)}
+      end
+    else
+      {:unauthorized, socket} -> {:noreply, socket}
+    end
+  end
+
   def handle_event("match_modal_pick_episode", %{"episode_id" => episode_id}, socket) do
     {:submit, {item_id, ep_id}} =
       MatchDialog.select_episode(socket.assigns.match_modal, episode_id)

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -14,6 +14,7 @@ defmodule MydiaWeb.DownloadsLive.Index do
   alias Phoenix.PubSub
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.DownloadsLive.Components
+  alias MydiaWeb.DownloadsLive.MatchDialog
   import MydiaWeb.Formatters
 
   require Logger
@@ -633,15 +634,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
   def handle_event("open_match_modal", %{"id" => id, "mode" => mode}, socket)
       when mode in ["inflight", "postimport"] do
     with :ok <- Authorization.authorize_manage_downloads(socket) do
-      {:noreply,
-       assign(socket, :match_modal, %{
-         download_id: id,
-         mode: String.to_existing_atom(mode),
-         query: "",
-         results: [],
-         selected: nil,
-         episodes: []
-       })}
+      with_download(socket, id, [preload: [:media_item]], fn download ->
+        dialog =
+          download
+          |> MatchDialog.open(mode_atom(mode))
+          |> then(&MatchDialog.search(&1, &1.query))
+
+        {:noreply, assign(socket, :match_modal, dialog)}
+      end)
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -652,41 +652,30 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("match_modal_search", %{"q" => query}, socket) do
-    results =
-      if String.length(query) >= 2 do
-        Media.list_media_items(search: query) |> Enum.take(10)
-      else
-        []
-      end
-
-    {:noreply,
-     update(socket, :match_modal, fn modal ->
-       %{modal | query: query, results: results}
-     end)}
+    {:noreply, update(socket, :match_modal, &MatchDialog.search(&1, query))}
   end
 
-  def handle_event(
-        "match_modal_pick_item",
-        %{"media_item_id" => media_item_id, "type" => type, "title" => title},
-        socket
-      ) do
-    if type == "tv_show" do
-      # TV: choose the specific episode in a second step.
-      episodes = Media.list_episodes(media_item_id)
+  def handle_event("match_modal_set_type", %{"type" => type}, socket)
+      when type in ["movie", "tv_show"] do
+    {:noreply, update(socket, :match_modal, &MatchDialog.set_type(&1, media_type_atom(type)))}
+  end
 
-      {:noreply,
-       update(socket, :match_modal, fn modal ->
-         %{modal | selected: %{id: media_item_id, title: title}, episodes: episodes}
-       end)}
-    else
-      # Movie: submit immediately.
-      submit_match(socket, media_item_id, nil)
+  def handle_event("match_modal_pick_item", %{"media_item_id" => media_item_id}, socket) do
+    case MatchDialog.select(socket.assigns.match_modal, media_item_id) do
+      {:submit, {item_id, episode_id}} -> submit_match(socket, item_id, episode_id)
+      {:episodes, dialog} -> {:noreply, assign(socket, :match_modal, dialog)}
     end
   end
 
+  def handle_event("match_modal_show_episodes", %{"media_item_id" => media_item_id}, socket) do
+    {:noreply, update(socket, :match_modal, &MatchDialog.show_episodes(&1, media_item_id))}
+  end
+
   def handle_event("match_modal_pick_episode", %{"episode_id" => episode_id}, socket) do
-    %{selected: %{id: media_item_id}} = socket.assigns.match_modal
-    submit_match(socket, media_item_id, episode_id)
+    {:submit, {item_id, ep_id}} =
+      MatchDialog.select_episode(socket.assigns.match_modal, episode_id)
+
+    submit_match(socket, item_id, ep_id)
   end
 
   # --- Match files modal (manual file matching on import failure) ---
@@ -949,6 +938,14 @@ defmodule MydiaWeb.DownloadsLive.Index do
       {:unauthorized, socket} -> {:noreply, socket}
     end
   end
+
+  # Event params are strings from the browser. Matched explicitly rather than
+  # converted, so a forged value cannot reach String.to_atom/1.
+  defp mode_atom("inflight"), do: :inflight
+  defp mode_atom("postimport"), do: :postimport
+
+  defp media_type_atom("movie"), do: :movie
+  defp media_type_atom("tv_show"), do: :tv_show
 
   @impl true
   def handle_info({:download_updated, _download_id}, socket) do

--- a/lib/mydia_web/live/downloads_live/index.ex
+++ b/lib/mydia_web/live/downloads_live/index.ex
@@ -691,10 +691,10 @@ defmodule MydiaWeb.DownloadsLive.Index do
   end
 
   def handle_event("match_modal_pick_episode", %{"episode_id" => episode_id}, socket) do
-    {:submit, {item_id, ep_id}} =
-      MatchDialog.select_episode(socket.assigns.match_modal, episode_id)
-
-    submit_match(socket, item_id, ep_id)
+    case MatchDialog.select_episode(socket.assigns.match_modal, episode_id) do
+      {:submit, {item_id, ep_id}} -> submit_match(socket, item_id, ep_id)
+      {:error, dialog} -> {:noreply, assign(socket, :match_modal, dialog)}
+    end
   end
 
   # --- Match files modal (manual file matching on import failure) ---

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -924,74 +924,7 @@
     </.modal>
 
     <%!-- Match / re-match modal (in-flight correction + post-import re-match) --%>
-    <.modal :if={@match_modal} id="match-modal" show={true} on_cancel="close_match_modal">
-      <:title>
-        {if @match_modal.mode == :inflight, do: "Change match", else: "Re-match download"}
-      </:title>
-
-      <%= if @match_modal.selected do %>
-        <p class="text-sm text-base-content/80">
-          Choose the episode for <span class="font-medium">{@match_modal.selected.title}</span>:
-        </p>
-        <div
-          :if={@match_modal.episodes == []}
-          class="text-sm text-base-content/50 mt-2"
-        >
-          No episodes found for this show.
-        </div>
-        <div class="mt-2 max-h-64 overflow-y-auto flex flex-col gap-1">
-          <button
-            :for={ep <- @match_modal.episodes}
-            type="button"
-            class="btn btn-sm btn-ghost justify-start"
-            phx-click="match_modal_pick_episode"
-            phx-value-episode_id={ep.id}
-          >
-            S{String.pad_leading("#{ep.season_number}", 2, "0")}E{String.pad_leading(
-              "#{ep.episode_number}",
-              2,
-              "0"
-            )}
-            <span :if={ep.title} class="text-base-content/60">- {ep.title}</span>
-          </button>
-        </div>
-      <% else %>
-        <form id="match-modal-search-form" phx-change="match_modal_search">
-          <input
-            type="text"
-            name="q"
-            value={@match_modal.query}
-            class="input input-bordered w-full"
-            phx-debounce="300"
-            autocomplete="off"
-            placeholder="Search your library by title..."
-          />
-        </form>
-        <div class="mt-2 max-h-64 overflow-y-auto flex flex-col gap-1">
-          <button
-            :for={item <- @match_modal.results}
-            type="button"
-            class="btn btn-sm btn-ghost justify-start"
-            phx-click="match_modal_pick_item"
-            phx-value-media_item_id={item.id}
-            phx-value-type={item.type}
-            phx-value-title={item.title}
-          >
-            <span class="font-medium">{item.title}</span>
-            <span :if={item.year} class="text-base-content/60">({item.year})</span>
-            <span class="badge badge-xs badge-outline">
-              {if item.type == "tv_show", do: "TV", else: "Movie"}
-            </span>
-          </button>
-        </div>
-      <% end %>
-
-      <:actions>
-        <button type="button" class="btn btn-ghost" phx-click="close_match_modal">
-          Cancel
-        </button>
-      </:actions>
-    </.modal>
+    <Components.match_modal :if={@match_modal} dialog={@match_modal} />
 
     <%!-- Match files modal (manual file matching on import failure) --%>
     <Components.match_files_modal

--- a/lib/mydia_web/live/downloads_live/match_dialog.ex
+++ b/lib/mydia_web/live/downloads_live/match_dialog.ex
@@ -102,6 +102,44 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
     search(%{dialog | type: type}, dialog.query)
   end
 
+  @doc """
+  Chooses a library item.
+
+  Movies always submit. A TV show submits at show level in `:inflight`, where
+  the import job resolves each file's episode from its filename. In
+  `:postimport` the download is one file on disk, which is one episode, so the
+  episode list opens instead.
+  """
+  @spec select(t(), binary()) :: {:submit, {binary(), binary() | nil}} | {:episodes, t()}
+  def select(%__MODULE__{} = dialog, media_item_id) do
+    item = Media.get_media_item!(media_item_id)
+
+    if item.type == "tv_show" and dialog.mode == :postimport do
+      {:episodes, put_selected(dialog, item)}
+    else
+      {:submit, {item.id, nil}}
+    end
+  end
+
+  @doc """
+  Opens the episode list for a show without submitting.
+
+  This is the "Pick episode" escape on an in-flight TV row, for the download
+  that really is one mis-named episode.
+  """
+  @spec show_episodes(t(), binary()) :: t()
+  def show_episodes(%__MODULE__{} = dialog, media_item_id) do
+    put_selected(dialog, Media.get_media_item!(media_item_id))
+  end
+
+  @doc """
+  Submits the chosen show together with the chosen episode.
+  """
+  @spec select_episode(t(), binary()) :: {:submit, {binary(), binary()}}
+  def select_episode(%__MODULE__{selected: %{id: media_item_id}}, episode_id) do
+    {:submit, {media_item_id, episode_id}}
+  end
+
   # A relay outage must not empty the dialog: the library half still works and
   # is often all the operator needs.
   defp provider_search(type, query, library) do
@@ -136,6 +174,15 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
 
   defp provider_key(item, :tv_show), do: item.tvdb_id
   defp provider_key(item, :movie), do: item.tmdb_id
+
+  defp put_selected(dialog, item) do
+    %{
+      dialog
+      | selected: %{id: item.id, title: item.title, type: item.type},
+        episodes: Media.list_episodes(item.id),
+        error: nil
+    }
+  end
 
   defp type_string(:tv_show), do: "tv_show"
   defp type_string(:movie), do: "movie"

--- a/lib/mydia_web/live/downloads_live/match_dialog.ex
+++ b/lib/mydia_web/live/downloads_live/match_dialog.ex
@@ -15,6 +15,11 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
   """
 
   alias Mydia.Library.ReleaseParser
+  alias Mydia.Media
+  alias Mydia.Metadata
+
+  @result_limit 10
+  @relay_down "Couldn't reach the metadata service. Showing library results only."
 
   defstruct [
     :download_id,
@@ -64,6 +69,76 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
       type: seed_type(parsed, download)
     }
   end
+
+  @doc """
+  Runs the library and provider searches for `query`.
+
+  Queries under two characters clear the lists rather than returning the whole
+  library. Any prior selection is dropped, because the operator is looking for
+  something else now.
+  """
+  @spec search(t(), String.t()) :: t()
+  def search(%__MODULE__{} = dialog, query) do
+    dialog = %{dialog | query: query, selected: nil, episodes: [], error: nil}
+
+    if String.length(String.trim(query)) < 2 do
+      %{dialog | library_results: [], external_results: [], search_warning: nil}
+    else
+      library = Media.list_media_items(search: query, limit: @result_limit)
+      {external, warning} = provider_search(dialog.type, query, library)
+
+      %{dialog | library_results: library, external_results: external, search_warning: warning}
+    end
+  end
+
+  @doc """
+  Switches the provider search between movies and TV and re-runs it.
+
+  There is no TMDB multi-search endpoint, so the type is a real choice rather
+  than a filter over one result set.
+  """
+  @spec set_type(t(), media_type()) :: t()
+  def set_type(%__MODULE__{} = dialog, type) when type in [:movie, :tv_show] do
+    search(%{dialog | type: type}, dialog.query)
+  end
+
+  # A relay outage must not empty the dialog: the library half still works and
+  # is often all the operator needs.
+  defp provider_search(type, query, library) do
+    case Metadata.search_cached(Metadata.default_relay_config(), query, media_type: type) do
+      {:ok, results} ->
+        {results |> reject_known(library, type) |> Enum.take(@result_limit), nil}
+
+      {:error, _reason} ->
+        {[], @relay_down}
+    end
+  end
+
+  # Deduped against the library rows already fetched rather than with a second
+  # query. Best effort by design: a library item whose stored title differs
+  # from the provider's misses the title search and reappears here, and
+  # `Media.Add.from_attrs/3` catches that case with `:already_in_library`.
+  defp reject_known(results, library, type) do
+    taken =
+      library
+      |> Enum.filter(&(&1.type == type_string(type)))
+      |> Enum.map(&provider_key(&1, type))
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    Enum.reject(results, fn result ->
+      case Integer.parse(to_string(result.provider_id)) do
+        {id, _rest} -> MapSet.member?(taken, id)
+        :error -> false
+      end
+    end)
+  end
+
+  defp provider_key(item, :tv_show), do: item.tvdb_id
+  defp provider_key(item, :movie), do: item.tmdb_id
+
+  defp type_string(:tv_show), do: "tv_show"
+  defp type_string(:movie), do: "movie"
 
   defp seed_query(%{title: parsed_title}, _title)
        when is_binary(parsed_title) and parsed_title != "",

--- a/lib/mydia_web/live/downloads_live/match_dialog.ex
+++ b/lib/mydia_web/live/downloads_live/match_dialog.ex
@@ -1,0 +1,81 @@
+defmodule MydiaWeb.DownloadsLive.MatchDialog do
+  @moduledoc """
+  State and transitions for the downloads match dialog.
+
+  The dialog serves two modes through one struct. `:inflight` corrects a
+  download that is still running, where matching to a TV show alone is the
+  useful answer: `Mydia.Jobs.MediaImport` resolves each file's episode from its
+  own filename, including the `Complete S01-S03` case. `:postimport` re-matches
+  a download that already produced exactly one file on disk, where one file
+  means one episode, so an episode stays required for TV.
+
+  Every function takes and returns the struct so `MydiaWeb.DownloadsLive.Index`
+  holds no dialog logic. Provider calls live here rather than in the LiveView,
+  matching `MydiaWeb.Live.Helpers.MediaAddHelpers`.
+  """
+
+  alias Mydia.Library.ReleaseParser
+
+  defstruct [
+    :download_id,
+    :mode,
+    :query,
+    :type,
+    :selected,
+    library_results: [],
+    external_results: [],
+    episodes: [],
+    adding: nil,
+    error: nil,
+    search_warning: nil
+  ]
+
+  @type mode :: :inflight | :postimport
+  @type media_type :: :movie | :tv_show
+
+  @type t :: %__MODULE__{
+          download_id: binary() | nil,
+          mode: mode() | nil,
+          query: String.t() | nil,
+          type: media_type() | nil,
+          selected: %{id: binary(), title: String.t(), type: String.t()} | nil,
+          library_results: [Mydia.Media.MediaItem.t()],
+          external_results: [Mydia.Metadata.Structs.SearchResult.t()],
+          episodes: [Mydia.Media.Episode.t()],
+          adding: String.t() | nil,
+          error: String.t() | nil,
+          search_warning: String.t() | nil
+        }
+
+  @doc """
+  Builds a dialog for `download` in `mode`.
+
+  The download must have `:media_item` preloaded; the type fallback reads it.
+  """
+  @spec open(map(), mode()) :: t()
+  def open(download, mode) when mode in [:inflight, :postimport] do
+    title = download.title || ""
+    parsed = ReleaseParser.parse(title)
+
+    %__MODULE__{
+      download_id: download.id,
+      mode: mode,
+      query: seed_query(parsed, title),
+      type: seed_type(parsed, download)
+    }
+  end
+
+  defp seed_query(%{title: parsed_title}, _title)
+       when is_binary(parsed_title) and parsed_title != "",
+       do: parsed_title
+
+  defp seed_query(_parsed, title), do: title
+
+  # An unloaded association is a struct without a `:type` key, so the map
+  # patterns below decline it and the movie default applies.
+  defp seed_type(%{type: :tv_show}, _download), do: :tv_show
+  defp seed_type(%{type: :movie}, _download), do: :movie
+  defp seed_type(_parsed, %{media_item: %{type: "tv_show"}}), do: :tv_show
+  defp seed_type(_parsed, %{media_item: %{type: "movie"}}), do: :movie
+  defp seed_type(_parsed, _download), do: :movie
+end

--- a/lib/mydia_web/live/downloads_live/match_dialog.ex
+++ b/lib/mydia_web/live/downloads_live/match_dialog.ex
@@ -16,7 +16,9 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
 
   alias Mydia.Library.ReleaseParser
   alias Mydia.Media
+  alias Mydia.Media.Add
   alias Mydia.Metadata
+  alias Mydia.Settings
 
   @result_limit 10
   @relay_down "Couldn't reach the metadata service. Showing library results only."
@@ -200,4 +202,52 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
   defp seed_type(_parsed, %{media_item: %{type: "tv_show"}}), do: :tv_show
   defp seed_type(_parsed, %{media_item: %{type: "movie"}}), do: :movie
   defp seed_type(_parsed, _download), do: :movie
+
+  @doc """
+  Adds a provider result to the library and hands back the new item.
+
+  `:library_path_id` is deliberately not sent, which is what removes the need
+  for a library picker here: `Mydia.Library.TargetResolver` resolves the
+  destination by `:type_default` and then `:first_compatible`.
+
+  `{:already_in_library, item}` is success, not failure. It means the dedupe in
+  `search/2` and the provider disagreed, and the item the operator wanted
+  already exists.
+  """
+  @spec add_external(t(), String.t()) :: {:added, Mydia.Media.MediaItem.t()} | {:error, t()}
+  def add_external(%__MODULE__{} = dialog, provider_id) do
+    case find_external(dialog, provider_id) do
+      nil ->
+        {:error,
+         %{dialog | adding: nil, error: "That result is no longer available. Search again."}}
+
+      result ->
+        case Add.from_provider(result.provider_id, dialog.type, nil, add_opts(result)) do
+          {:ok, item} -> {:added, item}
+          {:error, {:already_in_library, item}} -> {:added, item}
+          {:error, reason} -> {:error, %{dialog | adding: nil, error: add_error(reason)}}
+        end
+    end
+  end
+
+  defp find_external(dialog, provider_id) do
+    Enum.find(dialog.external_results, fn result ->
+      to_string(result.provider_id) == to_string(provider_id)
+    end)
+  end
+
+  # A TV search result carries a TVDB id, but Add defaults TV to TMDB. Without
+  # this the TVDB id is sent to TMDB and resolves to the wrong show or nothing.
+  defp add_opts(result) do
+    opts = [
+      monitored: true,
+      season_monitoring: "all",
+      quality_profile_id: Settings.get_default_quality_profile_id()
+    ]
+
+    if result.provider == :tvdb, do: Keyword.put(opts, :provider, :tvdb), else: opts
+  end
+
+  defp add_error({:metadata, _reason}), do: "Couldn't fetch metadata for that title."
+  defp add_error(_reason), do: "Couldn't add that title to your library."
 end

--- a/lib/mydia_web/live/downloads_live/match_dialog.ex
+++ b/lib/mydia_web/live/downloads_live/match_dialog.ex
@@ -32,7 +32,6 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
     library_results: [],
     external_results: [],
     episodes: [],
-    adding: nil,
     error: nil,
     search_warning: nil
   ]
@@ -49,7 +48,6 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
           library_results: [Mydia.Media.MediaItem.t()],
           external_results: [Mydia.Metadata.Structs.SearchResult.t()],
           episodes: [Mydia.Media.Episode.t()],
-          adding: String.t() | nil,
           error: String.t() | nil,
           search_warning: String.t() | nil
         }
@@ -218,14 +216,13 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
   def add_external(%__MODULE__{} = dialog, provider_id) do
     case find_external(dialog, provider_id) do
       nil ->
-        {:error,
-         %{dialog | adding: nil, error: "That result is no longer available. Search again."}}
+        {:error, %{dialog | error: "That result is no longer available. Search again."}}
 
       result ->
         case Add.from_provider(result.provider_id, dialog.type, nil, add_opts(result)) do
           {:ok, item} -> {:added, item}
           {:error, {:already_in_library, item}} -> {:added, item}
-          {:error, reason} -> {:error, %{dialog | adding: nil, error: add_error(reason)}}
+          {:error, reason} -> {:error, %{dialog | error: add_error(reason)}}
         end
     end
   end

--- a/lib/mydia_web/live/downloads_live/match_dialog.ex
+++ b/lib/mydia_web/live/downloads_live/match_dialog.ex
@@ -134,10 +134,28 @@ defmodule MydiaWeb.DownloadsLive.MatchDialog do
 
   @doc """
   Submits the chosen show together with the chosen episode.
+
+  The episode id comes from a browser event, so it is checked against
+  `dialog.episodes`, the authoritative list `put_selected/2` loaded for the
+  selected show. The foreign key alone only proves the episode exists, not
+  that it belongs to this show, and a forged `episode_id` paired with an
+  unrelated show would file the import under a nonsense path.
   """
-  @spec select_episode(t(), binary()) :: {:submit, {binary(), binary()}}
-  def select_episode(%__MODULE__{selected: %{id: media_item_id}}, episode_id) do
-    {:submit, {media_item_id, episode_id}}
+  @spec select_episode(t(), binary()) :: {:submit, {binary(), binary()}} | {:error, t()}
+  def select_episode(%__MODULE__{selected: %{id: media_item_id}} = dialog, episode_id) do
+    if Enum.any?(dialog.episodes, &(&1.id == episode_id)) do
+      {:submit, {media_item_id, episode_id}}
+    else
+      {:error, episode_mismatch(dialog)}
+    end
+  end
+
+  def select_episode(%__MODULE__{selected: nil} = dialog, _episode_id) do
+    {:error, episode_mismatch(dialog)}
+  end
+
+  defp episode_mismatch(dialog) do
+    %{dialog | error: "That episode is not part of the selected show. Search again."}
   end
 
   # A relay outage must not empty the dialog: the library half still works and

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -12,9 +12,16 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
   import Mydia.DownloadsFixtures
   import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
+  import Mydia.MetadataStub, only: [setup_metadata_stub: 1]
 
   alias Mydia.Downloads
   alias Mydia.Library
+
+  # The match dialog's search/2 reaches the metadata relay for provider
+  # results. Swapping in the stub provider (like MatchDialogTest itself does)
+  # keeps every test in this file off the network rather than warming a cache
+  # entry per randomly-generated download title.
+  setup :setup_metadata_stub
 
   setup %{conn: conn} do
     admin = admin_user_fixture()
@@ -687,6 +694,73 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       # The flash alone would pass even if the modal stayed open on a download
       # that no longer exists, leaving the operator submitting into nothing.
       refute has_element?(view, "#match-files-modal")
+    end
+  end
+
+  describe "match dialog: in-flight season pack" do
+    test "opens prefilled from the release name with results already listed", %{conn: conn} do
+      show = media_item_fixture(%{type: "tv_show", title: "Prefilled Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: show.id,
+          imported_at: nil,
+          title: "Prefilled.Show.S01-S03.1080p.WEB-DL.x265"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      html = render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "inflight"})
+
+      assert has_element?(view, "#match-modal")
+      assert html =~ "Prefilled Show"
+      assert has_element?(view, "#match-dialog-result-#{show.id}")
+    end
+
+    test "matching a TV show in flight submits with no episode", %{conn: conn} do
+      old_show = media_item_fixture(%{type: "tv_show", title: "Wrong Show"})
+      new_show = media_item_fixture(%{type: "tv_show", title: "Right Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: old_show.id,
+          imported_at: nil,
+          title: "Right.Show.S01-S03.1080p.WEB-DL.x265"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "inflight"})
+      render_change(view, "match_modal_search", %{"q" => "Right Show"})
+      render_click(view, "match_modal_pick_item", %{"media_item_id" => new_show.id})
+
+      updated = Downloads.get_download!(download.id)
+      assert updated.media_item_id == new_show.id
+      assert updated.episode_id == nil
+      refute has_element?(view, "#match-modal")
+    end
+
+    test "the Pick episode escape opens the episode list without submitting", %{conn: conn} do
+      show = media_item_fixture(%{type: "tv_show", title: "Escape Show"})
+      download = download_fixture(%{media_item_id: show.id, imported_at: nil})
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "inflight"})
+      render_change(view, "match_modal_search", %{"q" => "Escape"})
+      render_click(view, "match_modal_show_episodes", %{"media_item_id" => show.id})
+
+      assert has_element?(view, "#match-modal")
+      assert Downloads.get_download!(download.id).media_item_id == show.id
+    end
+
+    test "flipping the type chips keeps the dialog open", %{conn: conn} do
+      show = media_item_fixture(%{type: "tv_show", title: "Chip Show"})
+      download = download_fixture(%{media_item_id: show.id, imported_at: nil})
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "inflight"})
+      render_click(view, "match_modal_set_type", %{"type" => "movie"})
+
+      assert has_element?(view, "#match-modal")
+      assert has_element?(view, "#match-dialog-type-movie")
     end
   end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -862,5 +862,48 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
 
       refute has_element?(view, "#match-dialog-pick-episode-#{show.id}")
     end
+
+    test "adding a not-yet-in-library show after import opens the episode list instead of submitting",
+         %{conn: conn} do
+      library = library_path_fixture(%{type: "series", monitored: true})
+      old_show = media_item_fixture(%{type: "tv_show", title: "Old Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: old_show.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, _file} =
+        Library.create_media_file(%{
+          relative_path: "Old Show/Season 01/S01E01.mkv",
+          library_path_id: library.id,
+          media_item_id: old_show.id,
+          size: 100,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "postimport"})
+      render_change(view, "match_modal_search", %{"q" => "Stub"})
+
+      assert has_element?(view, "#match-dialog-add-81189")
+
+      render_click(view, "match_modal_add_external", %{"provider_id" => "81189"})
+
+      # The show is legitimately created by this flow, but the download's match
+      # must not be written until an episode is chosen: a nil episode_id on a
+      # post-import download makes MediaRematch.apply_relink/5 drop the file in
+      # the show root with no episode association instead of Season 01/.
+      assert has_element?(view, "#match-modal")
+      assert Downloads.get_download!(download.id).media_item_id == old_show.id
+      refute_enqueued(worker: Mydia.Jobs.MediaRematch)
+
+      # The show itself IS legitimately created by this flow; only the
+      # download's match must stay unwritten.
+      [added] = Mydia.Media.list_media_items(search: "Stub Series")
+      assert added.tvdb_id == 81_189
+    end
   end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -801,4 +801,66 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       assert added.tvdb_id == 81_189
     end
   end
+
+  describe "match dialog: post-import still requires an episode for TV" do
+    test "picking a TV show after import opens the episode list instead of submitting",
+         %{conn: conn} do
+      library = library_path_fixture(%{type: "series", monitored: true})
+      old_show = media_item_fixture(%{type: "tv_show", title: "Old Show"})
+      new_show = media_item_fixture(%{type: "tv_show", title: "New Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: old_show.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, _file} =
+        Library.create_media_file(%{
+          relative_path: "Old Show/Season 01/S01E01.mkv",
+          library_path_id: library.id,
+          media_item_id: old_show.id,
+          size: 100,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "postimport"})
+      render_change(view, "match_modal_search", %{"q" => "New Show"})
+      render_click(view, "match_modal_pick_item", %{"media_item_id" => new_show.id})
+
+      # The dialog stays open on the episode step and nothing was written.
+      assert has_element?(view, "#match-modal")
+      assert Downloads.get_download!(download.id).media_item_id == old_show.id
+      refute_enqueued(worker: Mydia.Jobs.MediaRematch)
+    end
+
+    test "no Pick episode escape is offered after import", %{conn: conn} do
+      library = library_path_fixture(%{type: "series", monitored: true})
+      show = media_item_fixture(%{type: "tv_show", title: "Imported Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: show.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, _file} =
+        Library.create_media_file(%{
+          relative_path: "Imported Show/Season 01/S01E01.mkv",
+          library_path_id: library.id,
+          media_item_id: show.id,
+          size: 100,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "postimport"})
+      render_change(view, "match_modal_search", %{"q" => "Imported"})
+
+      refute has_element?(view, "#match-dialog-pick-episode-#{show.id}")
+    end
+  end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -761,6 +761,44 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
 
       assert has_element?(view, "#match-modal")
       assert has_element?(view, "#match-dialog-type-movie")
+      # #match-dialog-type-movie renders unconditionally regardless of the
+      # actual dialog type, so it alone would pass even if the handler were a
+      # no-op. Pin the flip itself: the provider row list must have swapped
+      # from the series stub (TVDB 81189) to the movie stub (TMDB 550).
+      assert has_element?(view, "#match-dialog-add-550")
+      refute has_element?(view, "#match-dialog-add-81189")
+    end
+  end
+
+  describe "match dialog: adding a title from the provider" do
+    test "adds the show and matches the download to it", %{conn: conn} do
+      # download_fixture creates its own media item when none is given, so the
+      # row always starts matched to something. Assert the match CHANGED to the
+      # newly added show rather than that it started empty.
+      wrong = media_item_fixture(%{type: "tv_show", title: "Wrong Show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: wrong.id,
+          imported_at: nil,
+          title: "Stub.Series.S01-S03.1080p.WEB-DL"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "inflight"})
+      render_change(view, "match_modal_search", %{"q" => "Stub"})
+
+      assert has_element?(view, "#match-dialog-add-81189")
+
+      render_click(view, "match_modal_add_external", %{"provider_id" => "81189"})
+
+      updated = Downloads.get_download!(download.id)
+      refute updated.media_item_id == wrong.id
+      assert updated.episode_id == nil
+
+      added = Mydia.Media.get_media_item!(updated.media_item_id)
+      assert added.title == "Stub Series"
+      assert added.tvdb_id == 81_189
     end
   end
 end

--- a/test/mydia_web/live/downloads_live/index_test.exs
+++ b/test/mydia_web/live/downloads_live/index_test.exs
@@ -905,5 +905,45 @@ defmodule MydiaWeb.DownloadsLive.IndexTest do
       [added] = Mydia.Media.list_media_items(search: "Stub Series")
       assert added.tvdb_id == 81_189
     end
+
+    test "a forged episode pick from another show is rejected, not written", %{conn: conn} do
+      library = library_path_fixture(%{type: "series", monitored: true})
+      old_show = media_item_fixture(%{type: "tv_show", title: "Old Show"})
+      new_show = media_item_fixture(%{type: "tv_show", title: "New Show"})
+
+      other_show = media_item_fixture(%{type: "tv_show", title: "Other Show"})
+      foreign_episode = episode_fixture(%{media_item_id: other_show.id})
+
+      download =
+        download_fixture(%{
+          media_item_id: old_show.id,
+          imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      {:ok, _file} =
+        Library.create_media_file(%{
+          relative_path: "Old Show/Season 01/S01E01.mkv",
+          library_path_id: library.id,
+          media_item_id: old_show.id,
+          size: 100,
+          metadata: %{"imported_from_download_id" => download.id}
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/downloads")
+      render_click(view, "switch_tab", %{"tab" => "completed"})
+      render_click(view, "open_match_modal", %{"id" => download.id, "mode" => "postimport"})
+      render_change(view, "match_modal_search", %{"q" => "New Show"})
+      render_click(view, "match_modal_pick_item", %{"media_item_id" => new_show.id})
+
+      # The dialog is now on the episode step for new_show. Forge a pick for an
+      # episode that belongs to a different show entirely.
+      html =
+        render_click(view, "match_modal_pick_episode", %{"episode_id" => foreign_episode.id})
+
+      assert html =~ "not part of the selected show"
+      assert has_element?(view, "#match-modal")
+      assert Downloads.get_download!(download.id).media_item_id == old_show.id
+      refute_enqueued(worker: Mydia.Jobs.MediaRematch)
+    end
   end
 end

--- a/test/mydia_web/live/downloads_live/match_dialog_test.exs
+++ b/test/mydia_web/live/downloads_live/match_dialog_test.exs
@@ -215,4 +215,60 @@ defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
       assert MatchDialog.select_episode(dialog, "ep-1") == {:submit, {"show-1", "ep-1"}}
     end
   end
+
+  describe "add_external/2" do
+    setup :setup_metadata_stub
+
+    import Mydia.MediaFixtures
+
+    test "creates the media item for a provider result" do
+      dialog =
+        %MatchDialog{download_id: "d1", mode: :inflight, query: "Stub", type: :movie}
+        |> MatchDialog.search("Stub")
+
+      [result | _] = dialog.external_results
+
+      assert {:added, item} = MatchDialog.add_external(dialog, result.provider_id)
+      assert item.title == "Stub Movie"
+      assert item.type == "movie"
+      # No library_path_id is sent, so TargetResolver decides at import time.
+      assert item.library_path_id == nil
+    end
+
+    test "adds a TV result through TVDB rather than TMDB" do
+      dialog =
+        %MatchDialog{download_id: "d1", mode: :inflight, query: "Stub", type: :tv_show}
+        |> MatchDialog.search("Stub")
+
+      [result | _] = dialog.external_results
+      assert result.provider == :tvdb
+
+      assert {:added, item} = MatchDialog.add_external(dialog, result.provider_id)
+      assert item.type == "tv_show"
+      assert item.tvdb_id == 81_189
+    end
+
+    test "treats an item already in the library as a plain selection" do
+      _existing = media_item_fixture(%{type: "movie", title: "Unrelated", tmdb_id: 550})
+
+      dialog =
+        %MatchDialog{download_id: "d1", mode: :inflight, query: "Stub", type: :movie}
+        |> MatchDialog.search("Stub")
+
+      [result | _] = dialog.external_results
+
+      assert {:added, item} = MatchDialog.add_external(dialog, result.provider_id)
+      assert item.tmdb_id == 550
+    end
+
+    test "reports an unknown provider id as an inline error" do
+      dialog =
+        %MatchDialog{download_id: "d1", mode: :inflight, query: "Stub", type: :movie}
+        |> MatchDialog.search("Stub")
+
+      assert {:error, updated} = MatchDialog.add_external(dialog, "does-not-exist")
+      assert updated.error =~ "no longer available"
+      assert updated.adding == nil
+    end
+  end
 end

--- a/test/mydia_web/live/downloads_live/match_dialog_test.exs
+++ b/test/mydia_web/live/downloads_live/match_dialog_test.exs
@@ -5,6 +5,13 @@ defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
 
   alias MydiaWeb.DownloadsLive.MatchDialog
 
+  import Mydia.MediaFixtures
+  import Mydia.MetadataStub, only: [setup_metadata_stub: 1]
+
+  defp dialog_for(type) do
+    %MatchDialog{download_id: "d1", mode: :inflight, query: "", type: type}
+  end
+
   describe "open/2" do
     test "seeds the query from the parsed release title" do
       download = %{id: "d1", title: "Show.Name.S01-S03.1080p.WEB-DL.x265", media_item: nil}
@@ -66,6 +73,90 @@ defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
       assert dialog.error == nil
       assert dialog.search_warning == nil
       assert dialog.adding == nil
+    end
+  end
+
+  describe "search/2" do
+    setup :setup_metadata_stub
+
+    test "returns nothing for a query under two characters" do
+      dialog = MatchDialog.search(dialog_for(:movie), "a")
+
+      assert dialog.library_results == []
+      assert dialog.external_results == []
+      assert dialog.search_warning == nil
+    end
+
+    test "finds a library item by title" do
+      item = media_item_fixture(%{type: "movie", title: "Searchable Movie"})
+
+      dialog = MatchDialog.search(dialog_for(:movie), "Searchable")
+
+      assert Enum.map(dialog.library_results, & &1.id) == [item.id]
+    end
+
+    test "includes provider results alongside library results" do
+      dialog = MatchDialog.search(dialog_for(:movie), "Stub")
+
+      assert Enum.any?(dialog.external_results, &(&1.title == "Stub Movie"))
+      assert dialog.search_warning == nil
+    end
+
+    test "drops a provider result whose id is already a library item" do
+      _existing =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Stub Series",
+          tvdb_id: 81_189
+        })
+
+      dialog = MatchDialog.search(dialog_for(:tv_show), "Stub")
+
+      refute Enum.any?(dialog.external_results, &(to_string(&1.provider_id) == "81189"))
+      assert Enum.any?(dialog.library_results, &(&1.title == "Stub Series"))
+    end
+
+    test "clears any prior selection and error" do
+      dialog =
+        %{dialog_for(:movie) | selected: %{id: "x", title: "t", type: "movie"}, error: "boom"}
+        |> MatchDialog.search("Stub")
+
+      assert dialog.selected == nil
+      assert dialog.episodes == []
+      assert dialog.error == nil
+    end
+  end
+
+  describe "search/2 when the relay is unreachable" do
+    setup :setup_metadata_stub
+
+    setup do
+      Mydia.MetadataStubProvider.fail_search()
+      on_exit(&Mydia.MetadataStubProvider.clear_search_failure/0)
+      :ok
+    end
+
+    test "still returns library results and warns instead of emptying the dialog" do
+      item = media_item_fixture(%{type: "movie", title: "Offline Movie"})
+
+      dialog = MatchDialog.search(dialog_for(:movie), "Offline")
+
+      assert Enum.map(dialog.library_results, & &1.id) == [item.id]
+      assert dialog.external_results == []
+      assert dialog.search_warning =~ "metadata service"
+    end
+  end
+
+  describe "set_type/2" do
+    setup :setup_metadata_stub
+
+    test "re-runs the search under the new type" do
+      dialog =
+        %MatchDialog{download_id: "d1", mode: :inflight, query: "Stub", type: :movie}
+        |> MatchDialog.set_type(:tv_show)
+
+      assert dialog.type == :tv_show
+      assert Enum.any?(dialog.external_results, &(&1.media_type == :tv_show))
     end
   end
 end

--- a/test/mydia_web/live/downloads_live/match_dialog_test.exs
+++ b/test/mydia_web/live/downloads_live/match_dialog_test.exs
@@ -159,4 +159,60 @@ defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
       assert Enum.any?(dialog.external_results, &(&1.media_type == :tv_show))
     end
   end
+
+  describe "select/2" do
+    import Mydia.MediaFixtures
+
+    test "a movie submits immediately in either mode" do
+      movie = media_item_fixture(%{type: "movie", title: "A Movie"})
+
+      for mode <- [:inflight, :postimport] do
+        dialog = %MatchDialog{download_id: "d1", mode: mode, type: :movie}
+
+        assert {:submit, {id, nil}} = MatchDialog.select(dialog, movie.id)
+        assert id == movie.id
+      end
+    end
+
+    test "a TV show submits show-level in flight" do
+      show = media_item_fixture(%{type: "tv_show", title: "A Show"})
+      dialog = %MatchDialog{download_id: "d1", mode: :inflight, type: :tv_show}
+
+      assert {:submit, {id, nil}} = MatchDialog.select(dialog, show.id)
+      assert id == show.id
+    end
+
+    test "a TV show opens the episode list after import" do
+      show = media_item_fixture(%{type: "tv_show", title: "A Show"})
+      dialog = %MatchDialog{download_id: "d1", mode: :postimport, type: :tv_show}
+
+      assert {:episodes, updated} = MatchDialog.select(dialog, show.id)
+      assert updated.selected.id == show.id
+      assert updated.selected.title == "A Show"
+    end
+  end
+
+  describe "show_episodes/2 and select_episode/2" do
+    import Mydia.MediaFixtures
+
+    test "show_episodes loads the show's episodes in flight" do
+      show = media_item_fixture(%{type: "tv_show", title: "A Show"})
+      dialog = %MatchDialog{download_id: "d1", mode: :inflight, type: :tv_show}
+
+      updated = MatchDialog.show_episodes(dialog, show.id)
+
+      assert updated.selected.id == show.id
+      assert is_list(updated.episodes)
+    end
+
+    test "select_episode submits the selected show and episode" do
+      dialog = %MatchDialog{
+        download_id: "d1",
+        mode: :postimport,
+        selected: %{id: "show-1", title: "A Show", type: "tv_show"}
+      }
+
+      assert MatchDialog.select_episode(dialog, "ep-1") == {:submit, {"show-1", "ep-1"}}
+    end
+  end
 end

--- a/test/mydia_web/live/downloads_live/match_dialog_test.exs
+++ b/test/mydia_web/live/downloads_live/match_dialog_test.exs
@@ -1,0 +1,71 @@
+defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
+  # async: false because later tasks in this file register a global stub
+  # metadata provider through Provider.Registry, which is an Agent.
+  use Mydia.DataCase, async: false
+
+  alias MydiaWeb.DownloadsLive.MatchDialog
+
+  describe "open/2" do
+    test "seeds the query from the parsed release title" do
+      download = %{id: "d1", title: "Show.Name.S01-S03.1080p.WEB-DL.x265", media_item: nil}
+
+      dialog = MatchDialog.open(download, :inflight)
+
+      assert dialog.query == "Show Name"
+      assert dialog.type == :tv_show
+      assert dialog.mode == :inflight
+      assert dialog.download_id == "d1"
+    end
+
+    test "falls back to the raw title when the parser recovers none" do
+      download = %{id: "d2", title: "????", media_item: nil}
+
+      dialog = MatchDialog.open(download, :inflight)
+
+      assert dialog.query == "????"
+    end
+
+    test "falls back to the download's media item type when the parse is unknown" do
+      download = %{id: "d3", title: "1234", media_item: %{type: "tv_show"}}
+
+      dialog = MatchDialog.open(download, :postimport)
+
+      assert dialog.type == :tv_show
+      assert dialog.mode == :postimport
+    end
+
+    test "defaults to movie when nothing indicates a type" do
+      download = %{id: "d4", title: "1234", media_item: nil}
+
+      assert MatchDialog.open(download, :inflight).type == :movie
+    end
+
+    test "tolerates an unloaded media_item association" do
+      download = %{
+        id: "d5",
+        title: "1234",
+        media_item: %Ecto.Association.NotLoaded{
+          __field__: :media_item,
+          __owner__: Mydia.Downloads.Download,
+          __cardinality__: :one
+        }
+      }
+
+      assert MatchDialog.open(download, :inflight).type == :movie
+    end
+
+    test "starts with empty results and no error" do
+      download = %{id: "d6", title: "Show.Name.S01", media_item: nil}
+
+      dialog = MatchDialog.open(download, :inflight)
+
+      assert dialog.library_results == []
+      assert dialog.external_results == []
+      assert dialog.episodes == []
+      assert dialog.selected == nil
+      assert dialog.error == nil
+      assert dialog.search_warning == nil
+      assert dialog.adding == nil
+    end
+  end
+end

--- a/test/mydia_web/live/downloads_live/match_dialog_test.exs
+++ b/test/mydia_web/live/downloads_live/match_dialog_test.exs
@@ -72,7 +72,6 @@ defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
       assert dialog.selected == nil
       assert dialog.error == nil
       assert dialog.search_warning == nil
-      assert dialog.adding == nil
     end
   end
 
@@ -268,7 +267,6 @@ defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
 
       assert {:error, updated} = MatchDialog.add_external(dialog, "does-not-exist")
       assert updated.error =~ "no longer available"
-      assert updated.adding == nil
     end
   end
 end

--- a/test/mydia_web/live/downloads_live/match_dialog_test.exs
+++ b/test/mydia_web/live/downloads_live/match_dialog_test.exs
@@ -205,13 +205,42 @@ defmodule MydiaWeb.DownloadsLive.MatchDialogTest do
     end
 
     test "select_episode submits the selected show and episode" do
+      show = media_item_fixture(%{type: "tv_show", title: "A Show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+
       dialog = %MatchDialog{
         download_id: "d1",
         mode: :postimport,
-        selected: %{id: "show-1", title: "A Show", type: "tv_show"}
+        selected: %{id: show.id, title: "A Show", type: "tv_show"},
+        episodes: [episode]
       }
 
-      assert MatchDialog.select_episode(dialog, "ep-1") == {:submit, {"show-1", "ep-1"}}
+      assert MatchDialog.select_episode(dialog, episode.id) == {:submit, {show.id, episode.id}}
+    end
+
+    test "select_episode rejects an episode that belongs to a different show" do
+      show = media_item_fixture(%{type: "tv_show", title: "A Show"})
+      episode = episode_fixture(%{media_item_id: show.id})
+
+      other_show = media_item_fixture(%{type: "tv_show", title: "Another Show"})
+      other_episode = episode_fixture(%{media_item_id: other_show.id})
+
+      dialog = %MatchDialog{
+        download_id: "d1",
+        mode: :postimport,
+        selected: %{id: show.id, title: "A Show", type: "tv_show"},
+        episodes: [episode]
+      }
+
+      assert {:error, updated} = MatchDialog.select_episode(dialog, other_episode.id)
+      assert updated.error =~ "not part of the selected show"
+    end
+
+    test "select_episode returns an error rather than raising when nothing is selected" do
+      dialog = %MatchDialog{download_id: "d1", mode: :postimport, selected: nil}
+
+      assert {:error, updated} = MatchDialog.select_episode(dialog, "ep-1")
+      assert updated.error =~ "not part of the selected show"
     end
   end
 

--- a/test/support/metadata_stub_provider.ex
+++ b/test/support/metadata_stub_provider.ex
@@ -36,6 +36,7 @@ defmodule Mydia.MetadataStubProvider do
   @season_fetch_block_key {__MODULE__, :season_fetch_block}
   @fetch_by_id_counts_table :mydia_metadata_stub_fetch_by_id_counts
   @raise_on_fetch_by_id_key {__MODULE__, :raise_on_fetch_by_id}
+  @search_failure_key {__MODULE__, :search_failure}
 
   @doc "TMDB id of the catalog movie."
   def movie_tmdb_id, do: @movie_tmdb_id
@@ -65,6 +66,23 @@ defmodule Mydia.MetadataStubProvider do
       {_owner, ^ref} -> :persistent_term.erase(@season_fetch_block_key)
       _other -> :ok
     end
+  end
+
+  @doc """
+  Makes the next and all subsequent `search/3` calls fail until cleared.
+
+  Opt-in: `search/3` only consults this key, so tests that never call it are
+  unaffected.
+  """
+  def fail_search do
+    :persistent_term.put(@search_failure_key, true)
+    :ok
+  end
+
+  @doc "Clears a search failure installed by `fail_search/0`."
+  def clear_search_failure do
+    :persistent_term.erase(@search_failure_key)
+    :ok
   end
 
   @doc """
@@ -131,9 +149,13 @@ defmodule Mydia.MetadataStubProvider do
 
   @impl true
   def search(_config, _query, opts) do
-    case Keyword.get(opts, :media_type) do
-      :tv_show -> {:ok, [series_search_result()]}
-      _ -> {:ok, [movie_search_result()]}
+    if :persistent_term.get(@search_failure_key, false) do
+      {:error, Error.connection_failed("stubbed search failure")}
+    else
+      case Keyword.get(opts, :media_type) do
+        :tv_show -> {:ok, [series_search_result()]}
+        _ -> {:ok, [movie_search_result()]}
+      end
     end
   end
 


### PR DESCRIPTION
## Problem

The match dialog on the downloads screen could not handle two common cases.

Picking a TV show forced you into a mandatory episode list. For an `S01-S03`
season pack there is no correct single episode, so you were stuck, and picking
one wrote a wrong `episode_id` onto the download row.

The search only queried titles already in your library, so a download of a show
you had not added yet could not be matched at all.

## What changed

Both fixes were already supported by the backend, so this is a UI rebuild with
zero backend changes:

- `Downloads.manually_match_download/3` already accepts a nil `episode_id`.
- `MediaImport.import_file/5` already resolves each file's episode from that
  file's own name, with an explicit branch for `Complete S01-S03` packs.

New `MydiaWeb.DownloadsLive.MatchDialog` owns the dialog's state and
transitions, including its provider calls, mirroring the existing
`MydiaWeb.Live.Helpers.MediaAddHelpers`. The modal markup moved out of
`index.html.heex` into `downloads_live/components.ex`, and the LiveView keeps
only thin delegating handlers.

The dialog now:

- Opens prefilled from the download's own release name, parsed by
  `ReleaseParser`, with results already listed. A pack titled
  `Show.Name.S01-S03.1080p.WEB-DL` needs no typing.
- Searches your library and the metadata relay together, deduplicated, with a
  TV/Movie chip row. A relay outage degrades to library-only with a warning
  instead of emptying the dialog.
- Adds a title that is not in your library in one click, omitting
  `:library_path_id` so `TargetResolver` picks the destination. No library
  picker needed.

## The one asymmetry worth knowing about

In `:inflight` mode a TV show matches at show level with no episode. In
`:postimport` mode an episode is still required.

That is deliberate. `MediaRematch.apply_relink/5` branches on
`download.episode_id`, and a nil there writes a `MediaFile` with no episode and
drops the file in the show root instead of a `Season XX/` directory, silently. A
post-import download is exactly one file on disk, and one file is one episode.
Two regression tests guard it.

## Notes

- A TV search result carries a TVDB id, but `Media.Add.resolve_tv_show_attrs/4`
  defaults to TMDB, so `provider: :tvdb` is forwarded explicitly for
  TVDB-sourced results.
- Out of scope, deliberately: the Issues tab keeps its library-only inline
  search, and the Completed tab still hides re-match for multi-file downloads.

## Verification

`mix precommit` green: 9803 tests, 0 failures, all phases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a match and re-match dialog for downloads.
  - Search the library and external metadata by title.
  - Filter results by movie or TV show.
  - Add external titles to the library from search results.
  - Select episodes when required for TV matching.
  - Show warnings when metadata searches fail.

- **Bug Fixes**
  - Improved matching for in-progress and completed downloads.
  - Prevented invalid episode selections from being submitted.
  - Prevented duplicate library entries when adding external results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->