### PR TITLE
fix(streaming): stop windowed HLS sessions crashing on segment reports

### DIFF
--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -408,6 +408,7 @@ defmodule Mydia.Streaming.HlsSession do
           start_number: first_index,
           grid_aligned: grid_aligned?(playlist_mode, media_file, max_bitrate),
           absolute_timestamps: playlist_mode == :full,
+          playlist_mode: playlist_mode,
           audio_language: playback.audio_language,
           show_audio_language: playback.show_audio_language
         ]
@@ -611,6 +612,16 @@ defmodule Mydia.Streaming.HlsSession do
       when generation != current do
     # A dead backend's final poll. Its indices belong to a window that has
     # already been replaced.
+    {:noreply, state}
+  end
+
+  # A :window session has no TranscodeWindow to mark ready and no segment
+  # waiters to answer (see start_backend/6, which no longer wires on_segments
+  # for this mode). This clause is defence in depth: TranscodeWindow.mark_ready/2
+  # pattern-matches %TranscodeWindow{} in its head, so a nil window here would
+  # crash the whole session GenServer the moment any caller re-introduces the
+  # callback for :window sessions.
+  def handle_cast({:segments_ready, _generation, _indices}, %{window: nil} = state) do
     {:noreply, state}
   end
 
@@ -835,6 +846,11 @@ defmodule Mydia.Streaming.HlsSession do
           else: []
         )
 
+    # Only a :full session has a TranscodeWindow to mark ready, so only wire
+    # the callback that reports segment completion for that mode. A :window
+    # session has no window and no segment waiters, so notify_segments would
+    # be pure overhead even if handle_cast tolerated a nil window (see the
+    # {segments_ready, _, _} clause guarding on `window: nil` below).
     transcoder_opts =
       base_opts ++
         [
@@ -867,11 +883,17 @@ defmodule Mydia.Streaming.HlsSession do
           end,
           on_error: fn error ->
             Logger.error("FFmpeg transcoding error for #{absolute_path}: #{error}")
-          end,
-          on_segments: fn indices ->
-            __MODULE__.notify_segments(session_pid, generation, indices)
           end
-        ]
+        ] ++
+        if Keyword.get(opts, :playlist_mode) == :full do
+          [
+            on_segments: fn indices ->
+              __MODULE__.notify_segments(session_pid, generation, indices)
+            end
+          ]
+        else
+          []
+        end
 
     # Overridable per-session so a test can drive relocation without spawning
     # real FFmpeg (see test/mydia/streaming/hls_session_segments_test.exs).

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -404,16 +404,23 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
           window: nil
         )
 
-      {:ok, pid} = Harness.start_link(state)
+      # Trapping exits keeps a crash from taking the test process down with the
+      # link, so the failure surfaces as :sys.get_state/1 exiting with :noproc
+      # rather than as an unrelated-looking test process death.
       Process.flag(:trap_exit, true)
+      {:ok, pid} = Harness.start_link(state)
 
       # window_generation defaults to 0 in base_state/1; matching it here
       # means this notification is not discarded by the stale-generation
       # guard clause and actually reaches the window: nil clause under test.
       HlsSession.notify_segments(pid, 0, [0])
 
-      refute_receive {:EXIT, ^pid, _reason}, 200
-      assert Process.alive?(pid)
+      # :sys.get_state/1 is a synchronous system message. Sent from the same
+      # process right after the cast, it is guaranteed to be handled after it,
+      # so this synchronises on the cast actually being processed instead of
+      # sleeping and hoping. If the cast crashed the session, the call exits
+      # with :noproc and the test fails.
+      assert %{window: nil} = :sys.get_state(pid)
     end
   end
 end

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -375,4 +375,45 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
       refute Map.has_key?(:sys.get_state(pid).segment_waiters, 100)
     end
   end
+
+  describe "a :window session's segments_ready notification" do
+    # Regression test for a crash that reached master: FfmpegHlsTranscoder's
+    # on_segments callback used to be wired unconditionally in start_backend/6,
+    # for both :full and :window sessions. A :window session has no
+    # TranscodeWindow (its `window` field is nil -- see start_registered_session/7,
+    # called from init/1), but
+    # TranscodeWindow.mark_ready/2 pattern-matches %TranscodeWindow{} in its
+    # head, so the first {:segments_ready, ...} cast a real encoder sent for a
+    # windowed session raised FunctionClauseError and took the whole session
+    # GenServer down roughly 60ms after start. Every later playlist request
+    # then 404'd because the session no longer existed (CI / Player E2E on
+    # master, run 33452019208; player/integration_test/p2p_streaming_test.dart
+    # failing on "HLS playlist should be ready with segments").
+    #
+    # The fix has two halves: start_backend/6 no longer wires on_segments at
+    # all for a :window session (nothing to notify), and handle_cast/2 gained
+    # a `%{window: nil}` clause as defence in depth so this cast is inert even
+    # if some future caller re-introduces it. This test exercises the
+    # handle_cast/2 guard directly, which is what actually protects the
+    # session if that ever happens.
+    test "does not crash the session" do
+      state =
+        base_state(
+          playlist_mode: :window,
+          segment_plan: nil,
+          window: nil
+        )
+
+      {:ok, pid} = Harness.start_link(state)
+      Process.flag(:trap_exit, true)
+
+      # window_generation defaults to 0 in base_state/1; matching it here
+      # means this notification is not discarded by the stale-generation
+      # guard clause and actually reaches the window: nil clause under test.
+      HlsSession.notify_segments(pid, 0, [0])
+
+      refute_receive {:EXIT, ^pid, _reason}, 200
+      assert Process.alive?(pid)
+    end
+  end
 end


### PR DESCRIPTION
## What broke

Every windowed HLS session (`playlist_mode: :window`, the default for any client that doesn't ask for `:full`, and the fallback whenever media duration is unknown) crashed within roughly 60ms of starting, the moment FFmpeg reported its first finished segment.

## Mechanism

`start_backend/6` wired the transcoder's `on_segments` callback unconditionally, for both `:full` and `:window` sessions. A `:window` session has no `TranscodeWindow` (`window: nil`), but `handle_cast({:segments_ready, ...}, state)` called `TranscodeWindow.mark_ready(state.window, indices)`, which pattern-matches `%TranscodeWindow{}` in its head. A `nil` window raised `FunctionClauseError`, killing the session GenServer. Every later `GET /api/v1/hls/<id>/index.m3u8` then 404'd because the session no longer existed.

## Fix

- `start_backend/6` now only wires `on_segments` when the session is `:full` (mirrors how `grid_aligned` is already conditioned on mode).
- `handle_cast/2` gained a `%{window: nil}` clause ahead of the existing one, as defence in depth against any future caller re-introducing the callback for `:window` sessions.

## How this shipped

The existing unit suite (`test/mydia/streaming/hls_session_segments_test.exs`) only ever drove `:full`-mode sessions through its `Harness`, so nothing exercised a real `{:segments_ready, ...}` cast against a windowed session. It was caught by `CI / Player E2E` on master (run 33452019208), not by the unit suite: a session would start, log `Terminating HLS session <id>, reason: {:function_clause, ...}` about 60ms later, and `player/integration_test/p2p_streaming_test.dart` would fail on "HLS playlist should be ready with segments".

Added a regression test that constructs a windowed session state (`window: nil`, `segment_plan: nil`, `playlist_mode: :window`) and sends it `{:segments_ready, generation, [0]}`, asserting the process stays alive. Verified it fails with the exact `FunctionClauseError` when the `%{window: nil}` guard clause is removed, and passes with it restored.

## Test plan

- [x] `./dev mix test test/mydia/streaming/ test/mydia_web/controllers/api/` - 524 tests, 0 failures
- [x] `./dev mix credo --strict` - no issues
- [x] Confirmed the new regression test fails with `FunctionClauseError` when the fix's guard clause is removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HLS streaming session stability when segment notifications are received unexpectedly.
  * Prevented windowed playback sessions from crashing under edge-case timing conditions.
  * Improved playlist mode and segment processing for more reliable playback.

* **Tests**
  * Added regression coverage confirming windowed sessions remain active during unexpected segment notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->