### PR TITLE
fix(import): restore durable background accept and re-match

### DIFF
--- a/docs/using/how-to/import-existing-collection.md
+++ b/docs/using/how-to/import-existing-collection.md
@@ -65,12 +65,13 @@ Below the scan controls, results are grouped by folder and filtered into
 chip for anything you have dismissed. Dismissing a result is durable: it
 survives later scans of the same library, and survives **Clear** too.
 
-**Queued** holds the groups whose import is already under way. Accepting a
-selection does not import it on the spot: it hands the work to a background job,
-so you can close the page and the import carries on. Groups leave Queued as they
-finish. A group that could not be imported returns to the main list with a short
-note explaining why, most often because its files match more than one title or
-because no provider recognised them.
+**Queued** holds the groups with work already under way, whether that is an
+import you accepted or a re-match you asked for. Neither happens on the spot:
+both hand the work to a background job, so you can close the page and it carries
+on without you. Groups leave Queued as they finish. A group whose work could not
+be completed returns to the main list with a short note explaining why, most
+often because its files match more than one title or because no provider
+recognised them.
 
 **Clear** removes unresolved scan results and finished scan history for the
 selected library so the next scan starts fresh, but it never removes a result

--- a/docs/using/how-to/import-existing-collection.md
+++ b/docs/using/how-to/import-existing-collection.md
@@ -65,6 +65,13 @@ Below the scan controls, results are grouped by folder and filtered into
 chip for anything you have dismissed. Dismissing a result is durable: it
 survives later scans of the same library, and survives **Clear** too.
 
+**Queued** holds the groups whose import is already under way. Accepting a
+selection does not import it on the spot: it hands the work to a background job,
+so you can close the page and the import carries on. Groups leave Queued as they
+finish. A group that could not be imported returns to the main list with a short
+note explaining why, most often because its files match more than one title or
+because no provider recognised them.
+
 **Clear** removes unresolved scan results and finished scan history for the
 selected library so the next scan starts fresh, but it never removes a result
 you have already dismissed -- that decision stays exactly as you left it.

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -924,7 +924,15 @@ defmodule Mydia.ImportCandidates do
       broadcast(scope.library_path_id)
     end
 
-    {:ok, %{queued: queued, skipped: selected - queued}}
+    # `queued`/`selected` are read before the UPDATE (see above) and so, on a
+    # `"queued"`-status scope, still count groups whose candidates already
+    # carry a `queued_op` -- the UPDATE's own `is_nil(c.queued_op)` guard then
+    # matches zero rows for them. Gating the return on `row_count` (as
+    # `dismiss/1` and `queue_rematch/1` already do) keeps this from reporting
+    # a queue that did not happen.
+    {queued, skipped} = if row_count > 0, do: {queued, selected - queued}, else: {0, selected}
+
+    {:ok, %{queued: queued, skipped: skipped}}
   end
 
   @doc """

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -68,6 +68,11 @@ defmodule Mydia.ImportCandidates do
   # allocation, while still being processed as a single logical group.
   @member_page_size 500
   @accept_group_page_size 50
+  @queue_anchor_page_size 25
+
+  # Refusals that will fail identically on every retry, so the marker is cleared
+  # and the reason surfaced instead of burning the retry budget.
+  @terminal_accept_errors [:no_match, :conflicting_providers, :local_show, :empty_group]
 
   @type cursor :: {non_neg_integer(), String.t()}
 
@@ -910,7 +915,7 @@ defmodule Mydia.ImportCandidates do
     do: {:error, :local_show}
 
   defp accept_group(%ImportCandidateGroup{library_path_id: lp_id, anchor_key: key}, opts) do
-    case load_all_members(lp_id, key) do
+    case load_queued_members(lp_id, key) do
       [] ->
         {:error, :empty_group}
 
@@ -919,6 +924,163 @@ defmodule Mydia.ImportCandidates do
         CandidatePromotion.promote_group(candidates, match, opts)
     end
   end
+
+  # Only the rows the user actually queued. A mixed anchor (queued rows plus a
+  # newcomer a concurrent scan inserted) must promote exactly the queued set,
+  # which is the set `get_group/3` computed the group's eligibility from. The
+  # newcomer stays pending and shows up in the review list on the next pass.
+  defp load_queued_members(library_path_id, anchor_key) do
+    library_path_id
+    |> load_all_members(anchor_key)
+    |> Enum.filter(&(&1.queued_op == "accept"))
+  end
+
+  @doc """
+  Promotes every group queued for accept on one library path.
+
+  Discovers its own work from `queued_op`, so a restarted job resumes where it
+  stopped and a second accept queued while this runs is picked up by the same
+  loop. Groups are drained one anchor page at a time; the whole membership of
+  one group still goes to `CandidatePromotion.promote_group/3` in a single call,
+  which is the only transaction boundary here.
+
+  A terminal refusal (no provider match, files matching different titles, a
+  synthetic local show, a group whose rows vanished) clears the marker and
+  records `queue_error`, returning the group to the pending list with an
+  explanation rather than leaving it queued forever. Anything else leaves the
+  marker in place, so `remaining` is non-zero and the worker reports failure for
+  Oban to retry.
+  """
+  @spec drain_accepted(binary(), keyword()) ::
+          {:ok,
+           %{
+             promoted: non_neg_integer(),
+             failed: non_neg_integer(),
+             remaining: non_neg_integer()
+           }}
+  def drain_accepted(library_path_id, opts \\ []) do
+    page_size = Keyword.get(opts, :anchor_page_size, @queue_anchor_page_size)
+
+    result =
+      drain_accepted_pages(
+        library_path_id,
+        opts,
+        page_size,
+        queued_count(library_path_id, "accept"),
+        %{promoted: 0, failed: 0}
+      )
+
+    broadcast(library_path_id)
+    result
+  end
+
+  defp drain_accepted_pages(library_path_id, opts, page_size, remaining_before, acc) do
+    keys = queued_anchor_keys(library_path_id, "accept", page_size)
+
+    if keys == [] do
+      {:ok, Map.put(acc, :remaining, 0)}
+    else
+      acc = Enum.reduce(keys, acc, &promote_queued_anchor(library_path_id, &1, opts, &2))
+
+      # One broadcast per page, not per group: the review page's Queued chip
+      # drains visibly while the job runs, and the LiveView's own burst debounce
+      # keeps that from becoming a re-render storm.
+      broadcast(library_path_id)
+
+      remaining = queued_count(library_path_id, "accept")
+
+      cond do
+        remaining == 0 ->
+          {:ok, Map.put(acc, :remaining, 0)}
+
+        remaining < remaining_before ->
+          drain_accepted_pages(library_path_id, opts, page_size, remaining, acc)
+
+        # No progress: every group on that page failed without clearing its
+        # marker, so another pass would fetch the same anchors and fail
+        # identically. Stop and let the worker's retry handle it.
+        true ->
+          {:ok, Map.put(acc, :remaining, remaining)}
+      end
+    end
+  end
+
+  defp promote_queued_anchor(library_path_id, anchor_key, opts, acc) do
+    case get_group(library_path_id, anchor_key, status: "queued") do
+      nil ->
+        # The rows went away mid-drain, which clear_for_library/1 and
+        # delete_missing/3 can both do. There is nothing left to promote, so
+        # this is not a retryable failure.
+        %{acc | failed: acc.failed + 1}
+
+      group ->
+        promote_queued_group(library_path_id, anchor_key, group, opts, acc)
+    end
+  end
+
+  defp promote_queued_group(library_path_id, anchor_key, group, opts, acc) do
+    case accept_group(group, opts) do
+      {:ok, _media_files} ->
+        %{acc | promoted: acc.promoted + 1}
+
+      {:error, reason} when reason in @terminal_accept_errors ->
+        clear_queue_marker(library_path_id, anchor_key, "accept", queue_error_message(reason))
+        %{acc | failed: acc.failed + 1}
+
+      {:error, reason} ->
+        Logger.warning("A queued import group did not promote, leaving it queued for retry",
+          library_path_id: library_path_id,
+          anchor_key: anchor_key,
+          reason: inspect(reason)
+        )
+
+        %{acc | failed: acc.failed + 1}
+    end
+  rescue
+    error ->
+      Logger.error("Promoting a queued import group raised, leaving it queued for retry",
+        library_path_id: library_path_id,
+        anchor_key: anchor_key,
+        error: Exception.format(:error, error, __STACKTRACE__)
+      )
+
+      %{acc | failed: acc.failed + 1}
+  end
+
+  defp queued_anchor_keys(library_path_id, op, limit) do
+    ImportCandidate
+    |> where([c], c.library_path_id == ^library_path_id and c.queued_op == ^op)
+    |> where([c], is_nil(c.dismissed_at))
+    |> distinct(true)
+    |> order_by([c], asc: c.anchor_key)
+    |> select([c], c.anchor_key)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  defp queued_count(library_path_id, op) do
+    ImportCandidate
+    |> where([c], c.library_path_id == ^library_path_id and c.queued_op == ^op)
+    |> where([c], is_nil(c.dismissed_at))
+    |> Repo.aggregate(:count)
+  end
+
+  defp clear_queue_marker(library_path_id, anchor_key, op, error) do
+    now = now()
+
+    ImportCandidate
+    |> where([c], c.library_path_id == ^library_path_id and c.anchor_key == ^anchor_key)
+    |> where([c], c.queued_op == ^op)
+    |> Repo.update_all(set: [queued_op: nil, queued_at: nil, queue_error: error, updated_at: now])
+  end
+
+  defp queue_error_message(:no_match), do: "No provider match to import from."
+
+  defp queue_error_message(:conflicting_providers),
+    do: "Files in this folder match different titles."
+
+  defp queue_error_message(:local_show), do: "Local shows are created directly, not imported."
+  defp queue_error_message(:empty_group), do: "No files left to import."
 
   @doc """
   Accepts every pending provider-matched group for one library path.

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -67,7 +67,6 @@ defmodule Mydia.ImportCandidates do
   # group the size of a whole season tree never becomes one unbounded
   # allocation, while still being processed as a single logical group.
   @member_page_size 500
-  @accept_group_page_size 50
   @queue_anchor_page_size 25
 
   # Refusals that will fail identically on every retry, so the marker is cleared
@@ -882,70 +881,90 @@ defmodule Mydia.ImportCandidates do
   defp parse_int(_), do: nil
 
   @doc """
-  Accepts a selection: promotes every selected group whose candidates carry a
-  real provider match, one group at a time.
+  Queues a selection for import.
 
-  A group with no provider match (`:no_match`), or whose provider identity is
-  the synthetic `"local"` marker (see `create_local_show/2`), has nothing for
-  `Mydia.Library.CandidatePromotion` to enrich from and is skipped rather than
-  attempted. Each accepted group's full membership is loaded in bounded pages
-  (see `load_all_members/2`) and handed to `CandidatePromotion.promote_group/3`
-  in one call, so the whole group's ownership change commits as the one
-  transaction that function already guarantees -- this function opens no
-  transaction of its own, and does no provider/network work inside one.
+  One `UPDATE ... WHERE` marks every eligible candidate in the selected anchors,
+  then one Oban job is enqueued for the library path. A `:filter`-mode selection
+  carries no ids, so this stays a single statement no matter how many groups it
+  covers, and the snapshot is taken against what the user was looking at rather
+  than re-derived when the job eventually runs.
+
+  Eligibility is applied here rather than in the worker. A group with no
+  provider match, or with files matching different titles, or carrying the
+  synthetic `"local"` provider can never be promoted, so letting it move into
+  Queued and bounce straight back with an error would be churn on the most
+  common bulk path.
   """
-  @spec accept(SelectionScope.t(), keyword()) ::
-          {:ok, %{accepted: non_neg_integer(), skipped: non_neg_integer()}}
-  def accept(%SelectionScope{} = scope, opts \\ []) do
-    page_size = Keyword.get(opts, :group_page_size, @accept_group_page_size)
+  @spec queue_accept(SelectionScope.t()) ::
+          {:ok, %{queued: non_neg_integer(), skipped: non_neg_integer()}}
+  def queue_accept(%SelectionScope{} = scope) do
+    now = now()
+    eligible = eligible_accept_keys(scope)
 
-    result = accept_group_pages(scope, opts, page_size, nil, %{accepted: 0, skipped: 0})
+    # Both counts have to be read before the UPDATE. Marking a row sets
+    # `queued_op`, which `filter_status/2` excludes from "pending", so the same
+    # two queries run afterwards would count only what was left behind.
+    queued = eligible |> subquery() |> Repo.aggregate(:count)
+    selected = selected_group_count(scope)
 
-    if result.accepted > 0, do: broadcast(scope.library_path_id)
-    {:ok, result}
+    {row_count, _} =
+      ImportCandidate
+      |> where([c], c.library_path_id == ^scope.library_path_id)
+      |> where([c], c.anchor_key in subquery(eligible))
+      |> where([c], is_nil(c.dismissed_at) and is_nil(c.queued_op))
+      |> Repo.update_all(
+        set: [queued_op: "accept", queued_at: now, queue_error: nil, updated_at: now]
+      )
+
+    if row_count > 0 do
+      enqueue(Mydia.Jobs.ApplyImportCandidates, scope.library_path_id)
+      broadcast(scope.library_path_id)
+    end
+
+    {:ok, %{queued: queued, skipped: selected - queued}}
   end
 
-  defp accept_group_pages(scope, opts, page_size, after_anchor, result) do
-    groups =
-      scope
-      |> SelectionScope.to_query()
-      |> maybe_after_anchor(after_anchor)
-      |> order_by([c], asc: c.anchor_key)
-      |> limit(^page_size)
-      |> Repo.all()
-      |> Enum.map(&to_group(&1, scope.status))
+  @doc """
+  Queues every pending provider-matched group for one library path.
 
-    case groups do
-      [] ->
-        result
-
-      groups ->
-        after_group_page(opts, groups)
-
-        result =
-          Enum.reduce(groups, result, fn group, acc ->
-            case accept_group(group, opts) do
-              {:ok, _media_files} -> %{acc | accepted: acc.accepted + 1}
-              {:error, _reason} -> %{acc | skipped: acc.skipped + 1}
-            end
-          end)
-
-        if length(groups) < page_size do
-          result
-        else
-          accept_group_pages(scope, opts, page_size, List.last(groups).anchor_key, result)
-        end
-    end
+  Confidence is deliberately not filtered: this is the explicit human override
+  behind the review page's "Import all" control.
+  """
+  @spec queue_accept_all_matched(binary()) ::
+          {:ok, %{queued: non_neg_integer(), skipped: non_neg_integer()}}
+  def queue_accept_all_matched(library_path_id) do
+    library_path_id
+    |> SelectionScope.new()
+    |> SelectionScope.select_all_matching(%{})
+    |> queue_accept()
   end
 
-  defp maybe_after_anchor(query, nil), do: query
-  defp maybe_after_anchor(query, anchor), do: where(query, [c], c.anchor_key > ^anchor)
+  # The selected anchors that `accept_group/2` would actually accept, as a
+  # grouped subquery of anchor keys. `count(provider_id, :distinct) == 1`
+  # subsumes the no-match case as well: SQL counts of a nullable column ignore
+  # NULLs, so a group with no provider match counts zero.
+  defp eligible_accept_keys(%SelectionScope{} = scope) do
+    scope
+    |> SelectionScope.to_query()
+    |> exclude(:select)
+    |> having([c], count(c.provider_id, :distinct) == 1)
+    |> having([c], is_nil(max(c.provider_type)) or max(c.provider_type) != "local")
+    |> select([c], c.anchor_key)
+  end
 
-  defp after_group_page(opts, groups) do
-    case Keyword.get(opts, :after_group_page) do
-      callback when is_function(callback, 1) -> callback.(groups)
-      _ -> :ok
-    end
+  # Oban's engine is disabled in test (config/test.exs sets `engine: false`), so
+  # Oban.insert/1 raises there. See test/README.md and
+  # Mydia.Downloads.Queue.insert_job/1, which uses the same fallback.
+  defp enqueue(worker, library_path_id) do
+    %{"library_path_id" => library_path_id}
+    |> worker.new()
+    |> insert_job()
+  end
+
+  defp insert_job(changeset) do
+    Oban.insert(changeset)
+  rescue
+    RuntimeError -> Repo.insert(changeset)
   end
 
   defp accept_group(%ImportCandidateGroup{provider_id: nil}, _opts), do: {:error, :no_match}
@@ -1128,22 +1147,6 @@ defmodule Mydia.ImportCandidates do
 
   defp queue_error_message(:local_show), do: "Local shows are created directly, not imported."
   defp queue_error_message(:empty_group), do: "No files left to import."
-
-  @doc """
-  Accepts every pending provider-matched group for one library path.
-
-  Unmatched and synthetic local groups are excluded by `accept/2` itself.
-  Confidence is deliberately not filtered here: this is the explicit human
-  override behind the review page's "Import all" control.
-  """
-  @spec accept_all_matched(binary(), keyword()) ::
-          {:ok, %{accepted: non_neg_integer(), skipped: non_neg_integer()}}
-  def accept_all_matched(library_path_id, opts \\ []) do
-    library_path_id
-    |> SelectionScope.new()
-    |> SelectionScope.select_all_matching(%{})
-    |> accept(opts)
-  end
 
   @doc """
   Re-runs metadata matching for the candidates in a selection.

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -966,9 +966,19 @@ defmodule Mydia.ImportCandidates do
   # Oban's engine is disabled in test (config/test.exs sets `engine: false`), so
   # Oban.insert/1 raises there. See test/README.md and
   # Mydia.Downloads.Queue.insert_job/1, which uses the same fallback.
+  #
+  # `states:` is overridden here rather than declared on `use Oban.Worker` in
+  # the worker modules themselves, so it deliberately excludes `:executing`: a
+  # click landing while a drain is already running must enqueue a fresh job
+  # rather than be swallowed by the uniqueness guard (see both workers'
+  # moduledocs). Declaring that narrowed list statically trips Oban's own
+  # `--warnings-as-errors` compile check (it warns whenever `:states` omits
+  # any incomplete state); overriding it only here, at the single call site
+  # both workers share, avoids the warning the same way
+  # `Jobs.MediaImport.schedule_snooze_retry/2` does for its own narrowed case.
   defp enqueue(worker, library_path_id) do
     %{"library_path_id" => library_path_id}
-    |> worker.new()
+    |> worker.new(unique: [states: [:available, :scheduled, :retryable]])
     |> insert_job()
   end
 

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -1081,11 +1081,49 @@ defmodule Mydia.ImportCandidates do
     result
   end
 
+  # A "no progress" stop has to be decided across one *complete* sweep of
+  # every currently-queued anchor, not one anchor page: `queued_anchor_keys/4`
+  # is keyset-paged, and an early page that makes zero progress must not
+  # short-circuit the anchors past it. Deciding per-page (as this used to)
+  # left later-ordered anchors permanently stranded behind a page-size-or-more
+  # run of identically-failing early ones, across every one of Oban's
+  # retries -- see the finding this fixed. `sweep_accepted/5` walks the whole
+  # queued set once, advancing its cursor past every anchor it touches
+  # regardless of outcome; only once that full walk completes does this
+  # compare `remaining` against `remaining_before` to decide whether another
+  # sweep is worth attempting or the loop should stop and let the worker's
+  # retry (or a stuck anchor's terminal clear) take over.
   defp drain_accepted_pages(library_path_id, opts, page_size, remaining_before, acc) do
-    keys = queued_anchor_keys(library_path_id, "accept", page_size)
+    acc = sweep_accepted(library_path_id, opts, page_size, nil, acc)
+    remaining = queued_count(library_path_id, "accept")
+
+    cond do
+      remaining == 0 ->
+        {:ok, Map.put(acc, :remaining, 0)}
+
+      remaining < remaining_before ->
+        drain_accepted_pages(library_path_id, opts, page_size, remaining, acc)
+
+      # No progress across a whole sweep: every still-queued anchor failed
+      # without clearing its marker, so another sweep would fetch the same
+      # anchors and fail identically. Stop and let the worker's retry handle
+      # it.
+      true ->
+        {:ok, Map.put(acc, :remaining, remaining)}
+    end
+  end
+
+  # One full keyset walk over every anchor currently queued for accept,
+  # advancing `after_key` past each page regardless of whether its anchors
+  # promoted or failed -- unlike re-fetching from the same cursor, a failure
+  # can never cause this to refetch (and re-attempt) the anchor(s) that just
+  # failed, so no later-ordered anchor is ever left unreached by a stuck
+  # earlier one.
+  defp sweep_accepted(library_path_id, opts, page_size, after_key, acc) do
+    keys = queued_anchor_keys(library_path_id, "accept", page_size, after_key)
 
     if keys == [] do
-      {:ok, Map.put(acc, :remaining, 0)}
+      acc
     else
       acc = Enum.reduce(keys, acc, &promote_queued_anchor(library_path_id, &1, opts, &2))
 
@@ -1094,21 +1132,7 @@ defmodule Mydia.ImportCandidates do
       # keeps that from becoming a re-render storm.
       broadcast(library_path_id)
 
-      remaining = queued_count(library_path_id, "accept")
-
-      cond do
-        remaining == 0 ->
-          {:ok, Map.put(acc, :remaining, 0)}
-
-        remaining < remaining_before ->
-          drain_accepted_pages(library_path_id, opts, page_size, remaining, acc)
-
-        # No progress: every group on that page failed without clearing its
-        # marker, so another pass would fetch the same anchors and fail
-        # identically. Stop and let the worker's retry handle it.
-        true ->
-          {:ok, Map.put(acc, :remaining, remaining)}
-      end
+      sweep_accepted(library_path_id, opts, page_size, List.last(keys), acc)
     end
   end
 
@@ -1154,15 +1178,19 @@ defmodule Mydia.ImportCandidates do
       %{acc | failed: acc.failed + 1}
   end
 
-  defp queued_anchor_keys(library_path_id, op, limit) do
+  defp queued_anchor_keys(library_path_id, op, limit, after_key) do
     library_path_id
     |> queued_query(op)
+    |> maybe_after_anchor_key(after_key)
     |> distinct(true)
     |> order_by([c], asc: c.anchor_key)
     |> select([c], c.anchor_key)
     |> limit(^limit)
     |> Repo.all()
   end
+
+  defp maybe_after_anchor_key(query, nil), do: query
+  defp maybe_after_anchor_key(query, key), do: where(query, [c], c.anchor_key > ^key)
 
   defp queued_count(library_path_id, op) do
     library_path_id

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -255,9 +255,8 @@ defmodule Mydia.ImportCandidates do
   straight off it, e.g. as a subquery of matching anchor keys (see
   `Mydia.Library.SelectionScope.to_query/1`, which delegates here).
 
-  `:status` (default `"pending"`) selects undismissed candidates; anything
-  else selects dismissed ones. `:band` and `:q` apply the same predicates
-  `page/2` exposes.
+  `:status` (default `"pending"`) is `"pending"`, `"queued"`, or anything else
+  for dismissed. `:band` and `:q` apply the same predicates `page/2` exposes.
   """
   @spec group_query(binary(), keyword()) :: Ecto.Query.t()
   def group_query(library_path_id, opts \\ []) do
@@ -265,7 +264,7 @@ defmodule Mydia.ImportCandidates do
 
     ImportCandidate
     |> where([c], c.library_path_id == ^library_path_id)
-    |> filter_dismissed(status)
+    |> filter_status(status)
     # `library_path_id` is constant across every row here (the WHERE clause
     # above already pins it), but PostgreSQL still requires a plain
     # (non-aggregate) selected column to appear in GROUP BY -- SQLite is
@@ -282,14 +281,25 @@ defmodule Mydia.ImportCandidates do
       provider_type: max(c.provider_type),
       suggested_title: max(c.title),
       suggested_year: max(c.year),
-      media_type: max(c.media_type)
+      media_type: max(c.media_type),
+      queued_op: max(c.queued_op),
+      queue_error: max(c.queue_error)
     })
     |> apply_band(Keyword.get(opts, :band))
     |> apply_search(Keyword.get(opts, :q))
   end
 
-  defp filter_dismissed(query, "pending"), do: where(query, [c], is_nil(c.dismissed_at))
-  defp filter_dismissed(query, _status), do: where(query, [c], not is_nil(c.dismissed_at))
+  # Three mutually exclusive states over two nullable columns. A queued row is
+  # never dismissed (queue_accept/1 and queue_rematch/1 only mark undismissed
+  # rows) and a dismissed row is never queued (dismiss/1 skips queued rows), so
+  # "pending" has to exclude both while the other two each name one.
+  defp filter_status(query, "pending"),
+    do: where(query, [c], is_nil(c.dismissed_at) and is_nil(c.queued_op))
+
+  defp filter_status(query, "queued"),
+    do: where(query, [c], is_nil(c.dismissed_at) and not is_nil(c.queued_op))
+
+  defp filter_status(query, _status), do: where(query, [c], not is_nil(c.dismissed_at))
 
   defp apply_band(query, nil), do: query
   defp apply_band(query, :all), do: query
@@ -455,7 +465,9 @@ defmodule Mydia.ImportCandidates do
       media_type: row.media_type,
       min_confidence: min_confidence,
       provider_count: row.provider_count,
-      dismissed?: status != "pending"
+      dismissed?: status == "ignored",
+      queued?: status == "queued",
+      queue_error: row.queue_error
     }
   end
 
@@ -500,7 +512,7 @@ defmodule Mydia.ImportCandidates do
   @spec count_pending() :: non_neg_integer()
   def count_pending do
     ImportCandidate
-    |> where([c], is_nil(c.dismissed_at))
+    |> where([c], is_nil(c.dismissed_at) and is_nil(c.queued_op))
     |> join(:inner, [c], lp in LibraryPath, on: lp.id == c.library_path_id)
     |> where([c, lp], lp.type in ^ImportRun.importable_types())
     |> group_by([c], [c.library_path_id, c.anchor_key])
@@ -657,7 +669,7 @@ defmodule Mydia.ImportCandidates do
 
     {row_count, _} =
       candidate_query(scope)
-      |> where([c], is_nil(c.dismissed_at))
+      |> where([c], is_nil(c.dismissed_at) and is_nil(c.queued_op))
       |> Repo.update_all(set: [dismissed_at: now, updated_at: now])
 
     if row_count > 0, do: broadcast(scope.library_path_id)

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -676,6 +676,9 @@ defmodule Mydia.ImportCandidates do
     |> where([c], is_nil(c.next_retry_at) or c.next_retry_at <= ^now)
   end
 
+  defp maybe_after_id(query, nil), do: query
+  defp maybe_after_id(query, id), do: where(query, [c], c.id > ^id)
+
   # Walks a whole group's undismissed candidates in keyset pages of
   # #{@member_page_size}, so a group the size of a full season tree is never
   # one unbounded allocation, while still handing callers (`accept/2`,
@@ -1148,65 +1151,93 @@ defmodule Mydia.ImportCandidates do
   defp queue_error_message(:local_show), do: "Local shows are created directly, not imported."
   defp queue_error_message(:empty_group), do: "No files left to import."
 
+  @rematch_page_size 250
+
   @doc """
-  Re-runs metadata matching for the candidates in a selection.
+  Queues a selection for re-matching.
 
-  Matches through `Mydia.Library.BatchMatcher` in bounded pages, writes each
-  result back onto its candidate via `Mydia.Library.FileIngest.ingest/3` under
-  the `:review` policy (write the verdict, never auto-promote), and broadcasts
-  one change event after the whole pass -- not once per page or per file.
+  Same shape as `queue_accept/1` with no eligibility filter, since any candidate
+  can be re-matched.
   """
-  @spec rematch(SelectionScope.t(), keyword()) ::
-          {:ok, %{files: non_neg_integer(), failures: non_neg_integer()}}
-  def rematch(%SelectionScope{} = scope, opts \\ []) do
-    library_path = Settings.get_library_path!(scope.library_path_id)
-    matcher = Keyword.get(opts, :matcher, Mydia.Library.MetadataMatcher)
-    config = Keyword.get(opts, :config) || Metadata.default_relay_config()
-    page_size = Keyword.get(opts, :page_size, 250)
+  @spec queue_rematch(SelectionScope.t()) :: {:ok, %{queued: non_neg_integer()}}
+  def queue_rematch(%SelectionScope{} = scope) do
+    now = now()
+    group_count = selected_group_count(scope)
 
-    base_query = candidate_query(scope) |> where([c], is_nil(c.dismissed_at))
+    {row_count, _} =
+      scope
+      |> candidate_query()
+      |> where([c], is_nil(c.dismissed_at) and is_nil(c.queued_op))
+      |> Repo.update_all(
+        set: [queued_op: "rematch", queued_at: now, queue_error: nil, updated_at: now]
+      )
 
-    stats =
-      rematch_pages(base_query, library_path, matcher, config, page_size, nil, %{
-        files: 0,
-        failures: 0
-      })
+    if row_count > 0 do
+      enqueue(Mydia.Jobs.RematchImportCandidates, scope.library_path_id)
+      broadcast(scope.library_path_id)
+    end
 
-    broadcast(scope.library_path_id)
-
-    {:ok, stats}
+    {:ok, %{queued: if(row_count > 0, do: group_count, else: 0)}}
   end
 
-  defp rematch_pages(base_query, library_path, matcher, config, page_size, after_id, stats) do
+  @doc """
+  Re-runs metadata matching for every candidate queued for re-match on one
+  library path.
+
+  Matches through `Mydia.Library.BatchMatcher` in bounded pages and writes each
+  result back with `Mydia.Library.FileIngest.ingest/3` under the `:review`
+  policy, which records the verdict and never auto-promotes. Every row in a page
+  has its marker cleared once the page is ingested, whether it matched or not, so
+  the loop always makes progress and a re-match is never retried forever over a
+  file no provider recognises.
+  """
+  @spec drain_rematch(binary(), keyword()) ::
+          {:ok,
+           %{files: non_neg_integer(), failures: non_neg_integer(), remaining: non_neg_integer()}}
+  def drain_rematch(library_path_id, opts \\ []) do
+    library_path = Settings.get_library_path!(library_path_id)
+    matcher = Keyword.get(opts, :matcher, Mydia.Library.MetadataMatcher)
+    config = Keyword.get(opts, :config) || Metadata.default_relay_config()
+    page_size = Keyword.get(opts, :page_size, @rematch_page_size)
+
+    result =
+      drain_rematch_pages(library_path, matcher, config, page_size, %{files: 0, failures: 0})
+
+    broadcast(library_path_id)
+    result
+  end
+
+  defp drain_rematch_pages(library_path, matcher, config, page_size, acc) do
     rows =
-      base_query
-      |> maybe_after_id(after_id)
+      library_path.id
+      |> queued_query("rematch")
       |> order_by([c], asc: c.id)
       |> limit(^page_size)
       |> Repo.all()
 
-    case rows do
-      [] ->
-        stats
+    if rows == [] do
+      {:ok, Map.put(acc, :remaining, 0)}
+    else
+      page_stats = rematch_rows(rows, library_path, matcher, config)
+      clear_rematch_markers(Enum.map(rows, & &1.id))
 
-      rows ->
-        page_stats = rematch_rows(rows, library_path, matcher, config)
-        stats = Map.merge(stats, page_stats, fn _key, left, right -> left + right end)
+      # One broadcast per page so the Queued chip drains visibly.
+      broadcast(library_path.id)
 
-        rematch_pages(
-          base_query,
-          library_path,
-          matcher,
-          config,
-          page_size,
-          List.last(rows).id,
-          stats
-        )
+      acc = Map.merge(acc, page_stats, fn _key, left, right -> left + right end)
+      drain_rematch_pages(library_path, matcher, config, page_size, acc)
     end
   end
 
-  defp maybe_after_id(query, nil), do: query
-  defp maybe_after_id(query, id), do: where(query, [c], c.id > ^id)
+  # Conditional on the op, so a row the user has since queued for accept keeps
+  # its new marker instead of being cleared by an in-flight re-match.
+  defp clear_rematch_markers(ids) do
+    now = now()
+
+    ImportCandidate
+    |> where([c], c.id in ^ids and c.queued_op == "rematch")
+    |> Repo.update_all(set: [queued_op: nil, queued_at: nil, updated_at: now])
+  end
 
   defp rematch_rows(rows, library_path, matcher, config) do
     rows_by_path = Map.new(rows, &{Path.join(library_path.path, &1.relative_path), &1})

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -270,8 +270,20 @@ defmodule Mydia.ImportCandidates do
     ImportCandidate
     |> where([c], c.library_path_id == ^library_path_id)
     |> filter_status(status)
-    # `library_path_id` is constant across every row here (the WHERE clause
-    # above already pins it), but PostgreSQL still requires a plain
+    |> aggregate_group_query()
+    |> apply_band(Keyword.get(opts, :band))
+    |> apply_search(Keyword.get(opts, :q))
+  end
+
+  # The anchor-key rollup `group_query/2` and `queued_group/3` both build on:
+  # groups an already-scoped base query by anchor, aggregating `count(id)`,
+  # `min(confidence)`, and `count(distinct provider_id)` alongside
+  # representative (`max/1`) provider/title/type values. Every row this
+  # returns is a plain map; convert it with the private `to_group/2`.
+  defp aggregate_group_query(query) do
+    query
+    # `library_path_id` is constant across every row here (the caller's WHERE
+    # clause already pins it), but PostgreSQL still requires a plain
     # (non-aggregate) selected column to appear in GROUP BY -- SQLite is
     # lenient about this and would let it through unmodified, so leaving it
     # out here would work in dev/test on SQLite and break on PostgreSQL.
@@ -290,8 +302,6 @@ defmodule Mydia.ImportCandidates do
       queued_op: max(c.queued_op),
       queue_error: max(c.queue_error)
     })
-    |> apply_band(Keyword.get(opts, :band))
-    |> apply_search(Keyword.get(opts, :q))
   end
 
   # Three mutually exclusive states over two nullable columns. A queued row is
@@ -439,6 +449,39 @@ defmodule Mydia.ImportCandidates do
       nil -> nil
       row -> to_group(row, status)
     end
+  end
+
+  # One anchor's aggregate row, scoped to rows queued for exactly `op` --
+  # unlike `get_group(..., status: "queued")`, which matches *any* queued_op
+  # via `filter_status/2`. An anchor can carry rows queued for different ops
+  # at once (a scan can insert a pending row under an already-queued anchor,
+  # and a second `queued_op` value queues its own subset later), so computing
+  # one op's promotion eligibility (`provider_id`, `provider_count`,
+  # `provider_type`) from the broader "any queued_op" aggregate would compute
+  # it over a superset of what actually gets promoted. Kept separate from
+  # `get_group/3` rather than folded into it, since `get_group/3` has other
+  # callers that depend on its existing `:status` semantics.
+  defp queued_group(library_path_id, anchor_key, op) do
+    library_path_id
+    |> queued_query(op)
+    |> where([c], c.anchor_key == ^anchor_key)
+    |> aggregate_group_query()
+    |> Repo.one()
+    |> case do
+      nil -> nil
+      row -> to_group(row, "queued")
+    end
+  end
+
+  # The op predicate every queued-drain query shares: undismissed rows on one
+  # library path, queued for exactly one op. Never loosen this to "any
+  # queued_op" the way `filter_status(query, "queued")` is for the review
+  # page's status filter -- an anchor can hold rows queued for different ops
+  # at once, and each op's drain must see only its own subset.
+  defp queued_query(library_path_id, op) do
+    ImportCandidate
+    |> where([c], c.library_path_id == ^library_path_id and c.queued_op == ^op)
+    |> where([c], is_nil(c.dismissed_at))
   end
 
   defp apply_cursor(query, nil), do: query
@@ -915,7 +958,7 @@ defmodule Mydia.ImportCandidates do
     do: {:error, :local_show}
 
   defp accept_group(%ImportCandidateGroup{library_path_id: lp_id, anchor_key: key}, opts) do
-    case load_queued_members(lp_id, key) do
+    case load_queued_members(lp_id, key, "accept") do
       [] ->
         {:error, :empty_group}
 
@@ -925,14 +968,20 @@ defmodule Mydia.ImportCandidates do
     end
   end
 
-  # Only the rows the user actually queued. A mixed anchor (queued rows plus a
-  # newcomer a concurrent scan inserted) must promote exactly the queued set,
-  # which is the set `get_group/3` computed the group's eligibility from. The
-  # newcomer stays pending and shows up in the review list on the next pass.
-  defp load_queued_members(library_path_id, anchor_key) do
+  # Only the rows queued for `op`. A mixed anchor (rows queued for `op` plus
+  # either a pending newcomer a concurrent scan inserted, or rows queued for a
+  # different op) must promote exactly its own op's subset, which is the set
+  # `queued_group/3` computed the group's eligibility from. Everything else
+  # stays put and shows up under its own status on the next pass.
+  #
+  # Filtering in memory rather than in SQL is deliberate: `load_all_members/2`
+  # already pages the anchor in bounded chunks and hands back the full
+  # membership, and a mixed anchor holds at most a handful of rows outside
+  # `op`.
+  defp load_queued_members(library_path_id, anchor_key, op) do
     library_path_id
     |> load_all_members(anchor_key)
-    |> Enum.filter(&(&1.queued_op == "accept"))
+    |> Enum.filter(&(&1.queued_op == op))
   end
 
   @doc """
@@ -1006,7 +1055,7 @@ defmodule Mydia.ImportCandidates do
   end
 
   defp promote_queued_anchor(library_path_id, anchor_key, opts, acc) do
-    case get_group(library_path_id, anchor_key, status: "queued") do
+    case queued_group(library_path_id, anchor_key, "accept") do
       nil ->
         # The rows went away mid-drain, which clear_for_library/1 and
         # delete_missing/3 can both do. There is nothing left to promote, so
@@ -1048,9 +1097,8 @@ defmodule Mydia.ImportCandidates do
   end
 
   defp queued_anchor_keys(library_path_id, op, limit) do
-    ImportCandidate
-    |> where([c], c.library_path_id == ^library_path_id and c.queued_op == ^op)
-    |> where([c], is_nil(c.dismissed_at))
+    library_path_id
+    |> queued_query(op)
     |> distinct(true)
     |> order_by([c], asc: c.anchor_key)
     |> select([c], c.anchor_key)
@@ -1059,18 +1107,17 @@ defmodule Mydia.ImportCandidates do
   end
 
   defp queued_count(library_path_id, op) do
-    ImportCandidate
-    |> where([c], c.library_path_id == ^library_path_id and c.queued_op == ^op)
-    |> where([c], is_nil(c.dismissed_at))
+    library_path_id
+    |> queued_query(op)
     |> Repo.aggregate(:count)
   end
 
   defp clear_queue_marker(library_path_id, anchor_key, op, error) do
     now = now()
 
-    ImportCandidate
-    |> where([c], c.library_path_id == ^library_path_id and c.anchor_key == ^anchor_key)
-    |> where([c], c.queued_op == ^op)
+    library_path_id
+    |> queued_query(op)
+    |> where([c], c.anchor_key == ^anchor_key)
     |> Repo.update_all(set: [queued_op: nil, queued_at: nil, queue_error: error, updated_at: now])
   end
 

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -1024,14 +1024,32 @@ defmodule Mydia.ImportCandidates do
     |> Enum.filter(&(&1.queued_op == op))
   end
 
+  # The pending (queued_op IS NULL) subset of one anchor's membership -- the
+  # counterpart to `load_queued_members/3` for callers that act on whatever
+  # has not already been claimed by a queued op. `create_local_show/2` uses
+  # this rather than `load_all_members/2`: a scan can insert a pending row
+  # under an anchor whose import is already queued (see the moduledoc on that
+  # theme), and a queued row's provider identity and eventual promotion must
+  # not be disturbed by an unrelated "create local show from folder" call
+  # against the same anchor.
+  defp load_pending_members(library_path_id, anchor_key) do
+    library_path_id
+    |> load_all_members(anchor_key)
+    |> Enum.filter(&is_nil(&1.queued_op))
+  end
+
   @doc """
   Promotes every group queued for accept on one library path.
 
   Discovers its own work from `queued_op`, so a restarted job resumes where it
   stopped and a second accept queued while this runs is picked up by the same
-  loop. Groups are drained one anchor page at a time; the whole membership of
-  one group still goes to `CandidatePromotion.promote_group/3` in a single call,
-  which is the only transaction boundary here.
+  loop. Groups are drained in anchor pages, but every currently-queued anchor
+  is swept once (in keyset-paged pages of `:anchor_page_size`) before this
+  decides whether the pass made progress -- an early anchor that fails
+  without clearing its marker cannot strand anchors ordered after it, only
+  slow down how many full sweeps a stuck queue costs. The whole membership of
+  one group still goes to `CandidatePromotion.promote_group/3` in a single
+  call, which is the only transaction boundary here.
 
   A terminal refusal (no provider match, files matching different titles, a
   synthetic local show, a group whose rows vanished) clears the marker and
@@ -1360,6 +1378,15 @@ defmodule Mydia.ImportCandidates do
   `band/1` and `group_query/2` already give a provider-matched local group),
   but this function's own precondition -- every remaining candidate already
   local-marked -- is what a second click actually hits.
+
+  Scoped to the anchor's *pending* subset (`queued_op IS NULL`) via
+  `load_pending_members/2`, not its full membership: a scan can insert a
+  pending row under an anchor whose import is already queued for accept, and
+  that queued row carries a real provider match this function must not
+  overwrite with a generic local identity, nor delete out from under the
+  drain that is about to promote it. The queued row is left untouched --
+  `queued_op`, its provider fields, and its existence all survive -- and
+  continues to be promoted normally.
   """
   @spec create_local_show(binary(), String.t()) :: {:ok, Media.MediaItem.t()} | {:error, term()}
   def create_local_show(library_path_id, anchor_key) do
@@ -1371,7 +1398,7 @@ defmodule Mydia.ImportCandidates do
   end
 
   defp create_local_show_transaction(library_path_id, anchor_key) do
-    case load_all_members(library_path_id, anchor_key) do
+    case load_pending_members(library_path_id, anchor_key) do
       [] ->
         {:error, :not_found}
 
@@ -1403,16 +1430,23 @@ defmodule Mydia.ImportCandidates do
   end
 
   # Every candidate `link_local_candidate/2` successfully linked is already
-  # deleted by the time this runs; what remains is exactly the unnumbered
-  # leftovers `create_local_show/2`'s doc promises to leave visible. Stamping
-  # them here (not before creating `item`, since `provider_id` needs its id)
-  # is what makes a second call against the same anchor see an
-  # all-local-marked group and refuse rather than minting a second show.
+  # deleted by the time this runs; what remains among the *pending* subset is
+  # exactly the unnumbered leftovers `create_local_show/2`'s doc promises to
+  # leave visible. Stamping them here (not before creating `item`, since
+  # `provider_id` needs its id) is what makes a second call against the same
+  # anchor see an all-local-marked pending group and refuse rather than
+  # minting a second show.
+  #
+  # Scoped to `is_nil(queued_op)`, matching `load_pending_members/2` above:
+  # `for_anchor/3` alone would also overwrite any row already queued for
+  # accept/rematch under this anchor, discarding its real provider identity
+  # in favour of this synthetic local one.
   defp mark_leftover_candidates_local(library_path_id, anchor_key, item) do
     now = now()
 
     ImportCandidate
     |> for_anchor(library_path_id, anchor_key)
+    |> where([c], is_nil(c.queued_op))
     |> Repo.update_all(set: [provider_type: "local", provider_id: item.id, updated_at: now])
   end
 

--- a/lib/mydia/jobs/apply_import_candidates.ex
+++ b/lib/mydia/jobs/apply_import_candidates.ex
@@ -16,7 +16,12 @@ defmodule Mydia.Jobs.ApplyImportCandidates do
   already running must enqueue a fresh job rather than be swallowed by the
   uniqueness guard, otherwise rows marked during the final page are stranded
   with nothing left to pick them up. `Jobs.MediaImport` documents the same
-  tradeoff.
+  tradeoff. The narrowed `states:` list lives on `ImportCandidates.enqueue/2`,
+  the single call site both this worker and `Jobs.RematchImportCandidates`
+  share, rather than here: declaring it statically on `use Oban.Worker` trips
+  Oban's compile-time `--warnings-as-errors` check for a missing incomplete
+  state, the same reason `Jobs.MediaImport.schedule_snooze_retry/2` overrides
+  it at its own call site instead of in its module attributes.
 
   A library with candidates still queued at the end is reported to Oban as a
   failure so `max_attempts` retries it. Terminal refusals do not reach that
@@ -26,7 +31,7 @@ defmodule Mydia.Jobs.ApplyImportCandidates do
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [period: 300, keys: [:library_path_id], states: [:available, :scheduled, :retryable]]
+    unique: [period: 300, keys: [:library_path_id]]
 
   alias Mydia.ImportCandidates
 

--- a/lib/mydia/jobs/apply_import_candidates.ex
+++ b/lib/mydia/jobs/apply_import_candidates.ex
@@ -1,0 +1,40 @@
+defmodule Mydia.Jobs.ApplyImportCandidates do
+  @moduledoc """
+  Promotes the import candidates a user queued for accept.
+
+  Runs on `:default` rather than `:imports`, which has concurrency 1 and is held
+  for the duration of a library scan. An accept queued behind a multi-hour run
+  would look like the button did nothing.
+
+  The job carries no selection. `Mydia.ImportCandidates.drain_accepted/2`
+  discovers its work from the `queued_op` column, so this is safe to enqueue
+  more than once for one library and safe to retry: a restart resumes from
+  whatever is still marked.
+
+  `unique` deliberately omits `:executing`, where the pre-split
+  `Jobs.ApplyImportGroups` used `:incomplete`. A click landing while a drain is
+  already running must enqueue a fresh job rather than be swallowed by the
+  uniqueness guard, otherwise rows marked during the final page are stranded
+  with nothing left to pick them up. `Jobs.MediaImport` documents the same
+  tradeoff.
+
+  A library with candidates still queued at the end is reported to Oban as a
+  failure so `max_attempts` retries it. Terminal refusals do not reach that
+  path; the drain clears their markers and records `queue_error` instead.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: 300, keys: [:library_path_id], states: [:available, :scheduled, :retryable]]
+
+  alias Mydia.ImportCandidates
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"library_path_id" => library_path_id}}) do
+    case ImportCandidates.drain_accepted(library_path_id, allow_episode_creation: true) do
+      {:ok, %{remaining: 0}} -> :ok
+      {:ok, %{remaining: n}} -> {:error, "#{n} queued candidate(s) did not import"}
+    end
+  end
+end

--- a/lib/mydia/jobs/rematch_import_candidates.ex
+++ b/lib/mydia/jobs/rematch_import_candidates.ex
@@ -8,15 +8,16 @@ defmodule Mydia.Jobs.RematchImportCandidates do
   re-derived from band and search predicates that may match different groups by
   the time the job runs.
 
-  Shares `Jobs.ApplyImportCandidates`'s queue and uniqueness reasoning. The two
-  workers never contend for a row, because a candidate carries at most one
+  Shares `Jobs.ApplyImportCandidates`'s queue and uniqueness reasoning
+  (including where the narrowed `unique` `states:` list actually lives). The
+  two workers never contend for a row, because a candidate carries at most one
   `queued_op` and each worker filters on its own value.
   """
 
   use Oban.Worker,
     queue: :default,
     max_attempts: 3,
-    unique: [period: 300, keys: [:library_path_id], states: [:available, :scheduled, :retryable]]
+    unique: [period: 300, keys: [:library_path_id]]
 
   require Logger
 

--- a/lib/mydia/jobs/rematch_import_candidates.ex
+++ b/lib/mydia/jobs/rematch_import_candidates.ex
@@ -1,0 +1,39 @@
+defmodule Mydia.Jobs.RematchImportCandidates do
+  @moduledoc """
+  Re-runs metadata matching for the candidates a user queued for re-match.
+
+  The pre-split `Jobs.RematchImportGroups` carried the selection in its args and
+  rebuilt it with `SelectionScope.from_args/1`. This one does not: the intent
+  lives on the row, so the snapshot is taken when the user clicks rather than
+  re-derived from band and search predicates that may match different groups by
+  the time the job runs.
+
+  Shares `Jobs.ApplyImportCandidates`'s queue and uniqueness reasoning. The two
+  workers never contend for a row, because a candidate carries at most one
+  `queued_op` and each worker filters on its own value.
+  """
+
+  use Oban.Worker,
+    queue: :default,
+    max_attempts: 3,
+    unique: [period: 300, keys: [:library_path_id], states: [:available, :scheduled, :retryable]]
+
+  require Logger
+
+  alias Mydia.ImportCandidates
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"library_path_id" => library_path_id}}) do
+    {:ok, stats} = ImportCandidates.drain_rematch(library_path_id)
+
+    if stats.failures > 0 do
+      Logger.warning("Import candidate re-match completed with file failures",
+        library_path_id: library_path_id,
+        processed_files: stats.files,
+        failed_files: stats.failures
+      )
+    end
+
+    :ok
+  end
+end

--- a/lib/mydia/library/batch_matcher.ex
+++ b/lib/mydia/library/batch_matcher.ex
@@ -28,7 +28,7 @@ defmodule Mydia.Library.BatchMatcher do
   path with no result gets no `ImportCandidate` update, stays in the
   outstanding set (`Mydia.ImportCandidates.outstanding/3`), and is reselected
   by every later chunk forever. `Mydia.ImportCandidates`'s rematch path
-  (`ImportCandidates.rematch/2`) depends on the same guarantee for its own
+  (`ImportCandidates.drain_rematch/2`) depends on the same guarantee for its own
   `ImportCandidate` rows.
 
   Two layers keep that true. `MetadataMatcher.match_file/2` is HTTP plus

--- a/lib/mydia/library/import_candidate.ex
+++ b/lib/mydia/library/import_candidate.ex
@@ -25,6 +25,9 @@ defmodule Mydia.Library.ImportCandidate do
     field :last_error, :string
     field :next_retry_at, :utc_datetime
     field :dismissed_at, :utc_datetime
+    field :queued_op, :string
+    field :queued_at, :utc_datetime
+    field :queue_error, :string
     field :discovered_at, :utc_datetime
 
     belongs_to :library_path, Mydia.Settings.LibraryPath
@@ -35,6 +38,7 @@ defmodule Mydia.Library.ImportCandidate do
   @castable ~w(
     library_path_id relative_path anchor_key size mtime parsed_info provider_type provider_id
     title year media_type confidence attempts last_error next_retry_at dismissed_at discovered_at
+    queued_op queued_at queue_error
   )a
 
   @spec changeset(t(), map()) :: Ecto.Changeset.t()

--- a/lib/mydia/library/import_candidate_group.ex
+++ b/lib/mydia/library/import_candidate_group.ex
@@ -30,7 +30,9 @@ defmodule Mydia.Library.ImportCandidateGroup do
     :media_type,
     :min_confidence,
     :provider_count,
-    :dismissed?
+    :dismissed?,
+    :queued?,
+    :queue_error
   ]
 
   @type t :: %__MODULE__{
@@ -46,7 +48,9 @@ defmodule Mydia.Library.ImportCandidateGroup do
           media_type: String.t() | nil,
           min_confidence: float() | nil,
           provider_count: non_neg_integer() | nil,
-          dismissed?: boolean() | nil
+          dismissed?: boolean() | nil,
+          queued?: boolean() | nil,
+          queue_error: String.t() | nil
         }
 
   @doc """

--- a/lib/mydia/library/import_candidate_group.ex
+++ b/lib/mydia/library/import_candidate_group.ex
@@ -14,6 +14,11 @@ defmodule Mydia.Library.ImportCandidateGroup do
   contain spaces, Unicode, or other characters that are not valid in a CSS/DOM
   id, so templates must render `dom_id/1` for the HTML `id` attribute rather
   than the raw `anchor_key` or `id` field.
+
+  `queued?` and `queue_error` reflect the group's `queued_op` state: `queued?`
+  is true when the group was read at `status: "queued"`, and `queue_error`
+  carries the message a terminal refusal left behind when a queued accept or
+  re-match was cleared without promoting -- see `Mydia.ImportCandidates.drain_accepted/2`.
   """
 
   @enforce_keys [:id, :anchor_key, :library_path_id, :file_count]

--- a/lib/mydia_web/live/import_media_live/components.ex
+++ b/lib/mydia_web/live/import_media_live/components.ex
@@ -109,6 +109,7 @@ defmodule MydiaWeb.ImportMediaLive.Components do
               {:ready, "band-ready", "Ready"},
               {:needs_attention, "band-needs-attention", "Needs attention"},
               {:no_match, "band-no-match", "No match"},
+              {:queued, "band-queued", "Queued"},
               {:ignored, "band-ignored", "Ignored"}
             ]
           }
@@ -322,6 +323,9 @@ defmodule MydiaWeb.ImportMediaLive.Components do
         <span class={["badge badge-sm shrink-0 font-medium", band_class(@band)]}>
           {band_label(@band)}
         </span>
+        <span :if={@group.queued?} class="badge badge-sm badge-info gap-1 shrink-0">
+          <.icon name="hero-arrow-path" class="w-3 h-3 animate-spin" /> Queued
+        </span>
       </div>
 
       <div class="pl-7 sm:pl-9 flex items-center justify-between gap-3 flex-wrap">
@@ -334,6 +338,9 @@ defmodule MydiaWeb.ImportMediaLive.Components do
             class="badge badge-warning/20 text-warning badge-xs"
           >
             {disagreement_label(@group)}
+          </span>
+          <span :if={@group.queue_error} class="badge badge-warning/20 text-warning badge-xs">
+            {@group.queue_error}
           </span>
         </div>
 

--- a/lib/mydia_web/live/import_media_live/components.ex
+++ b/lib/mydia_web/live/import_media_live/components.ex
@@ -215,46 +215,56 @@ defmodule MydiaWeb.ImportMediaLive.Components do
       </div>
 
       <div class="flex items-center gap-2 ml-auto flex-wrap">
-        <%= if @band == :ignored do %>
-          <button
-            id="restore-selected"
-            class="btn btn-sm btn-primary"
-            disabled={@count == 0}
-            phx-click="restore_selected"
-          >
-            <.icon name="hero-arrow-uturn-left" class="w-4 h-4 mr-1" /> Restore {@count}
-          </button>
-          <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
-            Clear
-          </button>
-        <% else %>
-          <button
-            id="accept-selected"
-            class="btn btn-sm btn-primary"
-            disabled={@count == 0}
-            phx-click="accept_selected"
-          >
-            <.icon name="hero-check" class="w-4 h-4 mr-1" /> Accept {@count}
-          </button>
-          <button
-            id="rematch-selected"
-            class="btn btn-sm btn-outline"
-            disabled={@count == 0}
-            phx-click="rematch_selected"
-          >
-            <.icon name="hero-arrow-path" class="w-4 h-4 mr-1" /> Re-match
-          </button>
-          <button
-            id="dismiss-selected"
-            class="btn btn-sm btn-ghost"
-            disabled={@count == 0}
-            phx-click="dismiss_selected"
-          >
-            Dismiss
-          </button>
-          <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
-            Clear
-          </button>
+        <%= cond do %>
+          <% @band == :ignored -> %>
+            <button
+              id="restore-selected"
+              class="btn btn-sm btn-primary"
+              disabled={@count == 0}
+              phx-click="restore_selected"
+            >
+              <.icon name="hero-arrow-uturn-left" class="w-4 h-4 mr-1" /> Restore {@count}
+            </button>
+            <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
+              Clear
+            </button>
+            <%!-- The Queued view's groups are already mid-import: Accept, Re-match,
+            Dismiss, and Restore all no-op there (their queries all require either
+            no queued_op or a dismissed_at that a queued group never has), so none
+            of them are offered here -- same reasoning as the Ignored view's own
+            omission of Accept/Re-match/Dismiss above. --%>
+          <% @band == :queued -> %>
+            <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
+              Clear
+            </button>
+          <% true -> %>
+            <button
+              id="accept-selected"
+              class="btn btn-sm btn-primary"
+              disabled={@count == 0}
+              phx-click="accept_selected"
+            >
+              <.icon name="hero-check" class="w-4 h-4 mr-1" /> Accept {@count}
+            </button>
+            <button
+              id="rematch-selected"
+              class="btn btn-sm btn-outline"
+              disabled={@count == 0}
+              phx-click="rematch_selected"
+            >
+              <.icon name="hero-arrow-path" class="w-4 h-4 mr-1" /> Re-match
+            </button>
+            <button
+              id="dismiss-selected"
+              class="btn btn-sm btn-ghost"
+              disabled={@count == 0}
+              phx-click="dismiss_selected"
+            >
+              Dismiss
+            </button>
+            <button id="clear-selection" class="btn btn-sm btn-ghost" phx-click="clear_selection">
+              Clear
+            </button>
         <% end %>
       </div>
     </div>

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -25,20 +25,21 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   # `phx-value-band` is client-controlled, so the atom it names is looked up
   # rather than converted. An unknown value is a silent no-op because there is
   # no form state to explain a rejection to.
-  # `:ignored` is not a confidence band -- it is a status -- but it rides the
-  # same chip row and the same client-controlled atom lookup as the real
-  # bands, and load_groups/1 translates it into ImportCandidates.page/2's
-  # `:status` option rather than its `:band` option (which has no clause for
-  # it and would raise).
+  # `:ignored` and `:queued` are not confidence bands -- they are statuses --
+  # but they ride the same chip row and the same client-controlled atom
+  # lookup as the real bands, and load_groups/1 translates them into
+  # ImportCandidates.page/2's `:status` option rather than its `:band` option
+  # (which has no clause for either and would raise).
   @bands %{
     "all" => :all,
     "ready" => :ready,
     "needs_attention" => :needs_attention,
     "no_match" => :no_match,
+    "queued" => :queued,
     "ignored" => :ignored
   }
 
-  @empty_band_counts %{ready: 0, needs_attention: 0, no_match: 0, ignored: 0, total: 0}
+  @empty_band_counts %{ready: 0, needs_attention: 0, no_match: 0, queued: 0, ignored: 0, total: 0}
 
   # How long an :import_candidates_changed burst is allowed to coalesce into
   # one refresh. The scanner and the match phase can each broadcast many of
@@ -288,7 +289,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   def handle_event("select_band", %{"band" => band}, socket) do
     case Map.fetch(@bands, band) do
       {:ok, band} ->
-        status = if band == :ignored, do: "ignored", else: "pending"
+        {status, _band} = status_for_band(band)
 
         {:noreply,
          socket
@@ -307,7 +308,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   def handle_event("search", %{"q" => q}, socket) do
-    status = if socket.assigns.band == :ignored, do: "ignored", else: "pending"
+    {status, _band} = status_for_band(socket.assigns.band)
 
     {:noreply,
      socket
@@ -360,7 +361,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   def handle_event("select_current_page", _params, socket) do
-    status = if socket.assigns.band == :ignored, do: "ignored", else: "pending"
+    {status, _band} = status_for_band(socket.assigns.band)
 
     selection =
       socket.assigns.selected_library_path_id
@@ -371,8 +372,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   end
 
   def handle_event("select_all_matching", _params, socket) do
-    status = if socket.assigns.band == :ignored, do: "ignored", else: "pending"
-    page_band = if socket.assigns.band == :ignored, do: :all, else: socket.assigns.band
+    {status, page_band} = status_for_band(socket.assigns.band)
     filter = %{band: page_band, q: socket.assigns.search}
 
     selection =
@@ -932,11 +932,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   defp load_groups(socket) do
     library_path_id = socket.assigns.selected_library_path_id
     band = socket.assigns.band
-    # `:ignored` is a status, not a real band -- ImportCandidates.page/2's
-    # :band option has no clause for it, so it goes through :status instead
-    # and the band filter itself is left at :all (a dismissed group's own
-    # confidence band plays no part in the Ignored view).
-    {status, page_band} = if band == :ignored, do: {"ignored", :all}, else: {"pending", band}
+    {status, page_band} = status_for_band(band)
     filter = %{band: page_band, q: socket.assigns.search}
 
     {groups, next_cursor} =
@@ -975,6 +971,14 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     |> assign(:expanded_ids, expanded)
   end
 
+  # `:queued` and `:ignored` are statuses, not confidence bands. Neither is a
+  # clause of ImportCandidates.page/2's `:band` option, which would raise, so
+  # both go through `:status` with the band itself left at `:all` (a queued or
+  # dismissed group's own confidence band plays no part in those views).
+  defp status_for_band(:ignored), do: {"ignored", :all}
+  defp status_for_band(:queued), do: {"queued", :all}
+  defp status_for_band(band), do: {"pending", band}
+
   # Recomputes the counts that only change when a group's status changes,
   # not on every page move or search keystroke: the current library's band
   # breakdown for the filter chips, the Ignored chip's own count, and every
@@ -994,6 +998,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       library_path_id
       |> ImportCandidates.band_counts()
       |> Map.put(:ignored, ImportCandidates.count_by_status(library_path_id, "ignored"))
+      |> Map.put(:queued, ImportCandidates.count_by_status(library_path_id, "queued"))
 
     socket
     |> assign(:band_counts, band_counts)
@@ -1019,7 +1024,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
   # will drop out on the next full `load_groups/1` regardless.
   defp refresh_group_row(socket, anchor_key) do
     library_path_id = socket.assigns.selected_library_path_id
-    status = if socket.assigns.band == :ignored, do: "ignored", else: "pending"
+    {status, _band} = status_for_band(socket.assigns.band)
 
     case ImportCandidates.get_group(library_path_id, anchor_key, status: status) do
       nil -> socket

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -243,9 +243,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
            socket.assigns.selected_library_path_id do
       {:noreply,
        socket
-       |> accept_result(
-         ImportCandidates.accept_all_matched(library_path_id, allow_episode_creation: true)
-       )}
+       |> queue_result(ImportCandidates.queue_accept_all_matched(library_path_id))}
     else
       {:unauthorized, socket} -> {:noreply, socket}
       nil -> {:noreply, put_flash(socket, :error, "Select a library before importing results.")}
@@ -401,11 +399,7 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
   def handle_event("accept_selected", _params, socket) do
     with :ok <- Authorization.authorize_import_media(socket) do
-      {:noreply,
-       socket
-       |> accept_result(
-         ImportCandidates.accept(socket.assigns.selection, allow_episode_creation: true)
-       )}
+      {:noreply, queue_result(socket, ImportCandidates.queue_accept(socket.assigns.selection))}
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -814,13 +808,26 @@ defmodule MydiaWeb.ImportMediaLive.Index do
     "Cleared #{candidates} scan result(s). Dismissed decisions are preserved."
   end
 
-  defp accept_result(socket, {:ok, %{accepted: accepted}}) do
+  defp queue_result(socket, {:ok, %{queued: queued, skipped: skipped}}) do
     socket
-    |> put_flash(:info, "Accepted #{accepted} group(s).")
+    |> put_flash(:info, queue_message(queued, skipped))
     |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
     |> load_groups()
     |> refresh_counts()
   end
+
+  # The skipped count was previously dropped on the floor, so a user who
+  # selected 40 groups and saw 12 promoted was told "Accepted 12 group(s)" with
+  # no account of the rest. The wording stays generic because a skip covers
+  # three distinct causes and the flash has no room to distinguish them; the
+  # per-group reason lands on the row as queue_error.
+  defp queue_message(queued, 0), do: "Queued #{queued} group(s) for import."
+
+  defp queue_message(0, skipped),
+    do: "Nothing queued. #{skipped} group(s) have nothing to import from."
+
+  defp queue_message(queued, skipped),
+    do: "Queued #{queued} group(s) for import. #{skipped} skipped, nothing to import from."
 
   defp show_outcome(socket, run) do
     socket =

--- a/lib/mydia_web/live/import_media_live/index.ex
+++ b/lib/mydia_web/live/import_media_live/index.ex
@@ -437,15 +437,14 @@ defmodule MydiaWeb.ImportMediaLive.Index do
 
   def handle_event("rematch_selected", _params, socket) do
     with :ok <- Authorization.authorize_import_media(socket) do
-      selection = socket.assigns.selection
-      count = SelectionScope.count(selection)
+      {:ok, %{queued: queued}} = ImportCandidates.queue_rematch(socket.assigns.selection)
 
       {:noreply,
        socket
-       |> put_flash(:info, "Re-matching #{count} group(s)…")
+       |> put_flash(:info, "Queued #{queued} group(s) for re-matching.")
        |> assign(:selection, SelectionScope.clear(socket.assigns.selection))
        |> load_groups()
-       |> start_async(:rematch_candidates, fn -> ImportCandidates.rematch(selection) end)}
+       |> refresh_counts()}
     else
       {:unauthorized, socket} -> {:noreply, socket}
     end
@@ -697,22 +696,6 @@ defmodule MydiaWeb.ImportMediaLive.Index do
       end
 
     {:noreply, socket}
-  end
-
-  def handle_async(:rematch_candidates, {:ok, {:ok, stats}}, socket) do
-    message =
-      if stats.failures > 0 do
-        "Re-matched #{stats.files} file(s), #{stats.failures} failed."
-      else
-        "Re-matched #{stats.files} file(s)."
-      end
-
-    {:noreply, socket |> put_flash(:info, message) |> load_groups() |> refresh_counts()}
-  end
-
-  def handle_async(:rematch_candidates, {:exit, reason}, socket) do
-    Logger.warning("Batch re-match crashed", reason: inspect(reason))
-    {:noreply, put_flash(socket, :error, "Re-match failed. Try again.")}
   end
 
   @impl true

--- a/priv/repo/migrations/20260901145004_add_queue_markers_to_import_candidates.exs
+++ b/priv/repo/migrations/20260901145004_add_queue_markers_to_import_candidates.exs
@@ -12,9 +12,13 @@ defmodule Mydia.Repo.Migrations.AddQueueMarkersToImportCandidates do
       add :queue_error, :text
     end
 
-    # Partial: the overwhelming majority of rows carry no marker, and every
-    # reader of this column filters on `queued_op IS NOT NULL`. Supported on
-    # both SQLite and PostgreSQL.
+    # Partial: the overwhelming majority of rows carry no marker, and readers
+    # of this column filter on it in both directions -- `is_nil(queued_op)`
+    # for the pending view (`filter_status/2`, `count_pending/0`, and both
+    # queue functions' UPDATE guards) and `not is_nil(queued_op)` for the
+    # queued one -- so this partial index still covers the selective,
+    # minority-row side of that split. Supported on both SQLite and
+    # PostgreSQL.
     create index(:import_candidates, [:library_path_id, :queued_op],
              where: "queued_op IS NOT NULL",
              name: :import_candidates_queued_op_index

--- a/priv/repo/migrations/20260901145004_add_queue_markers_to_import_candidates.exs
+++ b/priv/repo/migrations/20260901145004_add_queue_markers_to_import_candidates.exs
@@ -1,0 +1,23 @@
+defmodule Mydia.Repo.Migrations.AddQueueMarkersToImportCandidates do
+  use Ecto.Migration
+
+  # The user's intent to accept or re-match a group is durable state on the
+  # candidate row, not an Oban argument. A worker keyed on library_path_id
+  # discovers its own work from these columns, so a restart mid-drain resumes
+  # and a second click while a drain is running simply marks more rows.
+  def change do
+    alter table(:import_candidates) do
+      add :queued_op, :text
+      add :queued_at, :utc_datetime
+      add :queue_error, :text
+    end
+
+    # Partial: the overwhelming majority of rows carry no marker, and every
+    # reader of this column filters on `queued_op IS NOT NULL`. Supported on
+    # both SQLite and PostgreSQL.
+    create index(:import_candidates, [:library_path_id, :queued_op],
+             where: "queued_op IS NOT NULL",
+             name: :import_candidates_queued_op_index
+           )
+  end
+end

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -770,4 +770,35 @@ defmodule Mydia.ImportCandidatesTest do
       assert Repo.aggregate(MediaFile, :count) == 5
     end
   end
+
+  describe "queue marker fields" do
+    test "a candidate round-trips its queue markers" do
+      lp = library_path_fixture()
+      at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      candidate =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e01.mkv",
+          queued_op: "accept",
+          queued_at: at,
+          queue_error: "No provider match to import from."
+        })
+
+      reloaded = Mydia.Repo.get!(Mydia.Library.ImportCandidate, candidate.id)
+
+      assert reloaded.queued_op == "accept"
+      assert reloaded.queued_at == at
+      assert reloaded.queue_error == "No provider match to import from."
+    end
+
+    test "queue markers default to nil" do
+      lp = library_path_fixture()
+      candidate = import_candidate_fixture(%{library_path_id: lp.id})
+
+      assert is_nil(candidate.queued_op)
+      assert is_nil(candidate.queued_at)
+      assert is_nil(candidate.queue_error)
+    end
+  end
 end

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -801,4 +801,106 @@ defmodule Mydia.ImportCandidatesTest do
       assert is_nil(candidate.queue_error)
     end
   end
+
+  describe "queued status" do
+    setup do
+      lp = library_path_fixture()
+
+      pending =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: "9001",
+          title: "Wandering Aurora",
+          media_type: "tv_show",
+          confidence: 0.95
+        })
+
+      queued =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Glass Harbour/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: "9002",
+          title: "Glass Harbour",
+          media_type: "tv_show",
+          confidence: 0.95,
+          queued_op: "accept",
+          queued_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      %{lp: lp, pending: pending, queued: queued}
+    end
+
+    test "pending excludes queued groups", %{lp: lp, pending: pending} do
+      {groups, _cursor} = ImportCandidates.page(lp.id, status: "pending")
+
+      assert Enum.map(groups, & &1.anchor_key) == [pending.anchor_key]
+    end
+
+    test "queued returns only queued groups", %{lp: lp, queued: queued} do
+      {groups, _cursor} = ImportCandidates.page(lp.id, status: "queued")
+
+      assert [group] = groups
+      assert group.anchor_key == queued.anchor_key
+      assert group.queued? == true
+      assert group.dismissed? == false
+    end
+
+    test "count_by_status/2 counts queued groups", %{lp: lp} do
+      assert ImportCandidates.count_by_status(lp.id, "queued") == 1
+      assert ImportCandidates.count_by_status(lp.id, "pending") == 1
+    end
+
+    test "count_pending/0 excludes queued groups", %{lp: _lp} do
+      assert ImportCandidates.count_pending() == 1
+    end
+
+    test "a queued group carries its queue_error", %{lp: lp} do
+      import_candidate_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "Paper Lantern/s01e01.mkv",
+        queued_op: "accept",
+        queue_error: "Files in this folder match different titles."
+      })
+
+      {groups, _cursor} = ImportCandidates.page(lp.id, status: "queued")
+
+      assert Enum.any?(
+               groups,
+               &(&1.queue_error == "Files in this folder match different titles.")
+             )
+    end
+
+    test "dismiss/1 leaves a queued row alone when its anchor is also pending", %{
+      lp: lp,
+      queued: queued
+    } do
+      # The guard only matters for a mixed anchor, and a mixed anchor is a real
+      # state: a scan that discovers a new file inside a folder whose import is
+      # already queued inserts a pending row beside the queued ones.
+      # `SelectionScope.to_query/1` groups by anchor_key, so the pending row
+      # pulls the whole anchor into a "pending" selection, and
+      # `candidate_query/1` then matches every row under that key, queued rows
+      # included. Without the guard, dismiss/1 would stamp them.
+      newcomer =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: Path.join(Path.dirname(queued.relative_path), "s01e02.mkv")
+        })
+
+      assert newcomer.anchor_key == queued.anchor_key
+
+      scope =
+        lp.id
+        |> SelectionScope.new()
+        |> SelectionScope.select_all_matching(%{})
+
+      {:ok, _count} = ImportCandidates.dismiss(scope)
+
+      assert is_nil(Mydia.Repo.get!(Mydia.Library.ImportCandidate, queued.id).dismissed_at)
+      refute is_nil(Mydia.Repo.get!(Mydia.Library.ImportCandidate, newcomer.id).dismissed_at)
+    end
+  end
 end

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -690,6 +690,28 @@ defmodule Mydia.ImportCandidatesTest do
       assert Repo.get!(ImportCandidate, matched.id).queued_at == at
     end
 
+    test "a \"queued\"-status scope reports nothing queued instead of a false success", %{
+      lp: lp,
+      matched: matched
+    } do
+      pending_scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+      {:ok, %{queued: 1}} = ImportCandidates.queue_accept(pending_scope)
+
+      # `matched` is now queued (queued_op: "accept"). Re-running queue_accept/1
+      # against a "queued"-status scope -- the shape the Queued view's own
+      # selection would build -- must not report a second queue that never
+      # happened: eligible_accept_keys/1 still finds it eligible (single
+      # provider, not local), but the UPDATE's own `is_nil(c.queued_op)` guard
+      # matches zero rows for a candidate that is already queued.
+      queued_scope =
+        lp.id |> SelectionScope.new("queued") |> SelectionScope.select_all_matching(%{})
+
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "import_candidates:#{lp.id}")
+
+      assert {:ok, %{queued: 0, skipped: 1}} = ImportCandidates.queue_accept(queued_scope)
+      refute_receive {:import_candidates_changed, _lp_id}
+    end
+
     test "queue_accept_all_matched/1 queues every matched group", %{lp: lp, matched: matched} do
       assert {:ok, %{queued: 1, skipped: 1}} = ImportCandidates.queue_accept_all_matched(lp.id)
       assert Repo.get!(ImportCandidate, matched.id).queued_op == "accept"

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -1,12 +1,8 @@
 defmodule Mydia.ImportCandidatesTest do
-  # Some describe blocks swap in Mydia.MetadataStubProvider, a process-global
-  # registration -- see Mydia.MetadataStub's moduledoc for why every test
-  # using it (and therefore this whole module) must run synchronously.
   use Mydia.DataCase, async: false
 
   import Ecto.Query
   import Mydia.MediaFixtures
-  import Mydia.MetadataStub
   import Mydia.SettingsFixtures
 
   alias Mydia.ImportCandidates
@@ -621,153 +617,93 @@ defmodule Mydia.ImportCandidatesTest do
     end
   end
 
-  describe "accept/2 and accept_all_matched/2" do
-    setup :setup_metadata_stub
-
-    test "accept/2 promotes a matched group and skips a no-match one" do
-      lp = library_path_fixture(%{type: "movies"})
-
-      movie =
-        media_item_fixture(%{type: "movie", tmdb_id: Mydia.MetadataStubProvider.movie_tmdb_id()})
+  describe "queue_accept/1 and queue_accept_all_matched/1" do
+    setup do
+      lp = library_path_fixture(%{type: "series"})
 
       matched =
         import_candidate_fixture(%{
           library_path_id: lp.id,
-          anchor_key: "matched",
-          media_type: "movie",
-          provider_type: "tmdb",
-          provider_id: to_string(movie.tmdb_id),
-          title: movie.title,
-          year: movie.year,
-          confidence: 0.95,
-          parsed_info: %{"type" => "movie"}
+          relative_path: "Wandering Aurora/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: "9001",
+          title: "Wandering Aurora",
+          media_type: "tv_show",
+          confidence: 0.95
         })
 
       unmatched =
         import_candidate_fixture(%{
           library_path_id: lp.id,
-          anchor_key: "unmatched",
-          media_type: "movie",
-          parsed_info: %{"type" => "movie"}
+          relative_path: "Unknown Folder/file.mkv"
         })
 
-      scope =
-        lp.id |> SelectionScope.new() |> SelectionScope.select_page(["matched", "unmatched"])
-
-      assert {:ok, %{accepted: 1, skipped: 1}} =
-               ImportCandidates.accept(scope, config: Mydia.Metadata.default_relay_config())
-
-      refute Repo.get(ImportCandidate, matched.id)
-      assert Repo.get(ImportCandidate, unmatched.id)
-      assert Repo.exists?(from(f in MediaFile, where: f.media_item_id == ^movie.id))
+      %{lp: lp, matched: matched, unmatched: unmatched}
     end
 
-    test "accept_all_matched/2 imports every matched group and excludes no-match groups" do
-      lp = library_path_fixture(%{type: "movies"})
-
-      movie =
-        media_item_fixture(%{type: "movie", tmdb_id: Mydia.MetadataStubProvider.movie_tmdb_id()})
-
-      import_candidate_fixture(%{
-        library_path_id: lp.id,
-        anchor_key: "matched",
-        media_type: "movie",
-        provider_type: "tmdb",
-        provider_id: to_string(movie.tmdb_id),
-        title: movie.title,
-        year: movie.year,
-        confidence: 0.95,
-        parsed_info: %{"type" => "movie"}
-      })
-
-      import_candidate_fixture(%{
-        library_path_id: lp.id,
-        anchor_key: "unmatched",
-        media_type: "movie",
-        parsed_info: %{"type" => "movie"}
-      })
-
-      assert {:ok, %{accepted: 1, skipped: 1}} =
-               ImportCandidates.accept_all_matched(lp.id,
-                 config: Mydia.Metadata.default_relay_config()
-               )
-
-      assert {[group], nil} = ImportCandidates.page(lp.id)
-      assert group.anchor_key == "unmatched"
-    end
-
-    test "accept and import-all both reject a group with conflicting providers" do
-      lp = library_path_fixture(%{type: "movies"})
-      first_movie = media_item_fixture(%{type: "movie", tmdb_id: 61_001})
-      second_movie = media_item_fixture(%{type: "movie", tmdb_id: 61_002})
-
-      first =
-        import_candidate_fixture(%{
-          library_path_id: lp.id,
-          anchor_key: "conflict",
-          relative_path: "Conflict/a.mkv",
-          media_type: "movie",
-          provider_type: "tmdb",
-          provider_id: to_string(first_movie.tmdb_id),
-          confidence: 1.0,
-          parsed_info: %{"type" => "movie"}
-        })
-
-      second =
-        import_candidate_fixture(%{
-          library_path_id: lp.id,
-          anchor_key: "conflict",
-          relative_path: "Conflict/b.mkv",
-          media_type: "movie",
-          provider_type: "tmdb",
-          provider_id: to_string(second_movie.tmdb_id),
-          confidence: 1.0,
-          parsed_info: %{"type" => "movie"}
-        })
-
-      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_page(["conflict"])
-
-      assert {:ok, %{accepted: 0, skipped: 1}} = ImportCandidates.accept(scope)
-      assert {:ok, %{accepted: 0, skipped: 1}} = ImportCandidates.accept_all_matched(lp.id)
-
-      assert Repo.get(ImportCandidate, first.id)
-      assert Repo.get(ImportCandidate, second.id)
-      refute Repo.exists?(MediaFile)
-    end
-
-    test "accept keyset-pages selected groups instead of materializing the full selection" do
-      lp = library_path_fixture(%{type: "movies"})
-      movie = media_item_fixture(%{type: "movie", tmdb_id: 61_003})
-
-      for n <- 1..5 do
-        import_candidate_fixture(%{
-          library_path_id: lp.id,
-          anchor_key: "movie-#{n}",
-          relative_path: "Movie #{n}/movie.mkv",
-          media_type: "movie",
-          provider_type: "tmdb",
-          provider_id: to_string(movie.tmdb_id),
-          title: movie.title,
-          year: movie.year,
-          confidence: 1.0,
-          parsed_info: %{"type" => "movie"}
-        })
-      end
-
-      parent = self()
+    test "marks matched groups and skips unmatched ones", %{
+      lp: lp,
+      matched: matched,
+      unmatched: unmatched
+    } do
       scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
 
-      assert {:ok, %{accepted: 5, skipped: 0}} =
-               ImportCandidates.accept(scope,
-                 group_page_size: 2,
-                 after_group_page: fn groups -> send(parent, {:group_page, length(groups)}) end
-               )
+      assert {:ok, %{queued: 1, skipped: 1}} = ImportCandidates.queue_accept(scope)
 
-      assert_receive {:group_page, 2}
-      assert_receive {:group_page, 2}
-      assert_receive {:group_page, 1}
-      refute_receive {:group_page, _}
-      assert Repo.aggregate(MediaFile, :count) == 5
+      assert Repo.get!(ImportCandidate, matched.id).queued_op == "accept"
+      assert is_nil(Repo.get!(ImportCandidate, unmatched.id).queued_op)
+    end
+
+    test "a queued group leaves the pending list", %{lp: lp, unmatched: unmatched} do
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+      {:ok, _} = ImportCandidates.queue_accept(scope)
+
+      {groups, _cursor} = ImportCandidates.page(lp.id, status: "pending")
+      assert Enum.map(groups, & &1.anchor_key) == [unmatched.anchor_key]
+
+      {queued_groups, _cursor} = ImportCandidates.page(lp.id, status: "queued")
+      assert length(queued_groups) == 1
+    end
+
+    test "clears a stale queue_error when re-queued", %{lp: lp, matched: matched} do
+      matched
+      |> Ecto.Changeset.change(%{queue_error: "No provider match to import from."})
+      |> Repo.update!()
+
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+      {:ok, _} = ImportCandidates.queue_accept(scope)
+
+      assert is_nil(Repo.get!(ImportCandidate, matched.id).queue_error)
+    end
+
+    test "does not re-mark a group that is already queued", %{lp: lp, matched: matched} do
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+      {:ok, %{queued: 1}} = ImportCandidates.queue_accept(scope)
+
+      at = Repo.get!(ImportCandidate, matched.id).queued_at
+
+      # The second call sees a selection whose only remaining pending group is
+      # the unmatched one, so nothing new is queued and the timestamp stands.
+      assert {:ok, %{queued: 0, skipped: 1}} = ImportCandidates.queue_accept(scope)
+      assert Repo.get!(ImportCandidate, matched.id).queued_at == at
+    end
+
+    test "queue_accept_all_matched/1 queues every matched group", %{lp: lp, matched: matched} do
+      assert {:ok, %{queued: 1, skipped: 1}} = ImportCandidates.queue_accept_all_matched(lp.id)
+      assert Repo.get!(ImportCandidate, matched.id).queued_op == "accept"
+    end
+
+    test "a local-show group is skipped", %{lp: lp} do
+      import_candidate_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "Home Videos/clip.mkv",
+        provider_type: "local",
+        provider_id: "local:home-videos",
+        media_type: "tv_show",
+        confidence: 1.0
+      })
+
+      assert {:ok, %{queued: 1, skipped: 2}} = ImportCandidates.queue_accept_all_matched(lp.id)
     end
   end
 

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -515,6 +515,58 @@ defmodule Mydia.ImportCandidatesTest do
       assert {:error, :not_found} = ImportCandidates.create_local_show(lp.id, "missing")
     end
 
+    test "leaves an accept-queued sibling row untouched instead of linking or overwriting it" do
+      lp = library_path_fixture(%{type: "series", path: "/media/Series"})
+
+      # The pending subset of this anchor has no provider match -- what makes
+      # it show up as :no_match and offer "Create show from folder" in the
+      # first place.
+      pending =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          anchor_key: "split anchor",
+          relative_path: "Split Anchor/Season 01/ep1.mkv",
+          media_type: "tv_show",
+          parsed_info: %{"season" => 1, "episodes" => [1]}
+        })
+
+      # A second file under the same folder that a scan discovered after this
+      # anchor was already queued for accept -- it carries a real provider
+      # match and is eligible for CandidatePromotion.promote_group/3 once the
+      # drain reaches it.
+      queued =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          anchor_key: "split anchor",
+          relative_path: "Split Anchor/Season 01/ep2.mkv",
+          media_type: "tv_show",
+          provider_type: "tvdb",
+          provider_id: "9001",
+          title: "Split Anchor",
+          confidence: 0.95,
+          parsed_info: %{"season" => 1, "episodes" => [2]},
+          queued_op: "accept",
+          queued_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      assert {:ok, item} = ImportCandidates.create_local_show(lp.id, "split anchor")
+
+      # Only the pending row was linked into the new local show.
+      refute Repo.get(ImportCandidate, pending.id)
+
+      episodes = Repo.all(from(e in Mydia.Media.Episode, where: e.media_item_id == ^item.id))
+      assert length(episodes) == 1
+      assert hd(episodes).episode_number == 1
+
+      # The queued row survived: not linked, not deleted, not overwritten
+      # with the synthetic local provider identity, and still carrying its
+      # own queued_op for the drain to promote normally.
+      reloaded = Repo.get!(ImportCandidate, queued.id)
+      assert reloaded.queued_op == "accept"
+      assert reloaded.provider_type == "tvdb"
+      assert reloaded.provider_id == "9001"
+    end
+
     test "a repeat call against the same anchor is refused instead of creating a second show" do
       lp = library_path_fixture(%{type: "series", path: "/media/Series"})
 

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -573,7 +573,7 @@ defmodule Mydia.ImportCandidatesTest do
     end
   end
 
-  describe "rematch/2" do
+  describe "queue_rematch/1 and drain_rematch/2" do
     test "matches selected candidates and writes results back onto them" do
       lp = library_path_fixture(%{type: "series", path: "/media/Series"})
 
@@ -586,9 +586,10 @@ defmodule Mydia.ImportCandidatesTest do
         })
 
       scope = lp.id |> SelectionScope.new() |> SelectionScope.select_page(["doctor who"])
+      {:ok, _} = ImportCandidates.queue_rematch(scope)
 
       assert {:ok, %{files: 1, failures: 0}} =
-               ImportCandidates.rematch(scope, matcher: Mydia.Library.ParsedInfoMatcher)
+               ImportCandidates.drain_rematch(lp.id, matcher: Mydia.Library.ParsedInfoMatcher)
 
       reloaded = Repo.reload!(candidate)
       assert reloaded.provider_id == "stub"
@@ -605,12 +606,13 @@ defmodule Mydia.ImportCandidatesTest do
         relative_path: "Doctor Who (2005)/Season 01/Doctor Who - S01E01.mkv"
       })
 
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_page(["doctor who"])
+      {:ok, _} = ImportCandidates.queue_rematch(scope)
+
       Phoenix.PubSub.subscribe(Mydia.PubSub, "import_candidates:#{lp.id}")
 
-      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_page(["doctor who"])
-
       assert {:ok, %{files: 0, failures: 1}} =
-               ImportCandidates.rematch(scope, matcher: Mydia.Library.CrashingMatcher)
+               ImportCandidates.drain_rematch(lp.id, matcher: Mydia.Library.CrashingMatcher)
 
       assert_receive {:import_candidates_changed, lp_id}
       assert lp_id == lp.id

--- a/test/mydia/jobs/apply_import_candidates_test.exs
+++ b/test/mydia/jobs/apply_import_candidates_test.exs
@@ -164,6 +164,59 @@ defmodule Mydia.Jobs.ApplyImportCandidatesTest do
       assert Repo.get(ImportCandidate, newcomer.id)
     end
 
+    test "an anchor queued for both accept and rematch promotes only the accept-queued row" do
+      lp = library_path_fixture(%{type: "series"})
+
+      accepted =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: "9001",
+          title: "Wandering Aurora",
+          media_type: "tv_show",
+          confidence: 0.95,
+          parsed_info: %{"season" => 1, "episodes" => [1]}
+        })
+        |> queue()
+
+      # A different provider_id under the same anchor. If eligibility were
+      # ever computed over every queued_op at once (rather than "accept"
+      # alone), this row's presence would flip provider_count to 2 and the
+      # accepted row would wrongly be refused as :conflicting_providers.
+      rematching =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e02.mkv",
+          provider_type: "tvdb",
+          provider_id: "9002",
+          title: "Wandering Aurora (uncertain)",
+          media_type: "tv_show",
+          confidence: 0.4
+        })
+
+      assert rematching.anchor_key == accepted.anchor_key
+
+      rematching
+      |> Ecto.Changeset.change(%{
+        queued_op: "rematch",
+        queued_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+      |> Repo.update!()
+
+      assert {:ok, %{promoted: 1, remaining: 0}} =
+               ImportCandidates.drain_accepted(lp.id,
+                 config: Mydia.Metadata.default_relay_config(),
+                 allow_episode_creation: true
+               )
+
+      refute Repo.get(ImportCandidate, accepted.id)
+
+      reloaded_rematching = Repo.get!(ImportCandidate, rematching.id)
+      assert reloaded_rematching.queued_op == "rematch"
+      assert is_nil(reloaded_rematching.queue_error)
+    end
+
     test "a library with nothing queued is a no-op" do
       lp = library_path_fixture(%{type: "series"})
 

--- a/test/mydia/jobs/apply_import_candidates_test.exs
+++ b/test/mydia/jobs/apply_import_candidates_test.exs
@@ -217,6 +217,68 @@ defmodule Mydia.Jobs.ApplyImportCandidatesTest do
       assert is_nil(reloaded_rematching.queue_error)
     end
 
+    test "an early anchor stuck in a transient failure does not strand a later, healthy anchor" do
+      lp = library_path_fixture(%{type: "series"})
+      series_id = to_string(Mydia.MetadataStubProvider.series_tvdb_id())
+
+      # "blocked" sorts before "healthy", so with anchor_page_size: 1 it lands
+      # on the drain's first anchor page, ahead of the healthy anchor below.
+      stuck =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          anchor_key: "blocked show",
+          relative_path: "Blocked Show/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: series_id,
+          title: "Blocked Show",
+          media_type: "tv_show",
+          confidence: 0.95,
+          parsed_info: %{"season" => 1, "episodes" => [1]}
+        })
+        |> queue()
+
+      # A MediaFile already occupying the queued candidate's path makes
+      # CandidatePromotion's ensure_path_available/1 fail with
+      # {:error, {:duplicate_path, _, _}} -- a transient, non-terminal error
+      # (not in @terminal_accept_errors) that leaves queued_op in place for
+      # retry rather than clearing the marker. An episode-owned file, not a
+      # movie one, since `lp` is a series library path.
+      other_episode = episode_fixture()
+
+      media_file_fixture(%{
+        library_path_id: lp.id,
+        episode_id: other_episode.id,
+        relative_path: stuck.relative_path
+      })
+
+      healthy =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          anchor_key: "healthy show",
+          relative_path: "Healthy Show/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: series_id,
+          title: "Healthy Show",
+          media_type: "tv_show",
+          confidence: 0.95,
+          parsed_info: %{"season" => 1, "episodes" => [1]}
+        })
+        |> queue()
+
+      assert {:ok, %{promoted: 1, remaining: 1}} =
+               ImportCandidates.drain_accepted(lp.id,
+                 anchor_page_size: 1,
+                 config: Mydia.Metadata.default_relay_config(),
+                 allow_episode_creation: true
+               )
+
+      refute Repo.get(ImportCandidate, healthy.id)
+
+      reloaded_stuck = Repo.get!(ImportCandidate, stuck.id)
+      assert reloaded_stuck.queued_op == "accept"
+      assert is_nil(reloaded_stuck.queue_error)
+    end
+
     test "a library with nothing queued is a no-op" do
       lp = library_path_fixture(%{type: "series"})
 

--- a/test/mydia/jobs/apply_import_candidates_test.exs
+++ b/test/mydia/jobs/apply_import_candidates_test.exs
@@ -1,0 +1,185 @@
+defmodule Mydia.Jobs.ApplyImportCandidatesTest do
+  # Promotion runs through Mydia.MetadataStubProvider, a process-global
+  # registration -- see Mydia.MetadataStub's moduledoc for why every test that
+  # relies on it must run synchronously.
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.MetadataStub
+  import Mydia.SettingsFixtures
+
+  alias Mydia.ImportCandidates
+  alias Mydia.Jobs.ApplyImportCandidates
+  alias Mydia.Library.ImportCandidate
+  alias Mydia.Repo
+
+  setup :setup_metadata_stub
+
+  defp queue(candidate) do
+    candidate
+    |> Ecto.Changeset.change(%{
+      queued_op: "accept",
+      queued_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+    |> Repo.update!()
+  end
+
+  describe "drain_accepted/2" do
+    test "promotes a queued group and removes its candidates" do
+      lp = library_path_fixture(%{type: "series"})
+
+      candidate =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: "9001",
+          title: "Wandering Aurora",
+          media_type: "tv_show",
+          confidence: 0.95,
+          parsed_info: %{"season" => 1, "episodes" => [1]}
+        })
+        |> queue()
+
+      assert {:ok, %{promoted: 1, failed: 0, remaining: 0}} =
+               ImportCandidates.drain_accepted(lp.id,
+                 config: Mydia.Metadata.default_relay_config(),
+                 allow_episode_creation: true
+               )
+
+      refute Repo.get(ImportCandidate, candidate.id)
+    end
+
+    test "a group with no provider match clears its marker and records why" do
+      lp = library_path_fixture(%{type: "series"})
+
+      candidate =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Unknown Folder/file.mkv"
+        })
+        |> queue()
+
+      assert {:ok, %{promoted: 0, failed: 1, remaining: 0}} =
+               ImportCandidates.drain_accepted(lp.id)
+
+      reloaded = Repo.get!(ImportCandidate, candidate.id)
+      assert is_nil(reloaded.queued_op)
+      assert reloaded.queue_error == "No provider match to import from."
+    end
+
+    test "a group whose files match different titles clears its marker" do
+      lp = library_path_fixture(%{type: "series"})
+
+      for {path, provider_id} <- [{"Split Anchor/a.mkv", "9001"}, {"Split Anchor/b.mkv", "9002"}] do
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: path,
+          provider_type: "tvdb",
+          provider_id: provider_id,
+          media_type: "tv_show",
+          confidence: 0.9
+        })
+        |> queue()
+      end
+
+      assert {:ok, %{promoted: 0, failed: 1, remaining: 0}} =
+               ImportCandidates.drain_accepted(lp.id)
+
+      assert [error | _] =
+               ImportCandidate
+               |> Ecto.Query.where([c], c.library_path_id == ^lp.id)
+               |> Repo.all()
+               |> Enum.map(& &1.queue_error)
+
+      assert error == "Files in this folder match different titles."
+    end
+
+    test "drains more groups than one anchor page holds" do
+      lp = library_path_fixture(%{type: "series"})
+
+      # All three anchors resolve through Mydia.MetadataStubProvider, whose
+      # catalog has exactly one series -- see its moduledoc. Sharing that
+      # series' id (rather than three distinct ones the stub cannot
+      # differentiate) keeps each promotion from racing to create a second
+      # media item with the same tvdb id; each anchor still stays its own
+      # group, and each candidate targets a distinct episode of that series.
+      series_id = to_string(Mydia.MetadataStubProvider.series_tvdb_id())
+
+      for n <- 1..3 do
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Show #{n}/s01e0#{n}.mkv",
+          provider_type: "tvdb",
+          provider_id: series_id,
+          title: "Show #{n}",
+          media_type: "tv_show",
+          confidence: 0.95,
+          parsed_info: %{"season" => 1, "episodes" => [n]}
+        })
+        |> queue()
+      end
+
+      assert {:ok, %{promoted: 3, remaining: 0}} =
+               ImportCandidates.drain_accepted(lp.id,
+                 anchor_page_size: 1,
+                 config: Mydia.Metadata.default_relay_config(),
+                 allow_episode_creation: true
+               )
+    end
+
+    test "promotes only the queued rows of a mixed anchor" do
+      lp = library_path_fixture(%{type: "series"})
+
+      queued =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: "9001",
+          title: "Wandering Aurora",
+          media_type: "tv_show",
+          confidence: 0.95,
+          parsed_info: %{"season" => 1, "episodes" => [1]}
+        })
+        |> queue()
+
+      # What a scan discovering a new file mid-drain leaves behind: a pending
+      # row under an anchor whose import is already under way.
+      newcomer =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e02.mkv"
+        })
+
+      assert newcomer.anchor_key == queued.anchor_key
+
+      assert {:ok, %{promoted: 1, remaining: 0}} =
+               ImportCandidates.drain_accepted(lp.id,
+                 config: Mydia.Metadata.default_relay_config(),
+                 allow_episode_creation: true
+               )
+
+      refute Repo.get(ImportCandidate, queued.id)
+      assert Repo.get(ImportCandidate, newcomer.id)
+    end
+
+    test "a library with nothing queued is a no-op" do
+      lp = library_path_fixture(%{type: "series"})
+
+      assert {:ok, %{promoted: 0, failed: 0, remaining: 0}} =
+               ImportCandidates.drain_accepted(lp.id)
+    end
+  end
+
+  describe "perform/1" do
+    test "returns :ok when everything drained" do
+      lp = library_path_fixture(%{type: "series"})
+
+      assert :ok =
+               ApplyImportCandidates.perform(%Oban.Job{
+                 args: %{"library_path_id" => lp.id}
+               })
+    end
+  end
+end

--- a/test/mydia/jobs/rematch_import_candidates_test.exs
+++ b/test/mydia/jobs/rematch_import_candidates_test.exs
@@ -1,0 +1,102 @@
+defmodule Mydia.Jobs.RematchImportCandidatesTest do
+  use Mydia.DataCase, async: false
+
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.ImportCandidates
+  alias Mydia.Jobs.RematchImportCandidates
+  alias Mydia.Library.{ImportCandidate, SelectionScope}
+  alias Mydia.Repo
+
+  describe "queue_rematch/1" do
+    test "marks every candidate in the selection" do
+      lp = library_path_fixture(%{type: "series"})
+
+      candidate =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e01.mkv"
+        })
+
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+
+      assert {:ok, %{queued: 1}} = ImportCandidates.queue_rematch(scope)
+      assert Repo.get!(ImportCandidate, candidate.id).queued_op == "rematch"
+    end
+  end
+
+  describe "drain_rematch/2" do
+    test "re-matches queued candidates and clears their markers" do
+      lp = library_path_fixture(%{type: "series"})
+
+      candidate =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Wandering Aurora/s01e01.mkv"
+        })
+
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+      {:ok, _} = ImportCandidates.queue_rematch(scope)
+
+      assert {:ok, %{files: 1, failures: 0, remaining: 0}} =
+               ImportCandidates.drain_rematch(lp.id, matcher: Mydia.Library.ParsedInfoMatcher)
+
+      assert is_nil(Repo.get!(ImportCandidate, candidate.id).queued_op)
+    end
+
+    test "a crashing matcher counts as a failure and still clears the marker" do
+      lp = library_path_fixture(%{type: "series"})
+
+      candidate =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Glass Harbour/s01e01.mkv"
+        })
+
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+      {:ok, _} = ImportCandidates.queue_rematch(scope)
+
+      assert {:ok, %{failures: 1, remaining: 0}} =
+               ImportCandidates.drain_rematch(lp.id, matcher: Mydia.Library.CrashingMatcher)
+
+      assert is_nil(Repo.get!(ImportCandidate, candidate.id).queued_op)
+    end
+
+    test "drains more candidates than one page holds" do
+      lp = library_path_fixture(%{type: "series"})
+
+      for n <- 1..3 do
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Show #{n}/s01e01.mkv"
+        })
+      end
+
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_all_matching(%{})
+      {:ok, _} = ImportCandidates.queue_rematch(scope)
+
+      assert {:ok, %{files: 3, remaining: 0}} =
+               ImportCandidates.drain_rematch(lp.id,
+                 matcher: Mydia.Library.ParsedInfoMatcher,
+                 page_size: 1
+               )
+    end
+
+    test "a library with nothing queued is a no-op" do
+      lp = library_path_fixture(%{type: "series"})
+
+      assert {:ok, %{files: 0, failures: 0, remaining: 0}} =
+               ImportCandidates.drain_rematch(lp.id, matcher: Mydia.Library.ParsedInfoMatcher)
+    end
+  end
+
+  describe "perform/1" do
+    test "returns :ok when everything drained" do
+      lp = library_path_fixture(%{type: "series"})
+
+      assert :ok =
+               RematchImportCandidates.perform(%Oban.Job{args: %{"library_path_id" => lp.id}})
+    end
+  end
+end

--- a/test/mydia_web/live/import_media_review_test.exs
+++ b/test/mydia_web/live/import_media_review_test.exs
@@ -312,22 +312,26 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     assert has_element?(view, "#group-toggle-#{dom_b} .hero-chevron-down")
   end
 
-  test "select all matching the filter accepts every ready group", %{conn: conn} do
+  test "select all matching the filter queues every ready group for import", %{conn: conn} do
     lp = library_path_fixture(%{type: "movies"})
 
-    for n <- 1..3 do
-      movie = media_item_fixture(%{type: "movie", tmdb_id: 1_000 + n})
+    ready_candidates =
+      for n <- 1..3 do
+        movie = media_item_fixture(%{type: "movie", tmdb_id: 1_000 + n})
 
-      seed_group(lp, "r#{n}", %{
-        media_type: "movie",
-        provider_type: "tmdb",
-        provider_id: to_string(movie.tmdb_id),
-        title: movie.title,
-        year: movie.year,
-        confidence: 1.0,
-        parsed_info: %{"type" => "movie"}
-      })
-    end
+        [candidate] =
+          seed_group(lp, "r#{n}", %{
+            media_type: "movie",
+            provider_type: "tmdb",
+            provider_id: to_string(movie.tmdb_id),
+            title: movie.title,
+            year: movie.year,
+            confidence: 1.0,
+            parsed_info: %{"type" => "movie"}
+          })
+
+        candidate
+      end
 
     seed_group(lp, "low", %{media_type: "movie", confidence: 0.7})
 
@@ -337,8 +341,43 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     view |> element("#select-all-matching") |> render_click()
     view |> element("#accept-selected") |> render_click()
 
-    assert Repo.aggregate(from(f in Mydia.Library.MediaFile), :count) == 3
+    assert Enum.all?(ready_candidates, &(Repo.reload!(&1).queued_op == "accept"))
     assert ImportCandidates.count_pending() == 1
+  end
+
+  test "accepting a selection queues it and reports the skipped groups", %{conn: conn} do
+    lp = library_path_fixture(%{type: "series"})
+
+    matched =
+      import_candidate_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "Wandering Aurora/s01e01.mkv",
+        provider_type: "tvdb",
+        provider_id: "9001",
+        title: "Wandering Aurora",
+        media_type: "tv_show",
+        confidence: 0.95
+      })
+
+    import_candidate_fixture(%{
+      library_path_id: lp.id,
+      relative_path: "Unknown Folder/file.mkv"
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    # bulk_bar (and its select-all-matching shortcut) only renders once
+    # something is selected or the band/search narrows the page -- toggling
+    # one group first makes it appear without narrowing the band away from
+    # :all, so select_all_matching/1's fresh filter-mode selection spans
+    # every band and picks up both the matched and the unmatched group.
+    render_click(view, "toggle_group", %{"id" => matched.anchor_key})
+
+    view |> element("#select-all-matching") |> render_click()
+    html = view |> element("#accept-selected") |> render_click()
+
+    assert html =~ "Queued 1 group(s) for import."
+    assert html =~ "1 skipped"
   end
 
   test "select all matching and clear both redraw every checkbox on screen", %{conn: conn} do
@@ -378,20 +417,12 @@ defmodule MydiaWeb.ImportMediaReviewTest do
        %{conn: conn} do
     lp = library_path_fixture(%{type: "movies", path: "/media/Movies"})
     # ImportCandidates' default page size is 50; 55 forces the filter-mode
-    # accept to reach past a single page or this assertion catches it at 50.
-    # A real (non-"local") provider per group, at a needs_attention
-    # confidence, is deliberate: accept_group/2 refuses provider_type:
-    # "local" outright ({:error, :local_show}), so a "local" fixture here
-    # would make every click of #accept-selected a guaranteed no-op and this
-    # test would stop proving anything about the page boundary at all.
-    #
-    # Each movie is pre-created locally (not resolved through a fresh relay
-    # fetch) so promotion takes MetadataEnricher's "update existing item by
-    # id" branch: MetadataStubProvider.fetch_by_id/3 always returns the same
-    # canned movie regardless of the id requested, so 55 *new* creates driven
-    # by a stub fetch would all race to persist the *same* stubbed tmdb_id
-    # and only the first would ever land -- not a page-boundary bug, but a
-    # fixture-shape trap this test fell into once already.
+    # queue_accept to reach past a single page or this assertion catches it
+    # at 50. A real (non-"local") provider per group, at a needs_attention
+    # confidence, is deliberate: eligible_accept_keys/1 excludes
+    # provider_type: "local" outright, so a "local" fixture here would make
+    # every click of #accept-selected a guaranteed no-op and this test would
+    # stop proving anything about the page boundary at all.
     for n <- 1..55 do
       movie = insert(:media_item, type: "movie", tmdb_id: 9000 + n)
 
@@ -413,7 +444,9 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     view |> element("#accept-selected") |> render_click()
 
     assert Repo.aggregate(
-             from(f in Mydia.Library.MediaFile, where: f.library_path_id == ^lp.id),
+             from(c in ImportCandidate,
+               where: c.library_path_id == ^lp.id and c.queued_op == "accept"
+             ),
              :count
            ) == 55
 

--- a/test/mydia_web/live/import_media_review_test.exs
+++ b/test/mydia_web/live/import_media_review_test.exs
@@ -1103,9 +1103,10 @@ defmodule MydiaWeb.ImportMediaReviewTest do
       queued_at: DateTime.utc_now() |> DateTime.truncate(:second)
     })
 
-    {:ok, view, _html} = live(conn, ~p"/import")
+    {:ok, view, html} = live(conn, ~p"/import")
 
     assert has_element?(view, "#band-queued")
+    refute html =~ "Wandering Aurora"
 
     html = view |> element("#band-queued") |> render_click()
     assert html =~ "Wandering Aurora"
@@ -1123,6 +1124,40 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     {:ok, view, _html} = live(conn, ~p"/import")
 
     assert render(view) =~ "Files in this folder match different titles."
+  end
+
+  test "the Queued view offers no Accept, Re-match, Dismiss, or Restore controls", %{conn: conn} do
+    lp = library_path_fixture()
+
+    candidate =
+      import_candidate_fixture(%{
+        library_path_id: lp.id,
+        relative_path: "Wandering Aurora/s01e01.mkv",
+        provider_type: "tvdb",
+        provider_id: "9001",
+        title: "Wandering Aurora",
+        media_type: "tv_show",
+        confidence: 0.95,
+        queued_op: "accept",
+        queued_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    view |> element("#band-queued") |> render_click()
+    html = render_click(view, "toggle_group", %{"id" => candidate.anchor_key})
+
+    # None of these controls can do anything on the Queued view -- every one
+    # of them requires a row that is not already queued (Accept, Re-match,
+    # Dismiss) or one that is dismissed (Restore), and a queued group is
+    # neither. Regression coverage for the false-positive "Queued 1 group(s)
+    # for import." flash a since-fixed queue_accept/1 asymmetry would have
+    # produced had Accept still been offered here.
+    refute has_element?(view, "#accept-selected")
+    refute has_element?(view, "#rematch-selected")
+    refute has_element?(view, "#dismiss-selected")
+    refute has_element?(view, "#restore-selected")
+    refute html =~ "Queued 1 group(s) for import."
   end
 
   describe "member episode editing" do

--- a/test/mydia_web/live/import_media_review_test.exs
+++ b/test/mydia_web/live/import_media_review_test.exs
@@ -1276,7 +1276,7 @@ defmodule MydiaWeb.ImportMediaReviewTest do
              )
     end
 
-    test "batch rematch re-runs matcher on selected groups", %{conn: conn} do
+    test "batch rematch queues selected groups for re-matching", %{conn: conn} do
       lp = library_path_fixture(%{type: "series", path: "/media/Series"})
 
       candidate =
@@ -1292,13 +1292,10 @@ defmodule MydiaWeb.ImportMediaReviewTest do
       render_click(view, "toggle_group", %{"id" => "stub series"})
       assert has_element?(view, "#rematch-selected")
 
-      render_click(view, "rematch_selected", %{})
-      render_async(view)
+      html = view |> element("#rematch-selected") |> render_click()
 
-      assert render(view) =~ "Re-matched 1 file(s)."
-
-      reloaded = Repo.reload!(candidate)
-      assert reloaded.provider_id == to_string(MetadataStubProvider.series_tvdb_id())
+      assert html =~ "Queued 1 group(s) for re-matching."
+      assert Repo.reload!(candidate).queued_op == "rematch"
     end
   end
 end

--- a/test/mydia_web/live/import_media_review_test.exs
+++ b/test/mydia_web/live/import_media_review_test.exs
@@ -1088,6 +1088,43 @@ defmodule MydiaWeb.ImportMediaReviewTest do
     assert fetch_group(lp, "readonly-restore", status: "ignored")
   end
 
+  test "queued groups appear under the Queued chip, not the pending list", %{conn: conn} do
+    lp = library_path_fixture()
+
+    import_candidate_fixture(%{
+      library_path_id: lp.id,
+      relative_path: "Wandering Aurora/s01e01.mkv",
+      provider_type: "tvdb",
+      provider_id: "9001",
+      title: "Wandering Aurora",
+      media_type: "tv_show",
+      confidence: 0.95,
+      queued_op: "accept",
+      queued_at: DateTime.utc_now() |> DateTime.truncate(:second)
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    assert has_element?(view, "#band-queued")
+
+    html = view |> element("#band-queued") |> render_click()
+    assert html =~ "Wandering Aurora"
+  end
+
+  test "a group that failed to import shows its reason", %{conn: conn} do
+    lp = library_path_fixture()
+
+    import_candidate_fixture(%{
+      library_path_id: lp.id,
+      relative_path: "Split Anchor/a.mkv",
+      queue_error: "Files in this folder match different titles."
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/import")
+
+    assert render(view) =~ "Files in this folder match different titles."
+  end
+
   describe "member episode editing" do
     test "renders filename, folder, matched episode badge, and inline S/E inputs", %{conn: conn} do
       lp = library_path_fixture(%{type: "series"})

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -555,6 +555,54 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     assert is_nil(Repo.reload!(other).queued_op)
   end
 
+  test "queuing an accept enqueues the accept-drain worker", %{
+    conn: conn,
+    library_path: lp
+  } do
+    movie = media_item_fixture(%{type: "movie", tmdb_id: 9101})
+
+    import_candidate_fixture(%{
+      library_path_id: lp.id,
+      anchor_key: "queue worker movie",
+      media_type: "movie",
+      provider_type: "tmdb",
+      provider_id: to_string(movie.tmdb_id),
+      title: movie.title,
+      year: movie.year,
+      confidence: 0.99,
+      parsed_info: %{"type" => "movie"}
+    })
+
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{lp.id}")
+
+    view |> element("#import-all-results") |> render_click()
+
+    assert_enqueued(
+      worker: Mydia.Jobs.ApplyImportCandidates,
+      queue: :default,
+      args: %{"library_path_id" => lp.id}
+    )
+  end
+
+  test "queuing a re-match enqueues the rematch-drain worker", %{
+    conn: conn,
+    library_path: lp
+  } do
+    candidate =
+      import_candidate_fixture(%{library_path_id: lp.id, anchor_key: "queue worker rematch"})
+
+    {:ok, view, _html} = live(conn, ~p"/import?library_path_id=#{lp.id}")
+
+    render_click(view, "toggle_group", %{"id" => candidate.anchor_key})
+    view |> element("#rematch-selected") |> render_click()
+
+    assert_enqueued(
+      worker: Mydia.Jobs.RematchImportCandidates,
+      queue: :default,
+      args: %{"library_path_id" => lp.id}
+    )
+  end
+
   test "scan controls and review are both visible while idle", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/import")
 

--- a/test/mydia_web/live/import_media_run_control_test.exs
+++ b/test/mydia_web/live/import_media_run_control_test.exs
@@ -4,24 +4,15 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
   # jobs are inserted but never executed by the test run.
   use Oban.Testing, repo: Mydia.Repo
 
-  import Ecto.Query
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
   import Mydia.MediaFixtures
-  import Mydia.MetadataStub
   import Mydia.SettingsFixtures
 
   alias Mydia.ImportCandidates
   alias Mydia.Library
-  alias Mydia.Library.{ImportCandidate, ImportCandidateGroup, MediaFile}
+  alias Mydia.Library.{ImportCandidate, ImportCandidateGroup}
   alias Mydia.Repo
-
-  # "import all accepts every provider-matched result..." promotes a
-  # candidate with no locally pre-existing media item (the "uncertain" case),
-  # which makes CandidatePromotion enrich through a live provider fetch. The
-  # stub keeps that fetch on loopback instead of the real relay -- the test
-  # sandbox refuses real outbound HTTP outright.
-  setup :setup_metadata_stub
 
   setup %{conn: conn} do
     # The app skips Oban entirely in test env (see Mydia.Application), so
@@ -552,13 +543,16 @@ defmodule MydiaWeb.ImportMediaRunControlTest do
     |> element("#import-all-results")
     |> render_click()
 
-    refute Repo.get(ImportCandidate, confident.id)
-    refute Repo.get(ImportCandidate, uncertain.id)
-    assert Repo.get(ImportCandidate, unmatched.id)
-    assert Repo.get(ImportCandidate, local.id)
-    assert Repo.get(ImportCandidate, other.id)
-
-    assert Repo.exists?(from(f in MediaFile, where: f.media_item_id == ^confident_movie.id))
+    # Both provider-matched groups in the selected library are queued for
+    # import, regardless of confidence -- "Import all" is the explicit human
+    # override. The unmatched and local-show groups in the same library are
+    # left alone, and so is every candidate in the other library: that
+    # isolation is what this test exists to protect.
+    assert Repo.reload!(confident).queued_op == "accept"
+    assert Repo.reload!(uncertain).queued_op == "accept"
+    assert is_nil(Repo.reload!(unmatched).queued_op)
+    assert is_nil(Repo.reload!(local).queued_op)
+    assert is_nil(Repo.reload!(other).queued_op)
   end
 
   test "scan controls and review are both visible while idle", %{conn: conn} do

--- a/test/support/crashing_matcher.ex
+++ b/test/support/crashing_matcher.ex
@@ -4,7 +4,7 @@ defmodule Mydia.Library.CrashingMatcher do
 
   Distinct from `Mydia.Library.FailingMatcher`, whose `{:error, :no_match}`
   is a legitimate, recordable outcome. This is for exercising the genuine
-  failure path -- e.g. `Mydia.ImportCandidates.rematch/2`'s `:failures`
+  failure path -- e.g. `Mydia.ImportCandidates.drain_rematch/2`'s `:failures`
   counter -- where the matcher itself could not produce any verdict at all.
   """
 


### PR DESCRIPTION
Commit `b5a30705e` deleted `Mydia.Jobs.ApplyImportGroups` and `Mydia.Jobs.RematchImportGroups` and replaced neither. Since then the review page has promoted candidates **synchronously inside the LiveView process**, and re-matched them in a `start_async` task that dies with the LiveView.

That is expensive work to run in a `handle_event`. `CandidatePromotion.promote_group/3` calls `MetadataEnricher.prepare/2` before it opens its transaction, which reaches the metadata relay once per group plus once per season, then writes NFOs and reconciles sidecars after the commit. "Import all" over a fresh library is therefore N sequential relay round trips inside one event, with the page wedged for the duration.

What was lost with the workers: retries (a relay 503 partway through simply dropped the rest), durability (closing the tab killed an accept midway and killed a re-match outright), and per-library serialisation.

## Approach

The user's intent now lives on the candidate row (`queued_op`, `queued_at`, `queue_error`), written by one `UPDATE ... WHERE` at click time. A worker keyed on `library_path_id` then discovers its own work.

The alternative was serialising the `SelectionScope` into Oban args, which is what the deleted re-match worker did. It was rejected for accept because `:filter` mode deliberately carries no ids, so "select all" does not blow the bind limit — meaning the band and search predicates get re-evaluated when the job runs, and a scan landing in between lets the job promote groups the user never saw. Tolerable for a non-destructive re-match; not for a promotion that creates media items and deletes candidates.

Marking rows also makes per-library uniqueness correct rather than hazardous: a second accept just marks more rows and the running drain picks them up, where an args-carried selection would have been silently swallowed by the uniqueness guard.

## What changed

- **Schema:** three nullable columns plus a partial index on `(library_path_id, queued_op) WHERE queued_op IS NOT NULL`. Additive, no backfill, portable across both adapters.
- **Status is three-way:** `pending` / `queued` / `ignored`, replacing a derivation that read `dismissed_at` alone.
- **Two workers** on `:default` (not `:imports`, which is concurrency 1 and held for a whole scan, so an accept queued behind it would look like the button did nothing). `unique` omits `:executing` on purpose, so a click during a running drain enqueues a fresh job instead of vanishing.
- **The review page** gains a Queued chip beside Ignored. A group that cannot be imported returns to the pending list carrying the reason.
- **Fixed in passing:** the accept flash swallowed its `skipped` count, so a user who selected 40 groups and saw 12 promoted was told "Accepted 12 group(s)" with no account of the rest.

## Mixed anchors

An anchor can hold rows in different states at once, because a scan that finds a new file inside a folder whose import is already queued inserts a pending row under the same `anchor_key`. This produced four separate bugs, each caught by review rather than by tests:

1. `dismiss/1` could dismiss a queued row out from under a running worker.
2. `accept_group/2` loaded members with a filter on `dismissed_at` alone, so the drain would promote a newcomer against a `provider_id` nothing had validated for it.
3. The drain's eligibility read matched any non-null `queued_op` while every sibling query scoped to `"accept"` — latent until the re-match op existed.
4. "Create show from folder" could swallow an already-queued row, discard its real provider match, delete the candidate, and make the queued accept evaporate with no error shown.

All four are fixed and each has a regression test that fails without its fix.

## Drain termination

The first version stopped the whole pass on a page with no net progress, so 25 stuck alphabetically-early anchors could block everything after them — permanently, since exhausting Oban's attempts left no recovery path (both queue functions only mark rows where `queued_op IS NULL`, so re-clicking Accept cannot re-queue stuck rows). The drain now sweeps every queued anchor with a cursor that advances regardless of outcome, and only compares counts across a complete sweep. Termination still holds: `remaining` strictly decreases, bounding the sweeps.

The accepted trade-off is that a large, mostly-stuck queue makes one attempt slow rather than leaving work stranded.

## Verification

- Full suite: 9970 tests, 0 failures, 44 skipped.
- PostgreSQL checked for real, not assumed: the per-worktree Postgres was started and `psql` confirmed the partial index exists as declared. This matters because `CandidatePromotion.lock_candidates/1` only runs on PostgreSQL, so SQLite runs never exercise that path.
- Both workers now have `assert_enqueued` coverage. Oban's engine is disabled in test, so real uniqueness is not exercisable and is deliberately untested.

## Known gap

There is no way to cancel a queued operation. Before this branch accept was already irreversible by the time the flash rendered, so nothing was lost — but one click can now queue thousands of groups, so the regret window is materially longer. The marker column makes it cheap to add later (clear `queued_op` over a selection). Worth a follow-up issue rather than blocking this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import acceptance and re-matching now run in the background after being queued.
  * Added a **Queued** status view with progress indicators and failure explanations.
  * Users can close the page while processing continues.
  * Added controls to clear queued items and feedback for queued or skipped groups.

* **Bug Fixes**
  * Improved handling of retryable, ambiguous, and unrecognized matches.
  * Prevented queued candidates from being changed by unrelated actions.

* **Documentation**
  * Updated import guidance to explain queued processing and failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->