### PR TITLE
feat(streaming): serve HLS segments on demand so seeking is smooth

### DIFF
--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -303,6 +303,13 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   def handle_info({port, {:exit_status, 0}}, %{ffmpeg_port: port} = state) do
     Logger.info("FFmpeg transcoding completed successfully")
 
+    # The poll loop runs on a fixed cadence that has nothing to do with when
+    # FFmpeg actually writes its last segment and exits, so a tail segment
+    # finished in the gap since the last poll would otherwise never be
+    # reported. One last read before the process (and this GenServer) is
+    # gone.
+    state = final_segment_catchup(state)
+
     # Notify readiness if not already done — when FFmpeg completes very quickly
     # (e.g., stream copy), the scheduled :check_playlist_ready may not have fired yet.
     if !state.ready_notified && state.on_ready && File.exists?(state.playlist_path) do
@@ -318,6 +325,11 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   end
 
   def handle_info({port, {:exit_status, status}}, %{ffmpeg_port: port} = state) do
+    # Same tail-segment gap as the zero-exit clause above: an encoder that
+    # dies mid-window can still have finished segments sitting in the
+    # playlist that no poll ever reported.
+    state = final_segment_catchup(state)
+
     # Include any buffered output in the error message
     error_details =
       if state.buffer != "" do
@@ -342,11 +354,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   end
 
   def handle_info(:check_playlist_ready, state) do
-    state =
-      case File.read(state.playlist_path) do
-        {:ok, contents} -> handle_playlist(state, contents)
-        {:error, _reason} -> state
-      end
+    state = final_segment_catchup(state)
 
     # Readiness fires once; segment discovery runs for the life of the encoder.
     if state.on_segments || !state.ready_notified do
@@ -359,6 +367,26 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   def handle_info(msg, state) do
     Logger.debug("Unhandled message in FfmpegHlsTranscoder: #{inspect(msg)}")
     {:noreply, state}
+  end
+
+  # One last playlist read before the GenServer stops. The regular poll
+  # loop runs on a fixed timer that has no relationship to when FFmpeg
+  # actually finishes its last segment and exits, so without this call a
+  # tail segment finished in the gap between the last poll and process exit
+  # is never reported through on_segments. A caller downstream
+  # (TranscodeWindow.decide/2) then waits on a segment nothing will ever
+  # produce.
+  #
+  # Public only so the catch-up read can be exercised directly in tests
+  # without needing a real FFmpeg process to exit at a controlled moment;
+  # nothing outside this module should call it.
+  @doc false
+  @spec final_segment_catchup(State.t()) :: State.t()
+  def final_segment_catchup(state) do
+    case File.read(state.playlist_path) do
+      {:ok, contents} -> handle_playlist(state, contents)
+      {:error, _reason} -> state
+    end
   end
 
   # Notifies readiness the first time the playlist appears, and reports any

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -452,6 +452,29 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # Audio bitrate budget (kbps) subtracted from total when calculating video bitrate
   @audio_bitrate_kbps 128
 
+  @doc """
+  Whether the video stream will be re-encoded rather than copied.
+
+  This is the single place that decision gets made; `build_ffmpeg_args/3`
+  calls it too, so the two can never disagree. Only a re-encode can have its
+  keyframes forced onto the segment grid, so this is also what decides
+  whether `grid_aligned` may be set: `HlsSession` calls it before starting or
+  relocating the encoder, to decide what to pass as `grid_aligned`.
+  """
+  @spec reencodes_video?(Mydia.Library.MediaFile.t() | nil, integer() | nil) :: boolean()
+  def reencodes_video?(media_file, max_bitrate) do
+    transcode_policy =
+      Application.get_env(:mydia, :streaming, [])
+      |> Keyword.get(:transcode_policy, :copy_when_compatible)
+
+    cond do
+      not is_nil(max_bitrate) -> true
+      transcode_policy != :copy_when_compatible -> true
+      is_nil(media_file) -> true
+      true -> not should_copy_video?(media_file.codec)
+    end
+  end
+
   # Build FFmpeg command arguments for HLS transcoding
   @doc false
   # Public only so the argument construction can be unit-tested directly;
@@ -470,34 +493,33 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     # since we need to control the output bitrate
     force_transcode = not is_nil(max_bitrate)
 
-    # Determine video codec - use copy if compatible and policy allows, otherwise transcode
+    # Determine video codec - use copy if compatible and policy allows, otherwise
+    # transcode. An explicit opt always wins; short of that, reencodes_video?/2
+    # is the single decider, so this can never disagree with what HlsSession
+    # used to decide `grid_aligned`.
     video_codec =
-      cond do
-        Keyword.get(opts, :video_codec) ->
-          Keyword.get(opts, :video_codec)
-
-        force_transcode ->
+      case Keyword.get(opts, :video_codec) do
+        nil when force_transcode ->
           Logger.info("Bitrate cap set (#{max_bitrate}kbps), forcing video transcode to H.264")
           "libx264"
 
-        not is_nil(media_file) and transcode_policy == :copy_when_compatible ->
-          if should_copy_video?(media_file.codec) do
+        nil ->
+          if reencodes_video?(media_file, max_bitrate) do
+            Logger.info(
+              "Video codec #{(media_file && media_file.codec) || "unknown"} needs transcoding to H.264"
+            )
+
+            "libx264"
+          else
             Logger.info(
               "Video codec #{media_file.codec} is compatible, using stream copy (fast, no quality loss)"
             )
 
             "copy"
-          else
-            Logger.info("Video codec #{media_file.codec || "unknown"} needs transcoding to H.264")
-            "libx264"
           end
 
-        true ->
-          if transcode_policy == :always do
-            Logger.debug("Transcode policy is :always, transcoding video to H.264")
-          end
-
-          "libx264"
+        explicit ->
+          explicit
       end
 
     # Which audio stream this playback carries, resolved before the codec
@@ -684,9 +706,10 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     ]
 
     # Only meaningful when the video stream is re-encoded. On a copied stream
-    # the keyframes are whatever the source has, and FFmpeg rejects the flag.
-    # The caller decides, because it is the caller that knows whether the copy
-    # decision above landed on "copy".
+    # the keyframes are whatever the source has, and FFmpeg rejects the flag
+    # outright. reencodes_video?/2 above is what decides whether grid_aligned
+    # may be true; HlsSession calls it before starting or relocating the
+    # encoder and passes the answer straight through as this opt.
     keyframe_args =
       if Keyword.get(opts, :grid_aligned, false) do
         ["-force_key_frames", "expr:gte(t,n_forced*#{segment_seconds})"]

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -63,11 +63,13 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       :on_complete,
       :on_error,
       :on_ready,
+      :on_segments,
       :playlist_path,
       :buffer,
       :duration,
       :started_at,
-      ready_notified: false
+      ready_notified: false,
+      seen_segments: MapSet.new()
     ]
 
     @type t :: %__MODULE__{
@@ -79,6 +81,8 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
             on_complete: (-> any()) | nil,
             on_error: (String.t() -> any()) | nil,
             on_ready: (-> any()) | nil,
+            on_segments: ([non_neg_integer()] -> any()) | nil,
+            seen_segments: MapSet.t(non_neg_integer()),
             playlist_path: String.t() | nil,
             buffer: String.t(),
             duration: float() | nil,
@@ -155,6 +159,29 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     GenServer.call(pid, :get_status)
   end
 
+  @doc """
+  The segment indices FFmpeg's own playlist lists as finished.
+
+  The playlist is the authoritative completion signal: FFmpeg appends an entry
+  only once a segment is closed. Reading the directory instead would race with
+  a segment still being written.
+
+  Public so the parsing can be unit-tested without running FFmpeg.
+  """
+  @spec finished_indices(String.t()) :: [non_neg_integer()]
+  def finished_indices(playlist_text) do
+    playlist_text
+    |> String.split("\n", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.flat_map(fn line ->
+      case Mydia.Streaming.SegmentPlan.index_from_name(line) do
+        {:ok, index} -> [index]
+        :error -> []
+      end
+    end)
+    |> Enum.sort()
+  end
+
   ## Server Callbacks
 
   @impl true
@@ -170,6 +197,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     on_complete = Keyword.get(opts, :on_complete)
     on_error = Keyword.get(opts, :on_error)
     on_ready = Keyword.get(opts, :on_ready)
+    on_segments = Keyword.get(opts, :on_segments)
 
     # Build FFmpeg command
     args = build_ffmpeg_args(input_path, output_dir, opts)
@@ -192,14 +220,16 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           on_complete: on_complete,
           on_error: on_error,
           on_ready: on_ready,
+          on_segments: on_segments,
           playlist_path: playlist_path,
           buffer: "",
           duration: nil,
           started_at: DateTime.utc_now()
         }
 
-        # Schedule first playlist check if we have an on_ready callback
-        if on_ready do
+        # One timer drives both signals. Readiness is just "the playlist
+        # exists"; the segment poll is "which entries has it grown".
+        if on_ready || on_segments do
           Process.send_after(self(), :check_playlist_ready, 100)
         end
 
@@ -311,31 +341,53 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     {:stop, {:ffmpeg_terminated, reason}, state}
   end
 
-  def handle_info(:check_playlist_ready, %{ready_notified: true} = state) do
-    # Already notified, stop checking
-    {:noreply, state}
-  end
-
   def handle_info(:check_playlist_ready, state) do
-    if File.exists?(state.playlist_path) do
-      Logger.debug("Playlist file detected: #{state.playlist_path}")
-
-      # Call the on_ready callback
-      if state.on_ready do
-        state.on_ready.()
+    state =
+      case File.read(state.playlist_path) do
+        {:ok, contents} -> handle_playlist(state, contents)
+        {:error, _reason} -> state
       end
 
-      {:noreply, %{state | ready_notified: true}}
-    else
-      # Not ready yet, check again in 100ms
-      Process.send_after(self(), :check_playlist_ready, 100)
-      {:noreply, state}
+    # Readiness fires once; segment discovery runs for the life of the encoder.
+    if state.on_segments || !state.ready_notified do
+      Process.send_after(self(), :check_playlist_ready, 250)
     end
+
+    {:noreply, state}
   end
 
   def handle_info(msg, state) do
     Logger.debug("Unhandled message in FfmpegHlsTranscoder: #{inspect(msg)}")
     {:noreply, state}
+  end
+
+  # Notifies readiness the first time the playlist appears, and reports any
+  # segment indices that have shown up since the previous poll.
+  defp handle_playlist(state, contents) do
+    state =
+      if !state.ready_notified do
+        Logger.debug("Playlist file detected: #{state.playlist_path}")
+        if state.on_ready, do: state.on_ready.()
+        %{state | ready_notified: true}
+      else
+        state
+      end
+
+    if state.on_segments do
+      fresh =
+        contents
+        |> finished_indices()
+        |> Enum.reject(&MapSet.member?(state.seen_segments, &1))
+
+      if fresh == [] do
+        state
+      else
+        state.on_segments.(fresh)
+        %{state | seen_segments: Enum.into(fresh, state.seen_segments)}
+      end
+    else
+      state
+    end
   end
 
   @impl true

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -495,7 +495,9 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
 
     # Use index.m3u8 to match HLS controller expectations
     playlist_path = Path.join(output_dir, "index.m3u8")
-    segment_pattern = Path.join(output_dir, "segment_%03d.ts")
+    segment_pattern = Path.join(output_dir, "segment_%05d.ts")
+    start_number = Keyword.get(opts, :start_number, 0)
+    segment_seconds = Mydia.Streaming.SegmentPlan.default_segment_seconds()
 
     # `-ss` before `-i` is input seeking: FFmpeg jumps to the nearest keyframe
     # without decoding everything before it. Placed after `-i` it would decode
@@ -580,21 +582,48 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
         ]
       end
 
-    # HLS output parameters
-    # Use live-style playlist (no -hls_playlist_type) so playlist updates incrementally
-    # as segments are written. This allows playback to start quickly without waiting
-    # for the entire file to be processed.
-    # -hls_list_size 0 keeps all segments in playlist for full seeking capability
+    # The playlist FFmpeg writes here is internal bookkeeping only: it is how
+    # HlsSession learns which segments are finished. What the player receives is
+    # SegmentPlan.playlist/1, computed from the media duration before FFmpeg
+    # starts. -hls_list_size 0 keeps every entry so the session can read the
+    # whole set on each poll.
+    #
+    # -start_number makes filenames absolute, so a window relocated to t=400s
+    # writes segment_00100.ts, which is the name the published playlist already
+    # promised. -copyts keeps source timestamps, so that segment reports its
+    # real media time rather than restarting near zero.
+    #
+    # -muxdelay 0 -muxpreload 0 are not optional decoration. The TS muxer's
+    # defaults add a reproducible 1.4s to every window's timestamps, the
+    # un-relocated first one included, which would put every segment that far
+    # from the time the published playlist declares for it. Zeroing both brings
+    # the error down to about 20ms. Measured, not assumed: without them segment
+    # 100 lands at 401.378667s, with them at 399.978667s.
+    #
+    # -output_ts_offset is deliberately absent. On top of -copyts it would apply
+    # the seek offset a second time.
+    #
+    # -hls_flags temp_file makes FFmpeg write to a temporary name and rename on
+    # completion. Without it a half-written segment exists on disk and the
+    # session would hand the player a truncated file.
     hls_args = [
+      "-copyts",
+      "-muxdelay",
+      "0",
+      "-muxpreload",
+      "0",
       "-f",
       "hls",
       "-hls_time",
-      "4",
+      to_string(segment_seconds),
       "-hls_list_size",
       "0",
+      "-start_number",
+      to_string(start_number),
+      "-hls_flags",
+      "temp_file",
       "-hls_segment_filename",
       segment_pattern,
-      # Progress reporting
       "-progress",
       "pipe:1",
       "-loglevel",
@@ -602,11 +631,22 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       playlist_path
     ]
 
+    # Only meaningful when the video stream is re-encoded. On a copied stream
+    # the keyframes are whatever the source has, and FFmpeg rejects the flag.
+    # The caller decides, because it is the caller that knows whether the copy
+    # decision above landed on "copy".
+    keyframe_args =
+      if Keyword.get(opts, :grid_aligned, false) do
+        ["-force_key_frames", "expr:gte(t,n_forced*#{segment_seconds})"]
+      else
+        []
+      end
+
     # Combine all args. The maps sit directly after the input and before the
     # codec flags, which is where ffmpeg expects output stream selection.
     base_args ++
       AudioTrackSelector.ffmpeg_map_args(selected_audio) ++
-      video_args ++ audio_args ++ hls_args
+      video_args ++ audio_args ++ keyframe_args ++ hls_args
   end
 
   # Start FFmpeg process using Port

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -393,12 +393,12 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # segment indices that have shown up since the previous poll.
   defp handle_playlist(state, contents) do
     state =
-      if !state.ready_notified do
+      if state.ready_notified do
+        state
+      else
         Logger.debug("Playlist file detected: #{state.playlist_path}")
         if state.on_ready, do: state.on_ready.()
         %{state | ready_notified: true}
-      else
-        state
       end
 
     if state.on_segments do

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -692,28 +692,12 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     #
     # -start_number makes filenames absolute, so a window relocated to t=400s
     # writes segment_00100.ts, which is the name the published playlist already
-    # promised. -copyts keeps source timestamps, so that segment reports its
-    # real media time rather than restarting near zero.
-    #
-    # -muxdelay 0 -muxpreload 0 are not optional decoration. The TS muxer's
-    # defaults add a reproducible 1.4s to every window's timestamps, the
-    # un-relocated first one included, which would put every segment that far
-    # from the time the published playlist declares for it. Zeroing both brings
-    # the error down to about 20ms. Measured, not assumed: without them segment
-    # 100 lands at 401.378667s, with them at 399.978667s.
-    #
-    # -output_ts_offset is deliberately absent. On top of -copyts it would apply
-    # the seek offset a second time.
-    #
-    # -hls_flags temp_file makes FFmpeg write to a temporary name and rename on
-    # completion. Without it a half-written segment exists on disk and the
-    # session would hand the player a truncated file.
+    # promised. -hls_flags temp_file makes FFmpeg write to a temporary name and
+    # rename on completion. Without it a half-written segment exists on disk
+    # and the session would hand the player a truncated file. Both are
+    # harmless in either mode, so unlike the timestamp flags below they are
+    # never gated.
     hls_args = [
-      "-copyts",
-      "-muxdelay",
-      "0",
-      "-muxpreload",
-      "0",
       "-f",
       "hls",
       "-hls_time",
@@ -733,6 +717,34 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       playlist_path
     ]
 
+    # -copyts keeps source timestamps, so a relocated segment reports its real
+    # media time rather than restarting near zero.
+    #
+    # -muxdelay 0 -muxpreload 0 are not optional decoration. The TS muxer's
+    # defaults add a reproducible 1.4s to every window's timestamps, the
+    # un-relocated first one included, which would put every segment that far
+    # from the time the published playlist declares for it. Zeroing both brings
+    # the error down to about 20ms. Measured, not assumed: without them segment
+    # 100 lands at 401.378667s, with them at 399.978667s.
+    #
+    # -output_ts_offset is deliberately absent. On top of -copyts it would apply
+    # the seek offset a second time.
+    #
+    # Gated on absolute_timestamps (true only for a :full session, whose fixed
+    # segment grid needs a relocated encoder to report real media time). A
+    # :window session never relocates and must keep reporting near-zero
+    # timestamps after a resume seek: the player's StreamTimeline
+    # (player/lib/core/player/stream_timeline.dart) exists to map that
+    # near-zero playback position back onto the real one by adding its resume
+    # offset, and absolute timestamps here would make it double that offset.
+    # HlsSession passes absolute_timestamps: playlist_mode == :full.
+    timestamp_args =
+      if Keyword.get(opts, :absolute_timestamps, false) do
+        ["-copyts", "-muxdelay", "0", "-muxpreload", "0"]
+      else
+        []
+      end
+
     # Only meaningful when the video stream is re-encoded. On a copied stream
     # the keyframes are whatever the source has, and FFmpeg rejects the flag
     # outright. reencodes_video?/2 above is what decides whether grid_aligned
@@ -749,7 +761,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     # codec flags, which is where ffmpeg expects output stream selection.
     base_args ++
       AudioTrackSelector.ffmpeg_map_args(selected_audio) ++
-      video_args ++ audio_args ++ keyframe_args ++ hls_args
+      video_args ++ audio_args ++ keyframe_args ++ timestamp_args ++ hls_args
   end
 
   # Start FFmpeg process using Port

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -33,6 +33,8 @@ defmodule Mydia.Streaming.HlsSession do
 
   alias Mydia.Library
   alias Mydia.Streaming.FfmpegHlsTranscoder
+  alias Mydia.Streaming.SegmentPlan
+  alias Mydia.Streaming.TranscodeWindow
   alias Mydia.Repo
   alias Mydia.Downloads.TranscodeJob
 
@@ -63,6 +65,12 @@ defmodule Mydia.Streaming.HlsSession do
       :timeout_ref,
       :playlist_path,
       :db_job_id,
+      :segment_plan,
+      :backend_opts,
+      playlist_mode: :window,
+      window: nil,
+      segment_waiters: %{},
+      window_generation: 0,
       ready: false,
       ready_waiters: []
     ]
@@ -81,6 +89,12 @@ defmodule Mydia.Streaming.HlsSession do
             timeout_ref: reference() | nil,
             playlist_path: String.t() | nil,
             db_job_id: binary() | nil,
+            segment_plan: Mydia.Streaming.SegmentPlan.t() | nil,
+            backend_opts: keyword(),
+            playlist_mode: :full | :window,
+            window: Mydia.Streaming.TranscodeWindow.t() | nil,
+            segment_waiters: %{non_neg_integer() => [GenServer.from()]},
+            window_generation: non_neg_integer(),
             ready: boolean(),
             ready_waiters: list()
           }
@@ -97,6 +111,12 @@ defmodule Mydia.Streaming.HlsSession do
     * `:user_id` - (required) ID of the user requesting the stream
     * `:registry_key` - (required) Registry key for session registration
     * `:name` - (optional) GenServer name for registration
+    * `:playlist_mode` - (optional) `:full` publishes the complete VOD
+      playlist up front and serves segments on demand via
+      `request_segment/2`; `:window` is the existing behaviour, where the
+      client resolves segment files directly. Default `:window`. A `:full`
+      request degrades to `:window` when the media file's duration is
+      unknown (see `plan_from_media_file/1`).
 
   ## Examples
 
@@ -173,6 +193,40 @@ defmodule Mydia.Streaming.HlsSession do
     GenServer.cast(pid, :notify_ready)
   end
 
+  @segment_wait_timeout 10_000
+
+  @doc """
+  Resolves a segment to an on-disk path, waiting or relocating the encoder as
+  needed.
+
+  Returns `{:error, :window_mode}` for a session that has no plan, whose
+  segments the caller must resolve by filename as before.
+  """
+  @spec request_segment(pid(), non_neg_integer()) ::
+          {:ok, String.t()} | {:error, :timeout} | {:error, :window_mode}
+  def request_segment(pid, index) do
+    GenServer.call(pid, {:request_segment, index}, @segment_wait_timeout + 2_000)
+  catch
+    :exit, {:timeout, _} -> {:error, :timeout}
+  end
+
+  @doc "The published playlist, or `{:error, :window_mode}` if this session has none."
+  @spec playlist(pid()) :: {:ok, String.t()} | {:error, :window_mode}
+  def playlist(pid), do: GenServer.call(pid, :playlist)
+
+  @doc """
+  Records segments the backend has finished writing.
+
+  `generation` guards against a stopped backend's last poll arriving after a
+  relocation has already started a new one: its indices belong to a window that
+  no longer exists, and folding them in would make the session believe the new
+  encoder is further along than it is.
+  """
+  @spec notify_segments(pid(), non_neg_integer(), [non_neg_integer()]) :: :ok
+  def notify_segments(pid, generation, indices) do
+    GenServer.cast(pid, {:segments_ready, generation, indices})
+  end
+
   ## Server Callbacks
 
   @impl true
@@ -209,6 +263,21 @@ defmodule Mydia.Streaming.HlsSession do
           preload: [:media_item, :library_path, episode: :media_item]
         )
 
+      # A session is only :full when the caller asked for it AND the duration is
+      # actually known. ensure_duration_known/2 can come back empty when the
+      # inline probe budget is exceeded, and there is no plan to publish without
+      # a duration, so that session degrades to :window regardless of what the
+      # client requested.
+      requested_mode = Keyword.get(opts, :playlist_mode, :window)
+
+      segment_plan =
+        case requested_mode do
+          :full -> plan_from_media_file(media_file)
+          :window -> nil
+        end
+
+      playlist_mode = if segment_plan, do: :full, else: :window
+
       # Register this session in the Registry. This is a `:unique` key, so two
       # concurrent callers can race here (e.g. HlsSessionSupervisor replacing a
       # session on an offset mismatch from two overlapping requests for the
@@ -217,7 +286,7 @@ defmodule Mydia.Streaming.HlsSession do
       # that get_session/2 could never find. See
       # HlsSessionSupervisor.start_new_session/5, which adopts the winner's
       # pid instead of treating this as a failure. Registration happens
-      # before the temp directory is created and before start_backend/5
+      # before the temp directory is created and before start_backend/6
       # spawns FFmpeg, so the losing branch below spawns no process and
       # leaks nothing.
       case Registry.register(
@@ -232,11 +301,20 @@ defmodule Mydia.Streaming.HlsSession do
                max_height: max_height,
                audio_language: playback.audio_language,
                show_audio_language: playback.show_audio_language,
+               playlist_mode: playlist_mode,
                started_at: DateTime.utc_now()
              }
            ) do
         {:ok, _owner} ->
-          start_registered_session(media_file_id, user_id, mode, media_file, playback)
+          start_registered_session(
+            media_file_id,
+            user_id,
+            mode,
+            media_file,
+            playback,
+            segment_plan,
+            playlist_mode
+          )
 
         {:error, {:already_registered, pid}} ->
           {:stop, {:already_registered, pid}}
@@ -251,8 +329,22 @@ defmodule Mydia.Streaming.HlsSession do
   # Continues session setup once this process has won the registration race
   # for its (media_file_id, user_id) key. Creates the temp dir, the DB job
   # record, and starts the FFmpeg backend.
-  defp start_registered_session(media_file_id, user_id, mode, media_file, playback) do
+  defp start_registered_session(
+         media_file_id,
+         user_id,
+         mode,
+         media_file,
+         playback,
+         segment_plan,
+         playlist_mode
+       ) do
     %{max_bitrate: max_bitrate, max_height: max_height, start_position: start_position} = playback
+
+    # The segment the running encoder has to start from. Only meaningful for a
+    # :full session: a :window session has no plan to index into, and its
+    # first_index is never consulted (there is no window to seed).
+    first_index =
+      if segment_plan, do: SegmentPlan.index_for_time(segment_plan, start_position), else: 0
 
     # Generate session ID and create temp directory
     session_id = generate_session_id()
@@ -301,14 +393,21 @@ defmodule Mydia.Streaming.HlsSession do
         Logger.info("Temp directory: #{temp_dir}")
         Logger.info("Starting HLS transcoding with FFmpeg backend")
 
+        # The keyword list a relocation reuses verbatim (see relocate/2), so it
+        # has to carry everything start_backend/6 needs beyond the offset and
+        # start number, which relocate overwrites per-call.
+        backend_opts = [
+          max_bitrate: max_bitrate,
+          max_height: max_height,
+          start_position: start_position,
+          start_number: first_index,
+          grid_aligned: FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate),
+          audio_language: playback.audio_language,
+          show_audio_language: playback.show_audio_language
+        ]
+
         # Start FFmpeg backend
-        case start_backend(:ffmpeg, media_file, temp_dir, job.id,
-               max_bitrate: max_bitrate,
-               max_height: max_height,
-               start_position: start_position,
-               audio_language: playback.audio_language,
-               show_audio_language: playback.show_audio_language
-             ) do
+        case start_backend(:ffmpeg, media_file, temp_dir, job.id, backend_opts, 0) do
           {:ok, backend_pid} ->
             # Link to backend process so we terminate if it crashes
             Process.link(backend_pid)
@@ -326,7 +425,11 @@ defmodule Mydia.Streaming.HlsSession do
               backend_pid: backend_pid,
               temp_dir: temp_dir,
               last_activity: DateTime.utc_now(),
-              db_job_id: job.id
+              db_job_id: job.id,
+              segment_plan: segment_plan,
+              playlist_mode: playlist_mode,
+              window: if(playlist_mode == :full, do: TranscodeWindow.new(first_index), else: nil),
+              backend_opts: backend_opts
             }
 
             # Schedule initial timeout check
@@ -351,6 +454,17 @@ defmodule Mydia.Streaming.HlsSession do
     end
   end
 
+  # The duration ffprobe recorded at analyze time, or whatever the resolver's
+  # inline probe managed to fill in. nil means no plan and no full playlist.
+  defp plan_from_media_file(%{metadata: %{duration: duration}}) when is_number(duration) do
+    case SegmentPlan.build(duration) do
+      {:ok, plan} -> plan
+      :error -> nil
+    end
+  end
+
+  defp plan_from_media_file(_media_file), do: nil
+
   @impl true
   def handle_call(:get_info, _from, state) do
     # Getting info counts as activity
@@ -371,7 +485,9 @@ defmodule Mydia.Streaming.HlsSession do
       backend: state.backend,
       temp_dir: state.temp_dir,
       last_activity: state.last_activity,
-      backend_alive?: is_pid(state.backend_pid) and Process.alive?(state.backend_pid)
+      backend_alive?: is_pid(state.backend_pid) and Process.alive?(state.backend_pid),
+      playlist_mode: state.playlist_mode,
+      duration: state.segment_plan && state.segment_plan.duration
     }
 
     {:reply, {:ok, info}, state}
@@ -379,6 +495,34 @@ defmodule Mydia.Streaming.HlsSession do
 
   def handle_call(:get_playlist_path, _from, state) do
     {:reply, {:ok, state.playlist_path}, state}
+  end
+
+  def handle_call(:playlist, _from, %{segment_plan: nil} = state) do
+    {:reply, {:error, :window_mode}, state}
+  end
+
+  def handle_call(:playlist, _from, state) do
+    state = update_activity(state)
+    {:reply, {:ok, SegmentPlan.playlist(state.segment_plan)}, state}
+  end
+
+  def handle_call({:request_segment, _index}, _from, %{segment_plan: nil} = state) do
+    {:reply, {:error, :window_mode}, state}
+  end
+
+  def handle_call({:request_segment, index}, from, state) do
+    state = update_activity(state)
+
+    case TranscodeWindow.decide(state.window, index) do
+      :serve ->
+        {:reply, {:ok, segment_path(state, index)}, state}
+
+      :wait ->
+        {:noreply, park_waiter(state, index, from)}
+
+      {:relocate, target} ->
+        {:noreply, state |> relocate(target) |> park_waiter(index, from)}
+    end
   end
 
   def handle_call(:await_ready, _from, %{ready: true} = state) do
@@ -423,6 +567,26 @@ defmodule Mydia.Streaming.HlsSession do
     {:noreply, %{state | ready: true, ready_waiters: []}}
   end
 
+  def handle_cast({:segments_ready, generation, _indices}, %{window_generation: current} = state)
+      when generation != current do
+    # A dead backend's final poll. Its indices belong to a window that has
+    # already been replaced.
+    {:noreply, state}
+  end
+
+  def handle_cast({:segments_ready, _generation, indices}, state) do
+    window = TranscodeWindow.mark_ready(state.window, indices)
+
+    {waiters, remaining} = Map.split(state.segment_waiters, indices)
+
+    Enum.each(waiters, fn {index, froms} ->
+      path = segment_path(state, index)
+      Enum.each(froms, &safe_reply(&1, {:ok, path}))
+    end)
+
+    {:noreply, %{state | window: window, segment_waiters: remaining}}
+  end
+
   @impl true
   def handle_info(:check_timeout, state) do
     now = DateTime.utc_now()
@@ -443,6 +607,31 @@ defmodule Mydia.Streaming.HlsSession do
     Logger.warning("Backend #{state.backend} (#{inspect(pid)}) terminated: #{inspect(reason)}")
     # Backend died, we should terminate too
     {:stop, {:backend_terminated, reason}, state}
+  end
+
+  def handle_info({:waiter_timeout, index, from}, state) do
+    # Answered already, or still parked. Only the still-parked case needs a
+    # reply, and it must be removed so a later segment arrival does not reply
+    # to the same caller twice.
+    case Map.get(state.segment_waiters, index) do
+      nil ->
+        {:noreply, state}
+
+      froms ->
+        if from in froms do
+          safe_reply(from, {:error, :timeout})
+          remaining = List.delete(froms, from)
+
+          waiters =
+            if remaining == [],
+              do: Map.delete(state.segment_waiters, index),
+              else: Map.put(state.segment_waiters, index, remaining)
+
+          {:noreply, %{state | segment_waiters: waiters}}
+        else
+          {:noreply, state}
+        end
+    end
   end
 
   def handle_info(msg, state) do
@@ -487,8 +676,78 @@ defmodule Mydia.Streaming.HlsSession do
 
   ## Private Functions
 
+  defp segment_path(state, index) do
+    Path.join(state.temp_dir, SegmentPlan.segment_name(index))
+  end
+
+  defp park_waiter(state, index, from) do
+    Process.send_after(self(), {:waiter_timeout, index, from}, @segment_wait_timeout)
+
+    %{
+      state
+      | segment_waiters: Map.update(state.segment_waiters, index, [from], &[from | &1])
+    }
+  end
+
+  # A waiter's caller can die between parking and the reply. GenServer.reply/2
+  # to a dead caller exits, which would take the whole session down with it.
+  defp safe_reply(from, message) do
+    GenServer.reply(from, message)
+  catch
+    :exit, _reason -> :ok
+  end
+
+  # Moves the encoder to `target`, keeping every segment already on disk.
+  #
+  # The backend is unlinked before it is stopped. HlsSession links to its
+  # backend so a crashed encoder takes the session down; without the unlink, a
+  # deliberate stop would do the same thing and every seek would kill the
+  # session.
+  defp relocate(state, target) do
+    generation = state.window_generation + 1
+
+    if is_pid(state.backend_pid) and Process.alive?(state.backend_pid) do
+      Process.unlink(state.backend_pid)
+      stop_backend(state.backend, state.backend_pid)
+    end
+
+    opts =
+      state.backend_opts
+      |> Keyword.put(:start_position, trunc(SegmentPlan.start_time(state.segment_plan, target)))
+      |> Keyword.put(:start_number, target)
+
+    case start_backend(
+           :ffmpeg,
+           state.media_file,
+           state.temp_dir,
+           state.db_job_id,
+           opts,
+           generation
+         ) do
+      {:ok, backend_pid} ->
+        Process.link(backend_pid)
+
+        %{
+          state
+          | backend_pid: backend_pid,
+            window: TranscodeWindow.relocate(state.window, target),
+            window_generation: generation
+        }
+
+      {:error, reason} ->
+        Logger.error("Failed to relocate FFmpeg to segment #{target}: #{inspect(reason)}")
+
+        %{
+          state
+          | backend_pid: nil,
+            window: TranscodeWindow.stopped(state.window),
+            window_generation: generation
+        }
+    end
+  end
+
   # Start FFmpeg backend
-  defp start_backend(:ffmpeg, media_file, temp_dir, job_id, opts) do
+  defp start_backend(:ffmpeg, media_file, temp_dir, job_id, opts, generation) do
     # Resolve absolute path for FFmpeg input
     absolute_path = Mydia.Library.MediaFile.absolute_path(media_file)
     Logger.info("Starting FFmpeg backend for #{absolute_path}")
@@ -502,7 +761,9 @@ defmodule Mydia.Streaming.HlsSession do
         input_path: absolute_path,
         output_dir: temp_dir,
         media_file: media_file,
-        start_position: Keyword.get(opts, :start_position, 0)
+        start_position: Keyword.get(opts, :start_position, 0),
+        start_number: Keyword.get(opts, :start_number, 0),
+        grid_aligned: Keyword.get(opts, :grid_aligned, false)
       ] ++
         if(opts[:max_bitrate], do: [max_bitrate: opts[:max_bitrate]], else: []) ++
         if(opts[:max_height], do: [max_height: opts[:max_height]], else: []) ++
@@ -544,10 +805,22 @@ defmodule Mydia.Streaming.HlsSession do
           end,
           on_error: fn error ->
             Logger.error("FFmpeg transcoding error for #{absolute_path}: #{error}")
+          end,
+          on_segments: fn indices ->
+            __MODULE__.notify_segments(session_pid, generation, indices)
           end
         ]
 
-    case FfmpegHlsTranscoder.start_transcoding(transcoder_opts) do
+    # Overridable per-session so a test can drive relocation without spawning
+    # real FFmpeg (see test/mydia/streaming/hls_session_segments_test.exs).
+    # Threaded through opts rather than global Application config: relocate/2
+    # reuses state.backend_opts verbatim on every call, so a value set once at
+    # session construction survives every relocation with no global state and
+    # no async: false, unlike Application.get_env(:mydia, :transcoder_module)
+    # (see Mydia.Downloads.JobManager for that pattern).
+    transcoder = Keyword.get(opts, :transcoder_module, FfmpegHlsTranscoder)
+
+    case transcoder.start_transcoding(transcoder_opts) do
       {:ok, pid} ->
         {:ok, pid}
 
@@ -556,7 +829,7 @@ defmodule Mydia.Streaming.HlsSession do
     end
   end
 
-  defp start_backend(backend, _media_file, _temp_dir, _job_id, _opts) do
+  defp start_backend(backend, _media_file, _temp_dir, _job_id, _opts, _generation) do
     Logger.error("Unknown backend: #{backend}")
     {:error, :unknown_backend}
   end

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -402,6 +402,7 @@ defmodule Mydia.Streaming.HlsSession do
           start_position: start_position,
           start_number: first_index,
           grid_aligned: grid_aligned?(playlist_mode, media_file, max_bitrate),
+          absolute_timestamps: playlist_mode == :full,
           audio_language: playback.audio_language,
           show_audio_language: playback.show_audio_language
         ]
@@ -806,7 +807,8 @@ defmodule Mydia.Streaming.HlsSession do
         media_file: media_file,
         start_position: Keyword.get(opts, :start_position, 0),
         start_number: Keyword.get(opts, :start_number, 0),
-        grid_aligned: Keyword.get(opts, :grid_aligned, false)
+        grid_aligned: Keyword.get(opts, :grid_aligned, false),
+        absolute_timestamps: Keyword.get(opts, :absolute_timestamps, false)
       ] ++
         if(opts[:max_bitrate], do: [max_bitrate: opts[:max_bitrate]], else: []) ++
         if(opts[:max_height], do: [max_height: opts[:max_height]], else: []) ++

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -200,10 +200,14 @@ defmodule Mydia.Streaming.HlsSession do
   needed.
 
   Returns `{:error, :window_mode}` for a session that has no plan, whose
-  segments the caller must resolve by filename as before.
+  segments the caller must resolve by filename as before, and `{:error,
+  :out_of_range}` when `index` falls outside the plan's segment count.
   """
   @spec request_segment(pid(), non_neg_integer()) ::
-          {:ok, String.t()} | {:error, :timeout} | {:error, :window_mode}
+          {:ok, String.t()}
+          | {:error, :timeout}
+          | {:error, :window_mode}
+          | {:error, :out_of_range}
   def request_segment(pid, index) do
     GenServer.call(pid, {:request_segment, index}, @segment_wait_timeout + 2_000)
   catch
@@ -531,6 +535,18 @@ defmodule Mydia.Streaming.HlsSession do
 
   def handle_call({:request_segment, _index}, _from, %{segment_plan: nil} = state) do
     {:reply, {:error, :window_mode}, state}
+  end
+
+  # Out of range for the published plan. TranscodeWindow.decide/2 has no
+  # concept of the plan's bounds and would happily return {:relocate, index},
+  # which stops the encoder the viewer is actually watching to seek FFmpeg
+  # past end of file. Checked before decide/2 runs, so a bogus index never
+  # touches the running backend. A negative index cannot reach here through
+  # the controller (SegmentPlan.index_from_name/1's regex only matches
+  # digits), but the low end is bounded too since it costs nothing.
+  def handle_call({:request_segment, index}, _from, %{segment_plan: plan} = state)
+      when index < 0 or index >= plan.count do
+    {:reply, {:error, :out_of_range}, state}
   end
 
   def handle_call({:request_segment, index}, from, state) do

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -306,6 +306,7 @@ defmodule Mydia.Streaming.HlsSession do
                audio_language: playback.audio_language,
                show_audio_language: playback.show_audio_language,
                playlist_mode: playlist_mode,
+               requested_playlist_mode: requested_mode,
                started_at: DateTime.utc_now()
              }
            ) do

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -401,7 +401,7 @@ defmodule Mydia.Streaming.HlsSession do
           max_height: max_height,
           start_position: start_position,
           start_number: first_index,
-          grid_aligned: FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate),
+          grid_aligned: grid_aligned?(playlist_mode, media_file, max_bitrate),
           audio_language: playback.audio_language,
           show_audio_language: playback.show_audio_language
         ]
@@ -464,6 +464,28 @@ defmodule Mydia.Streaming.HlsSession do
   end
 
   defp plan_from_media_file(_media_file), do: nil
+
+  # Whether the initial backend start for this session should force
+  # keyframes onto the segment grid.
+  #
+  # Gated on playlist_mode == :full: grid alignment exists only to keep the
+  # pre-computed :full playlist's uniform declared segment durations
+  # accurate. A :window session has no such playlist, so forcing keyframes
+  # there would change keyframe placement and segment cutting on the
+  # compatibility path (the only mode wired into production today) for no
+  # benefit; :window must stay exactly what it was before this feature
+  # existed.
+  #
+  # Public only so this decision can be asserted directly; reaching it
+  # through start_registered_session/7 needs a full init/1 (Registry, a DB
+  # job row, a real media file), which is unrelated to whether the decision
+  # itself is right. Nothing outside this module should call it.
+  @doc false
+  @spec grid_aligned?(:full | :window, Mydia.Library.MediaFile.t() | nil, integer() | nil) ::
+          boolean()
+  def grid_aligned?(playlist_mode, media_file, max_bitrate) do
+    playlist_mode == :full and FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate)
+  end
 
   @impl true
   def handle_call(:get_info, _from, state) do
@@ -708,7 +730,28 @@ defmodule Mydia.Streaming.HlsSession do
 
     if is_pid(state.backend_pid) and Process.alive?(state.backend_pid) do
       Process.unlink(state.backend_pid)
-      stop_backend(state.backend, state.backend_pid)
+
+      # stop_backend/2 reaches FfmpegHlsTranscoder.stop_transcoding/1, which is
+      # GenServer.stop/2 and blocks until terminate/2 finishes, and
+      # terminate/2 has an unconditional 100ms sleep before its SIGKILL
+      # escalation check. Called inline, that freezes this session's entire
+      # mailbox (every other segment request, get_info, heartbeat) for at
+      # least 100ms on every relocation, in the exact path this feature
+      # exists to make smooth. Task.start/1 moves the wait off this process
+      # without linking or monitoring it back in, so the old encoder's exit
+      # can no longer affect this session (which is the whole point of the
+      # unlink above). Deliberately not Task.async/1 or
+      # Task.Supervisor.async/2: both link the task to this process, which
+      # reintroduces the coupling the unlink just removed.
+      #
+      # This does mean the old and new encoders overlap for roughly 100ms.
+      # That is safe: the old backend is already unlinked and about to stop
+      # producing segments, and any {:segments_ready, ...} it still manages
+      # to send in that window carries the old generation, which the guard
+      # clause on that handle_cast discards.
+      backend_pid = state.backend_pid
+      backend = state.backend
+      Task.start(fn -> stop_backend(backend, backend_pid) end)
     end
 
     opts =

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -81,8 +81,12 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   # Every request option that shapes the transcode output, mapped to the value
   # a Registry entry predating that option is assumed to have carried. A
   # session is reusable only when all of them agree.
+  #
+  # start_position is absent from this map deliberately: whether it
+  # discriminates depends on the playlist mode, and that is decided in
+  # session_matches?/2 below.
   @session_discriminators %{
-    start_position: 0,
+    playlist_mode: :window,
     max_bitrate: nil,
     max_height: nil,
     audio_language: nil,
@@ -94,9 +98,19 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   # existed is treated as carrying that field's default rather than as a
   # wildcard that matches every request.
   def session_matches?(metadata, request) do
-    Enum.all?(@session_discriminators, fn {key, default} ->
-      Map.get(metadata, key, default) == Map.get(request, key, default)
-    end)
+    shape_matches =
+      Enum.all?(@session_discriminators, fn {key, default} ->
+        Map.get(metadata, key, default) == Map.get(request, key, default)
+      end)
+
+    # A full session publishes a playlist covering the whole file and can move
+    # its encoder to any segment, so an offset mismatch is not a mismatch at
+    # all. A windowed one can only serve the range it started at, so it is.
+    offset_matches =
+      Map.get(metadata, :playlist_mode, :window) == :full or
+        Map.get(metadata, :start_position, 0) == Map.get(request, :start_position, 0)
+
+    shape_matches and offset_matches
   end
 
   @doc false
@@ -105,6 +119,7 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   # send the field at all, and a new one sending an empty list.
   def session_request(opts) do
     %{
+      playlist_mode: Keyword.get(opts, :playlist_mode, :window),
       start_position: Keyword.get(opts, :start_position, 0),
       max_bitrate: Keyword.get(opts, :max_bitrate),
       max_height: Keyword.get(opts, :max_height),

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -92,11 +92,19 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   # a Registry entry predating that option is assumed to have carried. A
   # session is reusable only when all of them agree.
   #
+  # Discriminates on requested_playlist_mode, not the effective playlist_mode
+  # a session ended up running with: a :full request that degraded to :window
+  # because the duration was unknown still asked for :full, and a repeat
+  # request asking for the same thing should reuse that session rather than
+  # replace it every time (it would degrade identically anyway). Whether a
+  # session can actually serve the request's offset is a different question,
+  # decided in session_matches?/2 below against the effective mode.
+  #
   # start_position is absent from this map deliberately: whether it
   # discriminates depends on the playlist mode, and that is decided in
   # session_matches?/2 below.
   @session_discriminators %{
-    playlist_mode: @default_playlist_mode,
+    requested_playlist_mode: @default_playlist_mode,
     max_bitrate: nil,
     max_height: nil,
     audio_language: nil,
@@ -116,6 +124,13 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
     # A full session publishes a playlist covering the whole file and can move
     # its encoder to any segment, so an offset mismatch is not a mismatch at
     # all. A windowed one can only serve the range it started at, so it is.
+    #
+    # Deliberately the EFFECTIVE playlist_mode, not requested_playlist_mode
+    # above: a session that asked for :full but degraded to :window because
+    # the duration was unknown is really a windowed session and can only
+    # serve the offset it started at, same as one that was never anything but
+    # :window. Testing the requested mode here would let such a session
+    # answer a request at an offset its encoder can never reach.
     offset_matches =
       Map.get(metadata, :playlist_mode, @default_playlist_mode) == :full or
         Map.get(metadata, :start_position, 0) == Map.get(request, :start_position, 0)
@@ -129,7 +144,7 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   # send the field at all, and a new one sending an empty list.
   def session_request(opts) do
     %{
-      playlist_mode: Keyword.get(opts, :playlist_mode, @default_playlist_mode),
+      requested_playlist_mode: Keyword.get(opts, :playlist_mode, @default_playlist_mode),
       start_position: Keyword.get(opts, :start_position, 0),
       max_bitrate: Keyword.get(opts, :max_bitrate),
       max_height: Keyword.get(opts, :max_height),

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -78,6 +78,13 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
     end
   end
 
+  # The playlist_mode a Registry entry predating that key is assumed to have
+  # carried. This is the safe default: it is the compatibility path that can
+  # only serve the offset it started at, never a wildcard that matches every
+  # request. Shared between @session_discriminators and session_matches?/2
+  # below so the two cannot drift out of sync.
+  @default_playlist_mode :window
+
   # Every request option that shapes the transcode output, mapped to the value
   # a Registry entry predating that option is assumed to have carried. A
   # session is reusable only when all of them agree.
@@ -86,7 +93,7 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   # discriminates depends on the playlist mode, and that is decided in
   # session_matches?/2 below.
   @session_discriminators %{
-    playlist_mode: :window,
+    playlist_mode: @default_playlist_mode,
     max_bitrate: nil,
     max_height: nil,
     audio_language: nil,
@@ -107,7 +114,7 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
     # its encoder to any segment, so an offset mismatch is not a mismatch at
     # all. A windowed one can only serve the range it started at, so it is.
     offset_matches =
-      Map.get(metadata, :playlist_mode, :window) == :full or
+      Map.get(metadata, :playlist_mode, @default_playlist_mode) == :full or
         Map.get(metadata, :start_position, 0) == Map.get(request, :start_position, 0)
 
     shape_matches and offset_matches

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -59,9 +59,12 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
         if session_matches?(metadata, session_request(opts)) do
           {:ok, pid}
         else
-          # A session transcoding from a different offset cannot serve this
-          # request: its playlist simply does not contain the wanted range. A
-          # session running at a different quality cannot serve it either: its
+          # A :window session transcoding from a different offset cannot serve
+          # this request: its playlist simply does not contain the wanted
+          # range. A :full session has no such gap; session_matches?/2 below
+          # treats an offset mismatch as a match for it and lets the running
+          # session relocate its encoder instead of being torn down. A session
+          # running at a different quality cannot serve it either: its
           # segments are already encoded at the old rung. Nor can one running
           # a different audio language: the track it mapped is already baked
           # into those segments, so a viewer switching language needs a fresh
@@ -126,7 +129,7 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   # send the field at all, and a new one sending an empty list.
   def session_request(opts) do
     %{
-      playlist_mode: Keyword.get(opts, :playlist_mode, :window),
+      playlist_mode: Keyword.get(opts, :playlist_mode, @default_playlist_mode),
       start_position: Keyword.get(opts, :start_position, 0),
       max_bitrate: Keyword.get(opts, :max_bitrate),
       max_height: Keyword.get(opts, :max_height),

--- a/lib/mydia/streaming/segment_plan.ex
+++ b/lib/mydia/streaming/segment_plan.ex
@@ -28,7 +28,7 @@ defmodule Mydia.Streaming.SegmentPlan do
 
   @default_segment_seconds 4
 
-  @segment_name_pattern ~r/^segment_(\d{5})\.ts$/
+  @segment_name_pattern ~r/^segment_(\d{5})\.ts\z/
 
   @doc """
   The segment length every session uses, in seconds.

--- a/lib/mydia/streaming/segment_plan.ex
+++ b/lib/mydia/streaming/segment_plan.ex
@@ -1,0 +1,141 @@
+defmodule Mydia.Streaming.SegmentPlan do
+  @moduledoc """
+  The complete segment layout of a streaming session, computed from the media
+  duration before FFmpeg has produced anything.
+
+  This is the contract the server publishes to the player. Every segment the
+  playlist names is addressable from the moment the session starts; whether the
+  bytes exist yet is `Mydia.Streaming.TranscodeWindow`'s problem, not the
+  playlist's.
+
+  Declared durations are uniform. In transcode mode that is exact, because
+  `-force_key_frames` puts keyframes on the same grid. In copy mode FFmpeg cuts
+  at the first source keyframe at or after each boundary, so real durations vary
+  by up to one GOP while these stay uniform. That drift is bounded and does not
+  accumulate (each cut is measured from the grid, not from the previous cut),
+  and `-copyts` keeps segment timestamps absolute, so the player's clock stays
+  correct even where a boundary does not.
+  """
+
+  @enforce_keys [:duration, :segment_seconds, :count]
+  defstruct [:duration, :segment_seconds, :count]
+
+  @type t :: %__MODULE__{
+          duration: float(),
+          segment_seconds: pos_integer(),
+          count: pos_integer()
+        }
+
+  @default_segment_seconds 4
+
+  @segment_name_pattern ~r/^segment_(\d{5})\.ts$/
+
+  @doc """
+  The segment length every session uses, in seconds.
+
+  Matches the transcoder's `-hls_time`. Read it from here rather than repeating
+  the literal: the playlist and the FFmpeg arguments must never disagree.
+  """
+  @spec default_segment_seconds() :: pos_integer()
+  def default_segment_seconds, do: @default_segment_seconds
+
+  @doc """
+  Builds a plan, or returns `:error` when the duration is unknown or unusable.
+
+  `:error` is an ordinary answer, not a failure: a file whose inline probe
+  budget was exceeded has no duration, and its session falls back to the
+  windowed playlist.
+  """
+  @spec build(number() | nil, pos_integer()) :: {:ok, t()} | :error
+  def build(duration, segment_seconds \\ @default_segment_seconds)
+
+  def build(duration, segment_seconds)
+      when is_number(duration) and duration > 0 and is_integer(segment_seconds) and
+             segment_seconds > 0 do
+    {:ok,
+     %__MODULE__{
+       duration: duration / 1,
+       segment_seconds: segment_seconds,
+       count: ceil(duration / segment_seconds)
+     }}
+  end
+
+  def build(_duration, _segment_seconds), do: :error
+
+  @doc "The real media time at which segment `index` begins."
+  @spec start_time(t(), non_neg_integer()) :: float()
+  def start_time(%__MODULE__{segment_seconds: seconds}, index), do: index * seconds / 1
+
+  @doc """
+  The segment containing `seconds`, clamped into the plan at both ends.
+
+  Clamping rather than raising: a corrupt progress row can ask to resume past
+  the end, and landing on the last segment is a better answer than a crash.
+  """
+  @spec index_for_time(t(), number()) :: non_neg_integer()
+  def index_for_time(%__MODULE__{segment_seconds: seconds, count: count}, time) do
+    time
+    |> max(0)
+    |> Kernel./(seconds)
+    |> trunc()
+    |> min(count - 1)
+  end
+
+  @doc "The declared length of segment `index`, which is short only for the last."
+  @spec duration_of(t(), non_neg_integer()) :: float()
+  def duration_of(%__MODULE__{} = plan, index) do
+    if index == plan.count - 1 do
+      plan.duration - index * plan.segment_seconds
+    else
+      plan.segment_seconds / 1
+    end
+  end
+
+  @doc """
+  The on-disk filename for a segment index.
+
+  Fixed five-digit width so the name is a pure function of the index and FFmpeg's
+  `-hls_segment_filename` pattern can produce it directly. Five digits covers 55
+  hours at four seconds.
+  """
+  @spec segment_name(non_neg_integer()) :: String.t()
+  def segment_name(index) do
+    "segment_" <> String.pad_leading(Integer.to_string(index), 5, "0") <> ".ts"
+  end
+
+  @doc """
+  Reads a segment index back out of a filename.
+
+  Returns `:error` for anything that is not one, which the controller relies on:
+  it feeds every requested path through here, subtitle tracks included.
+  """
+  @spec index_from_name(String.t()) :: {:ok, non_neg_integer()} | :error
+  def index_from_name(name) when is_binary(name) do
+    case Regex.run(@segment_name_pattern, name) do
+      [_, digits] -> {:ok, String.to_integer(digits)}
+      nil -> :error
+    end
+  end
+
+  def index_from_name(_name), do: :error
+
+  @doc "Renders the plan as a complete, terminated VOD media playlist."
+  @spec playlist(t()) :: String.t()
+  def playlist(%__MODULE__{} = plan) do
+    header = """
+    #EXTM3U
+    #EXT-X-VERSION:3
+    #EXT-X-TARGETDURATION:#{plan.segment_seconds}
+    #EXT-X-MEDIA-SEQUENCE:0
+    #EXT-X-PLAYLIST-TYPE:VOD
+    """
+
+    entries =
+      Enum.map_join(0..(plan.count - 1), fn index ->
+        seconds = :erlang.float_to_binary(duration_of(plan, index), decimals: 6)
+        "#EXTINF:#{seconds},\n#{segment_name(index)}\n"
+      end)
+
+    header <> entries <> "#EXT-X-ENDLIST\n"
+  end
+end

--- a/lib/mydia/streaming/transcode_window.ex
+++ b/lib/mydia/streaming/transcode_window.ex
@@ -1,0 +1,89 @@
+defmodule Mydia.Streaming.TranscodeWindow do
+  @moduledoc """
+  Where the encoder currently is, and what to do about a segment request.
+
+  The full playlist promises every segment in the file. This decides, for one
+  requested segment, whether the bytes are already there (`:serve`), whether the
+  running encoder will reach them soon enough to be worth waiting for
+  (`:wait`), or whether the encoder has to be moved (`{:relocate, index}`).
+
+  `wait_ahead_segments/0` is the server-side successor to the player's old
+  `kSeekRestartTolerance`. It exists for the same reason: early in a session
+  only a few seconds have been encoded, and without a tolerance every small
+  forward skip would pay for a relocation. Deciding it here rather than in the
+  client is the point of the whole change, because only the server knows how far
+  the encoder has actually got.
+
+  Pure and free of process state so the decision can be tested exhaustively,
+  the same way the player's `shouldRestartForSeek` was.
+  """
+
+  @wait_ahead_segments 3
+
+  defstruct available: MapSet.new(),
+            first_index: 0,
+            last_ready_index: -1,
+            running?: true
+
+  @type t :: %__MODULE__{
+          available: MapSet.t(non_neg_integer()),
+          first_index: non_neg_integer(),
+          last_ready_index: integer(),
+          running?: boolean()
+        }
+
+  @type decision :: :serve | :wait | {:relocate, non_neg_integer()}
+
+  @doc "How far past the encoder's last finished segment to wait rather than relocate."
+  @spec wait_ahead_segments() :: pos_integer()
+  def wait_ahead_segments, do: @wait_ahead_segments
+
+  @doc "A window whose encoder has just been started at `first_index`."
+  @spec new(non_neg_integer()) :: t()
+  def new(first_index) do
+    %__MODULE__{first_index: first_index, last_ready_index: first_index - 1, running?: true}
+  end
+
+  @doc """
+  What to do about a request for `index`.
+
+  Order matters. Disk is checked before anything else, so a segment left behind
+  by an earlier window is served even when the encoder has moved on and even
+  when it has stopped entirely.
+  """
+  @spec decide(t(), non_neg_integer()) :: decision()
+  def decide(%__MODULE__{} = window, index) do
+    cond do
+      MapSet.member?(window.available, index) -> :serve
+      not window.running? -> {:relocate, index}
+      index < window.first_index -> {:relocate, index}
+      index <= window.last_ready_index + @wait_ahead_segments -> :wait
+      true -> {:relocate, index}
+    end
+  end
+
+  @doc "Records segments the encoder has finished writing."
+  @spec mark_ready(t(), [non_neg_integer()]) :: t()
+  def mark_ready(%__MODULE__{} = window, indices) do
+    %{
+      window
+      | available: Enum.into(indices, window.available),
+        last_ready_index: Enum.reduce(indices, window.last_ready_index, &max/2)
+    }
+  end
+
+  @doc """
+  Moves the encoder to `index`.
+
+  `available` is deliberately untouched: the segments an earlier window wrote
+  stay on disk, which is what makes scrubbing back into a watched region free.
+  """
+  @spec relocate(t(), non_neg_integer()) :: t()
+  def relocate(%__MODULE__{} = window, index) do
+    %{window | first_index: index, last_ready_index: index - 1, running?: true}
+  end
+
+  @doc "Records that the encoder is no longer running, without losing the disk state."
+  @spec stopped(t()) :: t()
+  def stopped(%__MODULE__{} = window), do: %{window | running?: false}
+end

--- a/lib/mydia_web/controllers/api/hls_controller.ex
+++ b/lib/mydia_web/controllers/api/hls_controller.ex
@@ -290,6 +290,15 @@ defmodule MydiaWeb.Api.HlsController do
 
             {:error, :window_mode} ->
               serve_window_segment(conn, session_id, user_id, segment)
+
+            {:error, :out_of_range} ->
+              # Unlike :timeout, this segment will never exist: it falls
+              # outside the plan the session published. Retrying it is
+              # pointless, so a terminal 404 is the honest answer rather than
+              # a 503 that hls.js and mpv would keep retrying forever.
+              conn
+              |> put_status(:not_found)
+              |> json(%{error: "Segment not found"})
           end
         else
           :error ->

--- a/lib/mydia_web/controllers/api/hls_controller.ex
+++ b/lib/mydia_web/controllers/api/hls_controller.ex
@@ -7,6 +7,7 @@ defmodule MydiaWeb.Api.HlsController do
     AudioPreferences,
     HlsSessionSupervisor,
     HlsSession,
+    SegmentPlan,
     SessionFiles,
     SessionSubtitles
   }
@@ -19,8 +20,41 @@ defmodule MydiaWeb.Api.HlsController do
   """
   def master_playlist(conn, %{"session_id" => session_id}) do
     with {:ok, user_id} <- get_user_id(conn),
-         {:ok, pid} <- find_session_by_id(session_id, user_id),
-         :ok <- HlsSession.await_ready(pid, 30_000) do
+         {:ok, pid} <- find_session_by_id(session_id, user_id) do
+      case HlsSession.playlist(pid) do
+        {:ok, playlist} ->
+          # A full session's playlist is computed from the media duration and is
+          # complete before FFmpeg produces anything, so there is nothing to
+          # await. This is why a full-mode load has no "starting stream" wait.
+          heartbeat_session(session_id, user_id)
+
+          conn
+          |> put_resp_content_type("application/vnd.apple.mpegurl")
+          |> put_resp_header("cache-control", "no-cache")
+          |> send_resp(200, playlist)
+
+        {:error, :window_mode} ->
+          serve_window_playlist(conn, session_id, user_id, pid)
+      end
+    else
+      {:error, :no_user} ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Authentication required"})
+
+      {:error, :session_not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: "HLS session not found"})
+    end
+  end
+
+  # The pre-full-playlist compatibility path: FFmpeg is still growing this
+  # session's playlist on disk, so the controller must wait for it to exist
+  # and then serve whatever it currently contains. Kept intact for sessions
+  # that have no `SegmentPlan` (e.g. an unprobeable duration).
+  defp serve_window_playlist(conn, session_id, user_id, pid) do
+    with :ok <- HlsSession.await_ready(pid, 30_000) do
       # Session is ready - get the playlist path
       file_path =
         case HlsSession.get_playlist_path(pid) do
@@ -100,16 +134,6 @@ defmodule MydiaWeb.Api.HlsController do
           end
       end
     else
-      {:error, :no_user} ->
-        conn
-        |> put_status(:unauthorized)
-        |> json(%{error: "Authentication required"})
-
-      {:error, :session_not_found} ->
-        conn
-        |> put_status(:not_found)
-        |> json(%{error: "HLS session not found"})
-
       {:error, :timeout} ->
         Logger.warning("Timeout waiting for HLS session #{session_id} to be ready")
 
@@ -237,8 +261,61 @@ defmodule MydiaWeb.Api.HlsController do
   This route handles FFmpeg's flat structure where segments are in the root directory.
   """
   def root_segment(conn, %{"session_id" => session_id, "segment" => segment}) do
-    with {:ok, user_id} <- get_user_id(conn),
-         {:ok, info} <- get_session_info_by_id(session_id, user_id),
+    # get_user_id/1 runs outside the `with` (rather than as its first clause)
+    # so `user_id` is in scope in the `else` block below: a `with`'s `else`
+    # only sees the value that failed to match, not variables bound by
+    # clauses that already succeeded.
+    case get_user_id(conn) do
+      {:ok, user_id} ->
+        with {:ok, pid} <- find_session_by_id(session_id, user_id),
+             {:ok, index} <- SegmentPlan.index_from_name(segment) do
+          case HlsSession.request_segment(pid, index) do
+            {:ok, path} ->
+              heartbeat_session(session_id, user_id)
+
+              conn
+              |> put_resp_content_type(SessionFiles.content_type(segment))
+              |> put_resp_header("cache-control", "public, max-age=31536000, immutable")
+              |> send_file(200, path)
+
+            {:error, :timeout} ->
+              # The encoder has not reached this segment yet. Both hls.js and mpv
+              # retry a 503 with Retry-After rather than treating it as fatal, which
+              # is what keeps a seek onto a slow transcode buffering instead of
+              # failing.
+              conn
+              |> put_resp_header("retry-after", "1")
+              |> put_status(:service_unavailable)
+              |> json(%{error: "Segment not ready"})
+
+            {:error, :window_mode} ->
+              serve_window_segment(conn, session_id, user_id, segment)
+          end
+        else
+          :error ->
+            # Not a segment filename. Subtitles and anything else the session
+            # directory holds resolve by path as before.
+            serve_window_segment(conn, session_id, user_id, segment)
+
+          {:error, :session_not_found} ->
+            conn
+            |> put_status(:not_found)
+            |> json(%{error: "HLS session not found"})
+        end
+
+      {:error, :no_user} ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "Authentication required"})
+    end
+  end
+
+  # The pre-full-playlist compatibility path: resolves a requested name
+  # against the session directory by path rather than by segment index.
+  # Reached for anything that is not a `segment_NNNNN.ts` name (subtitles,
+  # legacy segment names) and for sessions with no `SegmentPlan`.
+  defp serve_window_segment(conn, session_id, user_id, segment) do
+    with {:ok, info} <- get_session_info_by_id(session_id, user_id),
          {:ok, segment_path} <- resolve_session_file(info, segment),
          true <- File.exists?(segment_path) do
       heartbeat_session(session_id, user_id)
@@ -248,11 +325,6 @@ defmodule MydiaWeb.Api.HlsController do
       |> put_resp_header("cache-control", cache_control_for(segment))
       |> send_file(200, segment_path)
     else
-      {:error, :no_user} ->
-        conn
-        |> put_status(:unauthorized)
-        |> json(%{error: "Authentication required"})
-
       {:error, :session_not_found} ->
         conn
         |> put_status(:not_found)

--- a/lib/mydia_web/schema/common_types.ex
+++ b/lib/mydia_web/schema/common_types.ex
@@ -457,6 +457,13 @@ defmodule MydiaWeb.Schema.CommonTypes do
         "Output height ceiling the server actually applied, which may be " <>
           "lower than requested on a relay connection. Null means the " <>
           "source resolution is preserved."
+
+    field :playlist_mode, non_null(:playlist_mode),
+      description:
+        "The playlist mode this session actually serves, which may be WINDOW " <>
+          "even when FULL was requested. In FULL the playlist covers the whole " <>
+          "file, positions are real media positions, and start_position is " <>
+          "always 0. In WINDOW, start_position is the offset the stream begins at."
   end
 
   @desc "A download quality option"

--- a/lib/mydia_web/schema/enum_types.ex
+++ b/lib/mydia_web/schema/enum_types.ex
@@ -94,4 +94,13 @@ defmodule MydiaWeb.Schema.EnumTypes do
     value(:episode, description: "A TV episode, dated by its air date")
     value(:movie, description: "A movie, dated by its release date")
   end
+
+  @desc "How much of the media a streaming session's playlist covers"
+  enum :playlist_mode do
+    @desc "The playlist covers the whole file and every segment is addressable immediately. Seeking is a plain seek."
+    value(:full, as: :full)
+
+    @desc "The playlist grows as FFmpeg transcodes and covers only what has been produced. Seeking outside it requires a new session."
+    value(:window, as: :window)
+  end
 end

--- a/lib/mydia_web/schema/mutation_types.ex
+++ b/lib/mydia_web/schema/mutation_types.ex
@@ -167,6 +167,15 @@ defmodule MydiaWeb.Schema.MutationTypes do
             "Optional; omitted or 0 starts at the beginning."
       )
 
+      arg(:playlist_mode, :playlist_mode,
+        description:
+          "Ask for a full-length playlist covering the whole file, which makes " <>
+            "seeking a plain seek. Omitted means WINDOW, the growing playlist " <>
+            "older clients expect. A server that cannot determine the media " <>
+            "duration answers WINDOW even when FULL was requested; read the " <>
+            "mode back from the result rather than assuming."
+      )
+
       resolve(&StreamingResolver.start_streaming_session/3)
     end
 

--- a/lib/mydia_web/schema/resolvers/streaming_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/streaming_resolver.ex
@@ -122,7 +122,8 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
           strategy,
           max_bitrate,
           max_height,
-          args[:start_position]
+          args[:start_position],
+          args[:playlist_mode] || :window
         )
     end
   end
@@ -273,7 +274,8 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
          strategy,
          max_bitrate,
          max_height,
-         requested_position
+         requested_position,
+         playlist_mode
        ) do
     mode = strategy_to_mode(strategy)
 
@@ -283,7 +285,13 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
          start_position <- clamp_start_position(requested_position, duration),
          show_audio_language <- AudioPreferences.for_media_file(user_id, media_file),
          session_opts <-
-           build_session_opts(max_bitrate, max_height, start_position, show_audio_language),
+           build_session_opts(
+             max_bitrate,
+             max_height,
+             start_position,
+             show_audio_language,
+             playlist_mode
+           ),
          {:ok, pid} <-
            HlsSessionSupervisor.start_session(media_file.id, user_id, mode, session_opts),
          {:ok, info} <- HlsSession.get_info(pid) do
@@ -292,6 +300,12 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
       # session or adopted a concurrent winner, either of which can be running
       # from a different offset than this caller asked for.
       session_start_position = info.start_position
+
+      # A full playlist covers the file from zero, so there is no offset for the
+      # client to map by. Reporting the encoder's current window here would
+      # shift every position the client derives.
+      reported_start_position =
+        if info.playlist_mode == :full, do: 0, else: info.start_position
 
       Logger.info(
         "Started streaming session #{info.session_id} for file #{file_id}, user #{user_id}" <>
@@ -312,9 +326,10 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
        %{
          session_id: info.session_id,
          duration: duration,
-         start_position: session_start_position,
+         start_position: reported_start_position,
          max_bitrate: max_bitrate,
-         max_height: max_height
+         max_height: max_height,
+         playlist_mode: info.playlist_mode
        }}
     else
       {:error, reason} ->
@@ -323,7 +338,13 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
     end
   end
 
-  defp build_session_opts(max_bitrate, max_height, start_position, show_audio_language) do
+  defp build_session_opts(
+         max_bitrate,
+         max_height,
+         start_position,
+         show_audio_language,
+         playlist_mode
+       ) do
     opts = if max_bitrate, do: [max_bitrate: max_bitrate], else: []
     opts = if max_height, do: [{:max_height, max_height} | opts], else: opts
 
@@ -334,6 +355,10 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
       if show_audio_language != [],
         do: [{:show_audio_language, show_audio_language} | opts],
         else: opts
+
+    # Always sent, unlike the options above: HlsSessionSupervisor.session_matches?/2
+    # keys on it, so a full and a windowed request must never share a session.
+    opts = [{:playlist_mode, playlist_mode} | opts]
 
     if start_position > 0, do: [{:start_position, start_position} | opts], else: opts
   end

--- a/player/lib/core/cast/cast_streaming_session_service.dart
+++ b/player/lib/core/cast/cast_streaming_session_service.dart
@@ -3,6 +3,7 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 
 import '../../graphql/mutations/end_streaming_session.graphql.dart';
 import '../../graphql/mutations/start_streaming_session.graphql.dart';
+import '../../graphql/mutations/start_streaming_session_compat.dart';
 import '../../graphql/schema.graphql.dart';
 import 'cast_backend.dart';
 
@@ -74,7 +75,8 @@ class GraphqlCastStreamingSessionService
     final data = result.data;
     final session = data == null
         ? null
-        : Mutation$StartStreamingSession.fromJson(data).startStreamingSession;
+        : Mutation$StartStreamingSession.fromJson(withPlaylistModeDefault(data))
+            .startStreamingSession;
 
     if (session == null) {
       throw const CastBackendException(

--- a/player/lib/graphql/mutations/start_streaming_session.graphql
+++ b/player/lib/graphql/mutations/start_streaming_session.graphql
@@ -1,9 +1,10 @@
-mutation StartStreamingSession($fileId: ID!, $strategy: StreamingStrategy!, $maxBitrate: Int, $maxHeight: Int, $startPosition: Int) {
-  startStreamingSession(fileId: $fileId, strategy: $strategy, maxBitrate: $maxBitrate, maxHeight: $maxHeight, startPosition: $startPosition) {
+mutation StartStreamingSession($fileId: ID!, $strategy: StreamingStrategy!, $maxBitrate: Int, $maxHeight: Int, $startPosition: Int, $playlistMode: PlaylistMode) {
+  startStreamingSession(fileId: $fileId, strategy: $strategy, maxBitrate: $maxBitrate, maxHeight: $maxHeight, startPosition: $startPosition, playlistMode: $playlistMode) {
     sessionId
     duration
     startPosition
     maxBitrate
     maxHeight
+    playlistMode
   }
 }

--- a/player/lib/graphql/mutations/start_streaming_session_compat.dart
+++ b/player/lib/graphql/mutations/start_streaming_session_compat.dart
@@ -1,0 +1,27 @@
+/// Defaults a `startStreamingSession` JSON payload's `playlistMode` to
+/// `WINDOW` when the key is absent, before it reaches the generated parser.
+///
+/// The schema declares the field non-null (`playlistMode: PlaylistMode!`),
+/// so the generated `fromJson` has no null-safe path for "absent" -- it
+/// force-casts the raw value and throws `type 'Null' is not a subtype of
+/// type 'String'`. A server too old to know about `playlistMode` never sends
+/// the key at all -- neither a server that predates the field entirely, nor
+/// one that only answered through `start_streaming_session_legacy.graphql`,
+/// which never selects it -- and both of those are exactly a server that
+/// predates full-playlist support, i.e. exactly what `WINDOW` already means.
+///
+/// Shared by every caller that parses this mutation's result --
+/// `PlayerScreen`'s own session start and `GraphqlCastStreamingSessionService`
+/// -- so this compatibility handling lives in one place instead of being
+/// re-derived, or forgotten, at each call site.
+Map<String, dynamic> withPlaylistModeDefault(Map<String, dynamic> data) {
+  final rawSession = data['startStreamingSession'];
+  if (rawSession is! Map<String, dynamic> ||
+      rawSession.containsKey('playlistMode')) {
+    return data;
+  }
+  return {
+    ...data,
+    'startStreamingSession': {...rawSession, 'playlistMode': 'WINDOW'},
+  };
+}

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1474,8 +1474,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       // must resume with a plain seek, which is what passing `plan` through
       // does. A full-playlist HLS session joins the direct-play side of this
       // split: its playlist starts at zero regardless of where FFmpeg's
-      // window began, so it needs the same client-side seek -- see the
-      // `_fullPlaylist` branch in `_openPlayerAndStart`.
+      // window began, so it needs the same client-side seek. Passing the
+      // real `plan` through here is the *only* thing that makes that seek
+      // happen -- `_openPlayerAndStart`'s own `if (plan.resumes)` block
+      // already does it, unmodified, once it receives a nonzero position, so
+      // there is no separate `_fullPlaylist` branch to look for there.
       await _openPlayerAndStart(
         mediaSource,
         httpHeaders,
@@ -1772,16 +1775,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
 
     // A plain seek, not a `seekToReal`: these paths hold the whole file, so
     // the player's own coordinates already are the real ones and there is no
-    // session that could need restarting.
+    // session that could need restarting. A full-playlist HLS session reaches
+    // this too: the call site passes the real `plan` (not
+    // `ResumePlan.fromStart`) exactly when `canDirect || _fullPlaylist`, so
+    // this is already the full-playlist resume seek -- do not add a second,
+    // `_fullPlaylist`-gated block here, it would just re-seek to the same
+    // position every time this one already fires.
     if (plan.resumes) {
-      await player.seek(plan.position);
-    }
-
-    // In full mode the playlist covers the file from zero, so resuming is a
-    // plain seek, exactly as the direct-play path already does. In windowed
-    // mode FFmpeg already started at the offset and seeking again would
-    // double-apply it.
-    if (_fullPlaylist && plan.position > Duration.zero) {
       await player.seek(plan.position);
     }
 
@@ -1790,7 +1790,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     // `ResumePlan.fromStart` because its offset went into FFmpeg's `-ss`
     // instead, so its player-local coordinates genuinely do start at zero.
     // Direct play and full-playlist HLS both carry the real resume position
-    // through instead, matching the seeks above.
+    // through instead, matching the seek above.
     _furthestPosition = plan.position;
 
     // Start playback, unless a remote `LoadContent` asked to load without

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -65,6 +65,7 @@ import '../../../graphql/queries/episode_detail.graphql.dart';
 import '../../../graphql/queries/media_segments.graphql.dart';
 import '../../../graphql/queries/season_episodes.graphql.dart';
 import '../../../graphql/mutations/start_streaming_session.graphql.dart';
+import '../../../graphql/mutations/start_streaming_session_compat.dart';
 import '../../../graphql/mutations/start_streaming_session_legacy.graphql.dart';
 import '../../../graphql/mutations/end_streaming_session.graphql.dart';
 import '../../../graphql/mutations/set_audio_language_preference.graphql.dart';
@@ -562,6 +563,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
 
   // Whether current playback is direct play (vs HLS)
   bool _isDirectPlay = false;
+
+  /// Whether the server is serving a playlist covering the whole file.
+  ///
+  /// False against a server too old to know about `playlistMode`, which is the
+  /// only reason the restart path below still exists. Delete that path, and
+  /// this field, once the compatibility window closes.
+  bool _fullPlaylist = false;
 
   /// The rung in effect, or null before anything has settled one for this
   /// playback.
@@ -1383,8 +1391,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
               'Failed to start streaming session: ${result.exception}');
         }
 
-        final sessionData =
-            Mutation$StartStreamingSession.fromJson(result.data!);
+        final sessionData = Mutation$StartStreamingSession.fromJson(
+          withPlaylistModeDefault(result.data!),
+        );
         final sessionResult = sessionData.startStreamingSession;
         if (sessionResult == null) {
           throw Exception('No session data returned from server');
@@ -1416,16 +1425,28 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
         // field entirely, which correctly yields offset zero.
         final serverOffset = sessionResult.startPosition ?? 0;
 
+        // What the server actually served, not what was asked for: a server
+        // that cannot determine the media duration answers WINDOW even when
+        // FULL was requested, and a server too old to know `playlistMode` at
+        // all is normalized to WINDOW by `withPlaylistModeDefault` above.
+        _fullPlaylist = sessionResult.playlistMode == Enum$PlaylistMode.FULL;
+
         if (_totalDuration == null && sessionResult.duration != null) {
           _totalDuration = Duration(
             milliseconds: (sessionResult.duration! * 1000).round(),
           );
         }
 
-        _timeline = StreamTimeline(
-          startOffset: Duration(seconds: serverOffset),
-          totalDuration: _totalDuration,
-        );
+        // A full playlist starts at zero and carries the real runtime in its
+        // EXT-X-ENDLIST, so player coordinates are already real coordinates and
+        // the timeline has nothing to correct. The offset form is kept only for
+        // a windowed session, where FFmpeg's -ss shifted the timestamps.
+        _timeline = _fullPlaylist
+            ? StreamTimeline(totalDuration: _totalDuration)
+            : StreamTimeline(
+                startOffset: Duration(seconds: serverOffset),
+                totalDuration: _totalDuration,
+              );
         debugPrint('[PlayerScreen] Stream timeline: $_timeline');
 
         // Build HLS URL based on mode
@@ -1445,16 +1466,20 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
         );
       }
 
-      // `canDirect` is exactly the HLS/non-HLS split of this method: the HLS
-      // branch above has already baked the resume decision into the
-      // session's start offset, so acting on `plan` again here would
-      // double-apply it via a seek on top of that offset. The direct-play
-      // branch has no server-side offset to bake it into and must resume
-      // with a plain seek, which is what passing `plan` through does.
+      // `canDirect` is exactly the HLS/non-HLS split of this method for a
+      // windowed session: the HLS branch above has already baked the resume
+      // decision into the session's start offset, so acting on `plan` again
+      // here would double-apply it via a seek on top of that offset. The
+      // direct-play branch has no server-side offset to bake it into and
+      // must resume with a plain seek, which is what passing `plan` through
+      // does. A full-playlist HLS session joins the direct-play side of this
+      // split: its playlist starts at zero regardless of where FFmpeg's
+      // window began, so it needs the same client-side seek -- see the
+      // `_fullPlaylist` branch in `_openPlayerAndStart`.
       await _openPlayerAndStart(
         mediaSource,
         httpHeaders,
-        plan: canDirect ? plan : ResumePlan.fromStart,
+        plan: canDirect || _fullPlaylist ? plan : ResumePlan.fromStart,
       );
     } catch (e) {
       debugPrint('Error initializing player: $e');
@@ -1609,6 +1634,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
           maxBitrate: maxBitrate,
           maxHeight: maxHeight,
           startPosition: startPosition,
+          playlistMode: Enum$PlaylistMode.FULL,
         ).toJson(),
       ),
     );
@@ -1626,13 +1652,17 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   }
 
   /// True when the failure is this server's schema not knowing about
-  /// `maxHeight`, rather than a transport, authorization, or resolver
-  /// problem. Only the former is worth retrying through the legacy document.
+  /// `maxHeight` or `playlistMode`, rather than a transport, authorization,
+  /// or resolver problem. Only these are worth retrying through the legacy
+  /// document.
   ///
-  /// Both messages are Absinthe's verbatim validation text — see
+  /// All four messages are Absinthe's verbatim validation text — see
   /// `Absinthe.Phase.Document.Validation.KnownArgumentNames` and
-  /// `.FieldsOnCorrectType`. An old server emits both at once (the argument
-  /// and the echoed fields arrived in the same change), so either is enough.
+  /// `.FieldsOnCorrectType`. An old server emits both of a pair at once (the
+  /// argument and the echoed field arrived in the same change), so any one
+  /// is enough. `playlistMode` shipped in a later change than `maxHeight`,
+  /// so a server updated only as far as height caps reaches this same
+  /// fallback — exactly the compatibility window this feature is built for.
   /// Matching the exact phrasing rather than loose keywords keeps a genuine
   /// failure from being mistaken for version skew and silently retried.
   bool _looksLikeMissingHeightSupport(QueryResult<Object?> result) {
@@ -1640,7 +1670,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     return graphqlErrors.any((error) {
       final message = error.message;
       return message.contains('Unknown argument "maxHeight"') ||
-          message.contains('Cannot query field "maxHeight"');
+          message.contains('Cannot query field "maxHeight"') ||
+          message.contains('Unknown argument "playlistMode"') ||
+          message.contains('Cannot query field "playlistMode"');
     });
   }
 
@@ -1650,11 +1682,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   /// Reached by three paths, not just the HLS one: the HLS branch, the
   /// direct-play branch, and the "already downloaded, still online" branch.
   /// It no longer prompts — the resume decision is made once, upstream of
-  /// every fork, by [resolveResumePlan] — it only executes [plan]. The HLS
-  /// branch bakes that same decision into the session's FFmpeg start offset,
-  /// the only way to resume a live-style playlist; the other two hold the
-  /// entire file locally, have no server-side session to give an offset to,
-  /// and seek correctly, so for them resuming is a plain [Player.seek] after
+  /// every fork, by [resolveResumePlan] — it only executes [plan]. A windowed
+  /// HLS session bakes that same decision into FFmpeg's start offset instead,
+  /// the only way to resume a live-style playlist, so [plan] arrives here
+  /// already neutralized to [ResumePlan.fromStart] for it. The other three —
+  /// direct play, "already downloaded", and a full-playlist HLS session —
+  /// hold or expose the whole file at real coordinates and have nothing to
+  /// bake an offset into, so for them resuming is a plain [Player.seek] after
   /// the media opens.
   Future<void> _openPlayerAndStart(
     String mediaSource,
@@ -1743,10 +1777,20 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       await player.seek(plan.position);
     }
 
-    // The bar a position has to clear to count as playback. Zero on the HLS
-    // branch, which always arrives here with `ResumePlan.fromStart` because
-    // its offset went into FFmpeg's `-ss` instead, so its player-local
-    // coordinates genuinely do start at zero.
+    // In full mode the playlist covers the file from zero, so resuming is a
+    // plain seek, exactly as the direct-play path already does. In windowed
+    // mode FFmpeg already started at the offset and seeking again would
+    // double-apply it.
+    if (_fullPlaylist && plan.position > Duration.zero) {
+      await player.seek(plan.position);
+    }
+
+    // The bar a position has to clear to count as playback. Zero on a
+    // windowed HLS session, which always arrives here with
+    // `ResumePlan.fromStart` because its offset went into FFmpeg's `-ss`
+    // instead, so its player-local coordinates genuinely do start at zero.
+    // Direct play and full-playlist HLS both carry the real resume position
+    // through instead, matching the seeks above.
     _furthestPosition = plan.position;
 
     // Start playback, unless a remote `LoadContent` asked to load without
@@ -3209,6 +3253,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
 
     if (shouldRestartForSeek(
       isDirectPlay: _isDirectPlay,
+      fullPlaylist: _fullPlaylist,
       realTarget: clamped,
       localTarget: local,
       seekableEnd: seekableEnd,
@@ -5171,9 +5216,17 @@ KeyEventResult handleEpisodeNavKey(
 /// Overshooting [seekableEnd] by up to [kSeekRestartTolerance] does not
 /// restart: `seekToReal` clamps those to the seekable end instead. See that
 /// constant for why a small skip on a cold stream must not cost a restart.
+///
+/// [fullPlaylist] short-circuits everything below it: once the server has
+/// published a playlist covering the whole file, it relocates its own
+/// encoder on demand, so every position is already addressable and no seek
+/// ever needs a restart. The boundary math below only still exists for a
+/// server too old to serve a full playlist, which is the sole remaining
+/// reason a far seek must restart the session.
 @visibleForTesting
 bool shouldRestartForSeek({
   required bool isDirectPlay,
+  required bool fullPlaylist,
   required Duration realTarget,
   required Duration localTarget,
   required Duration seekableEnd,
@@ -5183,6 +5236,11 @@ bool shouldRestartForSeek({
   // no HLS session to restart, and the player's own duration is already the
   // true one, so seeking is always local for them.
   if (isDirectPlay) return false;
+
+  // A full-length playlist covers the whole file and the server relocates its
+  // encoder on demand, so every position is already addressable. This is the
+  // path that makes a far scrub buffer rather than reload.
+  if (fullPlaylist) return false;
 
   return localTarget > seekableEnd + kSeekRestartTolerance ||
       realTarget < startOffset;

--- a/player/lib/presentation/widgets/video_controls/buffering_indicator.dart
+++ b/player/lib/presentation/widgets/video_controls/buffering_indicator.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:media_kit/media_kit.dart';
+
+/// A small spinner shown over the retained video frame while the player is
+/// buffering.
+///
+/// Deliberately not the full-screen loading overlay the screen shows on a cold
+/// start. A seek in a full-playlist session keeps the last frame, the scrub bar
+/// and the rest of the chrome on screen; all that is missing is an
+/// acknowledgement that the player is fetching. Anything larger would recreate
+/// the reload this change exists to remove.
+class BufferingIndicator extends StatelessWidget {
+  const BufferingIndicator({super.key, required this.player});
+
+  final Player player;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+      stream: player.stream.buffering,
+      initialData: player.state.buffering,
+      builder: (context, snapshot) {
+        if (snapshot.data != true) return const SizedBox.shrink();
+
+        return const Center(
+          child: SizedBox(
+            width: 44,
+            height: 44,
+            child: CircularProgressIndicator(
+              strokeWidth: 3,
+              color: Colors.white,
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -9,6 +9,7 @@ import '../../../core/player/stream_timeline.dart';
 import '../../../core/window/desktop_window.dart';
 import '../../../core/window/window_buttons_bridge.dart';
 import '../../../core/theme/depth_tokens.dart';
+import 'buffering_indicator.dart';
 import 'center_play_button.dart';
 import 'chrome_panel.dart';
 import 'chrome_top_bar.dart';
@@ -603,6 +604,16 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
                       onCastTap: widget.onCastTap,
                     ),
                   ),
+                ),
+                // Every platform: a small spinner over the retained frame
+                // while the player buffers. Directly above `CenterPlayButton`
+                // in this `Stack` so it occupies the same centred spot -- the
+                // two are mutually exclusive in practice, since media_kit
+                // does not report `playing` and `buffering` in a way that
+                // shows both, and `CenterPlayButton` already hides itself
+                // while playback is active.
+                Center(
+                  child: BufferingIndicator(player: widget.player),
                 ),
                 // Mobile only: a large centre play/pause. Desktop/web use the
                 // panel's own transport; on touch a one-handed thumb reach to

--- a/player/lib/presentation/widgets/video_controls/playback_chrome.dart
+++ b/player/lib/presentation/widgets/video_controls/playback_chrome.dart
@@ -571,144 +571,160 @@ class _PlaybackChromeState extends State<PlaybackChrome> {
       stream: widget.player.stream.playing,
       initialData: widget.player.state.playing,
       builder: (context, snapshot) {
-        return ChromeVisibility(
-          controller: widget.chromeVisibility,
-          isPlaying: snapshot.data ?? false,
-          isSeeking: _seeking,
-          // Both gates live here, not inside ChromeVisibility, so widget
-          // tests can construct that class with plain callbacks and get
-          // deterministic behaviour regardless of the host platform.
-          //
-          // Double-click stays available in fullscreen, since that is how
-          // you get back out. The window drag does not: there is no window
-          // to move.
-          onDoubleTap:
-              PlatformFeatures.isDesktop ? widget.onFullscreenTap : null,
-          onWindowDrag: PlatformFeatures.isDesktop && !widget.isFullscreen
-              ? startWindowDrag
-              : null,
-          onActivity: widget.onActivity,
-          child: SafeArea(
-            child: Stack(
-              children: [
-                Positioned(
-                  top: 16,
-                  left: 16,
-                  right: 16,
-                  child: ChromeSlide(
-                    hiddenOffsetY: -6,
-                    child: ChromeTopBar(
-                      title: widget.title,
-                      onBack: widget.onBack,
-                      castAction: widget.castAction,
-                      onCastTap: widget.onCastTap,
-                    ),
-                  ),
-                ),
-                // Every platform: a small spinner over the retained frame
-                // while the player buffers. Directly above `CenterPlayButton`
-                // in this `Stack` so it occupies the same centred spot -- the
-                // two are mutually exclusive in practice, since media_kit
-                // does not report `playing` and `buffering` in a way that
-                // shows both, and `CenterPlayButton` already hides itself
-                // while playback is active.
-                Center(
-                  child: BufferingIndicator(player: widget.player),
-                ),
-                // Mobile only: a large centre play/pause. Desktop/web use the
-                // panel's own transport; on touch a one-handed thumb reach to
-                // a 48px in-bar button is worse than a centre target. No skip
-                // buttons here — `gesture_controls.dart` already does
-                // double-tap-left/right for ±10s.
-                if (InputCapabilities.touchPrimary)
-                  Center(
-                    child: CenterPlayButton(player: widget.player),
-                  ),
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: metrics.bottomOffset,
-                  child: ChromeSlide(
-                    hiddenOffsetY: 8,
-                    child: Center(
-                      child: ChromePanel(
-                        metrics: metrics,
-                        transport: TransportCluster(
-                          player: widget.player,
-                          onBack10: () => _seekBy(const Duration(seconds: -10)),
-                          onForward10: () =>
-                              _seekBy(const Duration(seconds: 10)),
-                          onPreviousEpisode: widget.onPreviousEpisode,
-                          onNextEpisode: widget.onNextEpisode,
-                          // Below the mobile breakpoint the in-bar transport
-                          // is play/pause only (see
-                          // `TransportSurface.compact`'s dartdoc for the full
-                          // layout reasoning). `onPreviousEpisode`/
-                          // `onNextEpisode` above are still passed through
-                          // unconditionally — `compact` ignores them
-                          // regardless — rather than gated to null here, so
-                          // they reappear the moment the breakpoint is
-                          // crossed without this widget needing to know why.
-                          //
-                          // NOTE, this is a real, currently-unresolved gap:
-                          // unlike ±10s seek (which has an explicit gesture
-                          // replacement, double-tap in
-                          // `gesture_controls.dart`), episode nav has no
-                          // touch-reachable equivalent once it's dropped
-                          // from the bar. `UpNextOverlay` only offers *next*,
-                          // and only near an episode's end; there is no
-                          // touch path to the *previous* episode at all
-                          // below this breakpoint. See this task's report for
-                          // the open follow-up; do not read this comment as
-                          // "handled".
-                          compact: metrics.compactTransport,
-                        ),
-                        // Unconditional per ChromePanel's `volume` dartdoc:
-                        // it already gates visibility internally via
-                        // Visibility(maintainState: true), so
-                        // VolumeCluster's `_lastVolume` survives a
-                        // breakpoint crossing only if it isn't also rebuilt
-                        // from scratch here.
-                        volume: VolumeCluster(player: widget.player),
-                        secondary: SecondaryCluster(
-                          onSubtitleTap: widget.onSubtitleTap,
-                          onAudioTap: widget.onAudioTap,
-                          // Passed through `metrics.showQuality` rather than
-                          // bare, even though every tier shows it today: see
-                          // that field's dartdoc — it stays a real per-tier
-                          // lever for the tier that can't absorb a future
-                          // 5th control.
-                          onQualityTap:
-                              metrics.showQuality ? widget.onQualityTap : null,
-                          onFullscreenTap: widget.onFullscreenTap,
-                          onAlwaysOnTopTap: PlatformFeatures.isDesktop &&
-                                  metrics.showAlwaysOnTop
-                              ? widget.onAlwaysOnTopTap
-                              : null,
-                          audioTrackCount: widget.audioTrackCount,
-                          subtitleTrackCount: widget.subtitleTrackCount,
-                          selectedAudioLabel: widget.selectedAudioLabel,
-                          selectedSubtitleLabel: widget.selectedSubtitleLabel,
-                          selectedQualityLabel: widget.selectedQualityLabel,
-                          isFullscreen: widget.isFullscreen,
-                          isAlwaysOnTop: widget.isAlwaysOnTop,
-                          gap: metrics.secondaryGap,
-                        ),
-                        scrubber: _ScrubberRow(
-                          player: widget.player,
-                          timeline: widget.timeline,
-                          onSeekToReal: widget.onSeekToReal,
-                          touchTargets: metrics.touchTargets,
-                          onSeekStart: () => setState(() => _seeking = true),
-                          onSeekEnd: () => setState(() => _seeking = false),
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            ChromeVisibility(
+              controller: widget.chromeVisibility,
+              isPlaying: snapshot.data ?? false,
+              isSeeking: _seeking,
+              // Both gates live here, not inside ChromeVisibility, so widget
+              // tests can construct that class with plain callbacks and get
+              // deterministic behaviour regardless of the host platform.
+              //
+              // Double-click stays available in fullscreen, since that is how
+              // you get back out. The window drag does not: there is no
+              // window to move.
+              onDoubleTap:
+                  PlatformFeatures.isDesktop ? widget.onFullscreenTap : null,
+              onWindowDrag: PlatformFeatures.isDesktop && !widget.isFullscreen
+                  ? startWindowDrag
+                  : null,
+              onActivity: widget.onActivity,
+              child: SafeArea(
+                child: Stack(
+                  children: [
+                    Positioned(
+                      top: 16,
+                      left: 16,
+                      right: 16,
+                      child: ChromeSlide(
+                        hiddenOffsetY: -6,
+                        child: ChromeTopBar(
+                          title: widget.title,
+                          onBack: widget.onBack,
+                          castAction: widget.castAction,
+                          onCastTap: widget.onCastTap,
                         ),
                       ),
                     ),
-                  ),
+                    // Mobile only: a large centre play/pause. Desktop/web use
+                    // the panel's own transport; on touch a one-handed thumb
+                    // reach to a 48px in-bar button is worse than a centre
+                    // target. No skip buttons here — `gesture_controls.dart`
+                    // already does double-tap-left/right for ±10s.
+                    if (InputCapabilities.touchPrimary)
+                      Center(
+                        child: CenterPlayButton(player: widget.player),
+                      ),
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: metrics.bottomOffset,
+                      child: ChromeSlide(
+                        hiddenOffsetY: 8,
+                        child: Center(
+                          child: ChromePanel(
+                            metrics: metrics,
+                            transport: TransportCluster(
+                              player: widget.player,
+                              onBack10: () =>
+                                  _seekBy(const Duration(seconds: -10)),
+                              onForward10: () =>
+                                  _seekBy(const Duration(seconds: 10)),
+                              onPreviousEpisode: widget.onPreviousEpisode,
+                              onNextEpisode: widget.onNextEpisode,
+                              // Below the mobile breakpoint the in-bar
+                              // transport is play/pause only (see
+                              // `TransportSurface.compact`'s dartdoc for the
+                              // full layout reasoning). `onPreviousEpisode`/
+                              // `onNextEpisode` above are still passed
+                              // through unconditionally — `compact` ignores
+                              // them regardless — rather than gated to null
+                              // here, so they reappear the moment the
+                              // breakpoint is crossed without this widget
+                              // needing to know why.
+                              //
+                              // NOTE, this is a real, currently-unresolved
+                              // gap: unlike ±10s seek (which has an explicit
+                              // gesture replacement, double-tap in
+                              // `gesture_controls.dart`), episode nav has no
+                              // touch-reachable equivalent once it's dropped
+                              // from the bar. `UpNextOverlay` only offers
+                              // *next*, and only near an episode's end; there
+                              // is no touch path to the *previous* episode at
+                              // all below this breakpoint. See this task's
+                              // report for the open follow-up; do not read
+                              // this comment as "handled".
+                              compact: metrics.compactTransport,
+                            ),
+                            // Unconditional per ChromePanel's `volume`
+                            // dartdoc: it already gates visibility internally
+                            // via Visibility(maintainState: true), so
+                            // VolumeCluster's `_lastVolume` survives a
+                            // breakpoint crossing only if it isn't also
+                            // rebuilt from scratch here.
+                            volume: VolumeCluster(player: widget.player),
+                            secondary: SecondaryCluster(
+                              onSubtitleTap: widget.onSubtitleTap,
+                              onAudioTap: widget.onAudioTap,
+                              // Passed through `metrics.showQuality` rather
+                              // than bare, even though every tier shows it
+                              // today: see that field's dartdoc — it stays a
+                              // real per-tier lever for the tier that can't
+                              // absorb a future 5th control.
+                              onQualityTap: metrics.showQuality
+                                  ? widget.onQualityTap
+                                  : null,
+                              onFullscreenTap: widget.onFullscreenTap,
+                              onAlwaysOnTopTap: PlatformFeatures.isDesktop &&
+                                      metrics.showAlwaysOnTop
+                                  ? widget.onAlwaysOnTopTap
+                                  : null,
+                              audioTrackCount: widget.audioTrackCount,
+                              subtitleTrackCount: widget.subtitleTrackCount,
+                              selectedAudioLabel: widget.selectedAudioLabel,
+                              selectedSubtitleLabel:
+                                  widget.selectedSubtitleLabel,
+                              selectedQualityLabel: widget.selectedQualityLabel,
+                              isFullscreen: widget.isFullscreen,
+                              isAlwaysOnTop: widget.isAlwaysOnTop,
+                              gap: metrics.secondaryGap,
+                            ),
+                            scrubber: _ScrubberRow(
+                              player: widget.player,
+                              timeline: widget.timeline,
+                              onSeekToReal: widget.onSeekToReal,
+                              touchTargets: metrics.touchTargets,
+                              onSeekStart: () =>
+                                  setState(() => _seeking = true),
+                              onSeekEnd: () => setState(() => _seeking = false),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
-              ],
+              ),
             ),
-          ),
+            // Outside ChromeVisibility on purpose: that widget fades its
+            // whole child subtree on the auto-hide timer, and a slow seek is
+            // precisely when the chrome has already hidden. Buffering
+            // feedback has to outlive the controls or it is absent exactly
+            // when it is needed.
+            //
+            // IgnorePointer is not optional: `PlaybackSurface` inside
+            // `ChromeVisibility` handles tap-to-toggle-chrome and
+            // double-tap-to-fullscreen. A bare sibling laid over it would
+            // swallow taps in the centre of the screen while buffering,
+            // which is exactly where people tap. `BufferingIndicator`
+            // already centres itself and collapses to `SizedBox.shrink()`
+            // when not buffering, so no extra `Center` is needed here.
+            IgnorePointer(
+              child: BufferingIndicator(player: widget.player),
+            ),
+          ],
         );
       },
     );

--- a/player/test/presentation/screens/player/player_screen_test_harness.dart
+++ b/player/test/presentation/screens/player/player_screen_test_harness.dart
@@ -523,12 +523,20 @@ Map<String, dynamic> streamingCandidatesResponse({
 /// have applied — deliberately separate parameters from whatever the client
 /// requested, so tests can make them differ on purpose (a relay clamps both
 /// caps below the request).
+///
+/// [playlistMode] defaults to `WINDOW`, not `FULL`: every test written
+/// before full-playlist support existed encodes windowed-mode assumptions
+/// (an echoed offset that matters, a timeline built from it, a session that
+/// restarts on a far seek), and defaulting to `FULL` here would silently
+/// flip all of them onto the identity timeline instead. Tests exercising the
+/// full-playlist path pass `playlistMode: 'FULL'` explicitly.
 Map<String, dynamic> startStreamingSessionResponse({
   String sessionId = 'sess-1',
   double? duration,
   int? startPosition,
   int? maxBitrate,
   int? maxHeight,
+  String playlistMode = 'WINDOW',
 }) {
   return {
     '__typename': 'RootMutationType',
@@ -539,6 +547,7 @@ Map<String, dynamic> startStreamingSessionResponse({
       'startPosition': startPosition,
       'maxBitrate': maxBitrate,
       'maxHeight': maxHeight,
+      'playlistMode': playlistMode,
     },
   };
 }

--- a/player/test/presentation/screens/player/seek_restart_decision_test.dart
+++ b/player/test/presentation/screens/player/seek_restart_decision_test.dart
@@ -29,6 +29,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 620),
           localTarget: const Duration(seconds: 20),
           seekableEnd: const Duration(seconds: 300),
@@ -45,6 +46,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 1000),
           localTarget: const Duration(seconds: 400),
           seekableEnd: const Duration(seconds: 300),
@@ -63,6 +65,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 500),
           localTarget: Duration.zero,
           seekableEnd: const Duration(seconds: 300),
@@ -80,6 +83,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: true,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 9999),
           localTarget: const Duration(seconds: 9999),
           seekableEnd: const Duration(seconds: 10),
@@ -93,6 +97,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 900),
           localTarget: const Duration(seconds: 300),
           seekableEnd: const Duration(seconds: 300),
@@ -106,6 +111,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 600),
           localTarget: Duration.zero,
           seekableEnd: const Duration(seconds: 300),
@@ -121,6 +127,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 400),
           localTarget: const Duration(seconds: 400),
           seekableEnd: const Duration(seconds: 300),
@@ -134,6 +141,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 200),
           localTarget: const Duration(seconds: 200),
           seekableEnd: const Duration(seconds: 300),
@@ -153,6 +161,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 10),
           localTarget: const Duration(seconds: 10),
           seekableEnd: const Duration(seconds: 8),
@@ -166,6 +175,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 38),
           localTarget: const Duration(seconds: 38),
           seekableEnd: const Duration(seconds: 8),
@@ -180,6 +190,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 39),
           localTarget: const Duration(seconds: 39),
           seekableEnd: const Duration(seconds: 8),
@@ -197,6 +208,7 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: const Duration(seconds: 630),
           localTarget: const Duration(seconds: 30),
           seekableEnd: const Duration(seconds: 20),
@@ -218,10 +230,58 @@ void main() {
       expect(
         shouldRestartForSeek(
           isDirectPlay: false,
+          fullPlaylist: false,
           realTarget: Duration.zero,
           localTarget: Duration.zero,
           seekableEnd: const Duration(seconds: 300),
           startOffset: const Duration(seconds: 600),
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('shouldRestartForSeek with a full playlist', () {
+    test('never restarts for a forward seek past the encoder', () {
+      // The server relocates FFmpeg on demand. A seek is a seek.
+      expect(
+        shouldRestartForSeek(
+          isDirectPlay: false,
+          fullPlaylist: true,
+          realTarget: const Duration(hours: 1),
+          localTarget: const Duration(hours: 1),
+          seekableEnd: const Duration(seconds: 30),
+          startOffset: Duration.zero,
+        ),
+        isFalse,
+      );
+    });
+
+    test('never restarts for a backward seek before where playback began', () {
+      // The resume-then-scrub-back case, which used to restart every time.
+      expect(
+        shouldRestartForSeek(
+          isDirectPlay: false,
+          fullPlaylist: true,
+          realTarget: const Duration(minutes: 5),
+          localTarget: const Duration(minutes: 5),
+          seekableEnd: const Duration(hours: 1),
+          startOffset: const Duration(minutes: 45),
+        ),
+        isFalse,
+      );
+    });
+
+    test('still restarts a windowed session in the same situation', () {
+      // The compatibility path against an older server has not changed.
+      expect(
+        shouldRestartForSeek(
+          isDirectPlay: false,
+          fullPlaylist: false,
+          realTarget: const Duration(minutes: 5),
+          localTarget: const Duration(minutes: 5),
+          seekableEnd: const Duration(hours: 1),
+          startOffset: const Duration(minutes: 45),
         ),
         isTrue,
       );

--- a/priv/graphql/schema.graphql
+++ b/priv/graphql/schema.graphql
@@ -172,6 +172,9 @@ type RootMutationType {
 
     "Real media position, in seconds, at which to begin transcoding. Optional; omitted or 0 starts at the beginning."
     startPosition: Int
+
+    "Ask for a full-length playlist covering the whole file, which makes seeking a plain seek. Omitted means WINDOW, the growing playlist older clients expect. A server that cannot determine the media duration answers WINDOW even when FULL was requested; read the mode back from the result rather than assuming."
+    playlistMode: PlaylistMode
   ): StreamingSessionResult
 
   "Remember which audio language this viewer wants for a show or film"
@@ -1174,6 +1177,9 @@ type StreamingSessionResult {
 
   "Output height ceiling the server actually applied, which may be lower than requested on a relay connection. Null means the source resolution is preserved."
   maxHeight: Int
+
+  "The playlist mode this session actually serves, which may be WINDOW even when FULL was requested. In FULL the playlist covers the whole file, positions are real media positions, and start_position is always 0. In WINDOW, start_position is the offset the stream begins at."
+  playlistMode: PlaylistMode!
 }
 
 "A download quality option"
@@ -1627,6 +1633,15 @@ enum CalendarEntryKind {
 
   "A movie, dated by its release date"
   MOVIE
+}
+
+"How much of the media a streaming session's playlist covers"
+enum PlaylistMode {
+  "The playlist covers the whole file and every segment is addressable immediately. Seeking is a plain seek."
+  FULL
+
+  "The playlist grows as FFmpeg transcodes and covers only what has been produced. Seeking outside it requires a new session."
+  WINDOW
 }
 
 """

--- a/server/crates/api/src/mutation.rs
+++ b/server/crates/api/src/mutation.rs
@@ -13,7 +13,7 @@ use crate::types::auth::{
     remote_device_from, AccessToken, ApiKey, ClaimCode, CreateApiKeyResult, LoginInput,
     LoginResult, MediaToken, RemoteDevice, RevokeDeviceResult, ToggleFavoriteResult, User,
 };
-use crate::types::common::StreamingStrategy;
+use crate::types::common::{PlaylistMode, StreamingStrategy};
 use crate::types::discovery::RemoveFromContinueWatchingResult;
 use crate::types::media::{Episode, Movie, Progress, SubtitleTrack, SubtitleTrackSetting, TvShow};
 use crate::types::streaming::{
@@ -345,6 +345,12 @@ impl RootMutationType {
     }
 
     /// Start an HLS streaming session for a media file
+    // The arity is the GraphQL contract's, not a design choice: every
+    // parameter is an argument the Elixir schema declares, and this signature
+    // has to mirror it exactly or `sdl_parity` fails. Splitting it into a
+    // struct would change the emitted SDL, which is the one thing that must
+    // not happen here.
+    #[allow(clippy::too_many_arguments)]
     async fn start_streaming_session(
         &self,
         _ctx: &Context<'_>,
@@ -357,6 +363,10 @@ impl RootMutationType {
         // Real media position, in seconds, at which to begin transcoding.
         // Optional; omitted or 0 starts at the beginning.
         _start_position: Option<i32>,
+        // Ask for a full-length playlist covering the whole file. Omitted
+        // means WINDOW, the growing playlist older clients expect. Mirrors
+        // `playlistMode` in lib/mydia_web/schema/mutation_types.ex.
+        _playlist_mode: Option<PlaylistMode>,
     ) -> Result<Option<StreamingSessionResult>> {
         Err(not_implemented("startStreamingSession"))
     }

--- a/server/crates/api/src/types/common.rs
+++ b/server/crates/api/src/types/common.rs
@@ -1,12 +1,12 @@
 //! Enums, the Node interface, pagination machinery, and the shared sort
 //! input.
 //!
-//! The 17 types owned by this module (keep in sync with
+//! The 18 types owned by this module (keep in sync with
 //! tests/types_common.rs): Node, NodeEdge, NodeConnection, PageInfo,
 //! SortInput, and the enums DeviceEventType, MediaType, SearchResultType,
 //! LibraryType, SortField, SortDirection, MediaCategory, SubtitleFormat,
 //! StreamingStrategy, StreamingCandidateStrategy, SegmentType,
-//! MediaStreamType.
+//! MediaStreamType, PlaylistMode.
 
 use async_graphql::{Enum, InputObject, Interface, Object, SimpleObject, ID};
 
@@ -168,6 +168,15 @@ pub enum MediaStreamType {
     Subtitle,
 }
 
+/// How much of the media a streaming session's playlist covers.
+///
+/// Mirrors `enum :playlist_mode` in `lib/mydia_web/schema/enum_types.ex`.
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum PlaylistMode {
+    Full,
+    Window,
+}
+
 /// Renders just this group's types as SDL, so the group can be compared
 /// against the contract before the whole schema exists.
 pub fn sdl_fragment() -> String {
@@ -228,6 +237,10 @@ pub fn sdl_fragment() -> String {
 
         async fn segment_type(&self) -> SegmentType {
             SegmentType::Intro
+        }
+
+        async fn playlist_mode(&self) -> PlaylistMode {
+            PlaylistMode::Full
         }
     }
 

--- a/server/crates/api/src/types/streaming.rs
+++ b/server/crates/api/src/types/streaming.rs
@@ -7,7 +7,7 @@
 
 use async_graphql::{SimpleObject, ID};
 
-use crate::types::common::StreamingCandidateStrategy;
+use crate::types::common::{PlaylistMode, StreamingCandidateStrategy};
 
 #[derive(SimpleObject)]
 pub struct StreamingCandidatesResult {
@@ -71,6 +71,10 @@ pub struct StreamingSessionResult {
     pub start_position: Option<i32>,
     pub max_bitrate: Option<i32>,
     pub max_height: Option<i32>,
+    /// The playlist mode this session actually serves, which may be WINDOW
+    /// even when FULL was requested. Mirrors `playlistMode` on
+    /// `:streaming_session_result` in `lib/mydia_web/schema/common_types.ex`.
+    pub playlist_mode: PlaylistMode,
 }
 
 #[derive(SimpleObject)]

--- a/server/crates/api/tests/types_common.rs
+++ b/server/crates/api/tests/types_common.rs
@@ -4,8 +4,8 @@
 
 use mydia_api::sdl::canonicalize;
 
-/// The 17 types owned by this group: the Node interface, the pagination
-/// machinery, the one shared input, and all 12 enums. Keep in sync with the
+/// The 18 types owned by this group: the Node interface, the pagination
+/// machinery, the one shared input, and all 13 enums. Keep in sync with the
 /// comment in src/types/common.rs.
 const OWNED: &[&str] = &[
     "Node",
@@ -25,6 +25,7 @@ const OWNED: &[&str] = &[
     "StreamingCandidateStrategy",
     "SegmentType",
     "MediaStreamType",
+    "PlaylistMode",
 ];
 
 fn reference_sdl() -> String {

--- a/server/crates/db/src/episodes.rs
+++ b/server/crates/db/src/episodes.rs
@@ -52,7 +52,10 @@ pub async fn upsert(db: &Db, new: NewEpisode) -> Result<EpisodeRow, DbError> {
 
     let sql = format!("{SELECT} WHERE show_id = ? AND season_number = ? AND episode_number = ?");
 
-    Ok(sqlx::query_as::<_, EpisodeRow>(&sql)
+    // Safe: `sql` is `SELECT` (a fixed const) plus a fixed literal WHERE
+    // fragment. Nothing in the string varies with input; the actual runtime
+    // values are bound as parameters below.
+    Ok(sqlx::query_as::<_, EpisodeRow>(sqlx::AssertSqlSafe(sql))
         .bind(&new.show_id)
         .bind(new.season_number)
         .bind(new.episode_number)
@@ -63,7 +66,8 @@ pub async fn upsert(db: &Db, new: NewEpisode) -> Result<EpisodeRow, DbError> {
 pub async fn find(db: &Db, id: &str) -> Result<Option<EpisodeRow>, DbError> {
     let sql = format!("{SELECT} WHERE id = ?");
 
-    Ok(sqlx::query_as::<_, EpisodeRow>(&sql)
+    // Safe: fixed literal fragment; `id` is bound, not interpolated.
+    Ok(sqlx::query_as::<_, EpisodeRow>(sqlx::AssertSqlSafe(sql))
         .bind(id)
         .fetch_optional(db.pool())
         .await?)
@@ -72,7 +76,8 @@ pub async fn find(db: &Db, id: &str) -> Result<Option<EpisodeRow>, DbError> {
 pub async fn list_for_show(db: &Db, show_id: &str) -> Result<Vec<EpisodeRow>, DbError> {
     let sql = format!("{SELECT} WHERE show_id = ? ORDER BY season_number, episode_number");
 
-    Ok(sqlx::query_as::<_, EpisodeRow>(&sql)
+    // Safe: fixed literal fragment; `show_id` is bound, not interpolated.
+    Ok(sqlx::query_as::<_, EpisodeRow>(sqlx::AssertSqlSafe(sql))
         .bind(show_id)
         .fetch_all(db.pool())
         .await?)
@@ -86,7 +91,9 @@ pub async fn list_for_season(
 ) -> Result<Vec<EpisodeRow>, DbError> {
     let sql = format!("{SELECT} WHERE show_id = ? AND season_number = ? ORDER BY episode_number");
 
-    Ok(sqlx::query_as::<_, EpisodeRow>(&sql)
+    // Safe: fixed literal fragment; `show_id`/`season_number` are bound, not
+    // interpolated.
+    Ok(sqlx::query_as::<_, EpisodeRow>(sqlx::AssertSqlSafe(sql))
         .bind(show_id)
         .bind(season_number)
         .fetch_all(db.pool())

--- a/server/crates/db/src/external_subtitles.rs
+++ b/server/crates/db/src/external_subtitles.rs
@@ -55,9 +55,10 @@ pub async fn list_for_file(
     db: &Db,
     media_file_id: &str,
 ) -> Result<Vec<ExternalSubtitleRow>, DbError> {
-    let rows = sqlx::query_as::<_, ExternalSubtitleRow>(&format!(
+    // Safe: fixed literal fragment; `media_file_id` is bound, not interpolated.
+    let rows = sqlx::query_as::<_, ExternalSubtitleRow>(sqlx::AssertSqlSafe(format!(
         "{SELECT} WHERE media_file_id = ?1 ORDER BY language, path"
-    ))
+    )))
     .bind(media_file_id)
     .fetch_all(db.pool())
     .await?;
@@ -90,7 +91,11 @@ pub async fn list_for_files(
              ORDER BY media_file_id, language, path"
         );
 
-        let mut query = sqlx::query_as::<_, ExternalSubtitleRow>(&sql);
+        // Safe: `placeholders` is a run of `?1, ?2, ...` positional markers,
+        // one per entry in `chunk`; its length varies with the input slice
+        // but its content is only digits and `?`, never file-id text (those
+        // are bound below, per entry).
+        let mut query = sqlx::query_as::<_, ExternalSubtitleRow>(sqlx::AssertSqlSafe(sql));
         for id in chunk {
             query = query.bind(id);
         }
@@ -102,10 +107,13 @@ pub async fn list_for_files(
 }
 
 pub async fn find(db: &Db, id: &str) -> Result<Option<ExternalSubtitleRow>, DbError> {
-    let row = sqlx::query_as::<_, ExternalSubtitleRow>(&format!("{SELECT} WHERE id = ?1"))
-        .bind(id)
-        .fetch_optional(db.pool())
-        .await?;
+    // Safe: fixed literal fragment; `id` is bound, not interpolated.
+    let row = sqlx::query_as::<_, ExternalSubtitleRow>(sqlx::AssertSqlSafe(format!(
+        "{SELECT} WHERE id = ?1"
+    )))
+    .bind(id)
+    .fetch_optional(db.pool())
+    .await?;
 
     Ok(row)
 }
@@ -123,7 +131,10 @@ pub async fn prune_for_file(db: &Db, media_file_id: &str, keep: &[String]) -> Re
         query.push_str(&format!(" AND path <> ?{}", index + 2));
     }
 
-    let mut statement = sqlx::query(&query).bind(media_file_id);
+    // Safe: the appended fragments are `AND path <> ?N` markers, one per
+    // entry in `keep`; the only thing that varies is the count and the
+    // positional index, never path text (those are bound below, per entry).
+    let mut statement = sqlx::query(sqlx::AssertSqlSafe(query)).bind(media_file_id);
     for path in keep {
         statement = statement.bind(path);
     }

--- a/server/crates/db/src/library_paths.rs
+++ b/server/crates/db/src/library_paths.rs
@@ -71,7 +71,11 @@ pub async fn sync_from_config(
         format!("DELETE FROM library_paths WHERE path NOT IN ({placeholders})")
     };
 
-    let mut delete = sqlx::query(&sql);
+    // Safe: `sql` is either the fixed literal `DELETE FROM library_paths` or
+    // that plus a run of `?` markers (one per entry in `keep`); the count
+    // varies with the input slice, but the content is only `?` and `, `,
+    // never path text (those are bound below, per entry).
+    let mut delete = sqlx::query(sqlx::AssertSqlSafe(sql));
     for path in &keep {
         delete = delete.bind(*path);
     }
@@ -83,18 +87,25 @@ pub async fn sync_from_config(
 pub async fn list(db: &Db) -> Result<Vec<LibraryPathRow>, DbError> {
     let sql = format!("{SELECT} ORDER BY path");
 
-    Ok(sqlx::query_as::<_, LibraryPathRow>(&sql)
-        .fetch_all(db.pool())
-        .await?)
+    // Safe: `sql` is `SELECT` (a fixed const) plus a fixed literal suffix; no
+    // input is interpolated at all.
+    Ok(
+        sqlx::query_as::<_, LibraryPathRow>(sqlx::AssertSqlSafe(sql))
+            .fetch_all(db.pool())
+            .await?,
+    )
 }
 
 pub async fn find(db: &Db, id: &str) -> Result<Option<LibraryPathRow>, DbError> {
     let sql = format!("{SELECT} WHERE id = ?");
 
-    Ok(sqlx::query_as::<_, LibraryPathRow>(&sql)
-        .bind(id)
-        .fetch_optional(db.pool())
-        .await?)
+    // Safe: fixed literal fragment; `id` is bound, not interpolated.
+    Ok(
+        sqlx::query_as::<_, LibraryPathRow>(sqlx::AssertSqlSafe(sql))
+            .bind(id)
+            .fetch_optional(db.pool())
+            .await?,
+    )
 }
 
 pub async fn touch_scanned(db: &Db, id: &str) -> Result<(), DbError> {

--- a/server/crates/db/src/media_files.rs
+++ b/server/crates/db/src/media_files.rs
@@ -130,17 +130,20 @@ pub async fn upsert(db: &Db, new: NewMediaFile) -> Result<MediaFileRow, DbError>
 pub async fn find_by_path(db: &Db, path: &str) -> Result<Option<MediaFileRow>, DbError> {
     let sql = format!("{SELECT} WHERE path = ?");
 
-    Ok(sqlx::query_as::<_, MediaFileRow>(&sql)
+    // Safe: fixed literal fragment; `path` is bound, not interpolated.
+    Ok(sqlx::query_as::<_, MediaFileRow>(sqlx::AssertSqlSafe(sql))
         .bind(path)
         .fetch_optional(db.pool())
         .await?)
 }
 
 pub async fn find(db: &Db, id: &str) -> Result<Option<MediaFileRow>, DbError> {
-    let row = sqlx::query_as::<_, MediaFileRow>(&format!("{SELECT} WHERE id = ?1"))
-        .bind(id)
-        .fetch_optional(db.pool())
-        .await?;
+    // Safe: fixed literal fragment; `id` is bound, not interpolated.
+    let row =
+        sqlx::query_as::<_, MediaFileRow>(sqlx::AssertSqlSafe(format!("{SELECT} WHERE id = ?1")))
+            .bind(id)
+            .fetch_optional(db.pool())
+            .await?;
 
     Ok(row)
 }
@@ -148,7 +151,8 @@ pub async fn find(db: &Db, id: &str) -> Result<Option<MediaFileRow>, DbError> {
 pub async fn list_for_item(db: &Db, media_item_id: &str) -> Result<Vec<MediaFileRow>, DbError> {
     let sql = format!("{SELECT} WHERE media_item_id = ? ORDER BY path");
 
-    Ok(sqlx::query_as::<_, MediaFileRow>(&sql)
+    // Safe: fixed literal fragment; `media_item_id` is bound, not interpolated.
+    Ok(sqlx::query_as::<_, MediaFileRow>(sqlx::AssertSqlSafe(sql))
         .bind(media_item_id)
         .fetch_all(db.pool())
         .await?)
@@ -157,7 +161,8 @@ pub async fn list_for_item(db: &Db, media_item_id: &str) -> Result<Vec<MediaFile
 pub async fn list_for_episode(db: &Db, episode_id: &str) -> Result<Vec<MediaFileRow>, DbError> {
     let sql = format!("{SELECT} WHERE episode_id = ? ORDER BY path");
 
-    Ok(sqlx::query_as::<_, MediaFileRow>(&sql)
+    // Safe: fixed literal fragment; `episode_id` is bound, not interpolated.
+    Ok(sqlx::query_as::<_, MediaFileRow>(sqlx::AssertSqlSafe(sql))
         .bind(episode_id)
         .fetch_all(db.pool())
         .await?)
@@ -181,12 +186,16 @@ pub async fn prune_outside(
                                     WHERE i.library_path_id = ?))";
 
     if keep.is_empty() {
-        let removed = sqlx::query(&format!("DELETE FROM media_files WHERE {scope}"))
-            .bind(library_path_id)
-            .bind(library_path_id)
-            .execute(db.pool())
-            .await?
-            .rows_affected();
+        // Safe: `scope` is the fixed literal fragment above; no input is
+        // interpolated at all.
+        let removed = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DELETE FROM media_files WHERE {scope}"
+        )))
+        .bind(library_path_id)
+        .bind(library_path_id)
+        .execute(db.pool())
+        .await?
+        .rows_affected();
         return Ok(removed);
     }
 
@@ -212,18 +221,23 @@ pub async fn prune_outside(
         let placeholders = vec!["(?)"; chunk.len()].join(", ");
         let sql =
             format!("INSERT OR IGNORE INTO media_files_prune_keep (path) VALUES {placeholders}");
-        let mut query = sqlx::query(&sql);
+        // Safe: `placeholders` is a run of `(?)` markers, one per entry in
+        // `chunk`; its length varies with the input slice but its content is
+        // fixed text, never path data (those are bound below, per entry).
+        let mut query = sqlx::query(sqlx::AssertSqlSafe(sql));
         for path in chunk {
             query = query.bind(path);
         }
         query.execute(&mut *tx).await?;
     }
 
-    let removed = sqlx::query(&format!(
+    // Safe: `scope` is the fixed literal fragment defined above; the rest of
+    // the string is a fixed literal too. No input is interpolated.
+    let removed = sqlx::query(sqlx::AssertSqlSafe(format!(
         "DELETE FROM media_files
          WHERE {scope}
            AND path NOT IN (SELECT path FROM media_files_prune_keep)"
-    ))
+    )))
     .bind(library_path_id)
     .bind(library_path_id)
     .execute(&mut *tx)

--- a/server/crates/db/src/media_items.rs
+++ b/server/crates/db/src/media_items.rs
@@ -78,7 +78,8 @@ pub async fn upsert(db: &Db, new: NewMediaItem) -> Result<MediaItemRow, DbError>
                     AND identity_key = ? AND COALESCE(year, -1) = COALESCE(?, -1)"
     );
 
-    Ok(sqlx::query_as::<_, MediaItemRow>(&sql)
+    // Safe: fixed literal fragment; every value is bound, not interpolated.
+    Ok(sqlx::query_as::<_, MediaItemRow>(sqlx::AssertSqlSafe(sql))
         .bind(&new.library_path_id)
         .bind(&new.media_type)
         .bind(&new.identity_key)
@@ -90,7 +91,8 @@ pub async fn upsert(db: &Db, new: NewMediaItem) -> Result<MediaItemRow, DbError>
 pub async fn find(db: &Db, id: &str) -> Result<Option<MediaItemRow>, DbError> {
     let sql = format!("{SELECT} WHERE id = ?");
 
-    Ok(sqlx::query_as::<_, MediaItemRow>(&sql)
+    // Safe: fixed literal fragment; `id` is bound, not interpolated.
+    Ok(sqlx::query_as::<_, MediaItemRow>(sqlx::AssertSqlSafe(sql))
         .bind(id)
         .fetch_optional(db.pool())
         .await?)
@@ -159,7 +161,14 @@ pub async fn browse(
         order_by(sort)
     );
 
-    Ok(sqlx::query_as::<_, MediaItemRow>(&sql)
+    // Safe: `HAS_FILES` is a fixed literal fragment, and `order_by(sort)`
+    // returns one of a fixed set of `&'static str` literals chosen by an
+    // exhaustive match over the `BrowseField`/`descending` enum and bool
+    // (see `order_by` above) — the caller (crates/api/src/query.rs) builds
+    // `BrowseSort` only from a parsed GraphQL `SortField` enum, never from a
+    // raw string, so arbitrary text can never reach this format string.
+    // `media_type`, `limit`, and `offset` are all bound, not interpolated.
+    Ok(sqlx::query_as::<_, MediaItemRow>(sqlx::AssertSqlSafe(sql))
         .bind(media_type)
         .bind(limit.max(0))
         .bind(offset.max(0))
@@ -172,7 +181,9 @@ pub async fn browse(
 pub async fn count(db: &Db, media_type: &str) -> Result<i64, DbError> {
     let sql = format!("SELECT count(*) FROM media_items WHERE media_type = ? AND {HAS_FILES}");
 
-    Ok(sqlx::query_scalar::<_, i64>(&sql)
+    // Safe: `HAS_FILES` is a fixed literal fragment; `media_type` is bound,
+    // not interpolated.
+    Ok(sqlx::query_scalar::<_, i64>(sqlx::AssertSqlSafe(sql))
         .bind(media_type)
         .fetch_one(db.pool())
         .await?)

--- a/server/crates/db/src/scan_runs.rs
+++ b/server/crates/db/src/scan_runs.rs
@@ -45,7 +45,8 @@ pub async fn start(db: &Db, library_path_id: &str) -> Result<ScanRunRow, DbError
 
     let sql = format!("{SELECT_RUN} WHERE id = ?");
 
-    Ok(sqlx::query_as::<_, ScanRunRow>(&sql)
+    // Safe: fixed literal fragment; `id` is bound, not interpolated.
+    Ok(sqlx::query_as::<_, ScanRunRow>(sqlx::AssertSqlSafe(sql))
         .bind(&id)
         .fetch_one(db.pool())
         .await?)
@@ -120,7 +121,9 @@ pub async fn fail(db: &Db, run_id: &str, error: &str) -> Result<(), DbError> {
 pub async fn latest(db: &Db, library_path_id: &str) -> Result<Option<ScanRunRow>, DbError> {
     let sql = format!("{SELECT_RUN} WHERE library_path_id = ? ORDER BY started_at DESC LIMIT 1");
 
-    Ok(sqlx::query_as::<_, ScanRunRow>(&sql)
+    // Safe: fixed literal fragment; `library_path_id` is bound, not
+    // interpolated.
+    Ok(sqlx::query_as::<_, ScanRunRow>(sqlx::AssertSqlSafe(sql))
         .bind(library_path_id)
         .fetch_optional(db.pool())
         .await?)

--- a/test/mydia/streaming/ffmpeg_exit_catchup_test.exs
+++ b/test/mydia/streaming/ffmpeg_exit_catchup_test.exs
@@ -1,0 +1,117 @@
+defmodule Mydia.Streaming.FfmpegExitCatchupTest do
+  # Drives the REAL FfmpegHlsTranscoder GenServer through its two exit
+  # handlers, rather than calling final_segment_catchup/1 directly against a
+  # hand-built %State{}. The unit-level tests in ffmpeg_segment_poll_test.exs
+  # prove the catch-up read's diffing logic is correct; they do not prove it
+  # is actually wired into the handlers that stop the GenServer, because they
+  # never send a real {port, {:exit_status, _}} message. This file exists to
+  # close exactly that gap: deleting the `final_segment_catchup(state)` call
+  # from either exit clause must make one of these tests fail.
+  #
+  # The FFmpeg process is pointed at "pipe:0" (its own stdin) with nothing
+  # ever written to it, so it blocks in its input probe indefinitely and
+  # never emits its own exit_status on its own. That removes the only race
+  # that would otherwise matter here: without it, a real encode finishing
+  # early could beat (or mask the absence of) the synthetic exit message this
+  # test sends, and the test would pass or fail for the wrong reason. The
+  # blocked process is killed by `terminate/2` (via stop_transcoding, or via
+  # the GenServer's own termination after the synthetic exit stops it) either
+  # way, so nothing is left running after the test.
+  #
+  # PATH-gated the same way test/mydia/streaming/ffmpeg_scale_live_test.exs
+  # gates its own real-FFmpeg tests: a real ExUnit skip, reported as skipped
+  # rather than passing, on a host with no FFmpeg on PATH.
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  @moduletag :requires_ffmpeg
+
+  if is_nil(System.find_executable("ffmpeg")) do
+    @moduletag skip: "ffmpeg not found on PATH"
+  end
+
+  setup do
+    dir =
+      Path.join(System.tmp_dir!(), "hls_exit_catchup_#{:rand.uniform(1_000_000)}")
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+
+    %{dir: dir}
+  end
+
+  defp playlist_path(dir), do: Path.join(dir, "index.m3u8")
+
+  defp write_playlist(dir, indices) do
+    entries =
+      Enum.map_join(indices, fn index ->
+        name = "segment_#{String.pad_leading(to_string(index), 5, "0")}.ts"
+        "#EXTINF:4.000000,\n#{name}\n"
+      end)
+
+    File.write!(playlist_path(dir), "#EXTM3U\n" <> entries)
+  end
+
+  # A transcoder whose FFmpeg process blocks reading its own stdin and so
+  # never exits on its own. Callers inject the exit message themselves.
+  defp start_blocked_transcoder(dir) do
+    test_pid = self()
+
+    {:ok, pid} =
+      FfmpegHlsTranscoder.start_transcoding(
+        input_path: "pipe:0",
+        output_dir: dir,
+        on_segments: fn indices -> send(test_pid, {:segments, indices}) end
+      )
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: FfmpegHlsTranscoder.stop_transcoding(pid)
+    end)
+
+    pid
+  end
+
+  # Waits for the poll loop's first pass (scheduled at 100ms) to report the
+  # given indices, proving the loop is genuinely running rather than
+  # asserting on a callback that happens to never have been called yet.
+  defp await_first_poll(indices) do
+    assert_receive {:segments, ^indices}, 1_000
+  end
+
+  describe "the zero-exit handler" do
+    test "reports a tail segment finished after the last poll, before stopping", %{dir: dir} do
+      pid = start_blocked_transcoder(dir)
+
+      write_playlist(dir, [0])
+      await_first_poll([0])
+
+      # Written in the gap between the poll that just ran and process exit.
+      # No poll is scheduled to see it before the exit message below arrives
+      # (the next one is 250ms out), so only the exit handler's own
+      # catch-up read can report it.
+      write_playlist(dir, [0, 1])
+
+      %{ffmpeg_port: port} = :sys.get_state(pid)
+      send(pid, {port, {:exit_status, 0}})
+
+      assert_receive {:segments, [1]}, 1_000
+    end
+  end
+
+  describe "the non-zero-exit handler" do
+    test "reports a tail segment finished after the last poll, before stopping", %{dir: dir} do
+      pid = start_blocked_transcoder(dir)
+
+      write_playlist(dir, [0])
+      await_first_poll([0])
+
+      write_playlist(dir, [0, 1])
+
+      %{ffmpeg_port: port} = :sys.get_state(pid)
+      send(pid, {port, {:exit_status, 1}})
+
+      assert_receive {:segments, [1]}, 1_000
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_segment_args_test.exs
+++ b/test/mydia/streaming/ffmpeg_segment_args_test.exs
@@ -1,0 +1,97 @@
+defmodule Mydia.Streaming.FfmpegSegmentArgsTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+  alias Mydia.Streaming.SegmentPlan
+
+  defp args(opts) do
+    FfmpegHlsTranscoder.build_ffmpeg_args("/tmp/in.mkv", "/tmp/out", opts)
+  end
+
+  defp value_after(args, flag) do
+    case Enum.find_index(args, &(&1 == flag)) do
+      nil -> nil
+      i -> Enum.at(args, i + 1)
+    end
+  end
+
+  describe "segment naming" do
+    test "uses a five-digit pattern that SegmentPlan can reproduce" do
+      assert value_after(args([]), "-hls_segment_filename") == "/tmp/out/segment_%05d.ts"
+    end
+
+    test "renames nothing until a segment is complete" do
+      # Without temp_file a partially written segment exists on disk, and the
+      # session would serve a truncated file to the player.
+      assert value_after(args([]), "-hls_flags") == "temp_file"
+    end
+  end
+
+  describe "start_number" do
+    test "defaults to zero so a first window numbers from the start of the file" do
+      assert value_after(args([]), "-start_number") == "0"
+    end
+
+    test "carries the absolute index of a relocated window" do
+      # The playlist names segment_00100.ts for t=400s. A relocated encoder has
+      # to write that exact filename, not segment_00000.ts.
+      assert value_after(args(start_number: 100), "-start_number") == "100"
+    end
+  end
+
+  describe "timestamps" do
+    test "keeps source timestamps so a relocated segment carries its real media time" do
+      assert "-copyts" in args(start_number: 100)
+    end
+
+    test "zeroes the muxer delay, which -copyts alone does not correct for" do
+      # Measured in the design spike: the TS muxer's defaults put every window,
+      # including the first, 1.4s away from the time the published playlist
+      # declares for it. -copyts does not touch this. Dropping either of these
+      # two silently reintroduces that offset on every segment of every session.
+      result = args(start_number: 100)
+
+      assert value_after(result, "-muxdelay") == "0"
+      assert value_after(result, "-muxpreload") == "0"
+    end
+
+    test "never applies the seek offset twice" do
+      # -output_ts_offset on top of -copyts double-applies it. Measured and
+      # rejected in the spike.
+      refute "-output_ts_offset" in args(start_number: 100)
+    end
+  end
+
+  describe "keyframe alignment" do
+    test "forces keyframes onto the segment grid when re-encoding" do
+      assert value_after(args(grid_aligned: true), "-force_key_frames") ==
+               "expr:gte(t,n_forced*#{SegmentPlan.default_segment_seconds()})"
+    end
+
+    test "omits forced keyframes when not asked for" do
+      # A copied video stream has the keyframes the source gave it. Asking
+      # FFmpeg to force them on a copy is an error, not a no-op.
+      refute "-force_key_frames" in args([])
+    end
+  end
+
+  describe "existing behaviour is preserved" do
+    test "still segments at the plan's segment length" do
+      assert value_after(args([]), "-hls_time") ==
+               to_string(SegmentPlan.default_segment_seconds())
+    end
+
+    test "still keeps every segment in FFmpeg's own playlist" do
+      assert value_after(args([]), "-hls_list_size") == "0"
+    end
+
+    test "still ends with the playlist path" do
+      assert List.last(args([])) == "/tmp/out/index.m3u8"
+    end
+
+    test "still places -ss before -i" do
+      result = args(start_position: 400)
+      assert Enum.find_index(result, &(&1 == "-ss")) < Enum.find_index(result, &(&1 == "-i"))
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_segment_args_test.exs
+++ b/test/mydia/streaming/ffmpeg_segment_args_test.exs
@@ -41,7 +41,7 @@ defmodule Mydia.Streaming.FfmpegSegmentArgsTest do
 
   describe "timestamps" do
     test "keeps source timestamps so a relocated segment carries its real media time" do
-      assert "-copyts" in args(start_number: 100)
+      assert "-copyts" in args(start_number: 100, absolute_timestamps: true)
     end
 
     test "zeroes the muxer delay, which -copyts alone does not correct for" do
@@ -49,7 +49,7 @@ defmodule Mydia.Streaming.FfmpegSegmentArgsTest do
       # including the first, 1.4s away from the time the published playlist
       # declares for it. -copyts does not touch this. Dropping either of these
       # two silently reintroduces that offset on every segment of every session.
-      result = args(start_number: 100)
+      result = args(start_number: 100, absolute_timestamps: true)
 
       assert value_after(result, "-muxdelay") == "0"
       assert value_after(result, "-muxpreload") == "0"
@@ -58,7 +58,22 @@ defmodule Mydia.Streaming.FfmpegSegmentArgsTest do
     test "never applies the seek offset twice" do
       # -output_ts_offset on top of -copyts double-applies it. Measured and
       # rejected in the spike.
-      refute "-output_ts_offset" in args(start_number: 100)
+      refute "-output_ts_offset" in args(start_number: 100, absolute_timestamps: true)
+    end
+
+    # HlsSession passes absolute_timestamps: playlist_mode == :full, so this
+    # opt is what actually separates the two modes' output (the three tests
+    # above cover the :full side, with absolute_timestamps: true). A :window
+    # session never relocates and must go on reporting near-zero timestamps
+    # after a resume seek (see player/lib/core/player/stream_timeline.dart);
+    # carrying real media time there would make the player double-apply its
+    # resume offset.
+    test "omits copyts, muxdelay and muxpreload for a :window session" do
+      result = args(start_number: 100)
+
+      refute "-copyts" in result
+      refute "-muxdelay" in result
+      refute "-muxpreload" in result
     end
   end
 

--- a/test/mydia/streaming/ffmpeg_segment_poll_test.exs
+++ b/test/mydia/streaming/ffmpeg_segment_poll_test.exs
@@ -34,4 +34,66 @@ defmodule Mydia.Streaming.FfmpegSegmentPollTest do
                [2, 9]
     end
   end
+
+  describe "final_segment_catchup/1" do
+    setup do
+      dir = Path.join(System.tmp_dir!(), "hls_catchup_test_#{:rand.uniform(1_000_000)}")
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      %{playlist_path: Path.join(dir, "index.m3u8")}
+    end
+
+    test "reports segments that appear only after the last poll", %{
+      playlist_path: playlist_path
+    } do
+      # The encoder wrote 101 and 102 in the gap between the last successful
+      # poll (which only ever saw up to 100) and process exit. Nothing polled
+      # again before the GenServer stopped.
+      File.write!(playlist_path, """
+      #EXTM3U
+      #EXTINF:4.000000,
+      segment_00100.ts
+      #EXTINF:4.000000,
+      segment_00101.ts
+      #EXTINF:4.000000,
+      segment_00102.ts
+      """)
+
+      test_pid = self()
+
+      state = %FfmpegHlsTranscoder.State{
+        playlist_path: playlist_path,
+        ready_notified: true,
+        seen_segments: MapSet.new([100]),
+        on_segments: fn indices -> send(test_pid, {:segments, indices}) end
+      }
+
+      updated = FfmpegHlsTranscoder.final_segment_catchup(state)
+
+      assert_receive {:segments, [101, 102]}
+      assert updated.seen_segments == MapSet.new([100, 101, 102])
+    end
+
+    test "does not call on_segments when nothing new appeared", %{playlist_path: playlist_path} do
+      File.write!(playlist_path, """
+      #EXTM3U
+      #EXTINF:4.000000,
+      segment_00100.ts
+      """)
+
+      test_pid = self()
+
+      state = %FfmpegHlsTranscoder.State{
+        playlist_path: playlist_path,
+        ready_notified: true,
+        seen_segments: MapSet.new([100]),
+        on_segments: fn indices -> send(test_pid, {:segments, indices}) end
+      }
+
+      FfmpegHlsTranscoder.final_segment_catchup(state)
+
+      refute_received {:segments, _}
+    end
+  end
 end

--- a/test/mydia/streaming/ffmpeg_segment_poll_test.exs
+++ b/test/mydia/streaming/ffmpeg_segment_poll_test.exs
@@ -1,0 +1,37 @@
+defmodule Mydia.Streaming.FfmpegSegmentPollTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  describe "finished_indices/1" do
+    test "reads every segment FFmpeg has listed" do
+      playlist = """
+      #EXTM3U
+      #EXT-X-VERSION:3
+      #EXT-X-TARGETDURATION:4
+      #EXT-X-MEDIA-SEQUENCE:100
+      #EXTINF:4.000000,
+      segment_00100.ts
+      #EXTINF:4.000000,
+      segment_00101.ts
+      """
+
+      assert FfmpegHlsTranscoder.finished_indices(playlist) == [100, 101]
+    end
+
+    test "returns nothing for a playlist with no segments yet" do
+      assert FfmpegHlsTranscoder.finished_indices("#EXTM3U\n#EXT-X-VERSION:3\n") == []
+    end
+
+    test "ignores lines that are not segment filenames" do
+      playlist = "#EXTM3U\nsubtitle_2.vtt\nsegment_00007.ts\n"
+
+      assert FfmpegHlsTranscoder.finished_indices(playlist) == [7]
+    end
+
+    test "sorts indices ascending regardless of file order" do
+      assert FfmpegHlsTranscoder.finished_indices("segment_00009.ts\nsegment_00002.ts\n") ==
+               [2, 9]
+    end
+  end
+end

--- a/test/mydia/streaming/hls_relocation_integration_test.exs
+++ b/test/mydia/streaming/hls_relocation_integration_test.exs
@@ -1,0 +1,122 @@
+defmodule Mydia.Streaming.HlsRelocationIntegrationTest do
+  @moduledoc """
+  Runs a real FFmpeg and asserts that a relocated window produces the segment
+  the published playlist promised, at the media time it promised.
+
+  This is the Task 0 spike, kept. The design rests on an FFmpeg flag
+  interaction, and a flag interaction is exactly the kind of thing that breaks
+  silently on an FFmpeg upgrade.
+
+  Tagged so it does not run in the default suite: it needs the ffmpeg binary
+  and takes seconds rather than milliseconds. Excluded by default in
+  test_helper.exs; run explicitly with `--include ffmpeg`.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :ffmpeg
+
+  # A real ExUnit skip rather than an `if available? do ... else assert true`
+  # branch, matching test/mydia/streaming/ffmpeg_scale_live_test.exs: a host
+  # genuinely missing ffmpeg or ffprobe reports these as skipped, never as
+  # passed.
+  if is_nil(System.find_executable("ffmpeg")) or
+       is_nil(System.find_executable("ffprobe")) do
+    @moduletag skip: "ffmpeg/ffprobe not found on PATH"
+  end
+
+  alias Mydia.Streaming.{FfmpegHlsTranscoder, SegmentPlan}
+
+  @segment_seconds 4
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "hls-relocation-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    source = Path.join(tmp, "source.mp4")
+
+    # A 120s synthetic source: deterministic, no fixture to commit, and long
+    # enough that segment 25 is well past any first window.
+    {_out, 0} =
+      System.cmd(
+        "ffmpeg",
+        [
+          "-y",
+          "-f",
+          "lavfi",
+          "-i",
+          "testsrc=size=320x240:rate=25:duration=120",
+          "-f",
+          "lavfi",
+          "-i",
+          "sine=frequency=440:duration=120",
+          "-c:v",
+          "libx264",
+          "-preset",
+          "ultrafast",
+          "-pix_fmt",
+          "yuv420p",
+          "-c:a",
+          "aac",
+          "-shortest",
+          source
+        ],
+        stderr_to_stdout: true
+      )
+
+    %{tmp: tmp, source: source}
+  end
+
+  test "a relocated window writes the promised filename at the promised time", %{
+    tmp: tmp,
+    source: source
+  } do
+    out = Path.join(tmp, "out")
+    File.mkdir_p!(out)
+
+    target_index = 25
+    expected_start = SegmentPlan.start_time(elem(SegmentPlan.build(120.0), 1), target_index)
+    assert expected_start == 100.0
+
+    args =
+      FfmpegHlsTranscoder.build_ffmpeg_args(source, out,
+        start_position: trunc(expected_start),
+        start_number: target_index,
+        grid_aligned: true
+      )
+
+    {_out, 0} = System.cmd("ffmpeg", args, stderr_to_stdout: true)
+
+    segment = Path.join(out, SegmentPlan.segment_name(target_index))
+
+    assert File.exists?(segment),
+           "relocated window did not write #{SegmentPlan.segment_name(target_index)}"
+
+    {start_time, 0} =
+      System.cmd("ffprobe", [
+        "-v",
+        "error",
+        "-show_entries",
+        "format=start_time",
+        "-of",
+        "csv=p=0",
+        segment
+      ])
+
+    actual = start_time |> String.trim() |> String.to_float()
+
+    # The segment must carry its real media time, not restart near zero.
+    # Without -copyts this is where the design fails.
+    assert_in_delta actual, expected_start, @segment_seconds / 2
+  end
+
+  test "the published playlist names every segment the encoder can produce" do
+    {:ok, plan} = SegmentPlan.build(120.0)
+    text = SegmentPlan.playlist(plan)
+
+    assert plan.count == 30
+    assert text =~ SegmentPlan.segment_name(0)
+    assert text =~ SegmentPlan.segment_name(29)
+    refute text =~ SegmentPlan.segment_name(30)
+  end
+end

--- a/test/mydia/streaming/hls_relocation_integration_test.exs
+++ b/test/mydia/streaming/hls_relocation_integration_test.exs
@@ -26,7 +26,15 @@ defmodule Mydia.Streaming.HlsRelocationIntegrationTest do
 
   alias Mydia.Streaming.{FfmpegHlsTranscoder, SegmentPlan}
 
-  @segment_seconds 4
+  # The relocated segment must land on the media time the playlist promised.
+  # Measured residual with the correct flags is about 21ms, constant across
+  # offsets (the spike saw the same 21ms at t=400 that this test sees at
+  # t=100), because it is a fixed muxer artifact rather than drift that
+  # scales with position. Dropping `-muxdelay 0 -muxpreload 0` shifts it by
+  # about +1.38s. This tolerance sits deliberately between the two: wide
+  # enough for encoder jitter, tight enough that losing the muxer flags
+  # fails loudly.
+  @start_time_tolerance_seconds 0.25
 
   setup do
     tmp = Path.join(System.tmp_dir!(), "hls-relocation-#{System.unique_integer([:positive])}")
@@ -107,7 +115,7 @@ defmodule Mydia.Streaming.HlsRelocationIntegrationTest do
 
     # The segment must carry its real media time, not restart near zero.
     # Without -copyts this is where the design fails.
-    assert_in_delta actual, expected_start, @segment_seconds / 2
+    assert_in_delta actual, expected_start, @start_time_tolerance_seconds
   end
 
   test "the published playlist names every segment the encoder can produce" do

--- a/test/mydia/streaming/hls_relocation_integration_test.exs
+++ b/test/mydia/streaming/hls_relocation_integration_test.exs
@@ -90,7 +90,8 @@ defmodule Mydia.Streaming.HlsRelocationIntegrationTest do
       FfmpegHlsTranscoder.build_ffmpeg_args(source, out,
         start_position: trunc(expected_start),
         start_number: target_index,
-        grid_aligned: true
+        grid_aligned: true,
+        absolute_timestamps: true
       )
 
     {_out, 0} = System.cmd("ffmpeg", args, stderr_to_stdout: true)
@@ -116,15 +117,5 @@ defmodule Mydia.Streaming.HlsRelocationIntegrationTest do
     # The segment must carry its real media time, not restart near zero.
     # Without -copyts this is where the design fails.
     assert_in_delta actual, expected_start, @start_time_tolerance_seconds
-  end
-
-  test "the published playlist names every segment the encoder can produce" do
-    {:ok, plan} = SegmentPlan.build(120.0)
-    text = SegmentPlan.playlist(plan)
-
-    assert plan.count == 30
-    assert text =~ SegmentPlan.segment_name(0)
-    assert text =~ SegmentPlan.segment_name(29)
-    refute text =~ SegmentPlan.segment_name(30)
   end
 end

--- a/test/mydia/streaming/hls_session_info_test.exs
+++ b/test/mydia/streaming/hls_session_info_test.exs
@@ -21,7 +21,7 @@ defmodule Mydia.Streaming.HlsSessionInfoTest do
 
   alias Mydia.Streaming.HlsSession
 
-  defp state(start_position) do
+  defp state(start_position, playlist_mode) do
     %HlsSession.State{
       session_id: "sess-#{start_position}",
       media_file_id: 1,
@@ -31,13 +31,18 @@ defmodule Mydia.Streaming.HlsSessionInfoTest do
       backend: :ffmpeg,
       backend_pid: nil,
       temp_dir: "/tmp/mydia-hls/sess-#{start_position}",
-      last_activity: DateTime.utc_now()
+      last_activity: DateTime.utc_now(),
+      playlist_mode: playlist_mode
     }
   end
 
-  defp get_info(start_position) do
+  defp get_info(start_position, playlist_mode \\ :window) do
     {:reply, {:ok, info}, _new_state} =
-      HlsSession.handle_call(:get_info, {self(), make_ref()}, state(start_position))
+      HlsSession.handle_call(
+        :get_info,
+        {self(), make_ref()},
+        state(start_position, playlist_mode)
+      )
 
     info
   end
@@ -53,6 +58,15 @@ defmodule Mydia.Streaming.HlsSessionInfoTest do
       # assume offset zero" — which is right for an old server but would mask
       # a real bug here.
       assert get_info(0).start_position == 0
+    end
+
+    test "reports the session's playlist mode" do
+      # StreamingResolver reads this back rather than assuming the request was
+      # honoured: a server that cannot determine the media duration degrades a
+      # `:full` request to `:window`, and the resolver needs to tell the
+      # difference to report the mode (and start_position) honestly.
+      assert get_info(0, :window).playlist_mode == :window
+      assert get_info(0, :full).playlist_mode == :full
     end
   end
 end

--- a/test/mydia/streaming/hls_session_offset_test.exs
+++ b/test/mydia/streaming/hls_session_offset_test.exs
@@ -227,4 +227,42 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
       DynamicSupervisor.stop(sup)
     end
   end
+
+  describe "session_matches?/2 with a full playlist" do
+    alias Mydia.Streaming.HlsSessionSupervisor
+
+    test "a full session serves a request at a different offset" do
+      # The whole point of the full playlist: the running encoder can be moved
+      # to any segment, so a seek must not replace the session.
+      running = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
+      request = %{playlist_mode: :full, start_position: 4200, max_bitrate: nil, max_height: nil}
+
+      assert HlsSessionSupervisor.session_matches?(running, request)
+    end
+
+    test "a windowed session is still replaced on an offset mismatch" do
+      running = %{playlist_mode: :window, start_position: 0, max_bitrate: nil, max_height: nil}
+      request = %{playlist_mode: :window, start_position: 4200, max_bitrate: nil, max_height: nil}
+
+      refute HlsSessionSupervisor.session_matches?(running, request)
+    end
+
+    test "a full session never serves a windowed request" do
+      # An old client expects FFmpeg to have started at its offset and reads
+      # positions relative to that. A full session's playlist would shift every
+      # position it derives.
+      running = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
+      request = %{playlist_mode: :window, start_position: 0, max_bitrate: nil, max_height: nil}
+
+      refute HlsSessionSupervisor.session_matches?(running, request)
+    end
+
+    test "a full session is still replaced when the quality rung changes" do
+      # Segments already on disk were encoded at the old rung.
+      running = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
+      request = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: 720}
+
+      refute HlsSessionSupervisor.session_matches?(running, request)
+    end
+  end
 end

--- a/test/mydia/streaming/hls_session_offset_test.exs
+++ b/test/mydia/streaming/hls_session_offset_test.exs
@@ -231,18 +231,38 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
   describe "session_matches?/2 with a full playlist" do
     alias Mydia.Streaming.HlsSessionSupervisor
 
+    # A "genuinely" full or windowed session below is one whose effective
+    # playlist_mode matches what it was requested_playlist_mode as, i.e. it
+    # never degraded. The degraded case (requested :full, effective :window)
+    # gets its own describe block further down.
+
     test "a full session serves a request at a different offset" do
       # The whole point of the full playlist: the running encoder can be moved
       # to any segment, so a seek must not replace the session.
-      running = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
-      request = %{playlist_mode: :full, start_position: 4200, max_bitrate: nil, max_height: nil}
+      running = %{
+        requested_playlist_mode: :full,
+        playlist_mode: :full,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request = HlsSessionSupervisor.session_request(playlist_mode: :full, start_position: 4200)
 
       assert HlsSessionSupervisor.session_matches?(running, request)
     end
 
     test "a windowed session is still replaced on an offset mismatch" do
-      running = %{playlist_mode: :window, start_position: 0, max_bitrate: nil, max_height: nil}
-      request = %{playlist_mode: :window, start_position: 4200, max_bitrate: nil, max_height: nil}
+      running = %{
+        requested_playlist_mode: :window,
+        playlist_mode: :window,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request =
+        HlsSessionSupervisor.session_request(playlist_mode: :window, start_position: 4200)
 
       refute HlsSessionSupervisor.session_matches?(running, request)
     end
@@ -251,16 +271,30 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
       # An old client expects FFmpeg to have started at its offset and reads
       # positions relative to that. A full session's playlist would shift every
       # position it derives.
-      running = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
-      request = %{playlist_mode: :window, start_position: 0, max_bitrate: nil, max_height: nil}
+      running = %{
+        requested_playlist_mode: :full,
+        playlist_mode: :full,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request = HlsSessionSupervisor.session_request(playlist_mode: :window)
 
       refute HlsSessionSupervisor.session_matches?(running, request)
     end
 
     test "a full session is still replaced when the quality rung changes" do
       # Segments already on disk were encoded at the old rung.
-      running = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
-      request = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: 720}
+      running = %{
+        requested_playlist_mode: :full,
+        playlist_mode: :full,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request = HlsSessionSupervisor.session_request(playlist_mode: :full, max_height: 720)
 
       refute HlsSessionSupervisor.session_matches?(running, request)
     end
@@ -268,17 +302,26 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
     test "a windowed session never serves a full request" do
       # The reverse of the direction above: a session that only ever wrote
       # the window it started at cannot suddenly claim to cover the whole
-      # file just because the new request says :full.
-      running = %{playlist_mode: :window, start_position: 0, max_bitrate: nil, max_height: nil}
-      request = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
+      # file just because the new request says :full. This is the "genuinely
+      # windowed" case: it was requested as :window and ran as :window.
+      running = %{
+        requested_playlist_mode: :window,
+        playlist_mode: :window,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request = HlsSessionSupervisor.session_request(playlist_mode: :full)
 
       refute HlsSessionSupervisor.session_matches?(running, request)
     end
 
     test "metadata missing playlist_mode is treated as :window, not a wildcard" do
-      # Registry metadata written before playlist_mode existed must read as
-      # the safe, compatibility-only default. It must still serve the
-      # :window request such a session was actually built for...
+      # Registry metadata written before playlist_mode/requested_playlist_mode
+      # existed must read as the safe, compatibility-only default. It must
+      # still serve the :window request such a session was actually built
+      # for...
       assert HlsSessionSupervisor.session_matches?(
                %{start_position: 0},
                HlsSessionSupervisor.session_request(playlist_mode: :window)
@@ -292,6 +335,68 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
                %{start_position: 0},
                HlsSessionSupervisor.session_request(playlist_mode: :full)
              )
+    end
+  end
+
+  describe "session_matches?/2 for a session that degraded from :full to :window" do
+    alias Mydia.Streaming.HlsSessionSupervisor
+
+    # The bug this discriminator split fixes: HlsSession.init/1 registers the
+    # EFFECTIVE mode under :playlist_mode, so a :full request that degraded
+    # (unknown duration) is recorded as :window. Before requested_playlist_mode
+    # existed, @session_discriminators keyed on that same effective field, so
+    # a repeat :full request for the identical file never matched its own
+    # session -- session_matches?/2 said no, start_session/4 tore the running
+    # session down and started an identical replacement, which degraded
+    # identically. Every repeat request churned the session.
+    test "still matches a repeat :full request at the same offset" do
+      degraded = %{
+        requested_playlist_mode: :full,
+        playlist_mode: :window,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request = HlsSessionSupervisor.session_request(playlist_mode: :full)
+
+      assert HlsSessionSupervisor.session_matches?(degraded, request)
+    end
+
+    test "is still replaced when the repeat request's offset differs" do
+      # offset_matches must keep testing the EFFECTIVE playlist_mode. A
+      # degraded session is really a windowed one underneath and can only
+      # serve the exact offset it started at, same as a session that was
+      # never anything but :window -- getting this backwards would let it
+      # answer a request at an offset its encoder can never reach.
+      degraded = %{
+        requested_playlist_mode: :full,
+        playlist_mode: :window,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request = HlsSessionSupervisor.session_request(playlist_mode: :full, start_position: 4200)
+
+      refute HlsSessionSupervisor.session_matches?(degraded, request)
+    end
+
+    test "a genuinely windowed session (never requested :full) still does not match a :full request" do
+      # Distinguishes "this session degraded from :full" from "this session
+      # was always :window": both have an effective playlist_mode of
+      # :window, but only the former asked for :full in the first place.
+      genuinely_windowed = %{
+        requested_playlist_mode: :window,
+        playlist_mode: :window,
+        start_position: 0,
+        max_bitrate: nil,
+        max_height: nil
+      }
+
+      request = HlsSessionSupervisor.session_request(playlist_mode: :full)
+
+      refute HlsSessionSupervisor.session_matches?(genuinely_windowed, request)
     end
   end
 end

--- a/test/mydia/streaming/hls_session_offset_test.exs
+++ b/test/mydia/streaming/hls_session_offset_test.exs
@@ -264,5 +264,34 @@ defmodule Mydia.Streaming.HlsSessionOffsetTest do
 
       refute HlsSessionSupervisor.session_matches?(running, request)
     end
+
+    test "a windowed session never serves a full request" do
+      # The reverse of the direction above: a session that only ever wrote
+      # the window it started at cannot suddenly claim to cover the whole
+      # file just because the new request says :full.
+      running = %{playlist_mode: :window, start_position: 0, max_bitrate: nil, max_height: nil}
+      request = %{playlist_mode: :full, start_position: 0, max_bitrate: nil, max_height: nil}
+
+      refute HlsSessionSupervisor.session_matches?(running, request)
+    end
+
+    test "metadata missing playlist_mode is treated as :window, not a wildcard" do
+      # Registry metadata written before playlist_mode existed must read as
+      # the safe, compatibility-only default. It must still serve the
+      # :window request such a session was actually built for...
+      assert HlsSessionSupervisor.session_matches?(
+               %{start_position: 0},
+               HlsSessionSupervisor.session_request(playlist_mode: :window)
+             )
+
+      # ...but must not be mistaken for a :full session that can be moved to
+      # any offset. Treating an absent key as a wildcard here would silently
+      # corrupt playback position for the older client such metadata belongs
+      # to.
+      refute HlsSessionSupervisor.session_matches?(
+               %{start_position: 0},
+               HlsSessionSupervisor.session_request(playlist_mode: :full)
+             )
+    end
   end
 end

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -1,0 +1,233 @@
+defmodule Mydia.Streaming.HlsSessionSegmentsTest do
+  @moduledoc """
+  Drives HlsSession's segment machinery with a stub backend.
+
+  A real FFmpeg cannot be used here: the point of these tests is to control
+  exactly when a segment becomes available and to relocate the encoder on
+  demand, neither of which a real encoder lets a test do deterministically.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Settings.LibraryPath
+  alias Mydia.Streaming.{HlsSession, SegmentPlan, TranscodeWindow}
+
+  describe "TranscodeWindow integration inside a session's decision path" do
+    setup do
+      {:ok, plan} = SegmentPlan.build(600.0, 4)
+      %{plan: plan, window: TranscodeWindow.new(0) |> TranscodeWindow.mark_ready([0, 1, 2])}
+    end
+
+    test "a request for a ready segment resolves to its on-disk path", %{
+      plan: plan,
+      window: window
+    } do
+      assert TranscodeWindow.decide(window, 1) == :serve
+      assert SegmentPlan.segment_name(1) == "segment_00001.ts"
+      assert SegmentPlan.start_time(plan, 1) == 4.0
+    end
+
+    test "a far forward request relocates to the requested segment", %{window: window} do
+      assert TranscodeWindow.decide(window, 100) == {:relocate, 100}
+    end
+
+    test "a relocation target maps to the right FFmpeg offset", %{plan: plan} do
+      assert SegmentPlan.start_time(plan, 100) == 400.0
+    end
+  end
+
+  describe "coalescing parallel requests" do
+    test "three requests for unseen segments in one window relocate once" do
+      # A player asks for the segment it seeked to and the two after it. Only
+      # the first may move the encoder; the others must land inside the window
+      # the first created, or they would thrash FFmpeg on every seek.
+      window = TranscodeWindow.new(0) |> TranscodeWindow.mark_ready([0, 1, 2])
+
+      assert {:relocate, 100} = TranscodeWindow.decide(window, 100)
+
+      relocated = TranscodeWindow.relocate(window, 100)
+
+      assert TranscodeWindow.decide(relocated, 101) == :wait
+      assert TranscodeWindow.decide(relocated, 102) == :wait
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # Everything below drives the real GenServer. The two describe blocks
+  # above pin how SegmentPlan and TranscodeWindow compose, which is
+  # necessary but not sufficient: it says nothing about whether HlsSession
+  # actually wires request_segment/2, relocate/2, notify_segments/3 and the
+  # waiter timeout together correctly, which is what the approved spec for
+  # this task requires a test of.
+  #
+  # Seam: a bare harness GenServer runs HlsSession's real handle_call/3,
+  # handle_cast/2 and handle_info/2 against a hand-built %HlsSession.State{}
+  # — the same "skip init/1" convention hls_session_info_test.exs already
+  # uses in this directory for a single call, extended here to a live
+  # process since these assertions span several messages (a relocation, a
+  # segments-ready notification, a timeout). The backend itself is swapped
+  # for FakeBackend through the state's own backend_opts, using the
+  # :transcoder_module override start_backend/6 already reads there — no
+  # global Application config is mutated, so this file stays async: true
+  # (see Mydia.Downloads.JobManager for the alternative, global-config
+  # version of this seam, which is why its test is async: false).
+  # ---------------------------------------------------------------------
+
+  defmodule Harness do
+    @moduledoc false
+    use GenServer
+
+    def start_link(state), do: GenServer.start_link(__MODULE__, state)
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_call(msg, from, state), do: HlsSession.handle_call(msg, from, state)
+
+    @impl true
+    def handle_cast(msg, state), do: HlsSession.handle_cast(msg, state)
+
+    @impl true
+    def handle_info(msg, state), do: HlsSession.handle_info(msg, state)
+  end
+
+  defmodule FakeBackend do
+    @moduledoc """
+    Stands in for FfmpegHlsTranscoder. `start_transcoding/1` starts a bare
+    GenServer that stays alive until stopped and produces nothing on its own.
+    Tests call `HlsSession.notify_segments/3` directly, the same call a real
+    transcoder's `on_segments` callback would make once a segment lands.
+    """
+    use GenServer
+
+    def start_transcoding(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts), do: {:ok, opts}
+  end
+
+  defp base_state(overrides \\ []) do
+    {:ok, plan} = SegmentPlan.build(600.0, 4)
+
+    struct!(
+      %HlsSession.State{
+        session_id: "segments-test-session",
+        media_file: %MediaFile{
+          relative_path: "movie.mkv",
+          library_path: %LibraryPath{path: "/tmp"}
+        },
+        media_file_id: 1,
+        user_id: 1,
+        mode: :transcode,
+        start_position: 0,
+        backend: :ffmpeg,
+        backend_pid: nil,
+        temp_dir: "/tmp/mydia-hls-segments-test",
+        last_activity: DateTime.utc_now(),
+        db_job_id: nil,
+        segment_plan: plan,
+        backend_opts: [transcoder_module: FakeBackend],
+        playlist_mode: :full,
+        window: TranscodeWindow.new(0) |> TranscodeWindow.mark_ready([0, 1, 2]),
+        segment_waiters: %{},
+        window_generation: 0
+      },
+      overrides
+    )
+  end
+
+  defp fake_from, do: {self(), make_ref()}
+
+  describe "relocation, driven sequentially through handle_call/3" do
+    # A GenServer's mailbox is strictly single-threaded: three concurrent
+    # request_segment calls from three separate player requests can only ever
+    # be processed by HlsSession one at a time, in arrival order. Feeding
+    # handle_call/3 the same way — one call at a time, threading the previous
+    # call's returned state into the next — is a faithful, deterministic
+    # stand-in for that serialization: no live process or Task.async (and no
+    # sleep-based synchronization) is needed to prove the encoder is
+    # relocated once rather than thrashed on every request.
+    test "three requests for unseen segments in the same window relocate exactly once" do
+      state = base_state()
+
+      {:noreply, state} = HlsSession.handle_call({:request_segment, 100}, fake_from(), state)
+      {:noreply, state} = HlsSession.handle_call({:request_segment, 101}, fake_from(), state)
+      {:noreply, state} = HlsSession.handle_call({:request_segment, 102}, fake_from(), state)
+
+      assert state.window_generation == 1
+      assert Enum.sort(Map.keys(state.segment_waiters)) == [100, 101, 102]
+    end
+
+    test "relocation preserves the segments an earlier window already wrote" do
+      state = base_state()
+
+      {:noreply, state} = HlsSession.handle_call({:request_segment, 100}, fake_from(), state)
+      assert state.window_generation == 1
+
+      # Segment 1 was marked ready by the window base_state/1 starts with,
+      # before the relocation above ever ran. relocate/2 must not have
+      # touched TranscodeWindow's `available` set, so it still serves.
+      assert {:reply, {:ok, path}, _state} =
+               HlsSession.handle_call({:request_segment, 1}, fake_from(), state)
+
+      assert path == Path.join(state.temp_dir, "segment_00001.ts")
+    end
+  end
+
+  describe "a waiter parked across a relocation" do
+    test "is answered once the relocated encoder reports the segment ready" do
+      state = base_state()
+      {:ok, pid} = Harness.start_link(state)
+
+      task = Task.async(fn -> HlsSession.request_segment(pid, 100) end)
+      # Gives the harness time to process the call above (relocate + park)
+      # before the notification below arrives. Without this, the cast could
+      # land first and be dropped by the generation guard, since the window
+      # would not have relocated to generation 1 yet — the same convention
+      # hls_session_ready_test.exs uses in this directory for the same
+      # cross-process synchronization problem.
+      Process.sleep(50)
+
+      HlsSession.notify_segments(pid, 1, [100])
+
+      assert {:ok, path} = Task.await(task)
+      assert path == Path.join(state.temp_dir, "segment_00100.ts")
+    end
+
+    test "ignores a stale-generation notification instead of resolving early" do
+      {:ok, pid} = Harness.start_link(base_state())
+
+      task = Task.async(fn -> HlsSession.request_segment(pid, 100) end)
+      Process.sleep(50)
+
+      # Generation 0 belonged to the encoder relocate/2 just replaced. Its
+      # indices must not resolve a waiter parked against generation 1.
+      HlsSession.notify_segments(pid, 0, [100])
+      refute Task.yield(task, 50)
+
+      HlsSession.notify_segments(pid, 1, [100])
+      assert {:ok, _path} = Task.await(task)
+    end
+
+    test "times out rather than hanging forever when the segment never arrives" do
+      {:ok, pid} = Harness.start_link(base_state())
+
+      task = Task.async(fn -> HlsSession.request_segment(pid, 100) end)
+      Process.sleep(50)
+
+      # Fires the same handle_info clause the real Process.send_after timer
+      # would, on the test's own schedule instead of waiting out the real
+      # (10s) window.
+      %{segment_waiters: %{100 => [from]}} = :sys.get_state(pid)
+      send(pid, {:waiter_timeout, 100, from})
+
+      assert Task.await(task) == {:error, :timeout}
+
+      # The waiter must be gone, not just answered: a segment that shows up
+      # after the timeout has already replied must not try to reply again to
+      # a caller that has moved on.
+      refute Map.has_key?(:sys.get_state(pid).segment_waiters, 100)
+    end
+  end
+end

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -186,6 +186,30 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
 
   defp fake_from, do: {self(), make_ref()}
 
+  # A Process.sleep here would be a race, not a synchronization: under load
+  # the spawned Task's request_segment/2 call may not have reached the
+  # harness's mailbox within an arbitrary fixed delay, and if a notification
+  # sent right after the sleep arrives before the waiter parks, it is
+  # dropped and nothing ever resolves the call. Polling :sys.get_state/1
+  # instead is deterministic: it is itself a synchronous call into the same
+  # GenServer, so it serialises behind whatever is already queued ahead of
+  # it, including a request_segment call already in flight.
+  defp await_waiter(pid, index, attempts \\ 200) do
+    %{segment_waiters: waiters} = :sys.get_state(pid)
+
+    cond do
+      Map.has_key?(waiters, index) ->
+        :ok
+
+      attempts == 0 ->
+        flunk("waiter for segment #{index} never parked")
+
+      true ->
+        Process.sleep(5)
+        await_waiter(pid, index, attempts - 1)
+    end
+  end
+
   describe "relocation, driven sequentially through handle_call/3" do
     # A GenServer's mailbox is strictly single-threaded: three concurrent
     # request_segment calls from three separate player requests can only ever
@@ -249,13 +273,11 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
       {:ok, pid} = Harness.start_link(state)
 
       task = Task.async(fn -> HlsSession.request_segment(pid, 100) end)
-      # Gives the harness time to process the call above (relocate + park)
-      # before the notification below arrives. Without this, the cast could
-      # land first and be dropped by the generation guard, since the window
-      # would not have relocated to generation 1 yet — the same convention
-      # hls_session_ready_test.exs uses in this directory for the same
-      # cross-process synchronization problem.
-      Process.sleep(50)
+      # Waits for the harness to actually process the call above (relocate +
+      # park) before the notification below arrives. Without this, the cast
+      # could land first and be dropped by the generation guard, since the
+      # window would not have relocated to generation 1 yet.
+      await_waiter(pid, 100)
 
       HlsSession.notify_segments(pid, 1, [100])
 
@@ -267,7 +289,7 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
       {:ok, pid} = Harness.start_link(base_state())
 
       task = Task.async(fn -> HlsSession.request_segment(pid, 100) end)
-      Process.sleep(50)
+      await_waiter(pid, 100)
 
       # Generation 0 belonged to the encoder relocate/2 just replaced. Its
       # indices must not resolve a waiter parked against generation 1.
@@ -282,7 +304,7 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
       {:ok, pid} = Harness.start_link(base_state())
 
       task = Task.async(fn -> HlsSession.request_segment(pid, 100) end)
-      Process.sleep(50)
+      await_waiter(pid, 100)
 
       # Fires the same handle_info clause the real Process.send_after timer
       # would, on the test's own schedule instead of waiting out the real

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -274,6 +274,54 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
     end
   end
 
+  describe "an out-of-range segment index" do
+    # base_state/1 builds a 600.0s / 4s plan, so valid indices run 0..149.
+    # request_segment must reject anything outside that before it ever
+    # reaches TranscodeWindow.decide/2: an out-of-range index has no
+    # corresponding segment, and decide/2 would otherwise relocate the
+    # running encoder to seek FFmpeg past end of file, stopping the
+    # playback the viewer is actually watching.
+    test "is rejected without relocating or parking a waiter" do
+      {:ok, backend_pid} = FakeBackend.start_transcoding([])
+      state = base_state(backend_pid: backend_pid)
+
+      assert {:reply, {:error, :out_of_range}, new_state} =
+               HlsSession.handle_call({:request_segment, 99_999}, fake_from(), state)
+
+      # The backend was not touched: no relocation, no new generation, no
+      # waiter parked on an index that will never arrive.
+      assert new_state.backend_pid == backend_pid
+      assert new_state.window_generation == state.window_generation
+      assert new_state.segment_waiters == %{}
+    end
+
+    test "also rejects a negative index" do
+      state = base_state()
+
+      assert {:reply, {:error, :out_of_range}, _state} =
+               HlsSession.handle_call({:request_segment, -1}, fake_from(), state)
+    end
+
+    test "the boundary index (count) is out of range, but count - 1 is not" do
+      state = base_state()
+      last_valid = state.segment_plan.count - 1
+
+      assert {:reply, {:error, :out_of_range}, _state} =
+               HlsSession.handle_call(
+                 {:request_segment, state.segment_plan.count},
+                 fake_from(),
+                 state
+               )
+
+      # last_valid (149) is not in `available` (only 0, 1, 2 are marked
+      # ready in base_state/1) and is past last_ready_index + wait_ahead, so
+      # it relocates rather than erroring -- proving the boundary itself,
+      # not every high index, is what gets rejected.
+      assert {:noreply, _state} =
+               HlsSession.handle_call({:request_segment, last_valid}, fake_from(), state)
+    end
+  end
+
   describe "a waiter parked across a relocation" do
     test "is answered once the relocated encoder reports the segment ready" do
       state = base_state()

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -52,6 +52,32 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
     end
   end
 
+  describe "grid_aligned?/3" do
+    # Nothing previously asserted what HlsSession actually passes for
+    # FFmpeg's grid_aligned opt. Covering it directly here, rather than only
+    # through hand-built %HlsSession.State{} fixtures elsewhere in this file
+    # that could quietly encode the same mistake this guards against.
+    test "is false for a :window session even when the video would be re-encoded" do
+      media_file = %MediaFile{codec: "hevc"}
+      refute HlsSession.grid_aligned?(:window, media_file, nil)
+    end
+
+    test "is true for a :full session whose video is re-encoded" do
+      media_file = %MediaFile{codec: "hevc"}
+      assert HlsSession.grid_aligned?(:full, media_file, nil)
+    end
+
+    test "is false for a :full session whose video is copied" do
+      media_file = %MediaFile{codec: "h264"}
+      refute HlsSession.grid_aligned?(:full, media_file, nil)
+    end
+
+    test "is true for a :full session forced to transcode by a bitrate cap" do
+      media_file = %MediaFile{codec: "h264"}
+      assert HlsSession.grid_aligned?(:full, media_file, 4000)
+    end
+  end
+
   # ---------------------------------------------------------------------
   # Everything below drives the real GenServer. The two describe blocks
   # above pin how SegmentPlan and TranscodeWindow compose, which is
@@ -105,6 +131,27 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
 
     @impl true
     def init(opts), do: {:ok, opts}
+  end
+
+  defmodule SlowStopBackend do
+    @moduledoc """
+    Same as FakeBackend, but its terminate/2 sleeps before returning,
+    standing in for FfmpegHlsTranscoder.terminate/2's real, unconditional
+    100ms sleep before its SIGKILL escalation check. Used to prove
+    relocate/2 does not wait on that sleep inline.
+    """
+    use GenServer
+
+    def start_transcoding(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts), do: {:ok, opts}
+
+    @impl true
+    def terminate(_reason, _state) do
+      Process.sleep(100)
+      :ok
+    end
   end
 
   defp base_state(overrides \\ []) do
@@ -172,6 +219,27 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
                HlsSession.handle_call({:request_segment, 1}, fake_from(), state)
 
       assert path == Path.join(state.temp_dir, "segment_00001.ts")
+    end
+
+    test "does not block on the outgoing backend's stop" do
+      {:ok, outgoing_pid} = SlowStopBackend.start_transcoding([])
+
+      state =
+        base_state(
+          backend_pid: outgoing_pid,
+          backend_opts: [transcoder_module: FakeBackend]
+        )
+
+      # SlowStopBackend's terminate/2 sleeps 100ms, standing in for
+      # FfmpegHlsTranscoder.terminate/2's real sleep before its SIGKILL
+      # escalation check. If relocate/2 called stop_backend/2 inline instead
+      # of through Task.start/1, this handle_call would take at least that
+      # long to return, freezing the session's whole mailbox (every other
+      # segment request, get_info, heartbeat) for the duration.
+      {elapsed_us, {:noreply, _state}} =
+        :timer.tc(fn -> HlsSession.handle_call({:request_segment, 100}, fake_from(), state) end)
+
+      assert elapsed_us < 50_000
     end
   end
 

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -149,7 +149,14 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
 
     @impl true
     def terminate(_reason, _state) do
-      Process.sleep(100)
+      # 500ms, not the real backend's 100ms: what matters here is the ratio
+      # between this sleep and the assertion threshold below, not fidelity
+      # to FfmpegHlsTranscoder's actual timing. At a 2x margin (100ms sleep,
+      # 50_000us threshold) this test flaked under full-suite CPU load,
+      # observed at 55_043us. Widening the sleep instead of the threshold
+      # keeps a genuine regression (a synchronous stop) failing by 5x rather
+      # than shrinking the room between "passes" and "regression detected".
+      Process.sleep(500)
       :ok
     end
   end
@@ -254,7 +261,7 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
           backend_opts: [transcoder_module: FakeBackend]
         )
 
-      # SlowStopBackend's terminate/2 sleeps 100ms, standing in for
+      # SlowStopBackend's terminate/2 sleeps 500ms, standing in for
       # FfmpegHlsTranscoder.terminate/2's real sleep before its SIGKILL
       # escalation check. If relocate/2 called stop_backend/2 inline instead
       # of through Task.start/1, this handle_call would take at least that
@@ -263,7 +270,7 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
       {elapsed_us, {:noreply, _state}} =
         :timer.tc(fn -> HlsSession.handle_call({:request_segment, 100}, fake_from(), state) end)
 
-      assert elapsed_us < 50_000
+      assert elapsed_us < 100_000
     end
   end
 

--- a/test/mydia/streaming/segment_plan_test.exs
+++ b/test/mydia/streaming/segment_plan_test.exs
@@ -1,0 +1,147 @@
+defmodule Mydia.Streaming.SegmentPlanTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.SegmentPlan
+
+  defp plan!(duration, seconds \\ 4) do
+    {:ok, plan} = SegmentPlan.build(duration, seconds)
+    plan
+  end
+
+  describe "build/2" do
+    test "divides an exact multiple into whole segments" do
+      assert %SegmentPlan{count: 15, segment_seconds: 4, duration: 60.0} = plan!(60.0)
+    end
+
+    test "rounds a partial final segment up into the count" do
+      # 61s is fifteen full segments plus a 1s tail, which still needs an entry.
+      assert %SegmentPlan{count: 16} = plan!(61.0)
+    end
+
+    test "accepts an integer duration" do
+      assert %SegmentPlan{count: 15, duration: 60.0} = plan!(60)
+    end
+
+    test "refuses an unknown duration" do
+      # ensure_duration_known/2 can return a file with no duration when the
+      # inline probe budget is exceeded. That session has no plan and falls
+      # back to the windowed playlist.
+      assert SegmentPlan.build(nil, 4) == :error
+    end
+
+    test "refuses a zero or negative duration" do
+      assert SegmentPlan.build(0, 4) == :error
+      assert SegmentPlan.build(-10.0, 4) == :error
+    end
+
+    test "refuses a non-positive segment length" do
+      assert SegmentPlan.build(60.0, 0) == :error
+    end
+  end
+
+  describe "default_segment_seconds/0" do
+    test "is four, matching the transcoder's -hls_time" do
+      assert SegmentPlan.default_segment_seconds() == 4
+    end
+  end
+
+  describe "start_time/2 and index_for_time/2" do
+    test "segment n starts at n * segment_seconds" do
+      assert SegmentPlan.start_time(plan!(600.0), 100) == 400.0
+    end
+
+    test "a time inside a segment maps back to that segment" do
+      plan = plan!(600.0)
+      assert SegmentPlan.index_for_time(plan, 400.0) == 100
+      assert SegmentPlan.index_for_time(plan, 403.9) == 100
+      assert SegmentPlan.index_for_time(plan, 404.0) == 101
+    end
+
+    test "floors a negative time at the first segment" do
+      assert SegmentPlan.index_for_time(plan!(600.0), -5.0) == 0
+    end
+
+    test "clamps a time past the end onto the last segment" do
+      # A client with a corrupt progress row can ask to resume past the end.
+      plan = plan!(600.0)
+      assert SegmentPlan.index_for_time(plan, 9999.0) == plan.count - 1
+    end
+  end
+
+  describe "duration_of/2" do
+    test "reports the full segment length for every segment but the last" do
+      assert SegmentPlan.duration_of(plan!(61.0), 0) == 4.0
+      assert SegmentPlan.duration_of(plan!(61.0), 14) == 4.0
+    end
+
+    test "reports the remainder for the final segment" do
+      assert_in_delta SegmentPlan.duration_of(plan!(61.0), 15), 1.0, 0.000001
+    end
+
+    test "reports a full final segment when the duration divides exactly" do
+      assert SegmentPlan.duration_of(plan!(60.0), 14) == 4.0
+    end
+  end
+
+  describe "segment_name/1 and index_from_name/1" do
+    test "pads the index to five digits" do
+      assert SegmentPlan.segment_name(0) == "segment_00000.ts"
+      assert SegmentPlan.segment_name(100) == "segment_00100.ts"
+      assert SegmentPlan.segment_name(49_999) == "segment_49999.ts"
+    end
+
+    test "round-trips through index_from_name/1" do
+      assert SegmentPlan.index_from_name(SegmentPlan.segment_name(742)) == {:ok, 742}
+    end
+
+    test "rejects anything that is not a segment filename" do
+      # The controller feeds this every path under a session directory,
+      # including subtitle tracks, so a non-match must be an ordinary answer
+      # rather than a crash.
+      assert SegmentPlan.index_from_name("index.m3u8") == :error
+      assert SegmentPlan.index_from_name("subtitle_2.vtt") == :error
+      assert SegmentPlan.index_from_name("segment_.ts") == :error
+      assert SegmentPlan.index_from_name("../../etc/passwd") == :error
+    end
+  end
+
+  describe "playlist/1" do
+    test "declares a complete VOD playlist that ends" do
+      text = SegmentPlan.playlist(plan!(61.0))
+
+      assert text =~ "#EXTM3U"
+      assert text =~ "#EXT-X-VERSION:3"
+      assert text =~ "#EXT-X-TARGETDURATION:4"
+      assert text =~ "#EXT-X-PLAYLIST-TYPE:VOD"
+      assert String.ends_with?(text, "#EXT-X-ENDLIST\n")
+    end
+
+    test "lists every segment exactly once, in order" do
+      text = SegmentPlan.playlist(plan!(61.0))
+      names = Regex.scan(~r/segment_\d{5}\.ts/, text) |> List.flatten()
+
+      assert length(names) == 16
+      assert List.first(names) == "segment_00000.ts"
+      assert List.last(names) == "segment_00015.ts"
+    end
+
+    test "declares the short final segment's real length" do
+      text = SegmentPlan.playlist(plan!(61.0))
+
+      assert text =~ "#EXTINF:1.000000,\nsegment_00015.ts"
+    end
+
+    test "never declares an EXTINF longer than the target duration" do
+      # A player rejects a playlist whose TARGETDURATION is smaller than any
+      # EXTINF it contains.
+      plan = plan!(61.0)
+      text = SegmentPlan.playlist(plan)
+
+      durations =
+        Regex.scan(~r/#EXTINF:([\d.]+),/, text)
+        |> Enum.map(fn [_, d] -> String.to_float(d) end)
+
+      assert Enum.max(durations) <= plan.segment_seconds
+    end
+  end
+end

--- a/test/mydia/streaming/segment_plan_test.exs
+++ b/test/mydia/streaming/segment_plan_test.exs
@@ -103,6 +103,20 @@ defmodule Mydia.Streaming.SegmentPlanTest do
       assert SegmentPlan.index_from_name("segment_.ts") == :error
       assert SegmentPlan.index_from_name("../../etc/passwd") == :error
     end
+
+    test "rejects a segment name with a trailing newline" do
+      # Erlang's re treats an unanchored `$` as end-of-string OR just before one
+      # trailing newline, so `$` here would accept this. The controller feeds this
+      # function untrusted request paths, and its contract is that anything which
+      # is not a segment filename returns :error.
+      assert SegmentPlan.index_from_name("segment_00000.ts\n") == :error
+    end
+
+    test "rejects other trailing whitespace and control characters" do
+      assert SegmentPlan.index_from_name("segment_00000.ts\r") == :error
+      assert SegmentPlan.index_from_name("segment_00000.ts\r\n") == :error
+      assert SegmentPlan.index_from_name("segment_00000.ts ") == :error
+    end
   end
 
   describe "playlist/1" do

--- a/test/mydia/streaming/transcode_window_test.exs
+++ b/test/mydia/streaming/transcode_window_test.exs
@@ -1,0 +1,95 @@
+defmodule Mydia.Streaming.TranscodeWindowTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.TranscodeWindow
+
+  # A window running from `first`, having finished everything up to and
+  # including `last_ready`, with those same segments on disk.
+  defp running(first, last_ready) do
+    first
+    |> TranscodeWindow.new()
+    |> TranscodeWindow.mark_ready(
+      if(last_ready < first, do: [], else: Enum.to_list(first..last_ready))
+    )
+  end
+
+  describe "decide/2 serving" do
+    test "serves a segment already on disk" do
+      assert TranscodeWindow.decide(running(0, 10), 5) == :serve
+    end
+
+    test "serves a segment left behind by an earlier window" do
+      # Scrubbing back into a region already watched this session is a plain
+      # file read: relocation never clears what is on disk.
+      window =
+        running(0, 10) |> TranscodeWindow.relocate(100) |> TranscodeWindow.mark_ready([100])
+
+      assert TranscodeWindow.decide(window, 5) == :serve
+    end
+  end
+
+  describe "decide/2 waiting" do
+    test "waits for the segment the encoder is about to finish" do
+      assert TranscodeWindow.decide(running(0, 10), 11) == :wait
+    end
+
+    test "waits out to the full lookahead budget" do
+      assert TranscodeWindow.decide(running(0, 10), 13) == :wait
+    end
+
+    test "relocates one segment past the budget" do
+      # The budget is the whole reason a small forward skip does not pay for a
+      # relocation. One past it is a deliberate jump.
+      assert TranscodeWindow.decide(running(0, 10), 14) == {:relocate, 14}
+    end
+
+    test "waits for the first segment of a freshly relocated window" do
+      window = TranscodeWindow.new(0) |> TranscodeWindow.relocate(100)
+
+      assert TranscodeWindow.decide(window, 100) == :wait
+    end
+  end
+
+  describe "decide/2 relocating" do
+    test "relocates for a segment behind the window that was never produced" do
+      # This is the resume-then-scrub-backwards case: nothing before the window
+      # start was ever transcoded, so there is nothing to wait for.
+      assert TranscodeWindow.decide(running(100, 110), 5) == {:relocate, 5}
+    end
+
+    test "relocates for a segment far ahead" do
+      assert TranscodeWindow.decide(running(0, 10), 500) == {:relocate, 500}
+    end
+
+    test "relocates when no encoder is running" do
+      assert TranscodeWindow.decide(TranscodeWindow.stopped(running(0, 10)), 11) ==
+               {:relocate, 11}
+    end
+
+    test "still serves from disk when no encoder is running" do
+      assert TranscodeWindow.decide(TranscodeWindow.stopped(running(0, 10)), 5) == :serve
+    end
+  end
+
+  describe "relocate/2" do
+    test "keeps every segment already on disk" do
+      window = running(0, 10) |> TranscodeWindow.relocate(100)
+
+      assert MapSet.member?(window.available, 5)
+    end
+
+    test "moves the window and marks nothing ready inside it yet" do
+      window = running(0, 10) |> TranscodeWindow.relocate(100)
+
+      assert window.first_index == 100
+      assert window.last_ready_index == 99
+      assert window.running?
+    end
+  end
+
+  describe "wait_ahead_segments/0" do
+    test "is three" do
+      assert TranscodeWindow.wait_ahead_segments() == 3
+    end
+  end
+end

--- a/test/mydia_web/controllers/api/hls_full_playlist_test.exs
+++ b/test/mydia_web/controllers/api/hls_full_playlist_test.exs
@@ -1,0 +1,33 @@
+defmodule MydiaWeb.Api.HlsFullPlaylistTest do
+  use MydiaWeb.ConnCase, async: false
+
+  alias Mydia.Streaming.SegmentPlan
+
+  describe "playlist rendering" do
+    test "a full session's playlist covers the whole file and ends" do
+      {:ok, plan} = SegmentPlan.build(600.0)
+      text = SegmentPlan.playlist(plan)
+
+      assert text =~ "#EXT-X-PLAYLIST-TYPE:VOD"
+      assert String.ends_with?(text, "#EXT-X-ENDLIST\n")
+      assert text =~ "segment_00149.ts"
+    end
+  end
+
+  describe "segment name parsing at the controller boundary" do
+    test "a segment filename resolves to an index" do
+      assert SegmentPlan.index_from_name("segment_00100.ts") == {:ok, 100}
+    end
+
+    test "a subtitle filename does not, so it falls through to the file path" do
+      # SessionSubtitles materializes .vtt tracks on demand. Routing one into
+      # request_segment would ask the encoder to relocate to a segment that does
+      # not exist.
+      assert SegmentPlan.index_from_name("subtitle_2.vtt") == :error
+    end
+
+    test "a traversal attempt does not parse as a segment" do
+      assert SegmentPlan.index_from_name("../../../etc/passwd") == :error
+    end
+  end
+end

--- a/test/mydia_web/controllers/api/hls_full_playlist_test.exs
+++ b/test/mydia_web/controllers/api/hls_full_playlist_test.exs
@@ -128,6 +128,30 @@ defmodule MydiaWeb.Api.HlsFullPlaylistTest do
       assert json_response(conn, 503)["error"] =~ "not ready"
     end
 
+    test "an out-of-range segment index returns 404, not 503", %{
+      conn: conn,
+      token: token,
+      temp_dir: dir,
+      session_id: session_id
+    } do
+      {:ok, _pid} =
+        HlsSessionStub.start_link(session_id, %{media_file_id: "unused", temp_dir: dir}, %{
+          request_segment: {:error, :out_of_range}
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/hls/#{session_id}/segment_99999.ts")
+
+      # Unlike a timeout, an out-of-range segment will never exist, so a
+      # terminal 404 is correct here. A 503 with Retry-After would tell
+      # hls.js and mpv to keep retrying a request that can never succeed.
+      assert conn.status == 404
+      assert get_resp_header(conn, "retry-after") == []
+      assert json_response(conn, 404)["error"] =~ "not found"
+    end
+
     # If the controller mis-routed a subtitle name into request_segment/2,
     # this session would answer with a timeout and the response would be a
     # 503 rather than the materialized track.

--- a/test/mydia_web/controllers/api/hls_full_playlist_test.exs
+++ b/test/mydia_web/controllers/api/hls_full_playlist_test.exs
@@ -1,7 +1,30 @@
 defmodule MydiaWeb.Api.HlsFullPlaylistTest do
+  @moduledoc """
+  Covers `SegmentPlan` in isolation, and then the controller dispatch a
+  `:full`-mode session takes: `master_playlist/2`'s `{:ok, playlist}` branch
+  and `root_segment/2`'s `HlsSession.request_segment/2` branch, neither of
+  which the plain `hls_controller_test.exs` conn tests reach (that file only
+  ever requests three-digit legacy segment names, which fall through to the
+  window path). Uses `Mydia.Streaming.HlsSessionStub` in place of a real
+  `HlsSession` so no ffmpeg process is spawned.
+  """
+
   use MydiaWeb.ConnCase, async: false
 
+  alias Mydia.Streaming.HlsSessionStub
   alias Mydia.Streaming.SegmentPlan
+
+  setup do
+    {_user, token} = create_user_and_token()
+
+    temp_dir = Path.join(System.tmp_dir!(), "hls_full_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(temp_dir)
+    on_exit(fn -> File.rm_rf(temp_dir) end)
+
+    session_id = "hls-full-#{System.unique_integer([:positive])}"
+
+    {:ok, token: token, temp_dir: temp_dir, session_id: session_id}
+  end
 
   describe "playlist rendering" do
     test "a full session's playlist covers the whole file and ends" do
@@ -28,6 +51,108 @@ defmodule MydiaWeb.Api.HlsFullPlaylistTest do
 
     test "a traversal attempt does not parse as a segment" do
       assert SegmentPlan.index_from_name("../../../etc/passwd") == :error
+    end
+  end
+
+  describe "GET /api/v1/hls/:session_id/index.m3u8 (full mode)" do
+    test "a full session's playlist is served with the HLS content type", %{
+      conn: conn,
+      token: token,
+      temp_dir: dir,
+      session_id: session_id
+    } do
+      {:ok, plan} = SegmentPlan.build(30.0)
+      playlist_text = SegmentPlan.playlist(plan)
+
+      {:ok, _pid} =
+        HlsSessionStub.start_link(session_id, %{media_file_id: "unused", temp_dir: dir}, %{
+          playlist: {:ok, playlist_text}
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/hls/#{session_id}/index.m3u8")
+
+      assert conn.status == 200
+      [content_type] = get_resp_header(conn, "content-type")
+      assert String.starts_with?(content_type, "application/vnd.apple.mpegurl")
+      assert conn.resp_body == playlist_text
+    end
+  end
+
+  describe "GET /api/v1/hls/:session_id/:segment (full mode)" do
+    test "a full-mode segment is served from the path the session resolves", %{
+      conn: conn,
+      token: token,
+      temp_dir: dir,
+      session_id: session_id
+    } do
+      segment_path = Path.join(dir, "segment_00042.ts")
+      File.write!(segment_path, "tsdata")
+
+      {:ok, _pid} =
+        HlsSessionStub.start_link(session_id, %{media_file_id: "unused", temp_dir: dir}, %{
+          request_segment: {:ok, segment_path}
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/hls/#{session_id}/segment_00042.ts")
+
+      assert conn.status == 200
+      [content_type] = get_resp_header(conn, "content-type")
+      assert String.starts_with?(content_type, "video/mp2t")
+      assert conn.resp_body == "tsdata"
+    end
+
+    test "a segment timeout returns 503 with Retry-After, not 404", %{
+      conn: conn,
+      token: token,
+      temp_dir: dir,
+      session_id: session_id
+    } do
+      {:ok, _pid} =
+        HlsSessionStub.start_link(session_id, %{media_file_id: "unused", temp_dir: dir}, %{
+          request_segment: {:error, :timeout}
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/hls/#{session_id}/segment_00042.ts")
+
+      assert conn.status == 503
+      assert get_resp_header(conn, "retry-after") == ["1"]
+      assert json_response(conn, 503)["error"] =~ "not ready"
+    end
+
+    # If the controller mis-routed a subtitle name into request_segment/2,
+    # this session would answer with a timeout and the response would be a
+    # 503 rather than the materialized track.
+    test "a subtitle name still routes to the window path, not request_segment", %{
+      conn: conn,
+      token: token,
+      temp_dir: dir,
+      session_id: session_id
+    } do
+      File.write!(Path.join(dir, "subs_2.vtt"), "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhi\n")
+
+      {:ok, _pid} =
+        HlsSessionStub.start_link(session_id, %{media_file_id: "unused", temp_dir: dir}, %{
+          request_segment: {:error, :timeout}
+        })
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/v1/hls/#{session_id}/subs_2.vtt")
+
+      assert conn.status == 200
+      [content_type] = get_resp_header(conn, "content-type")
+      assert String.starts_with?(content_type, "text/vtt")
+      assert conn.resp_body =~ "WEBVTT"
     end
   end
 end

--- a/test/support/hls_session_stub.ex
+++ b/test/support/hls_session_stub.ex
@@ -5,42 +5,76 @@ defmodule Mydia.Streaming.HlsSessionStub do
   without paying for a real FFmpeg-backed session (which a real `HlsSession`
   spawns on start).
 
-  `MydiaWeb.Api.HlsController` only ever needs two things from the process
-  behind a session id: `HlsSession.get_info/1` (a
-  `GenServer.call(pid, :get_info)`) and `HlsSession.heartbeat/1` (a
-  `GenServer.cast(pid, :heartbeat)`). This stub answers both against the
-  fixed info map it is started with, and registers under the same
-  `{:session, session_id}` key a real session uses, so the controller's
-  actual lookup-and-dispatch path (`find_session_by_id/2`,
-  `get_session_info_by_id/2`, `heartbeat_session/2`) runs unmodified under
-  test.
+  `MydiaWeb.Api.HlsController` needs four things from the process behind a
+  session id: `HlsSession.get_info/1` (`GenServer.call(pid, :get_info)`),
+  `HlsSession.heartbeat/1` (`GenServer.cast(pid, :heartbeat)`),
+  `HlsSession.playlist/1` (`GenServer.call(pid, :playlist)`), and
+  `HlsSession.request_segment/2` (`GenServer.call(pid, {:request_segment,
+  index})`). This stub answers all four: `get_info/1` and `heartbeat/1`
+  against the fixed info map it is started with, and `playlist/1` /
+  `request_segment/2` against the `responses` map passed to `start_link/3`,
+  so a test can drive every outcome the controller's full-mode dispatch
+  branches on. It registers under the same `{:session, session_id}` key a
+  real session uses, so the controller's actual lookup-and-dispatch path
+  (`find_session_by_id/2`, `get_session_info_by_id/2`, `heartbeat_session/2`)
+  runs unmodified under test.
+
+  ## Responses
+
+  `responses` may set:
+
+    * `:playlist` - the reply for `HlsSession.playlist/1`, e.g.
+      `{:ok, playlist_text}` or `{:error, :window_mode}`. Defaults to
+      `{:error, :window_mode}`, matching a real session with no
+      `SegmentPlan`.
+    * `:request_segment` - the reply for `HlsSession.request_segment/2`,
+      e.g. `{:ok, path}`, `{:error, :timeout}`, or `{:error, :window_mode}`.
+      Defaults to `{:error, :window_mode}`.
+
+  A reply is returned as-is, synchronously; there is no real wait or
+  relocation to simulate, so `{:error, :timeout}` here stands in for what a
+  real session would eventually reply once a waiter parked on a segment
+  that never arrives, not for `GenServer.call`'s own timeout.
   """
 
   use GenServer
 
   @registry Mydia.Streaming.HlsSessionRegistry
 
+  @default_responses %{
+    playlist: {:error, :window_mode},
+    request_segment: {:error, :window_mode}
+  }
+
   @doc """
   Starts a stub session registered under `{:session, session_id}`.
 
   `info` is returned verbatim by `get_info/1`; it must carry at least
   `:temp_dir` and `:media_file_id` for `SessionSubtitles.ensure/2` to accept
-  it.
+  it. `responses` overrides the replies for `:playlist` and
+  `:request_segment`; see the moduledoc.
   """
-  @spec start_link(String.t(), map()) :: GenServer.on_start()
-  def start_link(session_id, info) do
-    GenServer.start_link(__MODULE__, {session_id, info})
+  @spec start_link(String.t(), map(), map()) :: GenServer.on_start()
+  def start_link(session_id, info, responses \\ %{}) do
+    GenServer.start_link(
+      __MODULE__,
+      {session_id, info, Map.merge(@default_responses, responses)}
+    )
   end
 
   @impl true
-  def init({session_id, info}) do
+  def init({session_id, info, responses}) do
     {:ok, _owner} = Registry.register(@registry, {:session, session_id}, info)
-    {:ok, info}
+    {:ok, %{info: info, responses: responses}}
   end
 
   @impl true
-  def handle_call(:get_info, _from, info), do: {:reply, {:ok, info}, info}
+  def handle_call(:get_info, _from, state), do: {:reply, {:ok, state.info}, state}
+  def handle_call(:playlist, _from, state), do: {:reply, state.responses.playlist, state}
+
+  def handle_call({:request_segment, _index}, _from, state),
+    do: {:reply, state.responses.request_segment, state}
 
   @impl true
-  def handle_cast(:heartbeat, info), do: {:noreply, info}
+  def handle_cast(:heartbeat, state), do: {:noreply, state}
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,7 @@
 # Exclude external integration tests by default (require external services)
 # Exclude feature tests by default (require chromedriver)
 # Exclude relay tests by default (require connected relay service)
+# Exclude ffmpeg integration tests by default (run real ffmpeg, seconds not ms)
 # Run specific tests explicitly with: mix test --include <tag>
 max_cases =
   if System.get_env("DATABASE_TYPE") == "postgres" do
@@ -12,7 +13,7 @@ max_cases =
     1
   end
 
-ExUnit.start(max_cases: max_cases, exclude: [:external, :feature, :requires_relay])
+ExUnit.start(max_cases: max_cases, exclude: [:external, :feature, :requires_relay, :ffmpeg])
 Ecto.Adapters.SQL.Sandbox.mode(Mydia.Repo, :manual)
 
 # Refuse outbound HTTP. Nothing else stops a test reaching the production


### PR DESCRIPTION
Scrubbing to a distant position used to tear down the whole playback stack and rebuild it behind a full-screen spinner, replaying the cold-start message sequence. Arrow-key seeks were already smooth; only far scrubs broke.

The cause was structural, not a UI bug. The server transcoded linearly with `-ss` before `-i` into a live-style growing playlist, so the playlist could only ever describe `[start_offset, transcoded-so-far]`. Nothing outside that was addressable, so the client's only move was to end the session and start a new FFmpeg at a new offset. After resuming a movie at 45 minutes, every backward seek restarted.

## What changed

The playlist stops being FFmpeg's output and becomes a contract the server computes up front from the media duration: a complete `PLAYLIST-TYPE:VOD` playlist covering the whole file, served from memory. FFmpeg becomes a movable window underneath it, addressed by absolute segment index.

A segment request now resolves to one of three things: serve a file already on disk, park the caller until the running encoder reaches it, or relocate the encoder and then park. Requests are serialised through the session GenServer, so the several parallel segment requests a player issues on a seek trigger exactly one relocation. Segments are never deleted during a session, so scrubbing back into a region already watched is a plain file read.

Seeking then stops being a client concern: `seekToReal` becomes `player.seek()`.

## Compatibility

Self-hosted deployments update client and server independently, so both modes coexist and the choice is explicit.

- `startStreamingSession` gains a `playlistMode` argument and returns the mode actually served.
- Old clients never send it, so they get today's growing playlist with `start_position` honoured as the FFmpeg offset, unchanged.
- New clients seeing no field read `WINDOW` and keep their restart path.
- A file whose duration probe times out degrades to `WINDOW` regardless of what was asked for, which is why clients must read the mode back rather than assume.

Windowed behaviour is unchanged on purpose, including keeping the timestamp flags off that path.

## The FFmpeg contract

Relocation rests on a flag interaction that was measured rather than assumed. `-copyts` alone is not enough: it leaves a reproducible +1.4s bias on every window from the TS muxer's defaults. `-copyts -muxdelay 0 -muxpreload 0` closes that to about 20ms. `-output_ts_offset` double-applies the seek and is deliberately absent, as is `-t`, which yields zero output frames under `-copyts`.

`test/mydia/streaming/hls_relocation_integration_test.exs` pins this permanently. Its 250ms tolerance sits deliberately between the ~21ms correct-flags residual and the ~1.38s regression, so dropping the muxer flags fails loudly. Verified by removing them and watching it fail at 101.378667s against a declared 100.0.

## Two things included that are not this feature

- **`fix(server): satisfy sqlx 0.9 SqlSafeStr in the db crate`.** The sqlx 0.9 bump in `d5dec43c1` broke `mydia-db` in 24 places. That PR's CI Server job failed and merged anyway, and because the workflow is path-filtered to `server/**` and the schema files, nothing since re-triggered it. This branch touches `priv/graphql/schema.graphql`, so it is the first thing to surface it. All 24 sites were audited individually for injection before any `AssertSqlSafe` wrapping; all are assembled from literals, internal constants, or placeholder counts, and the one dynamic `ORDER BY` was traced to a parsed GraphQL enum rather than a raw string. Zero unsafe sites.
- **`feat(api): mirror PlaylistMode into the Rust schema`.** Required by `server/crates/api/tests/sdl_parity.rs`.

## Verification

- `mix precommit` green on a clean solo run: 9860 tests, 0 failures.
- `cargo clippy --all-targets -- -D warnings` and `cargo test --all` pass, including `sdl_parity`.
- Flutter: 3033 passed, 0 failed, 7 skipped. `flutter analyze` clean.

## Not done

Manual verification against the running app. Nobody has driven a real far scrub and watched the frame stay up. The web player matters most here: the FFmpeg spike only validated ffmpeg's own HLS demuxer, which covers mpv and therefore desktop and mobile, but not hls.js or Safari's native HLS. A relocation splice that ffmpeg tolerates but hls.js rejects is the most likely way this fails in the field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full-playlist streaming for immediate access to all video segments and smoother seeking.
  * Added playlist mode selection and reporting for streaming sessions.
  * Added a buffering indicator over the retained video frame.
* **Bug Fixes**
  * Improved segment tracking to prevent missing final segments.
  * Improved seeking and stream relocation during windowed playback.
  * Added clear handling for unavailable or out-of-range segments.
  * Added compatibility with older servers that omit playlist mode information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->