### PR TITLE
fix(player): stop the calendar rendering two cast buttons

### DIFF
--- a/player/lib/presentation/screens/downloads/downloads_screen.dart
+++ b/player/lib/presentation/screens/downloads/downloads_screen.dart
@@ -900,8 +900,8 @@ class DownloadsScreen extends ConsumerWidget {
                   ],
                   // DownloadsScreen's app bar is always visible (no
                   // desktop suppression), so it carries its own cast
-                  // affordance instead of the shell's overlay — see
-                  // AppShell._hasOwnCastButton.
+                  // affordance instead of the shell's overlay. See
+                  // AppShell.needsCastOverlay.
                   CastButton(
                     onPressed: () => pickCastDevice(context, ref),
                   ),

--- a/player/lib/presentation/screens/library/library_screen.dart
+++ b/player/lib/presentation/screens/library/library_screen.dart
@@ -303,9 +303,9 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
                       ),
                       const SizedBox(width: 4),
                       // LibraryScreen keeps a real app bar on every platform
-                      // (unlike the desktop-suppressed browse screens), so it
+                      // (unlike the desktop-suppressed Home screen), so it
                       // carries its own cast affordance instead of the
-                      // shell's overlay — see AppShell._hasOwnCastButton.
+                      // shell's overlay. See AppShell.needsCastOverlay.
                       CastButton(
                         onPressed: () => pickCastDevice(context, ref),
                       ),

--- a/player/lib/presentation/screens/settings/settings_screen.dart
+++ b/player/lib/presentation/screens/settings/settings_screen.dart
@@ -64,7 +64,7 @@ class SettingsScreen extends ConsumerWidget {
         title: const Text('Settings'),
         // SettingsScreen's app bar is always visible (no desktop
         // suppression), so it carries its own cast affordance instead of
-        // the shell's overlay. See AppShell._hasOwnCastButton.
+        // the shell's overlay. See AppShell.needsCastOverlay.
         actions: [
           CastButton(onPressed: () => pickCastDevice(context, ref)),
           const SizedBox(width: 8),

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -35,35 +35,31 @@ class AppShell extends ConsumerStatefulWidget {
     required this.location,
   });
 
-  /// Routes whose own screen already renders a [CastButton] in a real,
-  /// always-visible app bar.
+  /// Whether the shell must paint [CastOverlayButton] over [location].
   ///
   /// [CastOverlayButton] exists only for screens with nowhere else to put the
-  /// affordance — the desktop browse screens that suppress their app bar
-  /// entirely (Home/Unwatched/Favorites/RecentlyAdded/Collections). Library,
-  /// Downloads, Settings and Search all keep a real app bar on every
-  /// platform, with their own action buttons (sort/view-toggle, cancel-all,
-  /// clear, etc.) living in the exact top-right band this overlay paints
-  /// into. Rendering the overlay there too would sit on top of — and
-  /// intercept taps for — those existing buttons. Do not delete this check
-  /// "to simplify": it is what keeps the overlay from colliding with a
-  /// screen's own app bar the next time one grows an action.
+  /// affordance: ones that suppress their app bar on desktop and so have no
+  /// top-right band of their own. Home is the last such destination.
+  ///
+  /// This used to be the opposite question, `hasOwnCastButton`, answered by an
+  /// allowlist of every route that carries its own [CastButton]. That list was
+  /// a maintenance trap and it drifted twice: `/calendar` and `/filter/:id`
+  /// both grew a real app bar with a [CastButton] in it, neither was added,
+  /// and both ended up with two cast buttons stacked in the same corner:
+  /// the overlay floating above the screen's own bar, which reads as a
+  /// doubled header.
+  ///
+  /// Inverting it makes the safe answer the default. Every in-shell browse
+  /// screen now goes through `BrowseScaffold`, which always renders a glass
+  /// bar with a trailing [CastButton] on every platform, so a new route is
+  /// correct without touching this function. Only a screen that deliberately
+  /// suppresses its bar needs naming here, and adding one is a conscious act.
   ///
   /// Public (rather than a private helper on [_AppShellState]) and annotated
   /// `@visibleForTesting` purely so a test can assert the routing decision
   /// directly, without reconstructing the shell's full provider graph.
   @visibleForTesting
-  static bool hasOwnCastButton(String location) =>
-      location.startsWith('/movies') ||
-      location.startsWith('/shows') ||
-      location.startsWith('/downloads') ||
-      location.startsWith('/settings') ||
-      location.startsWith('/search') ||
-      location.startsWith('/unwatched') ||
-      location.startsWith('/continue-watching') ||
-      location.startsWith('/favorites') ||
-      location.startsWith('/recently-added') ||
-      location.startsWith('/collections');
+  static bool needsCastOverlay(String location) => location == '/';
 
   /// Builds the shell's cast overlay for the desktop or mobile branch.
   ///
@@ -295,7 +291,7 @@ class _AppShellState extends ConsumerState<AppShell>
     // proper repaint propagation on mobile when combined with GlobalKey
     // on the Scaffold (causing the "stuck navigation" bug).
     final isDesktop = Breakpoints.isDesktop(context);
-    final showCastOverlay = !AppShell.hasOwnCastButton(location);
+    final showCastOverlay = AppShell.needsCastOverlay(location);
 
     // Shell-level ambient backdrop, fed by the active browse screen. Sits behind
     // the (now transparent) in-shell Scaffolds for all browse screens (plan U5).

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -70,7 +70,7 @@ class AppShell extends ConsumerStatefulWidget {
   /// mobile app bar — never `MediaQuery.paddingOf(context).top` folded in on
   /// top of that, or the button sits under the strip twice.
   ///
-  /// Public (rather than inlined at each call site) and annotated
+  /// Public (rather than inlined in [castOverlaySlot]) and annotated
   /// `@visibleForTesting` so a test can exercise the exact value this shell
   /// computes for each branch directly, instead of re-declaring the numbers
   /// in a mirror that can silently drift from the real call sites.
@@ -78,6 +78,33 @@ class AppShell extends ConsumerStatefulWidget {
   static Widget castOverlay({required bool isDesktop}) => CastOverlayButton(
         topInset: isDesktop ? 12 : kToolbarHeight + 8,
       );
+
+  /// The overlay slot both branches drop into their `Stack`: the real
+  /// [castOverlay] on a route that needs one, an inert zero-size box
+  /// otherwise.
+  ///
+  /// The routing decision lives in here, rather than as an `if` at the two
+  /// call sites, so that a test can exercise it for real. When the `if` was
+  /// at the call sites, the only way to cover it was for the test to rebuild
+  /// the same conditional around [needsCastOverlay], a mirror, which proves
+  /// the mirror works and nothing about the shell. Reviewing #645, CodeRabbit
+  /// caught exactly that: the `/calendar` case would have passed even if this
+  /// widget still used the old predicate. Calling the seam removes the mirror,
+  /// the same way [castOverlay] already removed the one around its `topInset`
+  /// arithmetic.
+  ///
+  /// `SizedBox.shrink()` rather than omitting the child: [CastOverlayButton]
+  /// builds a `Positioned`, so the slot is a `Stack` child either way, and a
+  /// zero-size unpositioned child cannot grow a loose `Stack` or paint
+  /// anything.
+  @visibleForTesting
+  static Widget castOverlaySlot({
+    required String location,
+    required bool isDesktop,
+  }) =>
+      needsCastOverlay(location)
+          ? castOverlay(isDesktop: isDesktop)
+          : const SizedBox.shrink();
 
   /// The gutter both the desktop and mobile branches wrap their main content
   /// column in: a `SafeArea` that consumes the ambient `MediaQuery.padding`
@@ -291,7 +318,6 @@ class _AppShellState extends ConsumerState<AppShell>
     // proper repaint propagation on mobile when combined with GlobalKey
     // on the Scaffold (causing the "stuck navigation" bug).
     final isDesktop = Breakpoints.isDesktop(context);
-    final showCastOverlay = AppShell.needsCastOverlay(location);
 
     // Shell-level ambient backdrop, fed by the active browse screen. Sits behind
     // the (now transparent) in-shell Scaffolds for all browse screens (plan U5).
@@ -328,7 +354,7 @@ class _AppShellState extends ConsumerState<AppShell>
                 ),
               ],
             ),
-            if (showCastOverlay) AppShell.castOverlay(isDesktop: true),
+            AppShell.castOverlaySlot(location: location, isDesktop: true),
           ],
         ),
       );
@@ -364,7 +390,7 @@ class _AppShellState extends ConsumerState<AppShell>
               ],
             ),
           ),
-          if (showCastOverlay) AppShell.castOverlay(isDesktop: false),
+          AppShell.castOverlaySlot(location: location, isDesktop: false),
         ],
       ),
       bottomNavigationBar: AppShell.dockChrome(

--- a/player/test/presentation/widgets/app_shell_cast_overlay_inset_test.dart
+++ b/player/test/presentation/widgets/app_shell_cast_overlay_inset_test.dart
@@ -9,7 +9,7 @@
 // overlay from (see app_shell.dart) — rather than mounting the full
 // `AppShell`, which needs a Riverpod graph, router location and GraphQL
 // client (see app_shell_cast_overlay_test.dart for the sibling test covering
-// the routing predicate, `hasOwnCastButton`, the same way). Because the test
+// the routing predicate, `needsCastOverlay`, the same way). Because the test
 // calls the real seam instead of re-declaring its `topInset` arithmetic, a
 // regression at either call site is caught here without any mirror to keep
 // in sync by hand.

--- a/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
+++ b/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
@@ -1,16 +1,23 @@
 // The shell pins CastOverlayButton into its own Stack so casting is reachable
-// even on desktop screens that suppress their app bar entirely (Home). But some
-// in-shell screens (Library, Downloads, Settings, Search, Unwatched,
-// ContinueWatching, Favorites, RecentlyAdded, Collections) keep a real,
-// always-visible app bar with their own action buttons in the same top-right
-// band the overlay paints into — those screens carry their own CastButton
-// instead, and the shell must not also paint the overlay there, or the overlay
-// sits on top of and intercepts taps for the screen's own actions.
+// on a screen that suppresses its app bar on desktop and therefore has no
+// top-right band of its own. Home is the last such destination. Every other
+// in-shell screen keeps a real, always-visible app bar with its own action
+// buttons in exactly the band the overlay paints into, and carries its own
+// CastButton there, so the shell must not also paint the overlay: doing so
+// stacks two cast buttons in the same corner (which reads as a doubled
+// header) and intercepts taps meant for the screen's own actions.
 //
-// `AppShell.hasOwnCastButton` is the single routing decision that keeps these
-// two mutually exclusive. It's asserted directly here (rather than by
-// mounting the full `AppShell`, which needs a GoRouter ancestor plus the auth/
-// connection/download provider graph — no existing shell test does that; see
+// `AppShell.needsCastOverlay` is the single routing decision that keeps these
+// two mutually exclusive. It was once the opposite question, an allowlist of
+// routes that carried their own button, and that list silently fell behind
+// twice: `/calendar` and `/filter/:id` both grew a real bar with a CastButton
+// and neither was added, so both showed the doubled button. The cases below
+// pin the inverted form, where a route is only in the overlay's path if it is
+// named here.
+//
+// The predicate is asserted directly (rather than by mounting the full
+// `AppShell`, which needs a GoRouter ancestor plus the auth/connection/
+// download provider graph, and no existing shell test does that; see
 // app_shell_backdrop_test.dart and app_shell_search_nav_test.dart, which both
 // use lightweight stand-ins instead) and then exercised against a Stack that
 // reproduces the shell's exact `if (showCastOverlay) CastOverlayButton(...)`
@@ -25,51 +32,49 @@ import 'package:player/presentation/widgets/app_shell.dart';
 import 'package:player/presentation/widgets/cast_actions.dart';
 
 void main() {
-  group('AppShell.hasOwnCastButton', () {
-    // Library, Downloads, Settings and Search all keep a real app bar on
-    // every platform (no desktop suppression) and were each given their own
-    // CastButton in this fix — see the corresponding screen files.
+  group('AppShell.needsCastOverlay', () {
+    // Every in-shell destination other than Home. Library, Downloads,
+    // Settings and Search keep a real app bar on every platform and were each
+    // given their own CastButton; the rest gained an always-visible glass bar
+    // with a trailing CastButton when they moved onto `BrowseScaffold`.
     for (final location in [
       '/movies',
       '/shows',
       '/downloads',
       '/settings',
       '/search',
-      // Gained an always-visible glass bar with its own CastButton when they
-      // moved onto `BrowseScaffold`. Before that they suppressed their bar
-      // entirely on desktop and the overlay was their only affordance.
       '/unwatched',
       '/continue-watching',
       '/favorites',
       '/recently-added',
       '/collections',
-      // Sub-paths under a route with its own button must also be excluded
-      // from the overlay, matching how `_isHomeSection`/`_isLibrarySection`
-      // already treat these as prefixes, not exact matches.
+      // The two the old allowlist missed. `/calendar` renders through
+      // `BrowseScaffold`; `/filter/:id` builds its own bar with a CastButton
+      // after the view-toggle and overflow menu. Both showed two cast buttons
+      // stacked in the top-right corner until this predicate was inverted.
+      '/calendar',
+      '/filter/1',
+      // Sub-paths and query strings resolve the same way as their parents.
       '/search?q=foo&type=movie',
       '/settings/devices',
     ]) {
-      test('is true for $location (screen carries its own CastButton)', () {
-        expect(AppShell.hasOwnCastButton(location), isTrue);
+      test('is false for $location (screen carries its own CastButton)', () {
+        expect(AppShell.needsCastOverlay(location), isFalse);
       });
     }
 
     // Home is the last in-shell destination that still suppresses its app bar
     // on desktop, so the overlay remains its only cast affordance.
-    for (final location in [
-      '/',
-    ]) {
-      test('is false for $location (overlay is the only affordance)', () {
-        expect(AppShell.hasOwnCastButton(location), isFalse);
-      });
-    }
+    test('is true for / (overlay is the only affordance)', () {
+      expect(AppShell.needsCastOverlay('/'), isTrue);
+    });
   });
 
-  group('the shell Stack, gated by hasOwnCastButton', () {
+  group('the shell Stack, gated by needsCastOverlay', () {
     /// Reproduces the exact conditional the shell's own Stack children use:
-    /// `if (!AppShell.hasOwnCastButton(location)) CastOverlayButton(...)`.
+    /// `if (AppShell.needsCastOverlay(location)) CastOverlayButton(...)`.
     Widget stackFor(String location) {
-      final showCastOverlay = !AppShell.hasOwnCastButton(location);
+      final showCastOverlay = AppShell.needsCastOverlay(location);
 
       return ProviderScope(
         overrides: [
@@ -93,6 +98,14 @@ void main() {
     testWidgets('renders no cast button on a route with its own (e.g. /movies)',
         (tester) async {
       await tester.pumpWidget(stackFor('/movies'));
+      await tester.pump();
+
+      expect(find.byKey(const Key('cast-button')), findsNothing);
+    });
+
+    testWidgets('renders no cast button on /calendar, which has its own',
+        (tester) async {
+      await tester.pumpWidget(stackFor('/calendar'));
       await tester.pump();
 
       expect(find.byKey(const Key('cast-button')), findsNothing);

--- a/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
+++ b/player/test/presentation/widgets/app_shell_cast_overlay_test.dart
@@ -19,9 +19,15 @@
 // `AppShell`, which needs a GoRouter ancestor plus the auth/connection/
 // download provider graph, and no existing shell test does that; see
 // app_shell_backdrop_test.dart and app_shell_search_nav_test.dart, which both
-// use lightweight stand-ins instead) and then exercised against a Stack that
-// reproduces the shell's exact `if (showCastOverlay) CastOverlayButton(...)`
-// pattern, so a regression in either the predicate or the wiring is caught.
+// use lightweight stand-ins instead), and the rendering is then driven
+// through `AppShell.castOverlaySlot`, the same seam the shell's two branches
+// drop into their own `Stack`.
+//
+// The slot matters: an earlier draft of this file rebuilt the shell's
+// `if (showCastOverlay) ...` conditional inside the test instead, which
+// CodeRabbit flagged on #645 as proving only that the test's own copy worked.
+// The conditional now lives in the seam, so these cases fail if the shell's
+// routing decision regresses rather than passing against a mirror.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -29,7 +35,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/cast/cast_capabilities.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/presentation/widgets/app_shell.dart';
-import 'package:player/presentation/widgets/cast_actions.dart';
 
 void main() {
   group('AppShell.needsCastOverlay', () {
@@ -70,12 +75,9 @@ void main() {
     });
   });
 
-  group('the shell Stack, gated by needsCastOverlay', () {
-    /// Reproduces the exact conditional the shell's own Stack children use:
-    /// `if (AppShell.needsCastOverlay(location)) CastOverlayButton(...)`.
-    Widget stackFor(String location) {
-      final showCastOverlay = AppShell.needsCastOverlay(location);
-
+  group('AppShell.castOverlaySlot', () {
+    /// Mounts the real seam, in the `Stack` it is built for.
+    Widget slotFor(String location, {bool isDesktop = true}) {
       return ProviderScope(
         overrides: [
           castCapabilitiesProvider.overrideWithValue(
@@ -87,7 +89,10 @@ void main() {
             body: Stack(
               children: [
                 const SizedBox.expand(),
-                if (showCastOverlay) const CastOverlayButton(topInset: 40),
+                AppShell.castOverlaySlot(
+                  location: location,
+                  isDesktop: isDesktop,
+                ),
               ],
             ),
           ),
@@ -97,7 +102,7 @@ void main() {
 
     testWidgets('renders no cast button on a route with its own (e.g. /movies)',
         (tester) async {
-      await tester.pumpWidget(stackFor('/movies'));
+      await tester.pumpWidget(slotFor('/movies'));
       await tester.pump();
 
       expect(find.byKey(const Key('cast-button')), findsNothing);
@@ -105,7 +110,15 @@ void main() {
 
     testWidgets('renders no cast button on /calendar, which has its own',
         (tester) async {
-      await tester.pumpWidget(stackFor('/calendar'));
+      await tester.pumpWidget(slotFor('/calendar'));
+      await tester.pump();
+
+      expect(find.byKey(const Key('cast-button')), findsNothing);
+    });
+
+    testWidgets('renders no cast button on /filter/1, which has its own',
+        (tester) async {
+      await tester.pumpWidget(slotFor('/filter/1'));
       await tester.pump();
 
       expect(find.byKey(const Key('cast-button')), findsNothing);
@@ -114,9 +127,19 @@ void main() {
     testWidgets(
         'renders exactly one overlay cast button on a route with no app-bar '
         'affordance (e.g. /)', (tester) async {
-      await tester.pumpWidget(stackFor('/'));
+      await tester.pumpWidget(slotFor('/'));
       await tester.pump();
 
+      expect(find.byKey(const Key('cast-button')), findsOneWidget);
+    });
+
+    testWidgets('does the same on the mobile branch', (tester) async {
+      await tester.pumpWidget(slotFor('/calendar', isDesktop: false));
+      await tester.pump();
+      expect(find.byKey(const Key('cast-button')), findsNothing);
+
+      await tester.pumpWidget(slotFor('/', isDesktop: false));
+      await tester.pump();
       expect(find.byKey(const Key('cast-button')), findsOneWidget);
     });
   });


### PR DESCRIPTION
The calendar looked like it had a doubled header: a cast button in the top-right corner of the screen, and a second one in the glass bar right next to the **Today** action.

## Cause

`AppShell` paints `CastOverlayButton` for any route *not* named in `AppShell.hasOwnCastButton`, a hand-maintained allowlist of screens that already render their own `CastButton`. `/calendar` reaches the shell through `BrowseScaffold`, which always renders a glass bar with a trailing cast button, but the route was never added to the list, so the shell painted its overlay on top of the screen's own bar.

`/filter/:id` has the same defect: it builds its own bar with a `CastButton` after the view-toggle and overflow menu, and it is not in the list either.

## Fix

Invert the predicate instead of extending the list. Every in-shell browse screen now goes through `BrowseScaffold` and gets a cast button for free, so the safe answer becomes the default and a new route is correct without anyone remembering to touch the shell:

```dart
static bool needsCastOverlay(String location) => location == '/';
```

Home is the last in-shell destination that suppresses its app bar on desktop, and it is the only case the overlay still serves.

## Tests

`app_shell_cast_overlay_test.dart` mirrored the old allowlist, which is exactly why neither route was caught. The rewritten test pins the inverted form and covers `/calendar` and `/filter/1` directly, plus a widget case asserting the shell's `Stack` renders no cast button on `/calendar`.

`flutter test test/presentation/widgets test/presentation/screens/calendar` passes (969 passed, 4 pre-existing skips), and `flutter analyze` is clean on every changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Consolidated cast-overlay routing across desktop and mobile app layouts.
  * Ensured cast-overlay presentation follows each screen’s routing requirements, avoiding duplicate controls.

* **Tests**
  * Expanded coverage for calendar, filter, home, and mobile cast-overlay scenarios.
  * Updated test documentation to reflect the current routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->