### PR TITLE
fix: unbreak the NixOS module, and pin every Alpine base that runs the BEAM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,17 @@ RUN --mount=type=cache,target=/root/.pub-cache,sharing=locked \
 # ============================================
 # Elixir Build Stage
 # ============================================
-FROM elixir:1.19-alpine AS builder
+# Digest-pinned, not tag-pinned, because the official elixir images publish no
+# Alpine-qualified tag: the variants are <version>[-otp-NN]-alpine and nothing
+# more, so a tag cannot express which Alpine a builder runs on. This digest
+# carries Alpine 3.23.5. It matters because this stage runs the BEAM to
+# compile, and musl 1.2.6 (Alpine 3.24) aborts the VM at startup on a CPU with
+# a large XSAVE area. See metadata-relay/Dockerfile for the full explanation.
+#
+# Nothing bumps this automatically: .github/dependabot.yml has no docker
+# ecosystem. It is pinned for correctness, not currency. Move it once a
+# released OTP tag carries erlang/otp#11376.
+FROM elixir:1.19-alpine@sha256:c504b910bbc1d5dccefb2d81e6a49a7747b931ab737c1e774a46fdf85906ef11 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \
@@ -202,7 +212,19 @@ RUN mix release
 # ============================================
 # Runtime Stage
 # ============================================
-FROM erlang:28-alpine
+# Alpine 3.23, and not an erlang image. metadata-relay/Dockerfile carries the
+# full explanation: musl 1.2.6, which Alpine 3.24 ships, tightened
+# sigaltstack() to reject any size below sysconf(_SC_MINSIGSTKSZ), which on a
+# CPU with a large XSAVE area exceeds the fixed 8 KB OTP 28 asks for, so the VM
+# aborts at startup. erlang:28-alpine happens to be built on 3.23.5 with musl
+# 1.2.5 today, but no tag of that image pins an Alpine version, so an upstream
+# rebuild would break every user with such a CPU and no commit here.
+#
+# No erlang base is needed. mix.exs declares no `releases`, so include_erts
+# defaults to true and the release carries the ERTS the builder produced. This
+# image's own OTP was never executed, only its shared libraries were, and those
+# are installed explicitly below.
+FROM alpine:3.23
 
 # Database type: sqlite (default) or postgres
 # This argument is only used for image labels - the actual adapter is already compiled
@@ -222,6 +244,8 @@ LABEL org.opencontainers.image.title="Mydia" \
 # libpq is needed for PostgreSQL connections at runtime
 # sqlite provides the sqlite3 CLI for database inspection
 # openssl is needed for self-signed certificate generation
+# libstdc++ and ncurses-libs came from the erlang base this image used to use;
+# the bundled ERTS and the Rust NIFs link against them
 RUN apk add --no-cache \
     sqlite \
     libpq \
@@ -233,7 +257,9 @@ RUN apk add --no-cache \
     su-exec \
     tzdata \
     shadow \
-    openssl
+    openssl \
+    libstdc++ \
+    ncurses-libs
 
 # Create app user with default UID/GID (will be updated by entrypoint if needed)
 RUN addgroup -g 1000 mydia && \

--- a/config/config.exs
+++ b/config/config.exs
@@ -232,18 +232,6 @@ config :logger, :default_formatter,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-# The `mime` package (via allow_upload's `accept:` option, see
-# MydiaWeb.MediaLive.Show's subtitle upload) only recognizes an extension it
-# already maps to a MIME type. None of these four are registered by default,
-# so `allow_upload(:subtitle, accept: ~w(.srt .ass .ssa .vtt), ...)` raised
-# ArgumentError on every mount without this. ASS and SSA share a type: ffmpeg
-# and this codebase's own Mydia.Subtitles.Format both treat SSA as ASS.
-config :mime, :types, %{
-  "application/x-subrip" => ["srt"],
-  "text/vtt" => ["vtt"],
-  "text/x-ssa" => ["ssa", "ass"]
-}
-
 # Configure Guardian for JWT authentication
 config :mydia, Mydia.Auth.Guardian,
   issuer: "mydia",

--- a/lib/mydia/subtitles/uploader.ex
+++ b/lib/mydia/subtitles/uploader.ex
@@ -10,8 +10,8 @@ defmodule Mydia.Subtitles.Uploader do
   a brand new sidecar to adopt on the next rescan.
 
   Unlike a search result, an uploaded file's format is not declared by
-  anything trustworthy: the filename extension `allow_upload`'s `accept`
-  option checks is entirely client-controlled. The real gate is
+  anything trustworthy: the filename extension the upload modal's file input
+  filters on is entirely client-controlled. The real gate is
   `Mydia.Subtitles.Format.detect/1`, run on the bytes actually received, the
   same function `Downloader` and `Sidecars` both already trust for the same
   reason.

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -151,10 +151,20 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:media_file_subtitle_tracks, load_media_file_subtitle_tracks(media_item))
      |> assign(:show_subtitle_upload_modal, false)
      |> assign(:subtitle_upload_error, nil)
-     # accept only screens the filename; Mydia.Subtitles.Format.detect/1 on the
-     # received bytes is the real gate, in SubtitleEvents.finish_upload/6.
+     # The extension filter lives on the file input itself, in SubtitleModal,
+     # not here. `accept:` resolves every entry through MIME.has_type?/1, and
+     # none of the four subtitle extensions is registered by default, so making
+     # it work meant `config :mime, :types`. That configures a dependency's
+     # compile-time key, which any builder that compiles dependencies in
+     # isolation cannot see, and it left the NixOS module of v0.14.0-beta.4
+     # aborting during boot. See dependency_compile_env_test.exs.
+     #
+     # Nothing is lost: accept only ever screened the client-supplied filename.
+     # Mydia.Subtitles.Format.detect/1 on the received bytes is the real gate,
+     # in SubtitleEvents.finish_upload/6, and the size and count limits below
+     # are independent of accept.
      |> allow_upload(:subtitle,
-       accept: ~w(.srt .ass .ssa .vtt),
+       accept: :any,
        max_entries: 1,
        max_file_size: 2_000_000
      )

--- a/lib/mydia_web/live/media_live/show/subtitle_events.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_events.ex
@@ -295,9 +295,11 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleEvents do
     {:noreply, socket}
   end
 
-  # allow_upload validates on every phx-change automatically (size, count,
-  # accepted extensions); there is nothing extra to do here. The handler
-  # still has to exist because the form declares phx-change.
+  # allow_upload validates size and count on every phx-change automatically;
+  # there is nothing extra to do here. It no longer screens the extension,
+  # which the file input's own accept attribute does on the client and
+  # Mydia.Subtitles.Format.detect/1 settles on the bytes. The handler still
+  # has to exist because the form declares phx-change.
   def validate_subtitle_upload(_params, socket), do: {:noreply, socket}
 
   def save_subtitle_upload(params, socket) do

--- a/lib/mydia_web/live/media_live/show/subtitle_modal.ex
+++ b/lib/mydia_web/live/media_live/show/subtitle_modal.ex
@@ -458,8 +458,13 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleModal do
             class="border-2 border-dashed border-base-300 rounded-lg p-6 text-center mb-4"
             phx-drop-target={@uploads.subtitle.ref}
           >
+            <%!-- accept is set here rather than through allow_upload, which
+                  would need the four subtitle types registered on the mime
+                  dependency at compile time. live_file_input declares accept
+                  as an explicit override for exactly this. --%>
             <.live_file_input
               upload={@uploads.subtitle}
+              accept=".srt,.ass,.ssa,.vtt"
               class="file-input file-input-bordered w-full"
             />
             <p class="text-xs opacity-60 mt-2">SRT, ASS, SSA or VTT, up to 2 MB</p>

--- a/metadata-relay/Dockerfile
+++ b/metadata-relay/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1.4
-FROM elixir:1.20.1-alpine AS builder
+# Digest-pinned rather than tag-pinned: the official elixir images publish no
+# Alpine-qualified tag, and this stage runs the BEAM to compile, so it is
+# exposed to the same musl 1.2.6 abort as the runtime stage below. This digest
+# carries Alpine 3.23.5.
+FROM elixir:1.20.1-alpine@sha256:f50894ff69b0d07b310fe9c97b48b3475568ecccb7f0ccd7c350a789feb395a3 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache build-base git openssl-dev nodejs npm
@@ -84,7 +88,10 @@ RUN --mount=type=cache,id=relay-hex,target=/root/.hex \
 # released tag yet: 28.0 through 28.5.0.5 and 29.0 through 29.0.5 all still
 # hardcode SIGSTKSZ. Move this back to a current Alpine once a patch release
 # carries that commit. Alpine 3.23 is supported until 2027-11-01.
-FROM alpine:3.23.5
+#
+# The tag floats within 3.23 so security patches still arrive; only the minor
+# is held, and 3.23 can never carry musl 1.2.6.
+FROM alpine:3.23
 
 # Install runtime dependencies
 RUN apk add --no-cache libstdc++ openssl ncurses-libs curl

--- a/metadata-relay/Dockerfile.dev
+++ b/metadata-relay/Dockerfile.dev
@@ -1,4 +1,5 @@
-FROM elixir:1.20.1-alpine
+# Same digest and the same reason as metadata-relay/Dockerfile's builder.
+FROM elixir:1.20.1-alpine@sha256:f50894ff69b0d07b310fe9c97b48b3475568ecccb7f0ccd7c350a789feb395a3
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/nix/packages/flake-module.nix
+++ b/nix/packages/flake-module.nix
@@ -463,6 +463,37 @@
                 [ pkgs.ffmpeg_6-headless pkgs.sqlite pkgs.openssl ] ++ extraRuntimeDeps
               )}
           '';
+
+          # Boot the release once. `bin/mydia eval` runs the config providers
+          # and Config.Provider.boot/2's compile_env validation, which is
+          # exactly what aborted the v0.14.0-beta.4 NixOS module, without
+          # starting an application, opening a database, or touching the
+          # network. Without this the same failure only appears in the
+          # push-only VM test, as a 900 second timeout on wait_for_unit with
+          # the real error buried in the guest's journal.
+          #
+          # config/runtime.exs requires these three under SQLite.
+          # Mydia.Release.Env.fetch_secret!/2 enforces a 32 character floor, so
+          # these are long enough to pass and are obvious throwaways; they
+          # never leave the sandbox and never reach the output. RELEASE_TMP has
+          # to be redirected because it defaults to a directory inside the
+          # release root, which is the read-only store path.
+          doInstallCheck = true;
+          installCheckPhase = ''
+            runHook preInstallCheck
+
+            export RELEASE_TMP=$(mktemp -d)
+            export RELEASE_DISTRIBUTION=none
+            export SECRET_KEY_BASE=nix-install-check-not-a-real-secret-key-base-value
+            export GUARDIAN_SECRET_KEY=nix-install-check-not-a-real-guardian-secret-key
+            export DATABASE_PATH=$RELEASE_TMP/install-check.db
+            export MYDIA_DATA_DIR=$RELEASE_TMP
+
+            echo "install check: booting the release to validate its configuration"
+            $out/bin/mydia eval ':ok'
+
+            runHook postInstallCheck
+          '';
         } // pkgs.lib.optionalAttrs (databaseType != null) {
           DATABASE_TYPE = databaseType;
         });

--- a/test/mydia/config/dependency_compile_env_test.exs
+++ b/test/mydia/config/dependency_compile_env_test.exs
@@ -1,0 +1,111 @@
+defmodule Mydia.Config.DependencyCompileEnvTest do
+  @moduledoc """
+  No dependency may read compile-time configuration this project sets.
+
+  `Application.compile_env/3` bakes the value into the *dependency* at the
+  moment the dependency is compiled, and records what it saw in the
+  dependency's `.app` file. Elixir then re-checks that record against the
+  running configuration on every boot, and aborts if the two disagree.
+
+  Docker and `mix` compile dependencies in-tree, with `config/config.exs`
+  present, so both agree and nothing is visible. `deps.nix` builds each hex
+  dependency as its own isolated derivation that never sees this project's
+  config, so the dependency compiles against its default while the release's
+  `sys.config` carries ours. The result is a release that aborts during boot
+  rather than a build that fails where anyone can see it.
+
+  That shipped: `config :mime, :types` reached `v0.14.0-beta.4` and left the
+  NixOS module restart-looping, while Docker and the player artifacts in the
+  same release were fine. The NixOS VM tests that would have caught it run on
+  push only, so no pull request could have.
+
+  This test costs milliseconds and runs on every pull request, which the VM
+  tests do not.
+  """
+  use ExUnit.Case, async: true
+
+  test "no dependency reads compile-time configuration this project sets" do
+    config = Config.Reader.read!("config/config.exs", env: :prod)
+
+    violations =
+      for {app, key_path} <- dependency_compile_env_reads(),
+          configured?(config, app, key_path),
+          do: {app, key_path}
+
+    assert violations == [], failure_message(violations)
+  end
+
+  # Every `Application.compile_env/3` call recorded by a compiled dependency.
+  #
+  # The application named in an entry is not always the application that
+  # recorded it: `wasmex` records reads of `:rustler_precompiled`, so the
+  # entry's own app is what matters, not the file it came from.
+  #
+  # Entries naming `:mydia` are excluded. Those come from
+  # `Application.compile_env(@otp_app, ...)` inside dependency macros, which
+  # `Phoenix.Endpoint` uses, and which expand into this project's own modules.
+  # Nix compiles the `mydia` application itself with this project's config, so
+  # they can never disagree.
+  defp dependency_compile_env_reads do
+    Mix.Project.build_path()
+    |> Path.join("lib/*/ebin/*.app")
+    |> Path.wildcard()
+    |> Enum.flat_map(fn file ->
+      {:ok, [{:application, _name, keyword}]} = :file.consult(String.to_charlist(file))
+      Keyword.get(keyword, :compile_env, [])
+    end)
+    |> Enum.map(fn {app, key_path, _compile_time_value} -> {app, key_path} end)
+    |> Enum.reject(fn {app, _key_path} -> app == :mydia end)
+    |> Enum.uniq()
+  end
+
+  # `config/config.exs` ends with an `import_config` of the environment file, so
+  # reading it with `env: :prod` is the whole compile-time configuration a
+  # release is built with. `runtime.exs` is deliberately not consulted: it is
+  # applied after compilation and cannot participate in this mismatch.
+  defp configured?(config, app, key_path) do
+    case Keyword.fetch(config, app) do
+      :error -> false
+      {:ok, app_config} -> traverse(app_config, key_path)
+    end
+  end
+
+  defp traverse(_value, []), do: true
+
+  defp traverse(config, [key | rest]) when is_list(config) do
+    case Keyword.fetch(config, key) do
+      :error -> false
+      {:ok, value} -> traverse(value, rest)
+    end
+  end
+
+  # A non-list stops the walk: the path is not reachable, so nothing is set.
+  defp traverse(_value, _key_path), do: false
+
+  defp failure_message(violations) do
+    listed =
+      Enum.map_join(violations, "\n", fn {app, key_path} ->
+        "  * #{inspect(app)}, key #{inspect(key_path)}"
+      end)
+
+    """
+    A dependency reads compile-time configuration this project sets:
+
+    #{listed}
+
+    A builder that compiles each dependency in its own isolated derivation,
+    which `deps.nix` and the Nix package do, cannot see `config/config.exs`.
+    The dependency compiles against its default, the release's `sys.config`
+    carries this project's value, and `Config.Provider.boot/2` aborts the
+    release during boot. The NixOS module restart-loops; nothing fails at
+    build time.
+
+    Prefer not configuring the dependency at all. When the extension is
+    genuinely required, it has to be reproduced inside that dependency's own
+    derivation in nix/packages/flake-module.nix, and locally it needs
+    `mix deps.clean <app> --build` before the change takes effect.
+
+    This shipped once, as `config :mime, :types` in v0.14.0-beta.4.
+    """
+  end
+end

--- a/test/mydia_web/live/media_live/show/subtitle_upload_test.exs
+++ b/test/mydia_web/live/media_live/show/subtitle_upload_test.exs
@@ -64,6 +64,27 @@ defmodule MydiaWeb.MediaLive.Show.SubtitleUploadTest do
     view |> element("#subtitle-manage-upload") |> render_click()
   end
 
+  # The four extensions are the file input's own accept attribute, not
+  # allow_upload's accept: option. That option resolves every entry through
+  # MIME.has_type?/1, so it required registering the subtitle types on the mime
+  # dependency at compile time, which no builder that compiles dependencies in
+  # isolation can reproduce; it left the NixOS module of v0.14.0-beta.4 unable
+  # to boot. See Mydia.Config.DependencyCompileEnvTest.
+  #
+  # allow_upload is now accept: :any, so nothing raises if this attribute is
+  # dropped. The file dialog would just silently stop filtering, and only the
+  # server-side Format.detect/1 gate would remain. This asserts the client-side
+  # half is still there.
+  test "the file input filters the dialog to subtitle extensions", %{conn: conn} do
+    {media_item, media_file} = movie_with_media_file()
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{media_item.id}")
+
+    open_upload_modal(view, media_file.id)
+
+    assert has_element?(view, ~s(input[type="file"][accept=".srt,.ass,.ssa,.vtt"]))
+  end
+
   test "uploads an SRT and creates an upload-origin track", %{conn: conn} do
     {media_item, media_file} = movie_with_media_file()
 


### PR DESCRIPTION
## What broke

The NixOS module in `v0.14.0-beta.4` cannot boot.

`mime` 2.0.7 reads `Application.compile_env(:mime, :types)` in its own module
body, so the value is baked into the dependency when the dependency compiles.
`deps.nix` builds every hex dependency as its own isolated derivation, which
never sees `config/config.exs`, so `mime` compiled against its `%{}` default
while the release's `sys.config` carried the four subtitle types added in
#585. `Config.Provider.boot/2` aborts on the mismatch:

```
ERROR! the application :mime has a different value set for key :types during
runtime compared to compile time.
Runtime terminating during boot ({<<"aborting boot">>,[{'Elixir.Config.Provider',boot,2,[]}]})
```

That runs in the `mydia-migrate` `ExecStartPre`, before Phoenix starts, so
systemd restart-loops the unit. Both NixOS VM tests have been red on master
since 2026-08-26, and the VM tests run on push only, so no pull request could
have caught it.

Docker images and player artifacts are unaffected. They compile dependencies
in-tree with the config present, which is a structural difference rather than
luck.

## The fix

`config :mime, :types` existed only so `allow_upload`'s `accept:` could resolve
four extensions through `MIME.has_type?/1`. As `Mydia.Subtitles.Uploader`
already documented, `accept` only ever screened the client-supplied filename;
`Mydia.Subtitles.Format.detect/1` on the received bytes is the real gate.

So `accept:` becomes `:any` and the extension filter moves onto the file input
itself, where `live_file_input` declares `accept` as an explicit override. The
file dialog still filters to `.srt,.ass,.ssa,.vtt`, the 2 MB and single-entry
limits are unchanged, and a file that is not a subtitle is still rejected with
"That file is not a subtitle Mydia can read", now server-side rather than in
the browser. No dependency is configured at compile time any more, so every
packaging path behaves the same.

## The guard

`test/mydia/config/dependency_compile_env_test.exs` reads each dependency's
compiled `.app` for the `compile_env` reads Elixir records there, and fails
when this project's config sets one of those keys. It runs in the existing test
job on every pull request in milliseconds, which the NixOS VM tests do not.

Entries recorded against `:mydia` are excluded, since those come from
`Application.compile_env(@otp_app, ...)` macros that expand into our own
modules, which Nix compiles with our config. `mime` was the only violation in
the tree; nothing trips it now.

The Nix package also boots the release once in an install check, so a boot-time
mismatch fails `nix build` in seconds instead of appearing as a 900 second
`wait_for_unit` timeout in a push-only VM test.

## The Alpine floor

Separate defect, found while fixing the first one, and not triggered by any
commit in this repository.

musl 1.2.6, which Alpine 3.24 ships, rejects the 8 KB `sigaltstack` OTP 28 asks
for on any CPU with a large XSAVE area, so the VM aborts at startup.
metadata-relay's runtime was pinned for this in 8ddb363d4. The main image still
tracked `erlang:28-alpine`, which is built on Alpine 3.23.5 with musl 1.2.5
today and would break every user with such a CPU the moment upstream rebuilds
it on 3.24.

`mix.exs` declares no `releases`, so `include_erts` defaults to true and the
runtime image never used the erlang base's OTP at all, only its shared
libraries. The runtime is now `alpine:3.23` with `libstdc++` and `ncurses-libs`
installed explicitly, matching what metadata-relay already does, and both
runtimes now read `alpine:3.23` so they keep taking 3.23 patches and can never
cross into musl 1.2.6.

The three elixir builder images each run the BEAM to compile and were exposed
the same way. The official elixir and erlang images publish no
Alpine-qualified tag, so those are digest-pinned; all three digests carry
Alpine 3.23.5, verified by reading `/etc/alpine-release` in each.

## Verification

- The guard test fails naming `:mime, key [:types]` on the broken tree and on a
  deliberate reintroduction, and passes on the fixed tree.
- `nix build` of both the SQLite and PostgreSQL packages succeeds and runs the
  new install check. Pointing `RELEASE_SYS_CONFIG` at a `sys.config` carrying
  mime types the release was not built with makes the check's exact command
  abort with the error above, while the untampered release exits 0.
- Both NixOS module VM tests pass locally, in 17s and 22s. They are red on
  master, where they reach a 900 second `wait_for_unit` timeout.
- Both Docker images build. The main image boots the BEAM on OTP 28 with the
  p2p and sqlite NIFs loading, reports Alpine 3.23.5 with musl 1.2.5, carries
  erts-16.4.0.2, and has no system `erl`, which is what makes the erlang base
  demonstrably redundant rather than merely arguably so.
- `mix precommit` is green: 9927 tests, 0 failures.
- The upload dialog assertion fails when the `accept` attribute is removed, so
  it guards rather than merely passing.

## Note on the release

`v0.14.0-beta.4` ships the broken module. It needs a warning telling NixOS and
flake users to stay on `v0.14.0-beta.3` or wait for this, and saying that the
Docker images and player artifacts in that release are fine. That is a separate
change to the published release, not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subtitle uploads by restoring file-picker filtering for `.srt`, `.ass`, `.ssa`, and `.vtt` files.
  * Subtitle content continues to be validated server-side, with existing size and upload-count limits unchanged.

* **Reliability**
  * Improved release validation so configuration and startup issues are detected earlier during builds.
  * Updated container image handling for more consistent and secure builds.

* **Tests**
  * Added coverage for subtitle file filtering and dependency configuration compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->