### PR TITLE
perf(docker): move BUILD_COMMIT below the dependency layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,60 @@ jobs:
           fi
           exit "$FAIL"
 
+      # BUILD_COMMIT's value changes on every commit, and BuildKit folds a RUN's
+      # environment into its ExecOp cache key while a COPY is a FileOp that
+      # ignores it. Declared above the dependency layers it therefore leaves
+      # `mix deps.get` and `mix deps.compile` permanently uncacheable across
+      # commits, in ci-docker.yml, release.yml and ci-player-e2e.yml at once,
+      # while the build log still reports the COPY above them as CACHED. That
+      # asymmetry hid the bug from the day it was introduced.
+      #
+      # Below `mix compile` is wrong for the opposite reason: Mydia.System
+      # captures BUILD_COMMIT into a module attribute, `mix release` recompiles
+      # nothing, and the commit suffix would disappear from the version and from
+      # crash reports with no build or test failure. Both bounds are checked.
+      #
+      # Comments are blanked rather than deleted, so line numbers survive,
+      # before matching. The Dockerfile comment explaining this rule quotes
+      # every string the guard searches for, which is the same trap the two
+      # guards below already document.
+      - name: Guard the Docker build-identity placement
+        run: |
+          set -euo pipefail
+          scrub="$(mktemp)"
+          sed 's/^[[:space:]]*#.*//' Dockerfile > "$scrub"
+
+          find_line() { grep -nE "$1" "$scrub" | head -1 | cut -d: -f1 || true; }
+
+          deps=$(find_line '^[[:space:]]*mix deps\.compile$')
+          comp=$(find_line '^[[:space:]]*mix compile$')
+          argline=$(find_line '^ARG BUILD_COMMIT')
+          envline=$(find_line '^ENV BUILD_COMMIT')
+
+          FAIL=0
+          for a in "mix deps.compile:$deps" "mix compile:$comp" \
+                   "ARG BUILD_COMMIT:$argline" "ENV BUILD_COMMIT:$envline"; do
+            if [ -z "${a##*:}" ]; then
+              echo "::error::Docker build-identity guard lost its anchor (${a%%:*}); update this step in ci.yml"
+              FAIL=1
+            fi
+          done
+          [ "$FAIL" = 0 ] || exit 1
+
+          for pair in "ARG:$argline" "ENV:$envline"; do
+            kind=${pair%%:*}
+            line=${pair##*:}
+            if [ "$line" -lt "$deps" ]; then
+              echo "::error file=Dockerfile,line=$line::$kind BUILD_COMMIT sits above 'mix deps.compile' (line $deps). Its value changes on every commit, so every RUN below it misses cache in ci-docker.yml, release.yml and ci-player-e2e.yml. Keep it beside BUILD_VERSION, just above 'mix compile'."
+              FAIL=1
+            fi
+            if [ "$line" -gt "$comp" ]; then
+              echo "::error file=Dockerfile,line=$line::$kind BUILD_COMMIT sits below 'mix compile' (line $comp). Mydia.System captures it into a module attribute at compile time and 'mix release' recompiles nothing, so the commit suffix would silently vanish from the version and from crash reports."
+              FAIL=1
+            fi
+          done
+          exit "$FAIL"
+
       # This task runs from devenv's mydia:ecto against a database that may have
       # no tables yet. Booting the supervision tree there is fatal, because
       # ClientHealth.init/1 queries download_client_configs synchronously, and

--- a/Dockerfile
+++ b/Dockerfile
@@ -132,14 +132,14 @@ RUN mix local.hex --force && mix local.rebar --force
 # It CANNOT be changed at runtime - each Docker image is built for a specific database
 ARG DATABASE_TYPE=sqlite
 
-# Build commit hash for development/master builds
-# When set, the version will display as "X.Y.Z*<short-commit>" instead of just "X.Y.Z"
-ARG BUILD_COMMIT=""
+# BUILD_COMMIT is deliberately not declared here. Its value changes on every
+# commit, so setting it at this height makes every RUN below uncacheable. It
+# lives beside BUILD_VERSION just above `mix compile`; the full explanation is
+# in the comment there, and ci.yml fails the build if it moves back up.
 
 # Set build environment
 ENV MIX_ENV=prod
 ENV DATABASE_TYPE=${DATABASE_TYPE}
-ENV BUILD_COMMIT=${BUILD_COMMIT}
 
 # Create app directory
 WORKDIR /app
@@ -178,9 +178,31 @@ COPY plugins ./plugins
 # Copy Flutter build output from flutter-builder stage
 COPY --from=flutter-builder /app/player/build/web ./priv/static/player
 
-# Application version: set by CI from the git tag, defaults to "dev" for local builds
+# Build identity. BUILD_VERSION is set by CI from the git tag and defaults to
+# "dev" for local builds. BUILD_COMMIT is the SHA, set for master and release
+# builds so the version renders as "X.Y.Z*<short-commit>".
+#
+# Both are read at compile time: mix.exs reads BUILD_VERSION for the project
+# version, and Mydia.System captures BUILD_COMMIT into a module attribute. Both
+# also change per build, so this position, below the dependency layers and above
+# `mix compile`, is load-bearing in both directions.
+#
+# Higher is wrong. BuildKit folds a RUN's environment into its ExecOp cache key,
+# while a COPY is a FileOp that ignores it, so a commit-varying ENV above
+# `mix deps.get` and `mix deps.compile` leaves those two permanently uncacheable
+# in ci-docker.yml, release.yml and ci-player-e2e.yml at once. That asymmetry is
+# what hid the bug for so long: the build log showed `COPY mix.exs mix.lock` as
+# CACHED with every RUN beneath it missing, which reads as impossible. Here it
+# costs nothing, because the source COPYs above already vary per commit.
+#
+# Lower is also wrong. `mix release` recompiles nothing, so setting BUILD_COMMIT
+# after `mix compile` leaves Mydia.System's attribute nil and drops the commit
+# suffix from the version and from crash reports, with no build or test failure
+# to catch it. ci.yml guards this placement.
 ARG BUILD_VERSION=""
 ENV BUILD_VERSION=${BUILD_VERSION}
+ARG BUILD_COMMIT=""
+ENV BUILD_COMMIT=${BUILD_COMMIT}
 
 # Compile application (includes building Rust NIFs via Rustler)
 # Cache cargo for Rust NIF compilation


### PR DESCRIPTION
`Dockerfile:142` set `ENV BUILD_COMMIT=${BUILD_COMMIT}` above `mix deps.get` and `mix deps.compile`. Three workflows pass a value that changes on every commit:

| Workflow | Argument |
| --- | --- |
| `ci-docker.yml:69` | `BUILD_COMMIT=${{ github.sha }}` |
| `release.yml:302` | `BUILD_COMMIT=${{ needs.prepare.outputs.sha }}` |
| `ci-player-e2e.yml:217` | `BUILD_COMMIT=${{ github.sha }}` |

So both dependency layers have been uncacheable across commits in three workflows at once, since the line was introduced. `ci-docker.yml` on master runs 12-19 min, median ~13.5. Merge #634 (`docs-ci-gate-findings`) took 13m08s despite touching no Elixir source, which is independent confirmation that nothing below line 142 was cached.

### Why it stayed invisible

The build log shows `COPY mix.exs mix.lock` as `CACHED` while every `RUN` after it misses, which reads as impossible.

It isn't. BuildKit folds a `RUN`'s environment into its `ExecOp` cache key; a `COPY` is a `FileOp` that ignores it. Measured on real BuildKit with a two-line probe, changing only the build arg:

```
#6 [2/4] COPY probe.txt /probe.txt
#6 CACHED
#7 [3/4] RUN echo run-above-env > /out     <- above the ENV
#7 CACHED
#8 [4/4] RUN echo run-below-env > /out2    <- below the ENV
#8 DONE 0.1s
```

`COPY` cached with every `RUN` beneath it missing is the exact signature of a commit-varying `ENV`.

### The fix

`ARG`/`ENV BUILD_COMMIT` move down beside `BUILD_VERSION`, just above `mix compile`. Everything from there down is already commit-variant through the source `COPY`s, so the position costs nothing. `mix deps.get --only prod` and `mix deps.compile` become keyed on `mix.exs`, `mix.lock` and `patches/` alone.

It deliberately does **not** go below `mix compile`. `lib/mydia/system.ex:10` is `@build_commit System.get_env("BUILD_COMMIT")`, a module attribute; `mix release` runs `compile` but nothing would have changed, so `Mydia.System` is not recompiled and Elixir does not treat `System.get_env/1` as a compile-time dependency. The `0.7.4*abc1234` suffix and `build_commit/0` (which the crash reporter sends) would silently go empty, with no build or test failure.

### Guard

A new step in `ci.yml`'s `test` job, beside the existing `Guard the Rust toolchain pin`, checks both bounds and fails loudly if an anchor string disappears rather than degrading to a silent pass. It blanks full-line comments before matching, keeping line numbers: the new Dockerfile comment quotes every string the guard searches for, which is the same trap the two guards below it already document. Verified against four fixtures locally: clean file passes; the pre-fix Dockerfile is caught on both lines; `ENV` below `mix compile` is caught; a removed anchor errors.

`docker buildx build --check` reports no warnings.

### Verifying after merge

The first master merge still pays full price, because the gha cache scope holds no entry for the new layer chain; that run populates it. The **second** merge is the proof: `mix deps.get` and `mix deps.compile` should report `CACHED`, and total wall time should drop off the ~13.5 min median. `ci-player-e2e.yml` is `cache-from` only and inherits the win once `ci-docker.yml` has written the scope.

### Not in this PR

- `npm ci` (line 203 pre-change) sits below `COPY assets` and `COPY lib`, so it also never caches across commits. Real and adjacent, but needs the npm install split off from `mix assets.deploy`.
- Making `BUILD_COMMIT` runtime-read, which would let a docs-only master commit reuse the whole builder stage. More churn than the marginal win justifies today.
- `BUILD_VERSION` stays put: `ci-docker.yml` never passes it, so it is a constant `""` there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Reliability**
  * Improved Docker image build consistency by positioning build identity information at the appropriate compilation stage.
  * Added automated checks to detect incorrect placement or missing build metadata during CI validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->