### PR TITLE
Flexible sidebar sections

### DIFF
--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -16,6 +16,7 @@ defmodule Mydia.Accounts do
   alias Mydia.Accounts.{User, ApiKey, UserPreference, ApiKeyRateLimiter}
 
   @changelog_key "last_seen_changelog_version"
+  @anime_nudge_key "anime_nudge_dismissed"
 
   ## Users
 
@@ -499,6 +500,26 @@ defmodule Mydia.Accounts do
           _ -> true
         end
     end
+  end
+
+  @doc """
+  Returns true when the user has dismissed the offer to create an Anime section.
+  """
+  @spec anime_nudge_dismissed?(User.t()) :: boolean()
+  def anime_nudge_dismissed?(%User{} = user) do
+    pref = get_user_preference!(user)
+    Map.get(pref.preferences || %{}, @anime_nudge_key, false) == true
+  end
+
+  @doc """
+  Records that the user dismissed the Anime section offer. Permanent.
+  """
+  @spec dismiss_anime_nudge(User.t()) ::
+          {:ok, UserPreference.t()} | {:error, Ecto.Changeset.t()}
+  def dismiss_anime_nudge(%User{} = user) do
+    user
+    |> get_user_preference!()
+    |> update_preference(%{@anime_nudge_key => true})
   end
 
   ## API Keys

--- a/lib/mydia/collections.ex
+++ b/lib/mydia/collections.ex
@@ -28,7 +28,7 @@ defmodule Mydia.Collections do
   import Mydia.QueryHelpers
   alias Mydia.Repo
   alias Mydia.Collections.{Collection, CollectionItem, SmartRules}
-  alias Mydia.Media.MediaItem
+  alias Mydia.Media.{MediaCategory, MediaItem}
   alias Mydia.Accounts.User
 
   ## Collections
@@ -65,6 +65,93 @@ defmodule Mydia.Collections do
     |> apply_collection_filters(opts)
     |> maybe_preload(opts[:preload])
     |> Repo.all()
+  end
+
+  @doc """
+  Returns the collections the user has pinned to their sidebar, in order.
+
+  Pins are owner scoped. A shared collection pinned by its owner appears only
+  in the owner's sidebar, which is what keeps a section from turning into a
+  fixed section for everyone on the instance.
+  """
+  @spec list_pinned_sections(User.t()) :: [Collection.t()]
+  def list_pinned_sections(%User{} = user) do
+    from(c in Collection,
+      where: c.user_id == ^user.id and not is_nil(c.pinned_position),
+      order_by: [asc: c.pinned_position, asc: c.name]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns the category names that the user's exclusive sections have claimed
+  away from the built-in Movies and TV pages.
+
+  Derived from the rules on every read rather than stored, so it cannot drift
+  from the rules that produced it. Returns `[]` for anything it cannot read
+  with certainty, including malformed JSON, because the caller is the sidebar
+  and the library pages: failing open is the only safe direction.
+  """
+  @spec claimed_categories(User.t()) :: [binary()]
+  def claimed_categories(%User{} = user) do
+    user
+    |> list_pinned_sections()
+    |> Enum.filter(& &1.exclusive)
+    |> Enum.flat_map(&section_categories/1)
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Returns true when a collection's rules are simple enough to be made exclusive.
+
+  Only a single `category in [...]` condition qualifies. A richer rule set
+  cannot be cleanly subtracted from the Movies and TV queries, so the toggle is
+  not offered for it.
+  """
+  @spec exclusive_eligible?(Collection.t()) :: boolean()
+  def exclusive_eligible?(%Collection{} = collection) do
+    section_categories(collection) != []
+  end
+
+  @doc """
+  Pins a collection to the user's sidebar, appending it after existing sections.
+
+  ## Options
+    - `:sidebar_icon` - hero icon name from `Collection.valid_sidebar_icons/0`
+    - `:exclusive` - claim the section's categories away from Movies and TV
+  """
+  @spec pin_section(User.t(), Collection.t(), keyword()) ::
+          {:ok, Collection.t()} | {:error, Ecto.Changeset.t()}
+  def pin_section(%User{} = user, %Collection{} = collection, opts \\ []) do
+    next_position =
+      user
+      |> list_pinned_sections()
+      |> Enum.map(& &1.pinned_position)
+      |> Enum.max(fn -> -1 end)
+      |> Kernel.+(1)
+
+    exclusive = Keyword.get(opts, :exclusive, false) and exclusive_eligible?(collection)
+
+    update_collection(user, collection, %{
+      pinned_position: next_position,
+      sidebar_icon: Keyword.get(opts, :sidebar_icon),
+      exclusive: exclusive
+    })
+  end
+
+  @doc """
+  Removes a collection from the sidebar. The collection itself is kept.
+
+  Exclusivity is cleared at the same time, so an unpinned section can never go
+  on hiding items from a page the user can no longer navigate away from.
+  """
+  @spec unpin_section(User.t(), Collection.t()) ::
+          {:ok, Collection.t()} | {:error, Ecto.Changeset.t()}
+  def unpin_section(%User{} = user, %Collection{} = collection) do
+    update_collection(user, collection, %{
+      pinned_position: nil,
+      exclusive: false
+    })
   end
 
   @doc """
@@ -628,6 +715,30 @@ defmodule Mydia.Collections do
   end
 
   ## Private Helpers
+
+  # Returns the category names a section covers, or [] when the rules are
+  # anything other than exactly one `category in [...]` condition.
+  defp section_categories(%Collection{type: "smart", smart_rules: rules})
+       when is_binary(rules) do
+    case Jason.decode(rules) do
+      {:ok, %{"conditions" => [condition]}} -> condition_categories(condition)
+      _ -> []
+    end
+  end
+
+  defp section_categories(_collection), do: []
+
+  defp condition_categories(%{
+         "field" => "category",
+         "operator" => "in",
+         "value" => values
+       })
+       when is_list(values) do
+    known = Enum.map(MediaCategory.all(), &Atom.to_string/1)
+    Enum.filter(values, &(&1 in known))
+  end
+
+  defp condition_categories(_condition), do: []
 
   defp apply_pagination(query, opts) do
     query

--- a/lib/mydia/collections.ex
+++ b/lib/mydia/collections.ex
@@ -92,10 +92,13 @@ defmodule Mydia.Collections do
   with certainty, including malformed JSON, because the caller is the sidebar
   and the library pages: failing open is the only safe direction.
   """
-  @spec claimed_categories(User.t()) :: [binary()]
+  @spec claimed_categories(User.t() | [Collection.t()]) :: [binary()]
   def claimed_categories(%User{} = user) do
-    user
-    |> list_pinned_sections()
+    user |> list_pinned_sections() |> claimed_categories()
+  end
+
+  def claimed_categories(sections) when is_list(sections) do
+    sections
     |> Enum.filter(& &1.exclusive)
     |> Enum.flat_map(&section_categories/1)
     |> Enum.uniq()

--- a/lib/mydia/collections.ex
+++ b/lib/mydia/collections.ex
@@ -148,11 +148,15 @@ defmodule Mydia.Collections do
 
     exclusive = Keyword.get(opts, :exclusive, false) and exclusive_eligible?(collection)
 
-    update_collection(user, collection, %{
-      pinned_position: next_position,
-      sidebar_icon: Keyword.get(opts, :sidebar_icon),
-      exclusive: exclusive
-    })
+    attrs = %{pinned_position: next_position, exclusive: exclusive}
+
+    attrs =
+      case Keyword.fetch(opts, :sidebar_icon) do
+        {:ok, icon} -> Map.put(attrs, :sidebar_icon, icon)
+        :error -> attrs
+      end
+
+    update_collection(user, collection, attrs)
   end
 
   @doc """

--- a/lib/mydia/collections.ex
+++ b/lib/mydia/collections.ex
@@ -119,13 +119,26 @@ defmodule Mydia.Collections do
   @doc """
   Pins a collection to the user's sidebar, appending it after existing sections.
 
+  Only a smart collection can be pinned. A manual collection has no
+  `smart_rules`, and `MediaLive.Index`'s section page falls back to `"{}"` for
+  a nil rule set, which is an unfiltered query, so pinning one would put the
+  entire library behind a section link. Refuses with `{:error, :not_smart}`
+  instead.
+
   ## Options
     - `:sidebar_icon` - hero icon name from `Collection.valid_sidebar_icons/0`
     - `:exclusive` - claim the section's categories away from Movies and TV
   """
   @spec pin_section(User.t(), Collection.t(), keyword()) ::
-          {:ok, Collection.t()} | {:error, Ecto.Changeset.t()}
-  def pin_section(%User{} = user, %Collection{} = collection, opts \\ []) do
+          {:ok, Collection.t()}
+          | {:error, Ecto.Changeset.t() | :unauthorized | :system_collection | :not_smart}
+  def pin_section(user, collection, opts \\ [])
+
+  def pin_section(%User{} = _user, %Collection{type: "manual"} = _collection, _opts) do
+    {:error, :not_smart}
+  end
+
+  def pin_section(%User{} = user, %Collection{type: "smart"} = collection, opts) do
     next_position =
       user
       |> list_pinned_sections()

--- a/lib/mydia/collections/collection.ex
+++ b/lib/mydia/collections/collection.ex
@@ -100,6 +100,7 @@ defmodule Mydia.Collections.Collection do
     |> validate_inclusion(:sort_order, @sort_order_values)
     |> validate_inclusion(:sidebar_icon, @sidebar_icons, message: "is not a supported icon")
     |> validate_smart_rules()
+    |> validate_pinned_section_type()
     |> foreign_key_constraint(:user_id)
   end
 
@@ -165,6 +166,20 @@ defmodule Mydia.Collections.Collection do
 
       true ->
         changeset
+    end
+  end
+
+  # Only smart collections may be pinned as sidebar sections: pin_section/3
+  # and the :section LiveView route both already guard against a manual
+  # collection reaching /sections/:id, since smart_rules: nil would build an
+  # unfiltered query. This is the third layer, closing off the changeset
+  # itself as a way to bypass those guards.
+  defp validate_pinned_section_type(changeset) do
+    if get_field(changeset, :type) == "manual" and
+         not is_nil(get_field(changeset, :pinned_position)) do
+      add_error(changeset, :pinned_position, "only smart collections can be pinned")
+    else
+      changeset
     end
   end
 

--- a/lib/mydia/collections/collection.ex
+++ b/lib/mydia/collections/collection.ex
@@ -25,6 +25,16 @@ defmodule Mydia.Collections.Collection do
   @visibility_values ~w(private shared)
   @sort_order_values ~w(position title year added_date rating)
 
+  # Hero icons offered for sidebar sections. Every name is verified to exist in
+  # deps/heroicons/optimized/24/outline. Validating against an allowlist keeps a
+  # bad value from rendering a broken icon on every page in the app, since the
+  # sidebar is in the layout.
+  @sidebar_icons ~w(
+    hero-sparkles hero-film hero-tv hero-star hero-bolt hero-fire
+    hero-globe-alt hero-face-smile hero-rocket-launch hero-squares-2x2
+    hero-book-open hero-beaker
+  )
+
   @type t :: %__MODULE__{
           id: binary(),
           name: String.t() | nil,
@@ -36,6 +46,9 @@ defmodule Mydia.Collections.Collection do
           visibility: String.t(),
           is_system: boolean(),
           position: integer(),
+          pinned_position: integer() | nil,
+          sidebar_icon: String.t() | nil,
+          exclusive: boolean(),
           user: Mydia.Accounts.User.t() | Ecto.Association.NotLoaded.t(),
           collection_items:
             [Mydia.Collections.CollectionItem.t()] | Ecto.Association.NotLoaded.t(),
@@ -53,6 +66,9 @@ defmodule Mydia.Collections.Collection do
     field :visibility, :string, default: "private"
     field :is_system, :boolean, default: false
     field :position, :integer, default: 0
+    field :pinned_position, :integer
+    field :sidebar_icon, :string
+    field :exclusive, :boolean, default: false
 
     belongs_to :user, Mydia.Accounts.User
     has_many :collection_items, Mydia.Collections.CollectionItem
@@ -73,12 +89,16 @@ defmodule Mydia.Collections.Collection do
       :sort_order,
       :smart_rules,
       :visibility,
-      :position
+      :position,
+      :pinned_position,
+      :sidebar_icon,
+      :exclusive
     ])
     |> validate_required([:name, :type, :visibility])
     |> validate_inclusion(:type, @type_values)
     |> validate_inclusion(:visibility, @visibility_values)
     |> validate_inclusion(:sort_order, @sort_order_values)
+    |> validate_inclusion(:sidebar_icon, @sidebar_icons, message: "is not a supported icon")
     |> validate_smart_rules()
     |> foreign_key_constraint(:user_id)
   end
@@ -110,6 +130,11 @@ defmodule Mydia.Collections.Collection do
   Returns the list of valid sort order values.
   """
   def valid_sort_orders, do: @sort_order_values
+
+  @doc """
+  Returns the hero icon names offered for sidebar sections.
+  """
+  def valid_sidebar_icons, do: @sidebar_icons
 
   # Validates that smart_rules is valid JSON with at least one condition when type is "smart"
   defp validate_smart_rules(changeset) do

--- a/lib/mydia/collections/section_presets.ex
+++ b/lib/mydia/collections/section_presets.ex
@@ -1,0 +1,80 @@
+defmodule Mydia.Collections.SectionPresets do
+  @moduledoc """
+  Ready-made sidebar sections offered when a user adds one.
+
+  The catalog is deliberately limited to what `Mydia.Collections.SmartRules`
+  can express. Its `@valid_fields` has no quality field, so there is no "4K"
+  preset, and `Collection.changeset/2` requires at least one condition, so
+  there is no sort-only "Recently Added" preset either. Adding one of those
+  means extending the rule vocabulary first.
+  """
+
+  @type preset :: %{
+          key: String.t(),
+          name: String.t(),
+          icon: String.t(),
+          description: String.t(),
+          rules: map(),
+          exclusive: boolean()
+        }
+
+  @presets [
+    %{
+      key: "anime",
+      name: "Anime",
+      icon: "hero-sparkles",
+      description: "Japanese animation, movies and series, out of Movies and TV.",
+      rules: %{
+        "conditions" => [
+          %{
+            "field" => "category",
+            "operator" => "in",
+            "value" => ["anime_movie", "anime_series"]
+          }
+        ]
+      },
+      exclusive: true
+    },
+    %{
+      key: "cartoons",
+      name: "Cartoons",
+      icon: "hero-face-smile",
+      description: "Western animation, movies and series, out of Movies and TV.",
+      rules: %{
+        "conditions" => [
+          %{
+            "field" => "category",
+            "operator" => "in",
+            "value" => ["cartoon_movie", "cartoon_series"]
+          }
+        ]
+      },
+      exclusive: true
+    },
+    %{
+      key: "documentaries",
+      name: "Documentaries",
+      icon: "hero-globe-alt",
+      description: "Anything tagged with the Documentary genre. Stays in Movies and TV.",
+      rules: %{
+        "conditions" => [
+          %{"field" => "metadata.genres", "operator" => "contains", "value" => "Documentary"}
+        ]
+      },
+      exclusive: false
+    }
+  ]
+
+  @doc """
+  Returns every preset in display order.
+  """
+  @spec all() :: [preset()]
+  def all, do: @presets
+
+  @doc """
+  Returns the preset with the given key, or nil.
+  """
+  @spec get(String.t()) :: preset() | nil
+  def get(key) when is_binary(key), do: Enum.find(@presets, &(&1.key == key))
+  def get(_), do: nil
+end

--- a/lib/mydia/collections/smart_rules.ex
+++ b/lib/mydia/collections/smart_rules.ex
@@ -257,6 +257,30 @@ defmodule Mydia.Collections.SmartRules do
   """
   def valid_operators, do: @valid_operators
 
+  @doc """
+  Returns the validated Ecto query for a rule set without executing it.
+
+  Callers that need to compose further filters onto a smart collection (the
+  sidebar section view) use this instead of `execute_query/2`, which runs the
+  query and returns rows. Errors are returned rather than swallowed, so a
+  section with broken rules can render an editable error state instead of
+  looking like an empty library.
+  """
+  @spec query(binary() | map()) :: {:ok, Ecto.Query.t()} | {:error, binary()}
+  def query(rules) when is_binary(rules) do
+    case Jason.decode(rules) do
+      {:ok, decoded} -> query(decoded)
+      {:error, _} -> {:error, "Invalid JSON"}
+    end
+  end
+
+  def query(rules) when is_map(rules) do
+    case validate(rules) do
+      {:ok, _} -> {:ok, build_query(rules)}
+      {:error, errors} -> {:error, "Invalid rules: #{Enum.join(errors, ", ")}"}
+    end
+  end
+
   ## Private Functions
 
   defp validate_condition(condition, idx) when is_map(condition) do

--- a/lib/mydia/collections/smart_rules.ex
+++ b/lib/mydia/collections/smart_rules.ex
@@ -165,13 +165,11 @@ defmodule Mydia.Collections.SmartRules do
   def execute_query(rules, opts \\ [])
 
   def execute_query(rules, opts) when is_map(rules) do
-    # First validate the rules
-    case validate(rules) do
-      {:ok, _} ->
+    case query(rules) do
+      {:ok, q} ->
         try do
           items =
-            rules
-            |> build_query()
+            q
             |> apply_sort(rules)
             |> apply_limit(rules, opts)
             |> apply_offset(opts)
@@ -187,8 +185,8 @@ defmodule Mydia.Collections.SmartRules do
             {:error, "Query failed: #{Exception.message(e)}"}
         end
 
-      {:error, errors} ->
-        {:error, "Invalid rules: #{Enum.join(errors, ", ")}"}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -22,6 +22,8 @@ defmodule Mydia.Media do
     - `:ids` - Filter to a specific list of media item ids
     - `:monitored` - Filter by monitored status (true/false)
     - `:category` - Filter by category (atom or string, e.g., :anime_movie or "anime_movie")
+    - `:exclude_categories` - Drop these categories from the result (list of atoms or strings)
+    - `:base_query` - Ecto query to start from instead of the full MediaItem table
     - `:library_path_type` - Filter by library path type (:movies, :series, etc.)
     - `:search` - Search by title (case-insensitive substring match)
     - `:added_since` - Filter to items inserted after this DateTime
@@ -31,7 +33,7 @@ defmodule Mydia.Media do
   """
   @spec list_media_items(keyword()) :: [MediaItem.t()]
   def list_media_items(opts \\ []) do
-    MediaItem
+    (opts[:base_query] || MediaItem)
     |> apply_media_item_filters(opts)
     |> maybe_preload(opts[:preload])
     |> Repo.all()
@@ -831,21 +833,29 @@ defmodule Mydia.Media do
 
   @doc """
   Returns the count of movies in the library.
+
+  ## Options
+    - `:exclude_categories` - Drop these categories from the count
   """
-  @spec count_movies() :: non_neg_integer()
-  def count_movies do
+  @spec count_movies(keyword()) :: non_neg_integer()
+  def count_movies(opts \\ []) do
     MediaItem
     |> where([m], m.type == "movie")
+    |> apply_media_item_filters(Keyword.take(opts, [:exclude_categories]))
     |> Repo.aggregate(:count)
   end
 
   @doc """
   Returns the count of TV shows in the library.
+
+  ## Options
+    - `:exclude_categories` - Drop these categories from the count
   """
-  @spec count_tv_shows() :: non_neg_integer()
-  def count_tv_shows do
+  @spec count_tv_shows(keyword()) :: non_neg_integer()
+  def count_tv_shows(opts \\ []) do
     MediaItem
     |> where([m], m.type == "tv_show")
+    |> apply_media_item_filters(Keyword.take(opts, [:exclude_categories]))
     |> Repo.aggregate(:count)
   end
 
@@ -2147,6 +2157,16 @@ defmodule Mydia.Media do
 
       {:category, category}, query when is_binary(category) ->
         where(query, [m], m.category == ^category)
+
+      {:exclude_categories, []}, query ->
+        query
+
+      {:exclude_categories, categories}, query when is_list(categories) ->
+        names = Enum.map(categories, &to_string/1)
+        # `category` is nullable and SQL evaluates NULL NOT IN (...) to NULL,
+        # which drops the row. An item that has not been classified yet must
+        # stay on the page it is already on, so keep NULLs explicitly.
+        where(query, [m], is_nil(m.category) or m.category not in ^names)
 
       {:library_path_type, library_type}, query ->
         filter_by_library_path_type(query, library_type)

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -832,6 +832,19 @@ defmodule Mydia.Media do
   end
 
   @doc """
+  Returns the count of media items matching the given filter options.
+
+  Accepts the same options as `list_media_items/1`, but aggregates in the
+  database instead of loading rows.
+  """
+  @spec count_media_items(keyword()) :: non_neg_integer()
+  def count_media_items(opts \\ []) do
+    (opts[:base_query] || MediaItem)
+    |> apply_media_item_filters(opts)
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
   Returns the count of movies in the library.
 
   ## Options
@@ -839,10 +852,7 @@ defmodule Mydia.Media do
   """
   @spec count_movies(keyword()) :: non_neg_integer()
   def count_movies(opts \\ []) do
-    MediaItem
-    |> where([m], m.type == "movie")
-    |> apply_media_item_filters(Keyword.take(opts, [:exclude_categories]))
-    |> Repo.aggregate(:count)
+    count_media_items(Keyword.merge(Keyword.take(opts, [:exclude_categories]), type: "movie"))
   end
 
   @doc """
@@ -853,10 +863,7 @@ defmodule Mydia.Media do
   """
   @spec count_tv_shows(keyword()) :: non_neg_integer()
   def count_tv_shows(opts \\ []) do
-    MediaItem
-    |> where([m], m.type == "tv_show")
-    |> apply_media_item_filters(Keyword.take(opts, [:exclude_categories]))
-    |> Repo.aggregate(:count)
+    count_media_items(Keyword.merge(Keyword.take(opts, [:exclude_categories]), type: "tv_show"))
   end
 
   @doc """

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -23,6 +23,7 @@ defmodule Mydia.Media do
     - `:monitored` - Filter by monitored status (true/false)
     - `:category` - Filter by category (atom or string, e.g., :anime_movie or "anime_movie")
     - `:exclude_categories` - Drop these categories from the result (list of atoms or strings)
+    - `:category_in` - Keep only these categories in the result (list of atoms or strings)
     - `:base_query` - Ecto query to start from instead of the full MediaItem table
     - `:library_path_type` - Filter by library path type (:movies, :series, etc.)
     - `:search` - Search by title (case-insensitive substring match)

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -2187,6 +2187,13 @@ defmodule Mydia.Media do
       {:has_files, true}, query ->
         filter_by_has_files(query)
 
+      {:category_in, []}, query ->
+        query
+
+      {:category_in, categories}, query when is_list(categories) ->
+        names = Enum.map(categories, &to_string/1)
+        where(query, [m], m.category in ^names)
+
       _other, query ->
         query
     end)

--- a/lib/mydia/media/README.md
+++ b/lib/mydia/media/README.md
@@ -437,3 +437,23 @@ multi-member promotion success unpinned until `32820f75c` added a regression.
 When touching promotion locking, ownership transactions, or anything under
 `DB.postgres?()` / `DB.sqlite?()`, run the PostgreSQL suite before claiming done.
 A local PostgreSQL is available via devenv.
+
+## :exclude_categories keeps NULL rows on purpose
+
+`Media.list_media_items/1` and `Media.count_media_items/1` accept
+`:exclude_categories`, used by the Movies and TV pages to hide categories that
+an exclusive sidebar section has claimed for itself. The clause in
+`apply_media_item_filters/2` is `is_nil(m.category) or m.category not in
+^names`, which keeps rows whose `category` is NULL. That is deliberate: SQL
+evaluates `NULL NOT IN ('anime_series')` to NULL, and a NULL `WHERE` condition
+drops the row, which would silently remove every item that has not been
+classified yet from the page it already belongs on.
+
+`count_media_items/1` is a database aggregate (`Repo.aggregate(:count)`), and
+`count_movies/1` and `count_tv_shows/1` both delegate to it, forwarding only
+`:exclude_categories` alongside their own fixed `:type`. The sidebar's movie
+and TV badge counts are computed the same way, once per LiveView mount, by the
+`:load_navigation_data` hook in `lib/mydia_web/live/user_auth.ex`, from the
+same `Collections.claimed_categories/1` result the Movies and TV pages use.
+The badge and the page it links to therefore share one exclusion set and
+cannot disagree.

--- a/lib/mydia_web/components/README.md
+++ b/lib/mydia_web/components/README.md
@@ -257,3 +257,29 @@ Copy `admin_library_paths_live/` for the smallest complete example, or
 (`download_client_modal`). Env-sourced fields (`Settings.runtime_config?/1`)
 render read-only with an ENV lock badge and disabled Edit and Delete. Singletons
 such as FlareSolverr use one row plus Edit, with no add or delete.
+
+## Sidebar sections are pinned collections, and exclusion is page scoped
+
+A section is a `Mydia.Collections.Collection` with `pinned_position` set. It
+renders in the sidebar between TV Shows and the Management group and links to
+`/sections/:id`, which is `MediaLive.Index` in its `:section` live action,
+with the collection's smart rules supplying `:base_query`.
+
+Pins are owner scoped. `Collections.list_pinned_sections/1` filters on
+`c.user_id == ^user.id`, so a shared collection pinned by its owner never
+shows up in anyone else's sidebar. A section can therefore never become a
+fixed section for the whole instance, only a per-user shortcut.
+
+A section marked `exclusive` claims its categories away from `/movies` and
+`/tv`, but only for its owner. Only a single `category in [...]` condition
+qualifies (`Collections.exclusive_eligible?/1`), because a richer rule set
+cannot be cleanly subtracted from those pages. The claimed list is derived
+from the rules on every read by `Collections.claimed_categories/1`, never
+stored, and returns `[]` for anything it cannot parse: malformed JSON, or
+rules that are not exactly one `category in [...]` condition.
+
+The exclusion is applied only on the built-in Movies and TV pages, never on a
+section's own page. `MediaLive.Index.build_query_opts/1` passes
+`:exclude_categories` only when `assigns[:section]` is `nil`. A section's own
+query already filters to `category in [...]`, so subtracting the same
+categories again there would empty the section out.

--- a/lib/mydia_web/components/layouts.ex
+++ b/lib/mydia_web/components/layouts.ex
@@ -167,13 +167,13 @@ defmodule MydiaWeb.Layouts do
                   class={nav_active?(@current_path, "/movies", false) && "active"}
                 >
                   <.icon name="hero-film" class="w-5 h-5" /> Movies
-                  <span class="badge badge-sm">{@movie_count}</span>
+                  <span id="nav-movie-count" class="badge badge-sm">{@movie_count}</span>
                 </.link>
               </li>
               <li>
                 <.link navigate="/tv" class={nav_active?(@current_path, "/tv", false) && "active"}>
                   <.icon name="hero-tv" class="w-5 h-5" /> TV Shows
-                  <span class="badge badge-sm">{@tv_show_count}</span>
+                  <span id="nav-tv-count" class="badge badge-sm">{@tv_show_count}</span>
                 </.link>
               </li>
               <li class="menu-title mt-4">

--- a/lib/mydia_web/components/layouts.ex
+++ b/lib/mydia_web/components/layouts.ex
@@ -40,6 +40,7 @@ defmodule MydiaWeb.Layouts do
   attr :current_user, :map, default: nil, doc: "the currently authenticated user"
   attr :movie_count, :integer, default: 0, doc: "number of movies in library"
   attr :tv_show_count, :integer, default: 0, doc: "number of TV shows in library"
+  attr :sections, :list, default: [], doc: "collections the user pinned to the sidebar"
   attr :downloads_count, :integer, default: 0, doc: "number of active downloads"
   attr :pending_requests_count, :integer, default: 0, doc: "number of pending requests"
 
@@ -174,6 +175,25 @@ defmodule MydiaWeb.Layouts do
                 <.link navigate="/tv" class={nav_active?(@current_path, "/tv", false) && "active"}>
                   <.icon name="hero-tv" class="w-5 h-5" /> TV Shows
                   <span id="nav-tv-count" class="badge badge-sm">{@tv_show_count}</span>
+                </.link>
+              </li>
+              <li :for={section <- @sections}>
+                <.link
+                  id={"nav-section-#{section.id}"}
+                  navigate={~p"/sections/#{section.id}"}
+                  class={nav_active?(@current_path, "/sections/#{section.id}", false) && "active"}
+                >
+                  <.icon name={section.sidebar_icon || "hero-squares-2x2"} class="w-5 h-5" />
+                  {section.name}
+                </.link>
+              </li>
+              <li>
+                <.link
+                  id="nav-add-section"
+                  navigate={~p"/sections/new"}
+                  class="text-base-content/60 hover:text-base-content"
+                >
+                  <.icon name="hero-plus" class="w-5 h-5" /> Add section
                 </.link>
               </li>
               <li class="menu-title mt-4">

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -438,15 +438,18 @@ defmodule MydiaWeb.LibraryComponents do
 
   ## Attributes
 
+    * `:id` - Optional DOM id for the toggle button.
     * `:selection_mode` - Whether selection mode is active.
     * `:selected_count` - Number of selected items.
   """
+  attr :id, :string, default: nil
   attr :selection_mode, :boolean, required: true
   attr :selected_count, :integer, required: true
 
   def selection_controls(assigns) do
     ~H"""
     <button
+      id={@id}
       type="button"
       class={["btn btn-sm gap-1", @selection_mode && "btn-active"]}
       phx-click="toggle_selection_mode"

--- a/lib/mydia_web/live/collection_live/show.ex
+++ b/lib/mydia_web/live/collection_live/show.ex
@@ -192,6 +192,28 @@ defmodule MydiaWeb.CollectionLive.Show do
                 <.icon name="hero-funnel" class="w-4 h-4" /> Edit Rules
               </button>
             <% end %>
+            <%!-- Pin/unpin as a sidebar section: owned, smart, non-system collections only --%>
+            <%= if can_pin?(@collection, @current_user) do %>
+              <%= if @collection.pinned_position do %>
+                <button
+                  id="unpin-collection"
+                  type="button"
+                  class="btn btn-ghost btn-sm gap-1"
+                  phx-click="unpin_collection"
+                >
+                  <.icon name="hero-bookmark-slash" class="w-4 h-4" /> Unpin from sidebar
+                </button>
+              <% else %>
+                <button
+                  id="pin-collection"
+                  type="button"
+                  class="btn btn-outline btn-primary btn-sm gap-1"
+                  phx-click="pin_collection"
+                >
+                  <.icon name="hero-bookmark" class="w-4 h-4" /> Pin to sidebar
+                </button>
+              <% end %>
+            <% end %>
             <%!-- Settings dropdown for non-system collections --%>
             <%= if not @collection.is_system and can_edit?(@collection, @current_user) do %>
               <div class="dropdown dropdown-end">
@@ -759,6 +781,38 @@ defmodule MydiaWeb.CollectionLive.Show do
     end
   end
 
+  def handle_event("pin_collection", _params, socket) do
+    collection = socket.assigns.collection
+    user = socket.assigns.current_user
+
+    case Collections.pin_section(user, collection) do
+      {:ok, pinned} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Pinned to sidebar")
+         |> push_navigate(to: ~p"/sections/#{pinned.id}")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, pin_error_message(reason))}
+    end
+  end
+
+  def handle_event("unpin_collection", _params, socket) do
+    collection = socket.assigns.collection
+    user = socket.assigns.current_user
+
+    case Collections.unpin_section(user, collection) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> assign(:collection, updated)
+         |> put_flash(:info, "Removed from sidebar")}
+
+      {:error, reason} ->
+        {:noreply, put_flash(socket, :error, pin_error_message(reason))}
+    end
+  end
+
   # Add Items Modal handlers
 
   def handle_event("open_add_items_modal", _params, socket) do
@@ -1114,6 +1168,26 @@ defmodule MydiaWeb.CollectionLive.Show do
   defp can_edit?(%Collection{user_id: user_id}, %{id: current_user_id}) do
     user_id == current_user_id
   end
+
+  # A collection can be pinned to the sidebar only when it is owned, smart
+  # (a manual collection has no rules to scope a section query), and not a
+  # system collection (Favorites cannot be repurposed as a section).
+  defp can_pin?(%Collection{type: "smart", is_system: false} = collection, user) do
+    can_edit?(collection, user)
+  end
+
+  defp can_pin?(_collection, _user), do: false
+
+  defp pin_error_message(:not_smart),
+    do: "Only smart collections can be pinned to the sidebar"
+
+  defp pin_error_message(:unauthorized),
+    do: "You don't have permission to pin this collection"
+
+  defp pin_error_message(:system_collection),
+    do: "System collections cannot be pinned to the sidebar"
+
+  defp pin_error_message(%Ecto.Changeset{} = changeset), do: extract_changeset_error(changeset)
 
   defp type_badge_class("smart"), do: "badge-secondary"
   defp type_badge_class("manual"), do: "badge-primary"

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -78,9 +78,14 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   defp load_dashboard_data(socket) do
-    # Load basic stats
-    movie_count = Media.count_movies()
-    tv_show_count = Media.count_tv_shows()
+    # Load basic stats. The nav hook (MydiaWeb.Live.UserAuth.on_mount
+    # :load_navigation_data) runs before mount/3 and already assigns
+    # :excluded_categories, so reuse it here rather than recomputing it. This
+    # keeps the dashboard's :movie_count / :tv_show_count assigns in sync with
+    # the sidebar badges, which the same assign keys drive in Layouts.app.
+    excluded_categories = socket.assigns[:excluded_categories] || []
+    movie_count = Media.count_movies(exclude_categories: excluded_categories)
+    tv_show_count = Media.count_tv_shows(exclude_categories: excluded_categories)
     active_downloads_count = Downloads.count_active_downloads()
     total_storage = Library.total_storage_bytes() |> format_bytes()
 

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.MediaLive.Index do
   alias Mydia.Metadata.Structs.MediaMetadata
   alias Mydia.Settings
   alias Mydia.Collections
+  alias Mydia.Collections.SmartRules
   alias Mydia.Downloads.DownloadService
   alias Mydia.Search
   alias MydiaWeb.Live.Authorization
@@ -48,6 +49,9 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:scanning, false)
      |> assign(:scan_result, nil)
      |> assign(:scan_progress, nil)
+     |> assign(:section, nil)
+     |> assign(:section_query, nil)
+     |> assign(:section_error, false)
      |> assign(:show_add_to_collection_modal, false)
      |> assign(:user_collections, [])
      |> assign(:all_visible_ids, MapSet.new())
@@ -71,6 +75,46 @@ defmodule MydiaWeb.MediaLive.Index do
     |> assign(:page_title, "TV Shows")
     |> assign(:filter_type, "tv_show")
     |> load_media_items(reset: true)
+  end
+
+  defp apply_action(socket, :section, %{"id" => id}) do
+    case Collections.get_collection(socket.assigns.current_user, id) do
+      nil ->
+        socket
+        |> put_flash(:error, "That section is no longer available.")
+        |> push_navigate(to: ~p"/")
+
+      collection ->
+        socket
+        |> assign(:page_title, collection.name)
+        # mount/3 does not assign :filter_type; only :movies and :tv_shows do.
+        # The library scan handlers read it unguarded, and their existing
+        # {nil, _} clause is the right behaviour for a section.
+        |> assign(:filter_type, nil)
+        |> assign(:section, collection)
+        |> load_section(collection)
+    end
+  end
+
+  defp load_section(socket, collection) do
+    case SmartRules.query(collection.smart_rules || "{}") do
+      {:ok, query} ->
+        socket
+        |> assign(:section_query, query)
+        |> assign(:section_error, false)
+        |> load_media_items(reset: true)
+
+      {:error, reason} ->
+        Logger.warning("Section #{collection.id} has unusable rules: #{inspect(reason)}")
+
+        socket
+        |> assign(:section_query, nil)
+        |> assign(:section_error, true)
+        |> assign(:media_items_empty?, true)
+        |> assign(:all_visible_ids, MapSet.new())
+        |> assign(:has_more, false)
+        |> stream(:media_items, [], reset: true)
+    end
   end
 
   @impl true
@@ -733,6 +777,7 @@ defmodule MydiaWeb.MediaLive.Index do
     active_files_query = Mydia.Library.MediaFile.versions()
 
     []
+    |> maybe_add_filter(:base_query, assigns[:section_query])
     |> maybe_add_filter(:type, assigns.filter_type)
     |> maybe_add_filter(:monitored, assigns.filter_monitored)
     |> Keyword.put(:preload, [
@@ -743,6 +788,7 @@ defmodule MydiaWeb.MediaLive.Index do
     ])
   end
 
+  defp maybe_add_filter(opts, _key, []), do: opts
   defp maybe_add_filter(opts, _key, nil), do: opts
   defp maybe_add_filter(opts, key, value), do: Keyword.put(opts, key, value)
 

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -126,7 +126,7 @@ defmodule MydiaWeb.MediaLive.Index do
         0
 
       categories ->
-        length(Media.list_media_items(type: type, category_in: categories))
+        Media.count_media_items(type: type, category_in: categories)
     end
   end
 

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -6,6 +6,7 @@ defmodule MydiaWeb.MediaLive.Index do
   alias Mydia.Metadata.Structs.MediaMetadata
   alias Mydia.Settings
   alias Mydia.Collections
+  alias Mydia.Collections.Collection
   alias Mydia.Collections.SmartRules
   alias Mydia.Downloads.DownloadService
   alias Mydia.Search
@@ -98,12 +99,7 @@ defmodule MydiaWeb.MediaLive.Index do
 
   defp apply_action(socket, :section, %{"id" => id}) do
     case Collections.get_collection(socket.assigns.current_user, id) do
-      nil ->
-        socket
-        |> put_flash(:error, "That section is no longer available.")
-        |> push_navigate(to: ~p"/")
-
-      collection ->
+      %Collection{type: "smart"} = collection ->
         socket
         |> assign(:page_title, collection.name)
         # mount/3 does not assign :filter_type; only :movies and :tv_shows do.
@@ -113,6 +109,11 @@ defmodule MydiaWeb.MediaLive.Index do
         |> assign(:section, collection)
         |> assign(:section_owned?, collection.user_id == socket.assigns.current_user.id)
         |> load_section(collection)
+
+      _not_found_or_not_smart ->
+        socket
+        |> put_flash(:error, "That section is no longer available.")
+        |> push_navigate(to: ~p"/")
     end
   end
 

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -56,9 +56,11 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:scan_result, nil)
      |> assign(:scan_progress, nil)
      |> assign(:section, nil)
+     |> assign(:section_owned?, false)
      |> assign(:section_query, nil)
      |> assign(:section_error, false)
      |> assign(:excluded_count, 0)
+     |> assign(:claiming_sections, [])
      |> assign(:show_section_settings, false)
      |> assign(:section_form, nil)
      |> assign(:section_exclusive_eligible, false)
@@ -79,6 +81,7 @@ defmodule MydiaWeb.MediaLive.Index do
     |> assign(:page_title, "Movies")
     |> assign(:filter_type, "movie")
     |> assign(:excluded_count, excluded_count(socket, "movie"))
+    |> assign(:claiming_sections, claiming_sections(socket))
     |> assign(:show_anime_nudge, anime_nudge?(socket))
     |> load_media_items(reset: true)
   end
@@ -88,6 +91,7 @@ defmodule MydiaWeb.MediaLive.Index do
     |> assign(:page_title, "TV Shows")
     |> assign(:filter_type, "tv_show")
     |> assign(:excluded_count, excluded_count(socket, "tv_show"))
+    |> assign(:claiming_sections, claiming_sections(socket))
     |> assign(:show_anime_nudge, anime_nudge?(socket))
     |> load_media_items(reset: true)
   end
@@ -107,6 +111,7 @@ defmodule MydiaWeb.MediaLive.Index do
         # {nil, _} clause is the right behaviour for a section.
         |> assign(:filter_type, nil)
         |> assign(:section, collection)
+        |> assign(:section_owned?, collection.user_id == socket.assigns.current_user.id)
         |> load_section(collection)
     end
   end
@@ -151,6 +156,14 @@ defmodule MydiaWeb.MediaLive.Index do
       categories ->
         Media.count_media_items(type: type, category_in: categories)
     end
+  end
+
+  # The sections claiming categories away from this page, so the excluded
+  # items notice can name the one responsible instead of staying anonymous.
+  # `@sections` is already the current user's own pinned sections (the nav
+  # hook scopes it that way), so filtering it is enough without another query.
+  defp claiming_sections(socket) do
+    Enum.filter(socket.assigns[:sections] || [], & &1.exclusive)
   end
 
   @impl true
@@ -630,23 +643,23 @@ defmodule MydiaWeb.MediaLive.Index do
   end
 
   def handle_event("open_section_settings", _params, socket) do
-    section = socket.assigns.section
-
-    {:noreply,
-     socket
-     |> assign(:show_section_settings, true)
-     |> assign(:section_exclusive_eligible, Collections.exclusive_eligible?(section))
-     |> assign(
-       :section_form,
-       to_form(
-         %{
-           "name" => section.name,
-           "sidebar_icon" => section.sidebar_icon,
-           "exclusive" => section.exclusive
-         },
-         as: :section
-       )
-     )}
+    with_section(socket, fn section ->
+      {:noreply,
+       socket
+       |> assign(:show_section_settings, true)
+       |> assign(:section_exclusive_eligible, Collections.exclusive_eligible?(section))
+       |> assign(
+         :section_form,
+         to_form(
+           %{
+             "name" => section.name,
+             "sidebar_icon" => section.sidebar_icon,
+             "exclusive" => section.exclusive
+           },
+           as: :section
+         )
+       )}
+    end)
   end
 
   def handle_event("close_section_settings", _params, socket) do
@@ -654,43 +667,46 @@ defmodule MydiaWeb.MediaLive.Index do
   end
 
   def handle_event("save_section", %{"section" => params}, socket) do
-    user = socket.assigns.current_user
-    section = socket.assigns.section
+    with_section(socket, fn section ->
+      user = socket.assigns.current_user
 
-    attrs = %{
-      name: params["name"],
-      sidebar_icon: params["sidebar_icon"],
-      exclusive: params["exclusive"] == "true" and Collections.exclusive_eligible?(section)
-    }
+      attrs = %{
+        name: params["name"],
+        sidebar_icon: params["sidebar_icon"],
+        exclusive: params["exclusive"] == "true" and Collections.exclusive_eligible?(section)
+      }
 
-    case Collections.update_collection(user, section, attrs) do
-      {:ok, updated} ->
-        {:noreply,
-         socket
-         |> assign(:section, updated)
-         |> assign(:page_title, updated.name)
-         |> assign(:show_section_settings, false)
-         |> assign(:excluded_categories, Collections.claimed_categories(user))
-         |> put_flash(:info, "Section updated")}
+      case Collections.update_collection(user, section, attrs) do
+        {:ok, updated} ->
+          {:noreply,
+           socket
+           |> assign(:section, updated)
+           |> assign(:page_title, updated.name)
+           |> assign(:show_section_settings, false)
+           |> assign(:excluded_categories, Collections.claimed_categories(user))
+           |> put_flash(:info, "Section updated")}
 
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Could not update the section")}
-    end
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Could not update the section")}
+      end
+    end)
   end
 
   def handle_event("unpin_section", _params, socket) do
-    user = socket.assigns.current_user
+    with_section(socket, fn section ->
+      user = socket.assigns.current_user
 
-    case Collections.unpin_section(user, socket.assigns.section) do
-      {:ok, _collection} ->
-        {:noreply,
-         socket
-         |> put_flash(:info, "Section removed from the sidebar")
-         |> push_navigate(to: ~p"/tv")}
+      case Collections.unpin_section(user, section) do
+        {:ok, _collection} ->
+          {:noreply,
+           socket
+           |> put_flash(:info, "Section removed from the sidebar")
+           |> push_navigate(to: ~p"/tv")}
 
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Could not remove the section")}
-    end
+        {:error, _changeset} ->
+          {:noreply, put_flash(socket, :error, "Could not remove the section")}
+      end
+    end)
   end
 
   def handle_event("dismiss_anime_nudge", _params, socket) do
@@ -814,6 +830,16 @@ defmodule MydiaWeb.MediaLive.Index do
 
     Logger.warning("Unhandled message in MediaLive.Index: #{inspect(msg)}")
     {:noreply, socket}
+  end
+
+  # Guards event handlers that only make sense on a section page. A
+  # hand-crafted client event fired from /movies or /tv, where @section is
+  # nil, would otherwise crash the socket instead of being a no-op.
+  defp with_section(socket, fun) do
+    case socket.assigns.section do
+      nil -> {:noreply, socket}
+      section -> fun.(section)
+    end
   end
 
   defp run_batch_auto_search(socket) do

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -1,5 +1,6 @@
 defmodule MydiaWeb.MediaLive.Index do
   use MydiaWeb, :live_view
+  alias Mydia.Accounts
   alias Mydia.Media
   alias Mydia.Media.AvailabilityStatus
   alias Mydia.Metadata.Structs.MediaMetadata
@@ -20,6 +21,10 @@ defmodule MydiaWeb.MediaLive.Index do
   @items_per_page 50
   @items_per_scroll 25
   @auto_search_confirm_threshold 50
+
+  # Ten is enough anime to be a nuisance in a mixed list and few enough that a
+  # library with a handful of stray titles is left alone.
+  @anime_nudge_threshold 10
 
   @impl true
   def mount(_params, _session, socket) do
@@ -57,6 +62,7 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:show_section_settings, false)
      |> assign(:section_form, nil)
      |> assign(:section_exclusive_eligible, false)
+     |> assign(:show_anime_nudge, false)
      |> assign(:show_add_to_collection_modal, false)
      |> assign(:user_collections, [])
      |> assign(:all_visible_ids, MapSet.new())
@@ -73,6 +79,7 @@ defmodule MydiaWeb.MediaLive.Index do
     |> assign(:page_title, "Movies")
     |> assign(:filter_type, "movie")
     |> assign(:excluded_count, excluded_count(socket, "movie"))
+    |> assign(:show_anime_nudge, anime_nudge?(socket))
     |> load_media_items(reset: true)
   end
 
@@ -81,6 +88,7 @@ defmodule MydiaWeb.MediaLive.Index do
     |> assign(:page_title, "TV Shows")
     |> assign(:filter_type, "tv_show")
     |> assign(:excluded_count, excluded_count(socket, "tv_show"))
+    |> assign(:show_anime_nudge, anime_nudge?(socket))
     |> load_media_items(reset: true)
   end
 
@@ -121,6 +129,17 @@ defmodule MydiaWeb.MediaLive.Index do
         |> assign(:all_visible_ids, MapSet.new())
         |> assign(:has_more, false)
         |> stream(:media_items, [], reset: true)
+    end
+  end
+
+  defp anime_nudge?(socket) do
+    user = socket.assigns.current_user
+    anime = Enum.map(Mydia.Media.MediaCategory.anime_categories(), &Atom.to_string/1)
+
+    cond do
+      Enum.any?(anime, &(&1 in (socket.assigns[:excluded_categories] || []))) -> false
+      Accounts.anime_nudge_dismissed?(user) -> false
+      true -> Media.count_media_items(category_in: anime) >= @anime_nudge_threshold
     end
   end
 
@@ -671,6 +690,34 @@ defmodule MydiaWeb.MediaLive.Index do
 
       {:error, _changeset} ->
         {:noreply, put_flash(socket, :error, "Could not remove the section")}
+    end
+  end
+
+  def handle_event("dismiss_anime_nudge", _params, socket) do
+    Accounts.dismiss_anime_nudge(socket.assigns.current_user)
+    {:noreply, assign(socket, :show_anime_nudge, false)}
+  end
+
+  def handle_event("accept_anime_nudge", _params, socket) do
+    user = socket.assigns.current_user
+    preset = Mydia.Collections.SectionPresets.get("anime")
+
+    with {:ok, collection} <-
+           Collections.create_collection(user, %{
+             name: preset.name,
+             type: "smart",
+             visibility: "private",
+             smart_rules: Jason.encode!(preset.rules)
+           }),
+         {:ok, pinned} <-
+           Collections.pin_section(user, collection,
+             sidebar_icon: preset.icon,
+             exclusive: preset.exclusive
+           ) do
+      {:noreply, push_navigate(socket, to: ~p"/sections/#{pinned.id}")}
+    else
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not create the Anime section")}
     end
   end
 

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -52,6 +52,7 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:section, nil)
      |> assign(:section_query, nil)
      |> assign(:section_error, false)
+     |> assign(:excluded_count, 0)
      |> assign(:show_add_to_collection_modal, false)
      |> assign(:user_collections, [])
      |> assign(:all_visible_ids, MapSet.new())
@@ -67,6 +68,7 @@ defmodule MydiaWeb.MediaLive.Index do
     socket
     |> assign(:page_title, "Movies")
     |> assign(:filter_type, "movie")
+    |> assign(:excluded_count, excluded_count(socket, "movie"))
     |> load_media_items(reset: true)
   end
 
@@ -74,6 +76,7 @@ defmodule MydiaWeb.MediaLive.Index do
     socket
     |> assign(:page_title, "TV Shows")
     |> assign(:filter_type, "tv_show")
+    |> assign(:excluded_count, excluded_count(socket, "tv_show"))
     |> load_media_items(reset: true)
   end
 
@@ -114,6 +117,16 @@ defmodule MydiaWeb.MediaLive.Index do
         |> assign(:all_visible_ids, MapSet.new())
         |> assign(:has_more, false)
         |> stream(:media_items, [], reset: true)
+    end
+  end
+
+  defp excluded_count(socket, type) do
+    case socket.assigns[:excluded_categories] || [] do
+      [] ->
+        0
+
+      categories ->
+        length(Media.list_media_items(type: type, category_in: categories))
     end
   end
 
@@ -778,6 +791,14 @@ defmodule MydiaWeb.MediaLive.Index do
 
     []
     |> maybe_add_filter(:base_query, assigns[:section_query])
+    # A section's own base_query already selects its claimed categories, so
+    # excluding those same categories here would contradict it and empty the
+    # section out. The exclusion only makes sense off of section pages, where
+    # it is what removes claimed items from the built-in Movies/TV listings.
+    |> maybe_add_filter(
+      :exclude_categories,
+      if(is_nil(assigns[:section]), do: assigns[:excluded_categories], else: [])
+    )
     |> maybe_add_filter(:type, assigns.filter_type)
     |> maybe_add_filter(:monitored, assigns.filter_monitored)
     |> Keyword.put(:preload, [

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -13,6 +13,7 @@ defmodule MydiaWeb.MediaLive.Index do
   alias MydiaWeb.MediaLive.Show.Helpers, as: MediaFileHelpers
 
   import MydiaWeb.GridDensityComponents
+  import MydiaWeb.MediaLive.Index.SectionComponents
 
   require Logger
 
@@ -53,6 +54,9 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:section_query, nil)
      |> assign(:section_error, false)
      |> assign(:excluded_count, 0)
+     |> assign(:show_section_settings, false)
+     |> assign(:section_form, nil)
+     |> assign(:section_exclusive_eligible, false)
      |> assign(:show_add_to_collection_modal, false)
      |> assign(:user_collections, [])
      |> assign(:all_visible_ids, MapSet.new())
@@ -603,6 +607,70 @@ defmodule MydiaWeb.MediaLive.Index do
 
       {:error, _reason} ->
         {:noreply, put_flash(socket, :error, "Failed to start library scan")}
+    end
+  end
+
+  def handle_event("open_section_settings", _params, socket) do
+    section = socket.assigns.section
+
+    {:noreply,
+     socket
+     |> assign(:show_section_settings, true)
+     |> assign(:section_exclusive_eligible, Collections.exclusive_eligible?(section))
+     |> assign(
+       :section_form,
+       to_form(
+         %{
+           "name" => section.name,
+           "sidebar_icon" => section.sidebar_icon,
+           "exclusive" => section.exclusive
+         },
+         as: :section
+       )
+     )}
+  end
+
+  def handle_event("close_section_settings", _params, socket) do
+    {:noreply, assign(socket, :show_section_settings, false)}
+  end
+
+  def handle_event("save_section", %{"section" => params}, socket) do
+    user = socket.assigns.current_user
+    section = socket.assigns.section
+
+    attrs = %{
+      name: params["name"],
+      sidebar_icon: params["sidebar_icon"],
+      exclusive: params["exclusive"] == "true" and Collections.exclusive_eligible?(section)
+    }
+
+    case Collections.update_collection(user, section, attrs) do
+      {:ok, updated} ->
+        {:noreply,
+         socket
+         |> assign(:section, updated)
+         |> assign(:page_title, updated.name)
+         |> assign(:show_section_settings, false)
+         |> assign(:excluded_categories, Collections.claimed_categories(user))
+         |> put_flash(:info, "Section updated")}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not update the section")}
+    end
+  end
+
+  def handle_event("unpin_section", _params, socket) do
+    user = socket.assigns.current_user
+
+    case Collections.unpin_section(user, socket.assigns.section) do
+      {:ok, _collection} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Section removed from the sidebar")
+         |> push_navigate(to: ~p"/tv")}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not remove the section")}
     end
   end
 

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -3,19 +3,42 @@
     <%!-- Header with title and view controls --%>
     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3 md:gap-4 mb-4 md:mb-6">
       <div>
-        <h1 class="text-3xl font-bold">{@page_title}</h1>
+        <div class="flex items-center gap-3">
+          <.icon
+            :if={@section && @section.sidebar_icon}
+            name={@section.sidebar_icon}
+            class="w-7 h-7 text-primary"
+          />
+          <h1 id="section-heading" class="text-3xl font-bold">{@page_title}</h1>
+        </div>
         <p class="text-base-content/70 mt-1">
           Browse and manage your media library
         </p>
+
+        <div :if={@section_error} id="section-rules-error" class="alert alert-warning mt-3">
+          <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
+          <span>
+            This section's rules can't be read, so it has nothing to show. Edit the collection to fix them.
+          </span>
+          <.link navigate={~p"/collections/#{@section.id}"} class="btn btn-sm">Edit rules</.link>
+        </div>
       </div>
 
       <%!-- Actions and view controls --%>
       <div class="flex flex-wrap items-center gap-2">
         <%!-- Selection controls --%>
-        <.selection_controls
-          selection_mode={@selection_mode}
-          selected_count={MapSet.size(@selected_ids)}
-        />
+        <button
+          id="toggle-selection-mode"
+          type="button"
+          class={["btn btn-sm gap-1", @selection_mode && "btn-active"]}
+          phx-click="toggle_selection_mode"
+          title={if @selection_mode, do: "Exit selection mode", else: "Enter selection mode"}
+        >
+          <.icon name="hero-check-circle" class="w-4 h-4" />
+          <span class="hidden sm:inline">
+            {if @selection_mode, do: "Selecting", else: "Select"}
+          </span>
+        </button>
 
         <%!-- Re-scan button (shown on Movies and TV Shows pages) --%>
         <%= if @filter_type in ["movie", "tv_show"] do %>
@@ -555,6 +578,7 @@
               title={if all_selected, do: "Deselect all", else: "Select all"}
             >
               <input
+                id="select-all"
                 type="checkbox"
                 class="checkbox checkbox-sm checkbox-primary"
                 checked={all_selected}
@@ -589,6 +613,7 @@
 
               <div class="tooltip tooltip-top" data-tip="Monitor">
                 <button
+                  id="batch-monitor"
                   type="button"
                   class={["btn btn-sm btn-ghost btn-square", !has_selection && "btn-disabled"]}
                   phx-click="batch_monitor"
@@ -600,6 +625,7 @@
 
               <div class="tooltip tooltip-top" data-tip="Unmonitor">
                 <button
+                  id="batch-unmonitor"
                   type="button"
                   class={["btn btn-sm btn-ghost btn-square", !has_selection && "btn-disabled"]}
                   phx-click="batch_unmonitor"

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -27,18 +27,11 @@
       <%!-- Actions and view controls --%>
       <div class="flex flex-wrap items-center gap-2">
         <%!-- Selection controls --%>
-        <button
+        <.selection_controls
           id="toggle-selection-mode"
-          type="button"
-          class={["btn btn-sm gap-1", @selection_mode && "btn-active"]}
-          phx-click="toggle_selection_mode"
-          title={if @selection_mode, do: "Exit selection mode", else: "Enter selection mode"}
-        >
-          <.icon name="hero-check-circle" class="w-4 h-4" />
-          <span class="hidden sm:inline">
-            {if @selection_mode, do: "Selecting", else: "Select"}
-          </span>
-        </button>
+          selection_mode={@selection_mode}
+          selected_count={MapSet.size(@selected_ids)}
+        />
 
         <%!-- Re-scan button (shown on Movies and TV Shows pages) --%>
         <%= if @filter_type in ["movie", "tv_show"] do %>

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -33,9 +33,9 @@
           selected_count={MapSet.size(@selected_ids)}
         />
 
-        <%!-- Section settings (shown on section pages only) --%>
+        <%!-- Section settings (shown on section pages the current user owns) --%>
         <button
-          :if={@section}
+          :if={@section && @section_owned?}
           id="open-section-settings"
           type="button"
           phx-click="open_section_settings"
@@ -267,7 +267,14 @@
     >
       <.icon name="hero-information-circle" class="w-5 h-5" />
       <span>
-        {@excluded_count} {if(@excluded_count == 1, do: "item is", else: "items are")} in your pinned sections.
+        <%= case @claiming_sections do %>
+          <% [section] -> %>
+            {@excluded_count} {if(@excluded_count == 1, do: "item is", else: "items are")} in your
+            <.link navigate={~p"/sections/#{section.id}"} class="link link-primary font-semibold">{section.name}</.link>
+            section.
+          <% _ -> %>
+            {@excluded_count} {if(@excluded_count == 1, do: "item is", else: "items are")} in your pinned sections.
+        <% end %>
       </span>
     </div>
 

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -33,6 +33,18 @@
           selected_count={MapSet.size(@selected_ids)}
         />
 
+        <%!-- Section settings (shown on section pages only) --%>
+        <button
+          :if={@section}
+          id="open-section-settings"
+          type="button"
+          phx-click="open_section_settings"
+          class="btn btn-ghost btn-sm btn-circle"
+          aria-label="Section settings"
+        >
+          <.icon name="hero-cog-6-tooth" class="w-5 h-5" />
+        </button>
+
         <%!-- Re-scan button (shown on Movies and TV Shows pages) --%>
         <%= if @filter_type in ["movie", "tv_show"] do %>
           <button
@@ -108,6 +120,14 @@
         />
       </div>
     </div>
+
+    <.section_settings_modal
+      :if={@section && @section_form}
+      section={@section}
+      form={@section_form}
+      exclusive_eligible={@section_exclusive_eligible}
+      open={@show_section_settings}
+    />
 
     <%!-- Hidden debug info for tests --%>
     <div

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -237,6 +237,29 @@
       </.form>
     </div>
 
+    <div :if={@show_anime_nudge} id="anime-nudge" class="alert alert-info mb-4">
+      <.icon name="hero-sparkles" class="w-5 h-5" />
+      <span>
+        You have a fair bit of anime mixed in here. Want it in its own sidebar section?
+      </span>
+      <div class="flex gap-2">
+        <button
+          id="accept-anime-nudge"
+          phx-click="accept_anime_nudge"
+          class="btn btn-sm btn-primary"
+        >
+          Create Anime section
+        </button>
+        <button
+          id="dismiss-anime-nudge"
+          phx-click="dismiss_anime_nudge"
+          class="btn btn-sm btn-ghost"
+        >
+          No thanks
+        </button>
+      </div>
+    </div>
+
     <div
       :if={@excluded_count > 0 and is_nil(@section)}
       id="excluded-notice"

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -217,6 +217,17 @@
       </.form>
     </div>
 
+    <div
+      :if={@excluded_count > 0 and is_nil(@section)}
+      id="excluded-notice"
+      class="alert alert-info mb-4"
+    >
+      <.icon name="hero-information-circle" class="w-5 h-5" />
+      <span>
+        {@excluded_count} {if(@excluded_count == 1, do: "item is", else: "items are")} in your pinned sections.
+      </span>
+    </div>
+
     <%!-- Empty state (shown when no items) --%>
     <%= if @media_items_empty? do %>
       <div class="flex flex-col items-center justify-center py-16">

--- a/lib/mydia_web/live/media_live/index/section_components.ex
+++ b/lib/mydia_web/live/media_live/index/section_components.ex
@@ -1,0 +1,67 @@
+defmodule MydiaWeb.MediaLive.Index.SectionComponents do
+  @moduledoc """
+  Section-specific chrome for the media index. Used only by the sibling
+  LiveView, never imported globally.
+  """
+  use MydiaWeb, :html
+
+  alias Mydia.Collections.Collection
+
+  attr :section, :map, required: true
+  attr :form, :map, required: true
+  attr :exclusive_eligible, :boolean, required: true
+  attr :open, :boolean, default: false
+
+  def section_settings_modal(assigns) do
+    ~H"""
+    <div :if={@open} class="modal modal-open" id="section-settings-modal">
+      <div class="modal-box">
+        <h3 class="font-bold text-lg mb-4">Section settings</h3>
+
+        <.form for={@form} id="section-settings-form" phx-submit="save_section">
+          <.input field={@form[:name]} type="text" label="Name" />
+
+          <.input
+            field={@form[:sidebar_icon]}
+            type="select"
+            label="Icon"
+            options={Collection.valid_sidebar_icons()}
+          />
+
+          <div :if={@exclusive_eligible} class="form-control mt-4">
+            <label class="label cursor-pointer justify-start gap-3">
+              <input
+                id="section-exclusive-toggle"
+                type="checkbox"
+                name="section[exclusive]"
+                value="true"
+                checked={@form[:exclusive].value in [true, "true"]}
+                class="toggle toggle-primary"
+              />
+              <span class="label-text">
+                Keep these out of Movies and TV
+              </span>
+            </label>
+          </div>
+
+          <div class="modal-action">
+            <button
+              id="unpin-section"
+              type="button"
+              phx-click="unpin_section"
+              class="btn btn-ghost text-error"
+            >
+              Remove from sidebar
+            </button>
+            <button type="button" phx-click="close_section_settings" class="btn btn-ghost">
+              Cancel
+            </button>
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </.form>
+      </div>
+      <div class="modal-backdrop" phx-click="close_section_settings"></div>
+    </div>
+    """
+  end
+end

--- a/lib/mydia_web/live/section_live/new.ex
+++ b/lib/mydia_web/live/section_live/new.ex
@@ -1,0 +1,111 @@
+defmodule MydiaWeb.SectionLive.New do
+  @moduledoc """
+  Preset picker for adding a sidebar section.
+
+  This is a route rather than a modal in the layout because the layout is a
+  function component and cannot handle events.
+  """
+  use MydiaWeb, :live_view
+
+  alias Mydia.Collections
+  alias Mydia.Collections.SectionPresets
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Add a section")
+     |> assign(:presets, SectionPresets.all())}
+  end
+
+  @impl true
+  def handle_event("create", %{"preset" => key}, socket) do
+    user = socket.assigns.current_user
+
+    with %{} = preset <- SectionPresets.get(key),
+         {:ok, collection} <- find_or_create(user, preset) do
+      {:noreply, push_navigate(socket, to: ~p"/sections/#{collection.id}")}
+    else
+      nil ->
+        {:noreply, put_flash(socket, :error, "That section type is not available.")}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not create that section.")}
+    end
+  end
+
+  # A user who clicks the same preset twice should land on the section they
+  # already have rather than growing a duplicate sidebar entry.
+  defp find_or_create(user, preset) do
+    case Enum.find(Collections.list_pinned_sections(user), &(&1.name == preset.name)) do
+      nil -> create(user, preset)
+      existing -> {:ok, existing}
+    end
+  end
+
+  defp create(user, preset) do
+    with {:ok, collection} <-
+           Collections.create_collection(user, %{
+             name: preset.name,
+             type: "smart",
+             visibility: "private",
+             smart_rules: Jason.encode!(preset.rules)
+           }) do
+      Collections.pin_section(user, collection,
+        sidebar_icon: preset.icon,
+        exclusive: preset.exclusive
+      )
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app {assigns}>
+      <div class="max-w-2xl mx-auto py-8">
+        <h1 class="text-2xl font-bold mb-2">Add a section</h1>
+        <p class="text-base-content/70 mb-6">
+          A section is a saved filter pinned to your sidebar. It is yours alone;
+          nobody else's sidebar changes.
+        </p>
+
+        <ul class="space-y-3">
+          <li :for={preset <- @presets}>
+            <button
+              id={"preset-#{preset.key}"}
+              phx-click="create"
+              phx-value-preset={preset.key}
+              class="card bg-base-200 hover:bg-base-300 transition-colors w-full text-left"
+            >
+              <div class="card-body flex-row items-center gap-4 py-4">
+                <.icon name={preset.icon} class="w-8 h-8 text-primary shrink-0" />
+                <div>
+                  <div class="font-semibold">{preset.name}</div>
+                  <div class="text-sm text-base-content/70">{preset.description}</div>
+                </div>
+              </div>
+            </button>
+          </li>
+          <li>
+            <.link
+              id="preset-custom"
+              navigate={~p"/collections"}
+              class="card bg-base-200 hover:bg-base-300 transition-colors w-full"
+            >
+              <div class="card-body flex-row items-center gap-4 py-4">
+                <.icon name="hero-squares-2x2" class="w-8 h-8 text-primary shrink-0" />
+                <div>
+                  <div class="font-semibold">Custom</div>
+                  <div class="text-sm text-base-content/70">
+                    Build a smart collection with your own rules, then pin it.
+                  </div>
+                </div>
+              </div>
+            </.link>
+          </li>
+        </ul>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/mydia_web/live/section_live/new.ex
+++ b/lib/mydia_web/live/section_live/new.ex
@@ -97,7 +97,8 @@ defmodule MydiaWeb.SectionLive.New do
                 <div>
                   <div class="font-semibold">Custom</div>
                   <div class="text-sm text-base-content/70">
-                    Build a smart collection with your own rules, then pin it.
+                    Build a smart collection with your own rules, then use
+                    "Pin to sidebar" on it to add it here.
                   </div>
                 </div>
               </div>

--- a/lib/mydia_web/live/user_auth.ex
+++ b/lib/mydia_web/live/user_auth.ex
@@ -109,17 +109,13 @@ defmodule MydiaWeb.Live.UserAuth do
     # Get executing jobs for sidebar status indicator
     executing_jobs = Mydia.Jobs.list_executing_jobs()
 
-    excluded_categories =
-      case Map.fetch(socket.assigns, :current_user) do
-        {:ok, %{} = user} -> Mydia.Collections.claimed_categories(user)
-        _ -> []
-      end
-
     sections =
       case Map.fetch(socket.assigns, :current_user) do
         {:ok, %{} = user} -> Mydia.Collections.list_pinned_sections(user)
         _ -> []
       end
+
+    excluded_categories = Mydia.Collections.claimed_categories(sections)
 
     socket =
       socket

--- a/lib/mydia_web/live/user_auth.ex
+++ b/lib/mydia_web/live/user_auth.ex
@@ -109,10 +109,27 @@ defmodule MydiaWeb.Live.UserAuth do
     # Get executing jobs for sidebar status indicator
     executing_jobs = Mydia.Jobs.list_executing_jobs()
 
+    excluded_categories =
+      case Map.fetch(socket.assigns, :current_user) do
+        {:ok, %{} = user} -> Mydia.Collections.claimed_categories(user)
+        _ -> []
+      end
+
+    sections =
+      case Map.fetch(socket.assigns, :current_user) do
+        {:ok, %{} = user} -> Mydia.Collections.list_pinned_sections(user)
+        _ -> []
+      end
+
     socket =
       socket
-      |> assign(:movie_count, Mydia.Media.count_movies())
-      |> assign(:tv_show_count, Mydia.Media.count_tv_shows())
+      |> assign(:movie_count, Mydia.Media.count_movies(exclude_categories: excluded_categories))
+      |> assign(
+        :tv_show_count,
+        Mydia.Media.count_tv_shows(exclude_categories: excluded_categories)
+      )
+      |> assign(:excluded_categories, excluded_categories)
+      |> assign(:sections, sections)
       |> assign(:downloads_count, Mydia.Downloads.count_active_downloads())
       |> assign(:import_candidate_group_count, Mydia.ImportCandidates.count_pending())
       |> assign(:pending_requests_count, pending_requests_count)

--- a/lib/mydia_web/router.ex
+++ b/lib/mydia_web/router.ex
@@ -159,6 +159,7 @@ defmodule MydiaWeb.Router do
       live "/movies/:id", MediaLive.Show, :show
       live "/tv", MediaLive.Index, :tv_shows
       live "/tv/:id", MediaLive.Show, :show
+      live "/sections/:id", MediaLive.Index, :section
       live "/add/movie", AddMediaLive.Index, :add_movie
       live "/add/series", AddMediaLive.Index, :add_series
       live "/import", ImportMediaLive.Index, :index

--- a/lib/mydia_web/router.ex
+++ b/lib/mydia_web/router.ex
@@ -159,6 +159,7 @@ defmodule MydiaWeb.Router do
       live "/movies/:id", MediaLive.Show, :show
       live "/tv", MediaLive.Index, :tv_shows
       live "/tv/:id", MediaLive.Show, :show
+      live "/sections/new", SectionLive.New, :new
       live "/sections/:id", MediaLive.Index, :section
       live "/add/movie", AddMediaLive.Index, :add_movie
       live "/add/series", AddMediaLive.Index, :add_series

--- a/priv/repo/migrations/20260901120000_add_sidebar_sections_to_collections.exs
+++ b/priv/repo/migrations/20260901120000_add_sidebar_sections_to_collections.exs
@@ -1,0 +1,13 @@
+defmodule Mydia.Repo.Migrations.AddSidebarSectionsToCollections do
+  use Ecto.Migration
+
+  def change do
+    alter table(:collections) do
+      add :pinned_position, :integer
+      add :sidebar_icon, :text
+      add :exclusive, :boolean, default: false, null: false
+    end
+
+    create index(:collections, [:user_id, :pinned_position])
+  end
+end

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -211,4 +211,44 @@ defmodule Mydia.Collections.SectionsTest do
 
     Collections.create_collection(user, attrs)
   end
+
+  describe "SectionPresets" do
+    alias Mydia.Collections.SectionPresets
+
+    test "every preset produces a collection that validates" do
+      user = user_fixture()
+
+      for preset <- SectionPresets.all() do
+        assert {:ok, collection} =
+                 Collections.create_collection(user, %{
+                   name: preset.name,
+                   type: "smart",
+                   visibility: "private",
+                   smart_rules: Jason.encode!(preset.rules),
+                   sidebar_icon: preset.icon
+                 }),
+               "preset #{preset.key} did not create"
+
+        assert {:ok, _} = Collections.validate_smart_rules(collection.smart_rules)
+      end
+    end
+
+    test "every preset icon is on the allowlist" do
+      for preset <- SectionPresets.all() do
+        assert preset.icon in Collection.valid_sidebar_icons()
+      end
+    end
+
+    test "the anime preset claims both anime categories and is exclusive" do
+      preset = SectionPresets.get("anime")
+
+      assert preset.exclusive
+      assert %{"conditions" => [%{"field" => "category", "value" => values}]} = preset.rules
+      assert Enum.sort(values) == ["anime_movie", "anime_series"]
+    end
+
+    test "get/1 returns nil for an unknown key" do
+      assert is_nil(SectionPresets.get("nope"))
+    end
+  end
 end

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -59,6 +59,46 @@ defmodule Mydia.Collections.SectionsTest do
       assert Enum.all?(Collection.valid_sidebar_icons(), &String.starts_with?(&1, "hero-"))
       assert "hero-sparkles" in Collection.valid_sidebar_icons()
     end
+
+    test "a manual collection with a pinned_position is rejected" do
+      changeset =
+        Collection.changeset(%Collection{}, %{
+          name: "Watchlist",
+          type: "manual",
+          visibility: "private",
+          pinned_position: 0
+        })
+
+      refute changeset.valid?
+
+      assert %{pinned_position: ["only smart collections can be pinned"]} =
+               errors_on(changeset)
+    end
+
+    test "an unpinned manual collection still validates" do
+      changeset =
+        Collection.changeset(%Collection{}, %{
+          name: "Watchlist",
+          type: "manual",
+          visibility: "private"
+        })
+
+      assert changeset.valid?
+    end
+
+    test "a pinned smart collection still validates" do
+      changeset =
+        Collection.changeset(%Collection{}, %{
+          name: "Anime",
+          type: "smart",
+          visibility: "private",
+          smart_rules:
+            ~s({"conditions":[{"field":"category","operator":"in","value":["anime_movie"]}]}),
+          pinned_position: 0
+        })
+
+      assert changeset.valid?
+    end
   end
 
   describe "list_pinned_sections/1" do

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -172,6 +172,44 @@ defmodule Mydia.Collections.SectionsTest do
       assert Collections.pin_section(user, collection) == {:error, :not_smart}
       assert Collections.list_pinned_sections(user) == []
     end
+
+    test "re-pinning with no opts keeps a previously customized icon" do
+      user = user_fixture()
+
+      {:ok, collection} =
+        Collections.create_collection(user, smart_attrs("Anime", ["anime_movie"]))
+
+      {:ok, pinned_collection} =
+        Collections.pin_section(user, collection, sidebar_icon: "hero-face-smile")
+
+      # Simulate customizing the icon via the section settings gear, which
+      # goes through update_collection/3, not pin_section/3.
+      {:ok, customized} =
+        Collections.update_collection(user, pinned_collection, %{sidebar_icon: "hero-star"})
+
+      {:ok, unpinned} = Collections.unpin_section(user, customized)
+
+      {:ok, repinned} = Collections.pin_section(user, unpinned)
+
+      assert repinned.sidebar_icon == "hero-star"
+    end
+
+    test "re-pinning with an explicit sidebar_icon still overwrites it" do
+      user = user_fixture()
+
+      {:ok, collection} =
+        Collections.create_collection(user, smart_attrs("Anime", ["anime_movie"]))
+
+      {:ok, pinned_collection} =
+        Collections.pin_section(user, collection, sidebar_icon: "hero-star")
+
+      {:ok, unpinned} = Collections.unpin_section(user, pinned_collection)
+
+      {:ok, repinned} =
+        Collections.pin_section(user, unpinned, sidebar_icon: "hero-face-smile")
+
+      assert repinned.sidebar_icon == "hero-face-smile"
+    end
   end
 
   describe "exclusive_eligible?/1" do

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -1,0 +1,63 @@
+defmodule Mydia.Collections.SectionsTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Collections
+  alias Mydia.Collections.Collection
+
+  import Mydia.AccountsFixtures
+
+  describe "sidebar section fields" do
+    test "changeset accepts a pinned position, an allowlisted icon and exclusive" do
+      user = user_fixture()
+
+      {:ok, collection} =
+        Collections.create_collection(user, %{
+          name: "Anime",
+          type: "smart",
+          visibility: "private",
+          smart_rules:
+            ~s({"conditions":[{"field":"category","operator":"in","value":["anime_movie","anime_series"]}]}),
+          pinned_position: 0,
+          sidebar_icon: "hero-sparkles",
+          exclusive: true
+        })
+
+      assert collection.pinned_position == 0
+      assert collection.sidebar_icon == "hero-sparkles"
+      assert collection.exclusive == true
+    end
+
+    test "defaults leave a collection unpinned and non-exclusive" do
+      user = user_fixture()
+
+      {:ok, collection} =
+        Collections.create_collection(user, %{
+          name: "Plain List",
+          type: "manual",
+          visibility: "private"
+        })
+
+      assert is_nil(collection.pinned_position)
+      assert is_nil(collection.sidebar_icon)
+      assert collection.exclusive == false
+    end
+
+    test "an icon outside the allowlist is rejected" do
+      changeset =
+        Collection.changeset(%Collection{}, %{
+          name: "Bad Icon",
+          type: "manual",
+          visibility: "private",
+          sidebar_icon: "hero-not-a-real-icon"
+        })
+
+      refute changeset.valid?
+      assert %{sidebar_icon: ["is not a supported icon"]} = errors_on(changeset)
+    end
+
+    test "valid_sidebar_icons are all hero-prefixed" do
+      assert Enum.all?(Collection.valid_sidebar_icons(), &String.starts_with?(&1, "hero-"))
+      assert "hero-sparkles" in Collection.valid_sidebar_icons()
+    end
+  end
+end

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -164,6 +164,14 @@ defmodule Mydia.Collections.SectionsTest do
       assert unpinned.exclusive == false
       assert Collections.claimed_categories(user) == []
     end
+
+    test "pinning a manual collection is refused" do
+      user = user_fixture()
+      {:ok, collection} = Collections.create_collection(user, plain_attrs("Watchlist"))
+
+      assert Collections.pin_section(user, collection) == {:error, :not_smart}
+      assert Collections.list_pinned_sections(user) == []
+    end
   end
 
   describe "exclusive_eligible?/1" do

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -60,4 +60,155 @@ defmodule Mydia.Collections.SectionsTest do
       assert "hero-sparkles" in Collection.valid_sidebar_icons()
     end
   end
+
+  describe "list_pinned_sections/1" do
+    test "returns only the user's pinned collections, in position order" do
+      user = user_fixture()
+
+      {:ok, second} = pinned(user, "Cartoons", 1, ["cartoon_movie"])
+      {:ok, first} = pinned(user, "Anime", 0, ["anime_movie"])
+      {:ok, _unpinned} = Collections.create_collection(user, plain_attrs("Not Pinned"))
+
+      assert [^first, ^second] = Collections.list_pinned_sections(user)
+    end
+
+    test "does not return another user's pinned collection, even when shared" do
+      owner = admin_user_fixture()
+      other = user_fixture()
+
+      {:ok, collection} = pinned(owner, "Anime", 0, ["anime_movie"])
+      {:ok, _} = Collections.update_collection(owner, collection, %{visibility: "shared"})
+
+      assert Collections.list_pinned_sections(other) == []
+    end
+  end
+
+  describe "claimed_categories/1" do
+    test "returns the categories of an exclusive pure-category section" do
+      user = user_fixture()
+      {:ok, _} = pinned(user, "Anime", 0, ["anime_movie", "anime_series"], exclusive: true)
+
+      assert Enum.sort(Collections.claimed_categories(user)) ==
+               ["anime_movie", "anime_series"]
+    end
+
+    test "returns nothing when the section is not exclusive" do
+      user = user_fixture()
+      {:ok, _} = pinned(user, "Anime", 0, ["anime_movie"], exclusive: false)
+
+      assert Collections.claimed_categories(user) == []
+    end
+
+    test "returns nothing when the rules are not a single category condition" do
+      user = user_fixture()
+
+      rules =
+        ~s({"conditions":[{"field":"category","operator":"in","value":["anime_movie"]},) <>
+          ~s({"field":"year","operator":"gte","value":2020}]})
+
+      {:ok, _} =
+        Collections.create_collection(user, %{
+          name: "Recent Anime",
+          type: "smart",
+          visibility: "private",
+          smart_rules: rules,
+          pinned_position: 0,
+          exclusive: true
+        })
+
+      assert Collections.claimed_categories(user) == []
+    end
+
+    test "returns nothing and does not raise when the rules are unparseable" do
+      user = user_fixture()
+      {:ok, collection} = pinned(user, "Anime", 0, ["anime_movie"], exclusive: true)
+
+      # Bypass the changeset to simulate rules corrupted outside the app.
+      collection
+      |> Ecto.Changeset.change(%{smart_rules: "{not json"})
+      |> Mydia.Repo.update!()
+
+      assert Collections.claimed_categories(user) == []
+    end
+
+    test "ignores category values that are not real categories" do
+      user = user_fixture()
+      {:ok, _} = pinned(user, "Bogus", 0, ["anime_movie", "not_a_category"], exclusive: true)
+
+      assert Collections.claimed_categories(user) == ["anime_movie"]
+    end
+  end
+
+  describe "pin_section/3 and unpin_section/2" do
+    test "pinning appends to the end of the existing sections" do
+      user = user_fixture()
+      {:ok, _} = pinned(user, "Anime", 0, ["anime_movie"])
+
+      {:ok, collection} =
+        Collections.create_collection(user, smart_attrs("Cartoons", ["cartoon_movie"]))
+
+      {:ok, pinned_collection} =
+        Collections.pin_section(user, collection, sidebar_icon: "hero-face-smile")
+
+      assert pinned_collection.pinned_position == 1
+      assert pinned_collection.sidebar_icon == "hero-face-smile"
+    end
+
+    test "unpinning clears the position and exclusivity" do
+      user = user_fixture()
+      {:ok, collection} = pinned(user, "Anime", 0, ["anime_movie"], exclusive: true)
+
+      {:ok, unpinned} = Collections.unpin_section(user, collection)
+
+      assert is_nil(unpinned.pinned_position)
+      assert unpinned.exclusive == false
+      assert Collections.claimed_categories(user) == []
+    end
+  end
+
+  describe "exclusive_eligible?/1" do
+    test "true for a single category-in condition" do
+      user = user_fixture()
+      {:ok, collection} = pinned(user, "Anime", 0, ["anime_movie"])
+
+      assert Collections.exclusive_eligible?(collection)
+    end
+
+    test "false for a manual collection" do
+      user = user_fixture()
+      {:ok, collection} = Collections.create_collection(user, plain_attrs("Manual"))
+
+      refute Collections.exclusive_eligible?(collection)
+    end
+  end
+
+  defp plain_attrs(name) do
+    %{name: name, type: "manual", visibility: "private"}
+  end
+
+  defp smart_attrs(name, categories) do
+    %{
+      name: name,
+      type: "smart",
+      visibility: "private",
+      smart_rules:
+        Jason.encode!(%{
+          "conditions" => [
+            %{"field" => "category", "operator" => "in", "value" => categories}
+          ]
+        })
+    }
+  end
+
+  defp pinned(user, name, position, categories, opts \\ []) do
+    attrs =
+      name
+      |> smart_attrs(categories)
+      |> Map.merge(%{
+        pinned_position: position,
+        exclusive: Keyword.get(opts, :exclusive, false)
+      })
+
+    Collections.create_collection(user, attrs)
+  end
 end

--- a/test/mydia/collections/smart_rules_test.exs
+++ b/test/mydia/collections/smart_rules_test.exs
@@ -416,4 +416,35 @@ defmodule Mydia.Collections.SmartRulesTest do
       assert "contains" in operators
     end
   end
+
+  describe "query/1" do
+    test "returns a composable query for valid rules" do
+      rules =
+        ~s({"conditions":[{"field":"category","operator":"in","value":["anime_series"]}]})
+
+      assert {:ok, %Ecto.Query{} = query} = SmartRules.query(rules)
+      assert is_list(Mydia.Repo.all(query))
+    end
+
+    test "returns an error for invalid JSON" do
+      assert {:error, "Invalid JSON"} = SmartRules.query("{not json")
+    end
+
+    test "returns an error for an unknown field" do
+      rules = ~s({"conditions":[{"field":"nope","operator":"eq","value":"x"}]})
+
+      assert {:error, message} = SmartRules.query(rules)
+      assert message =~ "Invalid rules"
+    end
+
+    test "accepts a decoded map as well as a JSON string" do
+      rules = %{
+        "conditions" => [
+          %{"field" => "category", "operator" => "in", "value" => ["anime_movie"]}
+        ]
+      }
+
+      assert {:ok, %Ecto.Query{}} = SmartRules.query(rules)
+    end
+  end
 end

--- a/test/mydia/media/exclude_categories_test.exs
+++ b/test/mydia/media/exclude_categories_test.exs
@@ -1,0 +1,87 @@
+defmodule Mydia.Media.ExcludeCategoriesTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Media
+
+  import Mydia.MediaFixtures
+
+  setup do
+    live = categorized_media_item_fixture(%{title: "Harbor Lights", type: "tv_show"}, :tv_show)
+
+    anime =
+      categorized_media_item_fixture(%{title: "Comet Circuit", type: "tv_show"}, :anime_series)
+
+    unclassified =
+      categorized_media_item_fixture(%{title: "Paper Districts", type: "tv_show"}, nil)
+
+    movie = categorized_media_item_fixture(%{title: "Glass Meridian", type: "movie"}, :movie)
+
+    %{live: live, anime: anime, unclassified: unclassified, movie: movie}
+  end
+
+  describe "list_media_items/1 with :exclude_categories" do
+    test "drops the excluded categories", %{live: live, anime: anime} do
+      titles =
+        [type: "tv_show", exclude_categories: ["anime_series"]]
+        |> Media.list_media_items()
+        |> Enum.map(& &1.title)
+
+      assert live.title in titles
+      refute anime.title in titles
+    end
+
+    test "keeps items whose category is still nil", %{unclassified: unclassified} do
+      titles =
+        [type: "tv_show", exclude_categories: ["anime_series"]]
+        |> Media.list_media_items()
+        |> Enum.map(& &1.title)
+
+      assert unclassified.title in titles
+    end
+
+    test "accepts atoms as well as strings", %{anime: anime} do
+      titles =
+        [type: "tv_show", exclude_categories: [:anime_series]]
+        |> Media.list_media_items()
+        |> Enum.map(& &1.title)
+
+      refute anime.title in titles
+    end
+
+    test "an empty exclusion list changes nothing", %{anime: anime} do
+      titles =
+        [type: "tv_show", exclude_categories: []]
+        |> Media.list_media_items()
+        |> Enum.map(& &1.title)
+
+      assert anime.title in titles
+    end
+  end
+
+  describe "list_media_items/1 with :base_query" do
+    test "starts from the supplied query and still applies other filters", %{anime: anime} do
+      import Ecto.Query
+
+      base = from(m in Mydia.Media.MediaItem, where: m.category == "anime_series")
+
+      titles =
+        [base_query: base, type: "tv_show"]
+        |> Media.list_media_items()
+        |> Enum.map(& &1.title)
+
+      assert titles == [anime.title]
+    end
+  end
+
+  describe "counts" do
+    test "count_tv_shows/1 respects the exclusion" do
+      assert Media.count_tv_shows() == 3
+      assert Media.count_tv_shows(exclude_categories: ["anime_series"]) == 2
+    end
+
+    test "count_movies/1 respects the exclusion" do
+      assert Media.count_movies() == 1
+      assert Media.count_movies(exclude_categories: ["movie"]) == 0
+    end
+  end
+end

--- a/test/mydia_web/live/collection_live/pin_section_test.exs
+++ b/test/mydia_web/live/collection_live/pin_section_test.exs
@@ -1,0 +1,133 @@
+defmodule MydiaWeb.CollectionLive.PinSectionTest do
+  # async: false — a connected LiveView cannot share the PostgreSQL sandbox
+  # connection with an async test process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Collections
+
+  setup %{conn: conn} do
+    user = user_fixture(%{role: "admin"})
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  defp smart_collection(user, attrs \\ %{}) do
+    {:ok, collection} =
+      Collections.create_collection(
+        user,
+        Map.merge(
+          %{
+            name: "Anime",
+            type: "smart",
+            visibility: "private",
+            smart_rules:
+              Jason.encode!(%{
+                "conditions" => [
+                  %{"field" => "category", "operator" => "in", "value" => ["anime_movie"]}
+                ]
+              })
+          },
+          attrs
+        )
+      )
+
+    collection
+  end
+
+  defp manual_collection(user, attrs \\ %{}) do
+    {:ok, collection} =
+      Collections.create_collection(
+        user,
+        Map.merge(%{name: "Watchlist", type: "manual", visibility: "private"}, attrs)
+      )
+
+    collection
+  end
+
+  describe "pinning" do
+    test "pinning a smart collection adds it to the sidebar, lands on the section and flashes",
+         %{conn: conn, user: user} do
+      collection = smart_collection(user)
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}")
+
+      assert has_element?(view, "#pin-collection", "Pin to sidebar")
+
+      {:ok, section_view, html} =
+        view
+        |> element("#pin-collection")
+        |> render_click()
+        |> follow_redirect(conn, ~p"/sections/#{collection.id}")
+
+      assert html =~ "Pinned to sidebar"
+      assert section_view
+      assert [pinned] = Collections.list_pinned_sections(user)
+      assert pinned.id == collection.id
+    end
+  end
+
+  describe "unpinning" do
+    test "unpinning clears the sidebar entry and flips the button back", %{
+      conn: conn,
+      user: user
+    } do
+      collection = smart_collection(user, %{pinned_position: 0})
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}")
+
+      assert has_element?(view, "#unpin-collection", "Unpin from sidebar")
+
+      html = view |> element("#unpin-collection") |> render_click()
+
+      assert html =~ "Removed from sidebar"
+      assert has_element?(view, "#pin-collection", "Pin to sidebar")
+      refute has_element?(view, "#unpin-collection")
+      assert Collections.list_pinned_sections(user) == []
+    end
+  end
+
+  describe "control visibility" do
+    test "the control is absent for a manual collection", %{conn: conn, user: user} do
+      collection = manual_collection(user)
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}")
+
+      refute has_element?(view, "#pin-collection")
+      refute has_element?(view, "#unpin-collection")
+    end
+
+    test "the control is absent for a viewer who does not own a shared smart collection", %{
+      user: owner
+    } do
+      collection = smart_collection(owner, %{visibility: "shared"})
+
+      viewer = user_fixture(%{role: "admin"})
+      conn = log_in_user(Phoenix.ConnTest.build_conn(), viewer)
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}")
+
+      refute has_element?(view, "#pin-collection")
+      refute has_element?(view, "#unpin-collection")
+    end
+  end
+
+  describe "error handling" do
+    test "a forged pin attempt on a collection the viewer does not own does not crash", %{
+      user: owner
+    } do
+      collection = smart_collection(owner, %{visibility: "shared"})
+
+      viewer = user_fixture(%{role: "admin"})
+      conn = log_in_user(Phoenix.ConnTest.build_conn(), viewer)
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}")
+
+      html = render_click(view, "pin_collection", %{})
+
+      assert html =~ "permission"
+      assert Collections.list_pinned_sections(owner) == []
+    end
+  end
+end

--- a/test/mydia_web/live/dashboard_live/section_exclusion_test.exs
+++ b/test/mydia_web/live/dashboard_live/section_exclusion_test.exs
@@ -1,0 +1,106 @@
+defmodule MydiaWeb.DashboardLive.SectionExclusionTest do
+  @moduledoc """
+  The dashboard's Movies/TV Shows stat tiles and the sidebar count badges are
+  both driven by the `:movie_count` / `:tv_show_count` assigns, which
+  `Layouts.app` reads from whatever LiveView is currently mounted. An
+  exclusive pinned section must produce the same reduced counts on "/" as it
+  does on "/movies" and "/tv", or a user sees a different total depending on
+  which page they happen to be on.
+  """
+
+  # async: false - the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import Mydia.MetadataCacheHelpers
+
+  alias Mydia.Collections
+
+  setup %{conn: conn} do
+    # DashboardLive.Index unconditionally loads both trending rails on
+    # connected mount (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+
+    user = user_fixture(%{role: "admin"})
+
+    for n <- 1..2 do
+      categorized_media_item_fixture(
+        %{title: "Nebula Frame #{n}", type: "movie"},
+        :anime_movie
+      )
+    end
+
+    for n <- 1..4 do
+      categorized_media_item_fixture(
+        %{title: "Harbor Reel #{n}", type: "movie"},
+        :movie
+      )
+    end
+
+    for n <- 1..3 do
+      categorized_media_item_fixture(
+        %{title: "Comet Circuit #{n}", type: "tv_show"},
+        :anime_series
+      )
+    end
+
+    for n <- 1..5 do
+      categorized_media_item_fixture(
+        %{title: "Harbor Lights #{n}", type: "tv_show"},
+        :tv_show
+      )
+    end
+
+    {:ok, _section} =
+      Collections.create_collection(user, %{
+        name: "Anime",
+        type: "smart",
+        visibility: "private",
+        smart_rules:
+          Jason.encode!(%{
+            "conditions" => [
+              %{
+                "field" => "category",
+                "operator" => "in",
+                "value" => ["anime_movie", "anime_series"]
+              }
+            ]
+          }),
+        pinned_position: 0,
+        sidebar_icon: "hero-sparkles",
+        exclusive: true
+      })
+
+    %{conn: log_in_user(conn, user)}
+  end
+
+  test "the movies stat tile matches the exclusion-aware sidebar badge", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#nav-movie-count", "4")
+    assert has_element?(view, "#stat-tile-movies", "4")
+  end
+
+  test "the TV shows stat tile matches the exclusion-aware sidebar badge", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#nav-tv-count", "5")
+    assert has_element?(view, "#stat-tile-tv-shows", "5")
+  end
+
+  test "the counts agree with the Movies and TV pages themselves", %{conn: conn} do
+    {:ok, dashboard, _html} = live(conn, ~p"/")
+    {:ok, movies, _html} = live(conn, ~p"/movies")
+    {:ok, tv, _html} = live(conn, ~p"/tv")
+
+    assert has_element?(dashboard, "#stat-tile-movies", "4")
+    assert has_element?(movies, "#nav-movie-count", "4")
+
+    assert has_element?(dashboard, "#stat-tile-tv-shows", "5")
+    assert has_element?(tv, "#nav-tv-count", "5")
+  end
+end

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -1,0 +1,127 @@
+defmodule MydiaWeb.MediaLive.SectionTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+
+  alias Mydia.Collections
+
+  setup %{conn: conn} do
+    user = user_fixture(%{role: "admin"})
+
+    anime =
+      categorized_media_item_fixture(
+        %{title: "Comet Circuit", type: "tv_show"},
+        :anime_series
+      )
+
+    live =
+      categorized_media_item_fixture(
+        %{title: "Harbor Lights", type: "tv_show"},
+        :tv_show
+      )
+
+    {:ok, section} =
+      Collections.create_collection(user, %{
+        name: "Anime",
+        type: "smart",
+        visibility: "private",
+        smart_rules:
+          Jason.encode!(%{
+            "conditions" => [
+              %{
+                "field" => "category",
+                "operator" => "in",
+                "value" => ["anime_movie", "anime_series"]
+              }
+            ]
+          }),
+        pinned_position: 0,
+        sidebar_icon: "hero-sparkles",
+        exclusive: true
+      })
+
+    %{conn: log_in_user(conn, user), user: user, anime: anime, live: live, section: section}
+  end
+
+  describe "GET /sections/:id" do
+    test "renders only the items matching the section rules", %{
+      conn: conn,
+      section: section,
+      anime: anime,
+      live: live
+    } do
+      {:ok, _view, html} = live(conn, ~p"/sections/#{section.id}")
+
+      assert html =~ anime.title
+      refute html =~ live.title
+    end
+
+    test "shows the section name as the page heading", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      assert has_element?(view, "#section-heading", "Anime")
+    end
+
+    test "offers the same batch toolbar as the library pages", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      view |> element("#toggle-selection-mode") |> render_click()
+
+      assert has_element?(view, "#batch-monitor")
+    end
+
+    test "a batch operation applies to rule-sourced items", %{
+      conn: conn,
+      section: section,
+      anime: anime
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      view |> element("#toggle-selection-mode") |> render_click()
+      view |> element("#select-all") |> render_click()
+      view |> element("#batch-unmonitor") |> render_click()
+
+      refute Mydia.Media.get_media_item!(anime.id).monitored
+    end
+
+    test "redirects when the section belongs to someone else", %{conn: conn} do
+      stranger = user_fixture()
+
+      {:ok, theirs} =
+        Collections.create_collection(stranger, %{
+          name: "Private",
+          type: "manual",
+          visibility: "private",
+          pinned_position: 0
+        })
+
+      assert {:error, {:live_redirect, %{to: "/"}}} = live(conn, ~p"/sections/#{theirs.id}")
+    end
+
+    test "renders an error state rather than an empty library for broken rules", %{
+      conn: conn,
+      section: section
+    } do
+      section
+      |> Ecto.Changeset.change(%{smart_rules: "{not json"})
+      |> Mydia.Repo.update!()
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      assert has_element?(view, "#section-rules-error")
+    end
+
+    test "a library scan broadcast does not crash section mode", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      send(view.pid, {:library_scan_started, %{type: :series}})
+
+      assert render(view) =~ "Anime"
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -92,8 +92,14 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       {:ok, theirs} =
         Collections.create_collection(stranger, %{
           name: "Private",
-          type: "manual",
+          type: "smart",
           visibility: "private",
+          smart_rules:
+            Jason.encode!(%{
+              "conditions" => [
+                %{"field" => "category", "operator" => "in", "value" => ["anime_movie"]}
+              ]
+            }),
           pinned_position: 0
         })
 

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -250,4 +250,87 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       refute has_element?(view, "#section-exclusive-toggle")
     end
   end
+
+  describe "anime nudge" do
+    setup %{user: user, section: section} do
+      # These tests are about a library with no anime section yet. Rebind
+      # :section to the fresh struct: reusing the stale pre-unpin one would let
+      # a later pin_section/3 in the same test see no field-level change (its
+      # in-memory pinned_position/exclusive already matched the intended
+      # values), so Ecto would silently skip persisting them.
+      {:ok, section} = Collections.unpin_section(user, section)
+      %{section: section}
+    end
+
+    test "does not appear below the threshold", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      refute has_element?(view, "#anime-nudge")
+    end
+
+    test "appears once the library has enough anime", %{conn: conn} do
+      for n <- 1..10 do
+        categorized_media_item_fixture(
+          %{title: "Signal Garden #{n}", type: "tv_show"},
+          :anime_series
+        )
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert has_element?(view, "#anime-nudge")
+    end
+
+    test "does not appear when a section already claims anime", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      for n <- 1..10 do
+        categorized_media_item_fixture(
+          %{title: "Signal Garden #{n}", type: "tv_show"},
+          :anime_series
+        )
+      end
+
+      {:ok, _} = Collections.pin_section(user, section, exclusive: true)
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      refute has_element?(view, "#anime-nudge")
+    end
+
+    test "dismissal survives a remount", %{conn: conn} do
+      for n <- 1..10 do
+        categorized_media_item_fixture(
+          %{title: "Signal Garden #{n}", type: "tv_show"},
+          :anime_series
+        )
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+      view |> element("#dismiss-anime-nudge") |> render_click()
+
+      {:ok, view2, _html} = live(conn, ~p"/tv")
+      refute has_element?(view2, "#anime-nudge")
+    end
+
+    test "accepting creates the anime section", %{conn: conn, user: user} do
+      for n <- 1..10 do
+        categorized_media_item_fixture(
+          %{title: "Signal Garden #{n}", type: "tv_show"},
+          :anime_series
+        )
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      {:error, {:live_redirect, %{to: path}}} =
+        view |> element("#accept-anime-nudge") |> render_click()
+
+      assert [created] = Collections.list_pinned_sections(user)
+      assert created.name == "Anime"
+      assert path == "/sections/#{created.id}"
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -124,4 +124,42 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       assert render(view) =~ "Anime"
     end
   end
+
+  describe "exclusive sections and the built-in pages" do
+    test "the TV page hides the claimed categories", %{
+      conn: conn,
+      anime: anime,
+      live: live
+    } do
+      {:ok, _view, html} = live(conn, ~p"/tv")
+
+      assert html =~ live.title
+      refute html =~ anime.title
+    end
+
+    test "the TV page keeps everything when the section is not exclusive", %{
+      conn: conn,
+      user: user,
+      section: section,
+      anime: anime
+    } do
+      {:ok, _} = Collections.update_collection(user, section, %{exclusive: false})
+
+      {:ok, _view, html} = live(conn, ~p"/tv")
+
+      assert html =~ anime.title
+    end
+
+    test "the sidebar count agrees with the page", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert has_element?(view, "#nav-tv-count", "1")
+    end
+
+    test "the page explains where the hidden items went", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert has_element?(view, "#excluded-notice")
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -162,6 +162,44 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       assert has_element?(view, "#excluded-notice")
     end
 
+    test "the notice names the single claiming section and links to it", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert has_element?(
+               view,
+               ~s(#excluded-notice a[href="/sections/#{section.id}"]),
+               "Anime"
+             )
+    end
+
+    test "the notice falls back to aggregate wording when more than one section claims", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, _other} =
+        Collections.create_collection(user, %{
+          name: "Retro",
+          type: "smart",
+          visibility: "private",
+          smart_rules:
+            Jason.encode!(%{
+              "conditions" => [
+                %{"field" => "category", "operator" => "in", "value" => ["cartoon_series"]}
+              ]
+            }),
+          pinned_position: 1,
+          exclusive: true
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert has_element?(view, "#excluded-notice", "in your pinned sections")
+      refute has_element?(view, "#excluded-notice a")
+    end
+
     test "the sidebar shows the pinned section", %{conn: conn, section: section} do
       {:ok, view, _html} = live(conn, ~p"/tv")
 
@@ -248,6 +286,72 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       view |> element("#open-section-settings") |> render_click()
 
       refute has_element?(view, "#section-exclusive-toggle")
+    end
+  end
+
+  describe "section settings ownership" do
+    test "the gear icon is shown to the section's owner", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      assert has_element?(view, "#open-section-settings")
+    end
+
+    test "the gear icon is hidden from a viewer who does not own a shared section", %{
+      user: owner
+    } do
+      {:ok, shared} =
+        Collections.create_collection(owner, %{
+          name: "Everyone's Picks",
+          type: "smart",
+          visibility: "shared",
+          smart_rules:
+            Jason.encode!(%{
+              "conditions" => [
+                %{"field" => "category", "operator" => "in", "value" => ["anime_movie"]}
+              ]
+            }),
+          pinned_position: 1
+        })
+
+      viewer = user_fixture(%{role: "admin"})
+      conn = log_in_user(Phoenix.ConnTest.build_conn(), viewer)
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{shared.id}")
+
+      refute has_element?(view, "#open-section-settings")
+    end
+
+    test "a viewer who does not own the section cannot save changes to it either", %{
+      user: owner
+    } do
+      {:ok, shared} =
+        Collections.create_collection(owner, %{
+          name: "Everyone's Picks",
+          type: "smart",
+          visibility: "shared",
+          smart_rules:
+            Jason.encode!(%{
+              "conditions" => [
+                %{"field" => "category", "operator" => "in", "value" => ["anime_movie"]}
+              ]
+            }),
+          pinned_position: 1
+        })
+
+      viewer = user_fixture(%{role: "admin"})
+      conn = log_in_user(Phoenix.ConnTest.build_conn(), viewer)
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{shared.id}")
+
+      render_click(view, "save_section", %{
+        "section" => %{
+          "name" => "Hijacked",
+          "sidebar_icon" => "hero-fire",
+          "exclusive" => "false"
+        }
+      })
+
+      assert Collections.get_collection_by_id(shared.id).name == "Everyone's Picks"
     end
   end
 

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -100,6 +100,28 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       assert {:error, {:live_redirect, %{to: "/"}}} = live(conn, ~p"/sections/#{theirs.id}")
     end
 
+    test "redirects rather than rendering the whole library for a manual collection", %{
+      conn: conn,
+      user: user
+    } do
+      # A manual collection has no smart_rules, so a section page for one
+      # (pinned before the type: "smart" guard existed) would otherwise fall
+      # back to an unfiltered query. Bypass pin_section/3 with an update, the
+      # same way a pre-guard row would have gotten here.
+      {:ok, manual} =
+        Collections.create_collection(user, %{
+          name: "Watchlist",
+          type: "manual",
+          visibility: "private"
+        })
+
+      manual
+      |> Ecto.Changeset.change(%{pinned_position: 0})
+      |> Mydia.Repo.update!()
+
+      assert {:error, {:live_redirect, %{to: "/"}}} = live(conn, ~p"/sections/#{manual.id}")
+    end
+
     test "renders an error state rather than an empty library for broken rules", %{
       conn: conn,
       section: section

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -184,4 +184,70 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       assert Mydia.Collections.list_pinned_sections(other) == []
     end
   end
+
+  describe "section settings" do
+    test "unpinning removes the section and returns to the library", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      view |> element("#open-section-settings") |> render_click()
+
+      {:error, {:live_redirect, %{to: "/tv"}}} =
+        view |> element("#unpin-section") |> render_click()
+
+      assert Collections.list_pinned_sections(user) == []
+      assert Collections.get_collection(user, section.id)
+    end
+
+    test "unpinning restores the items to the TV page", %{
+      conn: conn,
+      section: section,
+      anime: anime
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+      view |> element("#open-section-settings") |> render_click()
+      view |> element("#unpin-section") |> render_click()
+
+      {:ok, _view, html} = live(conn, ~p"/tv")
+
+      assert html =~ anime.title
+    end
+
+    test "renaming the section updates the heading", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.id}")
+
+      view |> element("#open-section-settings") |> render_click()
+
+      view
+      |> form("#section-settings-form", section: %{name: "Animation", exclusive: "true"})
+      |> render_submit()
+
+      assert has_element?(view, "#section-heading", "Animation")
+    end
+
+    test "the exclusive toggle is absent when the rules are not category-only", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, complex} =
+        Collections.create_collection(user, %{
+          name: "Recent",
+          type: "smart",
+          visibility: "private",
+          smart_rules:
+            Jason.encode!(%{
+              "conditions" => [%{"field" => "year", "operator" => "gte", "value" => 2020}]
+            }),
+          pinned_position: 1
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{complex.id}")
+      view |> element("#open-section-settings") |> render_click()
+
+      refute has_element?(view, "#section-exclusive-toggle")
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -161,5 +161,27 @@ defmodule MydiaWeb.MediaLive.SectionTest do
 
       assert has_element?(view, "#excluded-notice")
     end
+
+    test "the sidebar shows the pinned section", %{conn: conn, section: section} do
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert has_element?(view, "#nav-section-#{section.id}", "Anime")
+    end
+
+    test "the sidebar offers an add-section entry", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      assert has_element?(view, "#nav-add-section")
+    end
+
+    test "another user's sidebar has no sections", %{conn: _conn} do
+      other = user_fixture(%{role: "admin"})
+      conn = log_in_user(Phoenix.ConnTest.build_conn(), other)
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      refute has_element?(view, "[id^='nav-section-']")
+      assert Mydia.Collections.list_pinned_sections(other) == []
+    end
   end
 end

--- a/test/mydia_web/live/section_live/new_test.exs
+++ b/test/mydia_web/live/section_live/new_test.exs
@@ -1,0 +1,56 @@
+defmodule MydiaWeb.SectionLive.NewTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Collections
+
+  setup %{conn: conn} do
+    user = user_fixture(%{role: "admin"})
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  test "lists every preset", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/sections/new")
+
+    for preset <- Mydia.Collections.SectionPresets.all() do
+      assert has_element?(view, "#preset-#{preset.key}")
+    end
+  end
+
+  test "offers a custom option that goes to the collections page", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/sections/new")
+
+    assert has_element?(view, "#preset-custom")
+  end
+
+  test "creating from a preset pins it and navigates to the section", %{
+    conn: conn,
+    user: user
+  } do
+    {:ok, view, _html} = live(conn, ~p"/sections/new")
+
+    {:error, {:live_redirect, %{to: path}}} =
+      view |> element("#preset-anime") |> render_click()
+
+    assert [section] = Collections.list_pinned_sections(user)
+    assert section.name == "Anime"
+    assert section.exclusive
+    assert section.sidebar_icon == "hero-sparkles"
+    assert path == "/sections/#{section.id}"
+  end
+
+  test "creating the same preset twice navigates to the existing section", %{
+    conn: conn,
+    user: user
+  } do
+    {:ok, view, _html} = live(conn, ~p"/sections/new")
+    view |> element("#preset-anime") |> render_click()
+
+    {:ok, view2, _html} = live(conn, ~p"/sections/new")
+    view2 |> element("#preset-anime") |> render_click()
+
+    assert length(Collections.list_pinned_sections(user)) == 1
+  end
+end

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -29,6 +29,30 @@ defmodule Mydia.MediaFixtures do
   end
 
   @doc """
+  Generate a media item with a specific category.
+
+  `MediaItem.changeset/2` does not cast `:category` and `create_media_item/2`
+  auto-classifies from metadata after insert, so a category passed to
+  `media_item_fixture/1` is silently dropped. This sets it afterwards with
+  `override: true` so nothing reclassifies it later. Pass `nil` for an item
+  that has not been classified yet.
+  """
+  def categorized_media_item_fixture(attrs, category) do
+    item = media_item_fixture(attrs)
+
+    case category do
+      nil ->
+        item
+        |> Ecto.Changeset.change(%{category: nil, category_override: true})
+        |> Mydia.Repo.update!()
+
+      category ->
+        {:ok, updated} = Mydia.Media.update_category(item, category, override: true)
+        updated
+    end
+  end
+
+  @doc """
   Generate an episode.
   """
   def episode_fixture(attrs \\ %{}) do


### PR DESCRIPTION
Answers the request in discussion #641 for an Anime category, without giving everyone a fixed Anime section.

## The shape

A **section** is a smart collection pinned to the sidebar. Nothing here is anime specific: `:anime_movie` and `:anime_series` already existed and are already assigned by `CategoryClassifier`, and `SmartRules` already accepted a `category in [...]` condition. What was missing was a way to promote a category slice into a first class library destination.

Sections render at `/sections/:id` through `MediaLive.Index` rather than the collection page, so a section gets the same toolbar as TV Shows: filters, sorting, selection, batch monitor, batch search, batch delete, batch edit. The seam is one option, `:base_query`, that lets the collection's rules supply the starting query.

A section marked **exclusive** claims its categories away from `/movies` and `/tv`, which is what actually answers the reporter's complaint that anime clutters the TV list. Only a rule that is exactly one `category in [...]` condition qualifies, because anything richer cannot be cleanly subtracted. Exclusivity is derived from the rules on every read, never stored, so it cannot drift.

Pins are per user. A shared collection pinned by its owner does not appear in anyone else's sidebar, so a section can never become a fixed section for the whole instance. Someone with no anime sees none of this.

## Getting one

Three presets (Anime, Cartoons, Documentaries) at `/sections/new`, or a **Pin to sidebar** button on any smart collection you own. When a library has at least 10 anime items and nothing claims them, the Movies and TV pages offer to create the Anime section once, dismissibly.

The preset list is limited to what `SmartRules` can express today. There is no 4K preset because there is no quality field, and no Recently Added preset because a smart collection requires at least one condition and a sort is not one.

## Things worth a reviewer's attention

- **NULL categories are kept deliberately.** SQL evaluates `NULL NOT IN ('anime_series')` to NULL, which `WHERE` treats as false. Without the explicit `is_nil` branch every item the classifier has not reached yet would vanish from the page it belongs on.
- **Exclusion is not applied on a section's own page.** A section's query already filters `category in [...]`; also applying `category not in [...]` would empty it out.
- **Counting goes through one aggregate.** `count_media_items/1` is a database aggregate that `count_movies/1` and `count_tv_shows/1` delegate to, so the sidebar badge and the page it links to share one exclusion set and cannot disagree. The Dashboard was reassigning those same assign keys with unexcluded counts and now uses the same exclusion.
- **Manual collections cannot be pinned.** A manual collection has `smart_rules: nil`, which falls back to `"{}"` and builds an unfiltered query, so pinning one would have put the entire library behind a section link. Refused in the context and again on the route.
- **Recovery paths.** Misclassification is the real risk of exclusivity. `category_override`, the per item category editor and `batch_reclassify` all already exist; the Movies and TV pages now name the section holding the missing items and link to it, and unpinning restores everything.

## Verification

`mix precommit` clean: compile, unused deps, format, Credo, and 10000 tests with 0 failures.

Migration adds three nullable columns to `collections` and is portable across SQLite and PostgreSQL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable sidebar sections with Anime, Cartoons, and Documentaries presets.
  * Pin, unpin, rename, customize icons, and configure exclusive sections.
  * Browse dedicated section pages with smart filtering.
  * Added an Anime section suggestion that can be accepted or dismissed.
* **Bug Fixes**
  * Movie and TV counts now remain consistent when sections exclude categories.
  * Unclassified media remains visible when category filters are applied.
* **Documentation**
  * Documented sidebar sections and category exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->