### PR TITLE
fix(player): make remote control discovery a reconciled invariant

### DIFF
--- a/lib/mydia/remote_access.ex
+++ b/lib/mydia/remote_access.ex
@@ -222,6 +222,45 @@ defmodule Mydia.RemoteAccess do
   end
 
   @doc """
+  Finds or creates the device row for a password login.
+
+  Pairing mints a device token and goes through `create_device/1`; a password
+  login authenticates the user directly, with no pairing flow to hand it a
+  device token. `remote_devices.token_hash` is still `NOT NULL` and `UNIQUE`
+  though, so this generates a random token exactly like pairing does, hashes
+  it into the new row, and discards the plaintext, on purpose: nobody ever
+  holds the preimage, so the row can never authenticate as a device token,
+  matching the reality that this device re-authenticates with the user's own
+  credentials. Both paths must end with a `RemoteDevice`, because that row is
+  what `registerDeviceNode` keys on and therefore what makes a player
+  discoverable at all.
+
+  Keyed on the client-supplied `client_device_id` so a returning client reuses
+  its row instead of adding one on every launch. The token is only generated
+  on the insert branch: a returning client keeps its original row and hash
+  untouched.
+  """
+  def find_or_create_login_device(%{user_id: user_id, client_device_id: client_device_id} = attrs) do
+    case Repo.get_by(RemoteDevice, user_id: user_id, client_device_id: client_device_id) do
+      nil ->
+        %RemoteDevice{}
+        |> RemoteDevice.login_changeset(Map.put(attrs, :token, generate_login_device_token()))
+        |> Repo.insert()
+
+      device ->
+        {:ok, device}
+    end
+  end
+
+  # Unused, unretrievable token for a password-login device. Hashed into
+  # token_hash and immediately discarded, so the row satisfies the NOT NULL
+  # and UNIQUE constraints on that column while remaining unable to
+  # authenticate as a device token.
+  defp generate_login_device_token do
+    :crypto.strong_rand_bytes(32) |> Base.encode64(padding: false)
+  end
+
+  @doc """
   Updates the last seen timestamp for a device.
   """
   def touch_device(device) do

--- a/lib/mydia/remote_access.ex
+++ b/lib/mydia/remote_access.ex
@@ -239,17 +239,45 @@ defmodule Mydia.RemoteAccess do
   its row instead of adding one on every launch. The token is only generated
   on the insert branch: a returning client keeps its original row and hash
   untouched.
+
+  Two concurrent first-time logins for the same `client_device_id` can both
+  pass the lookup above before either insert lands. The loser hits the
+  `unique_constraint([:user_id, :client_device_id])` on `login_changeset/2`;
+  rather than surface that as a failed login, re-read the row the winner just
+  created and return it, so both callers end up with the same device instead
+  of one of them erroring out.
   """
   def find_or_create_login_device(%{user_id: user_id, client_device_id: client_device_id} = attrs) do
     case Repo.get_by(RemoteDevice, user_id: user_id, client_device_id: client_device_id) do
-      nil ->
-        %RemoteDevice{}
-        |> RemoteDevice.login_changeset(Map.put(attrs, :token, generate_login_device_token()))
-        |> Repo.insert()
-
-      device ->
-        {:ok, device}
+      nil -> insert_login_device(attrs, user_id, client_device_id)
+      device -> {:ok, device}
     end
+  end
+
+  defp insert_login_device(attrs, user_id, client_device_id) do
+    %RemoteDevice{}
+    |> RemoteDevice.login_changeset(Map.put(attrs, :token, generate_login_device_token()))
+    |> Repo.insert()
+    |> case do
+      {:ok, device} ->
+        {:ok, device}
+
+      {:error, changeset} = error ->
+        if unique_constraint_error?(changeset) do
+          case Repo.get_by(RemoteDevice, user_id: user_id, client_device_id: client_device_id) do
+            nil -> error
+            device -> {:ok, device}
+          end
+        else
+          error
+        end
+    end
+  end
+
+  defp unique_constraint_error?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn {_field, {_message, opts}} ->
+      Keyword.get(opts, :constraint) == :unique
+    end)
   end
 
   # Unused, unretrievable token for a password-login device. Hashed into

--- a/lib/mydia/remote_access/remote_device.ex
+++ b/lib/mydia/remote_access/remote_device.ex
@@ -12,6 +12,7 @@ defmodule Mydia.RemoteAccess.RemoteDevice do
   @type t :: %__MODULE__{
           id: binary(),
           device_name: String.t() | nil,
+          client_device_id: String.t() | nil,
           platform: String.t() | nil,
           token_hash: String.t() | nil,
           token: String.t() | nil,
@@ -26,6 +27,7 @@ defmodule Mydia.RemoteAccess.RemoteDevice do
 
   schema "remote_devices" do
     field :device_name, :string
+    field :client_device_id, :string
     field :platform, :string
     field :token_hash, :string
     field :token, :string, virtual: true
@@ -60,6 +62,23 @@ defmodule Mydia.RemoteAccess.RemoteDevice do
     |> hash_token()
     |> foreign_key_constraint(:user_id)
     |> unique_constraint(:token_hash)
+  end
+
+  @doc """
+  Changeset for a device created by a password login rather than by pairing.
+
+  Distinct from `changeset/2` because that one requires `:token`: pairing
+  always mints a device token, while a password login authenticates the user
+  directly and has no device token to hash.
+  """
+  def login_changeset(device, attrs) do
+    device
+    |> cast(attrs, [:client_device_id, :device_name, :platform, :user_id])
+    |> validate_required([:client_device_id, :device_name, :platform, :user_id])
+    |> validate_length(:client_device_id, min: 1, max: 255)
+    |> validate_length(:device_name, min: 1, max: 100)
+    |> validate_length(:platform, min: 1, max: 50)
+    |> unique_constraint([:user_id, :client_device_id])
   end
 
   @doc """

--- a/lib/mydia/remote_access/remote_device.ex
+++ b/lib/mydia/remote_access/remote_device.ex
@@ -67,18 +67,26 @@ defmodule Mydia.RemoteAccess.RemoteDevice do
   @doc """
   Changeset for a device created by a password login rather than by pairing.
 
-  Distinct from `changeset/2` because that one requires `:token`: pairing
-  always mints a device token, while a password login authenticates the user
-  directly and has no device token to hash.
+  Distinct from `changeset/2` in that it also handles `:client_device_id` and
+  carries `unique_constraint([:user_id, :client_device_id])`. It still
+  requires and hashes `:token` exactly like `changeset/2` does, but the
+  caller generates that token itself and discards the plaintext immediately
+  after this changeset is applied. Nobody ever holds the preimage, so the
+  resulting `token_hash` is a unique value that can never authenticate
+  anything, on purpose: a password-login device re-authenticates with the
+  user's own credentials, never with a device token. This keeps `token_hash`
+  satisfying its `NOT NULL` and `UNIQUE` constraints without weakening them.
   """
   def login_changeset(device, attrs) do
     device
-    |> cast(attrs, [:client_device_id, :device_name, :platform, :user_id])
-    |> validate_required([:client_device_id, :device_name, :platform, :user_id])
+    |> cast(attrs, [:client_device_id, :device_name, :platform, :token, :user_id])
+    |> validate_required([:client_device_id, :device_name, :platform, :token, :user_id])
     |> validate_length(:client_device_id, min: 1, max: 255)
     |> validate_length(:device_name, min: 1, max: 100)
     |> validate_length(:platform, min: 1, max: 50)
+    |> hash_token()
     |> unique_constraint([:user_id, :client_device_id])
+    |> unique_constraint(:token_hash)
   end
 
   @doc """

--- a/lib/mydia_web/schema/resolvers/auth_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/auth_resolver.ex
@@ -6,17 +6,19 @@ defmodule MydiaWeb.Schema.Resolvers.AuthResolver do
   alias Mydia.Accounts
   alias Mydia.Auth.Guardian
   alias Mydia.Config
+  alias Mydia.RemoteAccess
 
   @doc """
   Login with username/password and device information.
 
   This resolver:
   1. Validates credentials
-  2. Creates a JWT token
+  2. Finds or creates the caller's `RemoteDevice` row and mints a device-scoped token
   3. Returns user info and token
 
-  Note: This does NOT create a device record - that's handled by the remote access flow.
-  For direct mode login, we just authenticate and return a token.
+  The device row is what `registerDeviceNode` keys on, so a password login has
+  to produce one just like pairing does, or the device that logged in this way
+  can never publish its iroh node id.
   """
   def login(_parent, %{input: input}, %{context: context}) do
     # Check if local auth is enabled
@@ -57,26 +59,38 @@ defmodule MydiaWeb.Schema.Resolvers.AuthResolver do
           # Update last login timestamp
           Accounts.update_last_login(user)
 
-          # Create JWT token
-          case Guardian.create_token(user) do
-            {:ok, token, claims} ->
-              # Get token expiration (default is 30 days for Guardian)
-              expires_in = Map.get(claims, "exp", 0) - Map.get(claims, "iat", 0)
-
-              {:ok,
-               %{
-                 token: token,
-                 user: user,
-                 expires_in: expires_in
-               }}
-
-            {:error, reason} ->
-              {:error, "Failed to create authentication token: #{inspect(reason)}"}
-          end
+          issue_login_token(user, input)
         else
           Accounts.record_login_failure(ip_address, input.username)
           {:error, "Invalid username or password"}
         end
+    end
+  end
+
+  # A password login must end with a device row and a `device_id` claim, the
+  # same shape pairing produces. Without them `registerDeviceNode` rejects the
+  # caller, the device never publishes its iroh node id, and it stays invisible
+  # to every other device on the account. The `login_input` fields this needs
+  # have been required by the schema all along and were previously discarded.
+  defp issue_login_token(user, input) do
+    with {:ok, device} <-
+           RemoteAccess.find_or_create_login_device(%{
+             user_id: user.id,
+             client_device_id: input.device_id,
+             device_name: input.device_name,
+             platform: input.platform
+           }),
+         {:ok, token, claims} <-
+           Guardian.encode_and_sign(user, %{"device_id" => device.id, "typ" => "access"}) do
+      expires_in = Map.get(claims, "exp", 0) - Map.get(claims, "iat", 0)
+
+      {:ok, %{token: token, user: user, expires_in: expires_in}}
+    else
+      {:error, %Ecto.Changeset{}} ->
+        {:error, "Failed to register this device"}
+
+      {:error, reason} ->
+        {:error, "Failed to create authentication token: #{inspect(reason)}"}
     end
   end
 end

--- a/player/lib/app.dart
+++ b/player/lib/app.dart
@@ -19,7 +19,8 @@ import 'core/downloads/download_service.dart';
 import 'core/auth/device_info_service.dart';
 import 'core/remote/ambient_lifecycle.dart';
 import 'core/remote/load_content_navigation.dart';
-import 'core/remote/node_registration.dart';
+import 'core/remote/node_registration_providers.dart';
+import 'core/remote/registration_status.dart';
 import 'core/remote/remote_control_intent.dart';
 import 'core/remote/remote_control_receiver.dart';
 import 'core/remote/remote_control_settings.dart';
@@ -223,6 +224,20 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       },
     );
 
+    // The receiver still needs a GraphQL client and a live host, and the first
+    // attempt above can run before either exists. Registration succeeding is
+    // proof that both are now present, so it is the right moment to try again.
+    // `_initRemoteControlIfEnabled` no-ops once a receiver is wired, so this
+    // costs nothing in the common case where the first attempt worked.
+    ref.listenManual<RegistrationStatus>(
+      nodeRegistrationProvider,
+      (previous, next) {
+        if (next is! RegistrationSucceeded) return;
+        unawaited(_initRemoteControlIfEnabled());
+      },
+      fireImmediately: true,
+    );
+
     // Fire and forget: the source starts on its fallback layout, so the
     // chrome renders correctly before this completes and simply re-renders
     // if the real layout differs.
@@ -285,19 +300,12 @@ class _MyAppState extends ConsumerState<MyApp> with WidgetsBindingObserver {
       final p2pService = ref.read(p2pServiceProvider);
       await p2pService.initialize();
 
-      final nodeId = p2pService.nodeId;
-      if (nodeId == null) {
-        debugPrint(
-            '[MyApp] Remote control: no node ID after initialize, skipping');
-        return;
-      }
-
+      // Registration deliberately does not happen here any more. It is an
+      // invariant maintained by `nodeRegistrationProvider`, not a startup
+      // step: doing it inline meant a node id or GraphQL client that had not
+      // arrived yet left this device unregistered, and therefore invisible to
+      // every other device, for the rest of the session.
       final client = await ref.read(asyncGraphqlClientProvider.future);
-      final registered = await NodeRegistration(
-        client: client,
-        nodeId: () async => p2pService.nodeId,
-      ).register();
-      debugPrint('[MyApp] Remote control node registration: $registered');
 
       final targetController = ref.read(remoteTargetControllerProvider);
       final receiver = RemoteControlReceiver(

--- a/player/lib/core/cast/cast_providers.dart
+++ b/player/lib/core/cast/cast_providers.dart
@@ -48,8 +48,8 @@ final castBackendProvider = Provider<CastBackend>((ref) {
 ///
 /// That is not the only way this goes stale, though, and the other way used
 /// to be steady-state. `p2pServiceProvider` is a plain, permanent
-/// `Provider` — it is never invalidated, so `ref.watch` here never triggers
-/// a rebuild on its own — and the same `P2pService` instance's `host` can be
+/// `Provider`: it is never invalidated, so `ref.watch` here never triggers
+/// a rebuild on its own. The same `P2pService` instance's `host` can still be
 /// swapped out from under it: `P2pStatusNotifier.reinitializeWithRelayUrl`
 /// (wired to the relay-URL field on `login_screen.dart`, reachable again any
 /// time auth is lost and the app falls back to that screen while a
@@ -66,8 +66,8 @@ final castBackendProvider = Provider<CastBackend>((ref) {
 /// lifetime. A rebuild here after the manager already exists does not
 /// reach it. The old host is never explicitly torn down either (the Rust
 /// side only drops it on GC). A real fix needs `CastSessionManager` to
-/// re-resolve its Mydia backend live instead of capturing it once — which
-/// means changing what `CastBackendRegistry` holds — or, short of that,
+/// re-resolve its Mydia backend live instead of capturing it once, which
+/// means changing what `CastBackendRegistry` holds, or, short of that,
 /// invalidating `castSessionManagerProvider` itself on every relay change,
 /// which would tear down *any* live cast session (Chromecast/DLNA included,
 /// not just Mydia) as a side effect of an unrelated P2P setting change. Both

--- a/player/lib/core/cast/cast_providers.dart
+++ b/player/lib/core/cast/cast_providers.dart
@@ -46,40 +46,46 @@ final castBackendProvider = Provider<CastBackend>((ref) {
 /// first-run/timing gap, not a steady-state condition: Mydia targets simply
 /// do not appear yet.
 ///
-/// That is not the only way this goes stale, though, and the other way *is*
-/// steady-state. `p2pServiceProvider` is a plain, permanent `Provider` — it
-/// is never invalidated, so `ref.watch` here never triggers a rebuild — yet
-/// the same `P2pService` instance's `host` can be swapped out from under it:
-/// `P2pStatusNotifier.reinitializeWithRelayUrl` (wired to the relay-URL
-/// field on `login_screen.dart`, reachable again any time auth is lost and
-/// the app falls back to that screen while a `CastSessionManager` built
-/// during an earlier authenticated session is still alive) calls
-/// `P2pService.reset()`, which nulls `_host` and rebuilds a new one via
-/// `initialize()` on that one long-lived service. Nothing observes that
-/// swap: whatever this provider last returned — including a
-/// `MydiaCastBackend` wrapping the *old*, now-abandoned `P2PHost` — keeps
-/// being handed out, and `castSessionManagerProvider` below reads this only
-/// once, baking the result into its `CastSessionManager`'s
-/// `CastBackendRegistry` for that manager's whole lifetime. The old host is
-/// never explicitly torn down either (the Rust side only drops it on GC),
-/// so the failure is silent: Mydia casting and discovery through the stale
-/// backend simply stop working, with nothing in the UI pointing at why.
+/// That is not the only way this goes stale, though, and the other way used
+/// to be steady-state. `p2pServiceProvider` is a plain, permanent
+/// `Provider` — it is never invalidated, so `ref.watch` here never triggers
+/// a rebuild on its own — and the same `P2pService` instance's `host` can be
+/// swapped out from under it: `P2pStatusNotifier.reinitializeWithRelayUrl`
+/// (wired to the relay-URL field on `login_screen.dart`, reachable again any
+/// time auth is lost and the app falls back to that screen while a
+/// `CastSessionManager` built during an earlier authenticated session is
+/// still alive) calls `P2pService.reset()`, which nulls `_host` and rebuilds
+/// a new one via `initialize()` on that one long-lived service. This
+/// provider now also watches `p2pStatusNotifierProvider`, which is broadcast
+/// on both `initialize()` and `reset()`, so that swap does trigger a rebuild
+/// here and the backend this provider hands out is refreshed.
 ///
-/// A real fix needs `CastSessionManager` to re-resolve its Mydia backend
-/// live instead of capturing it once — which means changing what
-/// `CastBackendRegistry` holds — or, short of that, invalidating
-/// `castSessionManagerProvider` itself on every relay change, which would
-/// tear down *any* live cast session (Chromecast/DLNA included, not just
-/// Mydia) as a side effect of an unrelated P2P setting change. Both are
-/// bigger than this provider; noted here rather than silently patched
+/// What is still broken: `castSessionManagerProvider` below reads this
+/// provider only once, baking whatever it returned at that moment into its
+/// `CastSessionManager`'s `CastBackendRegistry` for that manager's whole
+/// lifetime. A rebuild here after the manager already exists does not
+/// reach it. The old host is never explicitly torn down either (the Rust
+/// side only drops it on GC). A real fix needs `CastSessionManager` to
+/// re-resolve its Mydia backend live instead of capturing it once — which
+/// means changing what `CastBackendRegistry` holds — or, short of that,
+/// invalidating `castSessionManagerProvider` itself on every relay change,
+/// which would tear down *any* live cast session (Chromecast/DLNA included,
+/// not just Mydia) as a side effect of an unrelated P2P setting change. Both
+/// are bigger than this provider; noted here rather than silently patched
 /// half-way.
 ///
 /// Overridden in tests with a fake; the real construction path (a live iroh
 /// host, a real roster fetch) is not exercised by this build's test suite.
 final mydiaCastBackendProvider = Provider<CastBackend?>((ref) {
   final p2pService = ref.watch(p2pServiceProvider);
+  // Watched for its own sake: `p2pServiceProvider` is a plain `Provider`
+  // that is never invalidated, so watching it alone cannot observe
+  // `initialize()` or `reset()` swapping the host underneath, and this
+  // provider would keep handing out a backend wrapping an abandoned host.
+  // The status record is broadcast on both transitions.
+  final p2pStatus = ref.watch(p2pStatusNotifierProvider);
   final host = p2pService.host;
-  final selfNodeId = p2pService.nodeId;
+  final selfNodeId = p2pStatus.nodeId;
   final client = ref.watch(graphqlClientProvider);
 
   if (host == null || selfNodeId == null || client == null) return null;
@@ -128,8 +134,10 @@ const _ambientResweepInterval = Duration(seconds: 30);
 /// host yet, no resolved node ID, or no signed-in GraphQL client.
 final ambientTargetsProvider = Provider<AmbientTargets?>((ref) {
   final p2pService = ref.watch(p2pServiceProvider);
+  // Same reason as `mydiaCastBackendProvider` above.
+  final p2pStatus = ref.watch(p2pStatusNotifierProvider);
   final host = p2pService.host;
-  final selfNodeId = p2pService.nodeId;
+  final selfNodeId = p2pStatus.nodeId;
   final client = ref.watch(graphqlClientProvider);
 
   if (host == null || selfNodeId == null || client == null) return null;

--- a/player/lib/core/p2p/p2p_service.dart
+++ b/player/lib/core/p2p/p2p_service.dart
@@ -101,6 +101,14 @@ class P2pStatus {
   final bool isRelayConnected;
   final int connectedPeersCount;
   final String? nodeAddr;
+
+  /// This node's iroh node ID, or null until [P2pService.initialize] has
+  /// completed. Published here rather than read from `P2pService.nodeId`
+  /// because `p2pServiceProvider` is a plain `Provider` that is never
+  /// invalidated: watching it cannot observe `initialize()` or `reset()`
+  /// swapping the host underneath. This record is broadcast, so a consumer
+  /// that watches it rebuilds when the identity actually changes.
+  final String? nodeId;
   final String? relayUrl;
   final P2pConnectionType peerConnectionType;
 
@@ -109,6 +117,7 @@ class P2pStatus {
     required this.isRelayConnected,
     required this.connectedPeersCount,
     this.nodeAddr,
+    this.nodeId,
     this.relayUrl,
     this.peerConnectionType = P2pConnectionType.none,
   });
@@ -118,6 +127,7 @@ class P2pStatus {
         isRelayConnected = false,
         connectedPeersCount = 0,
         nodeAddr = null,
+        nodeId = null,
         relayUrl = null,
         peerConnectionType = P2pConnectionType.none;
 
@@ -126,6 +136,7 @@ class P2pStatus {
     bool? isRelayConnected,
     int? connectedPeersCount,
     String? nodeAddr,
+    String? nodeId,
     String? relayUrl,
     P2pConnectionType? peerConnectionType,
   }) {
@@ -134,6 +145,7 @@ class P2pStatus {
       isRelayConnected: isRelayConnected ?? this.isRelayConnected,
       connectedPeersCount: connectedPeersCount ?? this.connectedPeersCount,
       nodeAddr: nodeAddr ?? this.nodeAddr,
+      nodeId: nodeId ?? this.nodeId,
       relayUrl: relayUrl ?? this.relayUrl,
       peerConnectionType: peerConnectionType ?? this.peerConnectionType,
     );
@@ -270,6 +282,7 @@ class P2pService {
       isRelayConnected: _isRelayConnected,
       connectedPeersCount: _connectedPeers.length,
       nodeAddr: _nodeAddr,
+      nodeId: _nodeId,
       relayUrl: relayUrl,
       peerConnectionType: peerConnectionType,
     );

--- a/player/lib/core/remote/node_registration_providers.dart
+++ b/player/lib/core/remote/node_registration_providers.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../graphql/graphql_provider.dart';
+import '../p2p/p2p_service.dart';
+import 'node_registration.dart';
+import 'node_registration_service.dart';
+import 'registration_status.dart';
+import 'remote_control_settings.dart';
+
+/// One service for the app's lifetime.
+///
+/// The `register` callback resolves the GraphQL client per attempt rather than
+/// capturing one, so a token refresh or a switch between direct and p2p mode
+/// is picked up by the next retry instead of pinning a stale client.
+final nodeRegistrationServiceProvider =
+    Provider<NodeRegistrationService>((ref) {
+  final service = NodeRegistrationService(
+    register: (nodeId) async {
+      final client = await ref.read(asyncGraphqlClientProvider.future);
+      return NodeRegistration(
+        client: client,
+        nodeId: () async => nodeId,
+      ).register();
+    },
+  );
+  ref.onDispose(service.dispose);
+  return service;
+});
+
+/// Feeds [nodeRegistrationServiceProvider] from its three watched inputs and
+/// republishes its status as provider state.
+///
+/// `build()` re-runs whenever any input changes, which is the whole point: the
+/// previous implementation sampled these once during startup and gave up for
+/// the rest of the session if any of them had not arrived yet.
+class NodeRegistrationDriver extends Notifier<RegistrationStatus> {
+  @override
+  RegistrationStatus build() {
+    final service = ref.watch(nodeRegistrationServiceProvider);
+    final p2pStatus = ref.watch(p2pStatusNotifierProvider);
+    final client = ref.watch(graphqlClientProvider);
+    // Defaults to true to match `RemoteControlSettings.controllableEnabled`,
+    // so a device is not treated as opted out merely because Hive has not
+    // finished opening its box.
+    final controllable = ref.watch(remoteControlEnabledProvider).value ?? true;
+
+    final subscription = service.statuses.listen((status) {
+      // `cancel()` is async and does not retract an event already queued, so
+      // one can arrive after this provider is gone. Same guard, same reason,
+      // as `P2pStatusNotifier`.
+      if (!ref.mounted) return;
+      state = status;
+    });
+    ref.onDispose(subscription.cancel);
+
+    service.update(
+      controllable: controllable,
+      nodeId: p2pStatus.nodeId,
+      clientReady: client != null,
+    );
+
+    return service.status;
+  }
+
+  /// Abandons any pending backoff and tries again now.
+  void retry() => ref.read(nodeRegistrationServiceProvider).retryNow();
+}
+
+final nodeRegistrationProvider =
+    NotifierProvider<NodeRegistrationDriver, RegistrationStatus>(
+  NodeRegistrationDriver.new,
+);

--- a/player/lib/core/remote/node_registration_providers.dart
+++ b/player/lib/core/remote/node_registration_providers.dart
@@ -39,17 +39,39 @@ class NodeRegistrationDriver extends Notifier<RegistrationStatus> {
     final service = ref.watch(nodeRegistrationServiceProvider);
     final p2pStatus = ref.watch(p2pStatusNotifierProvider);
     final client = ref.watch(graphqlClientProvider);
-    // Defaults to true to match `RemoteControlSettings.controllableEnabled`,
-    // so a device is not treated as opted out merely because Hive has not
-    // finished opening its box.
-    final controllable = ref.watch(remoteControlEnabledProvider).value ?? true;
+    final controllableAsync = ref.watch(remoteControlEnabledProvider);
+
+    // `AsyncValue.value` is null both while Hive is still opening its box
+    // and if opening it failed, and treating either as "true" (the old
+    // behaviour) reads a device that explicitly opted out as controllable
+    // for however long that takes, republishing a node id nobody asked to
+    // publish. `RemoteControlSettings.controllableEnabled` only defaults to
+    // true once storage has actually resolved with nothing stored, so this
+    // must not race ahead of it: unresolved defaults to *not* controllable,
+    // and the rebuild that follows resolution decides for real.
+    final controllable = controllableAsync.value ?? false;
+    final settingUnresolved = !controllableAsync.hasValue;
+
+    // While the setting hasn't resolved, `controllable: false` above makes
+    // the service go idle, which reads to the user as "you turned this
+    // off" -- indistinguishable from a real opt-out. It is neither; it is
+    // still loading, the same reason `RegistrationWaiting` already exists
+    // for the node id and the server connection. Reclassify it the same
+    // way. `RegistrationIdle` is the *only* status the service ever emits
+    // while uncontrollable, so this cannot misfire on an unrelated idle.
+    RegistrationStatus reportedStatus(RegistrationStatus status) {
+      if (settingUnresolved && status is RegistrationIdle) {
+        return const RegistrationWaiting('the remote control setting');
+      }
+      return status;
+    }
 
     final subscription = service.statuses.listen((status) {
       // `cancel()` is async and does not retract an event already queued, so
       // one can arrive after this provider is gone. Same guard, same reason,
       // as `P2pStatusNotifier`.
       if (!ref.mounted) return;
-      state = status;
+      state = reportedStatus(status);
     });
     ref.onDispose(subscription.cancel);
 
@@ -57,9 +79,13 @@ class NodeRegistrationDriver extends Notifier<RegistrationStatus> {
       controllable: controllable,
       nodeId: p2pStatus.nodeId,
       clientReady: client != null,
+      // Scopes the service's "already registered" cache to this client, so
+      // signing into a different account or server on the same device (same
+      // iroh node id) re-registers instead of being skipped as a no-op.
+      clientScope: client,
     );
 
-    return service.status;
+    return reportedStatus(service.status);
   }
 
   /// Abandons any pending backoff and tries again now.

--- a/player/lib/core/remote/node_registration_service.dart
+++ b/player/lib/core/remote/node_registration_service.dart
@@ -57,12 +57,31 @@ class NodeRegistrationService {
   /// against [_desiredNodeId], which is what makes a node ID change re-register.
   String? _registeredNodeId;
 
+  /// The identity [update] most recently attached to [_registeredNodeId].
+  ///
+  /// The driver watches `graphqlClientProvider` and calls [update] with the
+  /// current client on every rebuild, so a plain client change already flows
+  /// through as ordinary input. But a client change caused by signing out
+  /// into a *different* account or server, on the same device with the same
+  /// iroh node ID, would otherwise leave `_registeredNodeId == nodeId` still
+  /// true and skip registration entirely -- the cached value is only true of
+  /// the client that produced it. Opaque on purpose: this never inspects the
+  /// scope, only compares its identity to the previous one.
+  Object? _clientScope;
+
   /// Bumped by every [update] and [retryNow]. The loop compares it against the
   /// value it started with, so inputs changing mid-attempt abandon that attempt
   /// instead of letting a stale result overwrite fresher state.
   int _generation = 0;
 
   bool _running = false;
+
+  /// Completed by [retryNow] and [dispose] to interrupt whichever backoff
+  /// wait is currently in [_attemptUntilSuccess], one fresh instance per
+  /// wait. `null` whenever no wait is in progress. A `Completer` can only be
+  /// completed once, so every completion site checks [Completer.isCompleted]
+  /// first.
+  Completer<void>? _wakeUp;
 
   /// Closing [_controller] only silences [_emit]'s output; it does not stop
   /// the reconcile loop itself. Without this flag, a disposed service whose
@@ -101,14 +120,26 @@ class NodeRegistrationService {
     return out.stream;
   }
 
-  /// Feeds the loop the latest view of its three inputs. Safe to call on every
+  /// Feeds the loop the latest view of its inputs. Safe to call on every
   /// rebuild: identical inputs that are already satisfied do no work.
+  ///
+  /// [clientScope] identifies which client [nodeId] would be registered
+  /// with, typically the `GraphQLClient` instance itself. Omitted (`null`)
+  /// by callers that never change scope, such as the existing tests below.
+  /// A scope change clears [_registeredNodeId] so a node ID that was already
+  /// confirmed against the previous scope is re-registered against the new
+  /// one instead of being treated as already done.
   void update({
     required bool controllable,
     required String? nodeId,
     required bool clientReady,
+    Object? clientScope,
   }) {
     if (_disposed) return;
+    if (!identical(clientScope, _clientScope)) {
+      _clientScope = clientScope;
+      _registeredNodeId = null;
+    }
     _controllable = controllable;
     _desiredNodeId = nodeId;
     _clientReady = clientReady;
@@ -118,10 +149,23 @@ class NodeRegistrationService {
 
   /// Abandons any pending backoff and reconciles immediately. Wired to the
   /// retry action in settings.
+  ///
+  /// Bumping [_generation] alone is not enough: the loop only checks it
+  /// between attempts, and a loop sleeping through [_delay] in
+  /// [_attemptUntilSuccess] does not reach that check until the delay
+  /// elapses, up to a minute later. Completing [_wakeUp] (when a wait is
+  /// actually in progress) races that delay via `Future.any` and lets the
+  /// retry happen immediately instead.
   void retryNow() {
     if (_disposed) return;
     _generation += 1;
+    _wakeCurrentWait();
     unawaited(_reconcile());
+  }
+
+  void _wakeCurrentWait() {
+    final wakeUp = _wakeUp;
+    if (wakeUp != null && !wakeUp.isCompleted) wakeUp.complete();
   }
 
   Future<void> _reconcile() async {
@@ -190,7 +234,17 @@ class NodeRegistrationService {
 
       final wait = _backoff[min(attempt - 1, _backoff.length - 1)];
       _emit(RegistrationFailed(reason, attempt, _now().add(wait)));
-      await _delay(wait);
+
+      // Fresh Completer per wait: one already completed by a previous
+      // retryNow() cannot be reused, and `_wakeCurrentWait` only ever
+      // touches whichever instance is currently assigned to `_wakeUp`.
+      final wakeUp = Completer<void>();
+      _wakeUp = wakeUp;
+      try {
+        await Future.any([_delay(wait), wakeUp.future]);
+      } finally {
+        if (identical(_wakeUp, wakeUp)) _wakeUp = null;
+      }
     }
   }
 
@@ -204,6 +258,11 @@ class NodeRegistrationService {
     // Bumped so an attempt still in flight abandons itself instead of emitting
     // into a closed controller.
     _generation += 1;
+    // Same reasoning as retryNow(): without this, a service disposed while
+    // sleeping through a backoff wait keeps that wait alive (harmlessly, since
+    // `_disposed` is checked once it wakes) for up to a minute instead of
+    // unwinding immediately.
+    _wakeCurrentWait();
     unawaited(_controller.close());
   }
 }

--- a/player/lib/core/remote/node_registration_service.dart
+++ b/player/lib/core/remote/node_registration_service.dart
@@ -74,11 +74,31 @@ class NodeRegistrationService {
   RegistrationStatus get status => _status;
 
   /// The current status, replayed to each new listener before any later
-  /// update. Without the replay, a listener attached after the terminal
-  /// transition would wait forever for an event that already happened.
-  Stream<RegistrationStatus> get statuses async* {
-    yield _status;
-    yield* _controller.stream;
+  /// update.
+  ///
+  /// Deliberately not `async*`. A generator body does not start until the
+  /// consumer listens and then advances over several microtasks, so a
+  /// caller that listens and then synchronously calls [update] loses every
+  /// event emitted before `yield*` managed to attach. `onListen` fires
+  /// synchronously from `listen()`, so the upstream subscription is in
+  /// place before any caller can emit.
+  Stream<RegistrationStatus> get statuses {
+    late final StreamController<RegistrationStatus> out;
+    StreamSubscription<RegistrationStatus>? subscription;
+
+    out = StreamController<RegistrationStatus>(
+      onListen: () {
+        subscription = _controller.stream.listen(
+          out.add,
+          onError: out.addError,
+          onDone: out.close,
+        );
+        out.add(_status);
+      },
+      onCancel: () => subscription?.cancel(),
+    );
+
+    return out.stream;
   }
 
   /// Feeds the loop the latest view of its three inputs. Safe to call on every

--- a/player/lib/core/remote/node_registration_service.dart
+++ b/player/lib/core/remote/node_registration_service.dart
@@ -64,6 +64,13 @@ class NodeRegistrationService {
 
   bool _running = false;
 
+  /// Closing [_controller] only silences [_emit]'s output; it does not stop
+  /// the reconcile loop itself. Without this flag, a disposed service whose
+  /// loop is between attempts would re-read its still-unchanged inputs, see
+  /// them unsatisfied, and start a fresh attempt that keeps calling
+  /// [_register] and [_delay] for real, forever.
+  bool _disposed = false;
+
   RegistrationStatus get status => _status;
 
   /// The current status, replayed to each new listener before any later
@@ -81,6 +88,7 @@ class NodeRegistrationService {
     required String? nodeId,
     required bool clientReady,
   }) {
+    if (_disposed) return;
     _controllable = controllable;
     _desiredNodeId = nodeId;
     _clientReady = clientReady;
@@ -91,6 +99,7 @@ class NodeRegistrationService {
   /// Abandons any pending backoff and reconciles immediately. Wired to the
   /// retry action in settings.
   void retryNow() {
+    if (_disposed) return;
     _generation += 1;
     unawaited(_reconcile());
   }
@@ -100,6 +109,8 @@ class NodeRegistrationService {
     _running = true;
     try {
       while (true) {
+        if (_disposed) return;
+
         final generation = _generation;
 
         if (!_controllable) {
@@ -169,6 +180,7 @@ class NodeRegistrationService {
   }
 
   void dispose() {
+    _disposed = true;
     // Bumped so an attempt still in flight abandons itself instead of emitting
     // into a closed controller.
     _generation += 1;

--- a/player/lib/core/remote/node_registration_service.dart
+++ b/player/lib/core/remote/node_registration_service.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:math' show min;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+
+import 'registration_status.dart';
+
+/// Publishes [nodeId] to the server. Returns whether the server confirmed it.
+/// Must not throw for an ordinary failure, but this service treats a throw as
+/// a retryable failure anyway, because a transport can always surprise it.
+typedef RegisterNode = Future<bool> Function(String nodeId);
+
+/// Backoff schedule, capped at the last entry.
+///
+/// Registration is cheap and the consequence of not registering is total
+/// invisibility, so the early steps are short. The cap keeps a server that is
+/// down for hours from being hammered.
+const _backoff = <Duration>[
+  Duration(seconds: 2),
+  Duration(seconds: 4),
+  Duration(seconds: 8),
+  Duration(seconds: 16),
+  Duration(seconds: 32),
+  Duration(seconds: 60),
+];
+
+/// Keeps the server's record of this device's iroh node ID current.
+///
+/// Registration used to be a startup event: one awaited chain in `app.dart`
+/// with three silent early returns and no retry, so a single unlucky moment
+/// during launch left the device undiscoverable for the whole session with no
+/// visible symptom. This class treats it as an invariant instead. Inputs are
+/// pushed in by [update] whenever they change, and the loop reconciles the
+/// desired state (the server holds the current node ID) against the observed
+/// one, retrying until they match.
+class NodeRegistrationService {
+  final RegisterNode _register;
+  final DateTime Function() _now;
+  final Future<void> Function(Duration) _delay;
+
+  NodeRegistrationService({
+    required RegisterNode register,
+    DateTime Function()? now,
+    Future<void> Function(Duration)? delay,
+  })  : _register = register,
+        _now = now ?? DateTime.now,
+        _delay = delay ?? Future.delayed;
+
+  RegistrationStatus _status = const RegistrationIdle();
+  final _controller = StreamController<RegistrationStatus>.broadcast();
+
+  bool _controllable = false;
+  String? _desiredNodeId;
+  bool _clientReady = false;
+
+  /// The node ID the server is known to hold. Cleared implicitly by comparing
+  /// against [_desiredNodeId], which is what makes a node ID change re-register.
+  String? _registeredNodeId;
+
+  /// Bumped by every [update] and [retryNow]. The loop compares it against the
+  /// value it started with, so inputs changing mid-attempt abandon that attempt
+  /// instead of letting a stale result overwrite fresher state.
+  int _generation = 0;
+
+  bool _running = false;
+
+  RegistrationStatus get status => _status;
+
+  /// The current status, replayed to each new listener before any later
+  /// update. Without the replay, a listener attached after the terminal
+  /// transition would wait forever for an event that already happened.
+  Stream<RegistrationStatus> get statuses async* {
+    yield _status;
+    yield* _controller.stream;
+  }
+
+  /// Feeds the loop the latest view of its three inputs. Safe to call on every
+  /// rebuild: identical inputs that are already satisfied do no work.
+  void update({
+    required bool controllable,
+    required String? nodeId,
+    required bool clientReady,
+  }) {
+    _controllable = controllable;
+    _desiredNodeId = nodeId;
+    _clientReady = clientReady;
+    _generation += 1;
+    unawaited(_reconcile());
+  }
+
+  /// Abandons any pending backoff and reconciles immediately. Wired to the
+  /// retry action in settings.
+  void retryNow() {
+    _generation += 1;
+    unawaited(_reconcile());
+  }
+
+  Future<void> _reconcile() async {
+    if (_running) return;
+    _running = true;
+    try {
+      while (true) {
+        final generation = _generation;
+
+        if (!_controllable) {
+          _emit(const RegistrationIdle());
+          return;
+        }
+
+        final nodeId = _desiredNodeId;
+        if (nodeId == null) {
+          _emit(const RegistrationWaiting('this device to come online'));
+          return;
+        }
+
+        if (!_clientReady) {
+          _emit(const RegistrationWaiting('a server connection'));
+          return;
+        }
+
+        if (_registeredNodeId == nodeId) return;
+
+        final restart = await _attemptUntilSuccess(nodeId, generation);
+        if (!restart) return;
+      }
+    } finally {
+      _running = false;
+    }
+  }
+
+  /// Retries [nodeId] until the server confirms it. Returns true when the
+  /// caller should re-read its inputs and start over, because [_generation]
+  /// moved while this was working.
+  Future<bool> _attemptUntilSuccess(String nodeId, int generation) async {
+    var attempt = 0;
+
+    while (true) {
+      if (generation != _generation) return true;
+
+      attempt += 1;
+      _emit(RegistrationInFlight(nodeId, attempt));
+
+      var confirmed = false;
+      var reason = 'the server did not confirm the registration';
+      try {
+        confirmed = await _register(nodeId);
+      } catch (error) {
+        debugPrint('[NodeRegistrationService] attempt $attempt threw: $error');
+        reason = 'could not reach the server';
+      }
+
+      if (generation != _generation) return true;
+
+      if (confirmed) {
+        _registeredNodeId = nodeId;
+        _emit(RegistrationSucceeded(nodeId, _now()));
+        return false;
+      }
+
+      final wait = _backoff[min(attempt - 1, _backoff.length - 1)];
+      _emit(RegistrationFailed(reason, attempt, _now().add(wait)));
+      await _delay(wait);
+    }
+  }
+
+  void _emit(RegistrationStatus status) {
+    _status = status;
+    if (!_controller.isClosed) _controller.add(status);
+  }
+
+  void dispose() {
+    // Bumped so an attempt still in flight abandons itself instead of emitting
+    // into a closed controller.
+    _generation += 1;
+    unawaited(_controller.close());
+  }
+}

--- a/player/lib/core/remote/registration_status.dart
+++ b/player/lib/core/remote/registration_status.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart' show immutable;
+
+/// Where this device stands in publishing its iroh node ID to the server.
+///
+/// A device the server has no node ID for is filtered out of every
+/// `RemoteRoster`, so it is invisible to and unreachable from every other
+/// device on the account. That failure used to be entirely silent, which is
+/// what let it persist unnoticed; this type exists so the settings screen can
+/// say which step is stuck.
+@immutable
+sealed class RegistrationStatus {
+  const RegistrationStatus();
+
+  /// One line of user-facing prose. Lives here rather than in the widget so
+  /// the wording is covered by a unit test instead of a widget test.
+  String describe();
+}
+
+/// This device has opted out of being controlled, so nothing is published.
+@immutable
+class RegistrationIdle extends RegistrationStatus {
+  const RegistrationIdle();
+
+  @override
+  String describe() => 'Not advertising this device';
+}
+
+/// A precondition has not arrived yet. Normal for the first seconds of a
+/// launch, and not an error.
+@immutable
+class RegistrationWaiting extends RegistrationStatus {
+  final String dependency;
+
+  const RegistrationWaiting(this.dependency);
+
+  @override
+  String describe() => 'Waiting for $dependency';
+}
+
+/// A registration attempt is in flight. [attempt] counts from 1.
+@immutable
+class RegistrationInFlight extends RegistrationStatus {
+  final String nodeId;
+  final int attempt;
+
+  const RegistrationInFlight(this.nodeId, this.attempt);
+
+  @override
+  String describe() => 'Registering with the server (attempt $attempt)';
+}
+
+/// The server has confirmed it holds [nodeId] for this device.
+@immutable
+class RegistrationSucceeded extends RegistrationStatus {
+  final String nodeId;
+  final DateTime at;
+
+  const RegistrationSucceeded(this.nodeId, this.at);
+
+  @override
+  String describe() => 'Discoverable by your other devices';
+}
+
+/// The last attempt failed. [nextRetryAt] is null when nothing is scheduled.
+@immutable
+class RegistrationFailed extends RegistrationStatus {
+  final String reason;
+  final int attempts;
+  final DateTime? nextRetryAt;
+
+  const RegistrationFailed(this.reason, this.attempts, this.nextRetryAt);
+
+  @override
+  String describe() => 'Not discoverable: $reason';
+}

--- a/player/lib/core/remote/remote_roster.dart
+++ b/player/lib/core/remote/remote_roster.dart
@@ -52,13 +52,15 @@ class RemoteRoster {
         deviceName
         platform
         nodeId
+        isRevoked
       }
     }
   ''';
 
   /// Devices that can actually be dialed. A device with no node ID has never
   /// reported one, so it is omitted rather than listed as permanently
-  /// offline.
+  /// offline, and a revoked device is omitted because revoking is documented
+  /// as preventing future access.
   Future<List<RemoteDeviceEntry>> entries() async {
     await _ensureFresh();
     return _entries;
@@ -128,6 +130,10 @@ class RemoteRoster {
       _entries = devices
           .cast<Map<String, dynamic>>()
           .where((d) => (d['nodeId'] as String?)?.isNotEmpty ?? false)
+          // Revoking is documented as preventing future access, and this list
+          // is the access control list as well as the picker list, so a
+          // revoked device must not be dialable or permitted to dial.
+          .where((d) => d['isRevoked'] != true)
           .map((d) => RemoteDeviceEntry(
                 id: d['id'] as String,
                 deviceName: d['deviceName'] as String,

--- a/player/lib/presentation/screens/settings/settings_screen.dart
+++ b/player/lib/presentation/screens/settings/settings_screen.dart
@@ -7,6 +7,8 @@ import '../../../core/connection/connection_summary.dart';
 import '../../../core/graphql/graphql_provider.dart';
 import '../../../core/p2p/p2p_service.dart';
 import '../../../core/player/platform_features.dart';
+import '../../../core/remote/node_registration_providers.dart';
+import '../../../core/remote/registration_status.dart';
 import '../../../core/remote/remote_control_settings.dart';
 import '../../../core/theme/colors.dart';
 import '../../../core/update/platform_updater.dart';
@@ -224,6 +226,7 @@ class _ManageSection extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final updateState = ref.watch(updateProvider);
     final controllableEnabled = ref.watch(remoteControlEnabledProvider).value;
+    final registration = ref.watch(nodeRegistrationProvider);
 
     return SettingsSection(
       label: 'Manage',
@@ -245,12 +248,20 @@ class _ManageSection extends ConsumerWidget {
           key: const Key('remote-control-enabled-switch'),
           icon: Icons.settings_remote,
           title: 'Allow this device to be controlled',
-          subtitle: 'Lets another paired device see and drive playback here',
+          subtitle: registration.describe(),
           value: controllableEnabled ?? true,
           onChanged: controllableEnabled == null
               ? null
               : (value) => _setControllable(ref, value),
         ),
+        if (registration is RegistrationFailed)
+          SettingsRow.action(
+            key: const Key('remote-control-retry-row'),
+            icon: Icons.refresh,
+            title: 'Retry registration',
+            subtitle: 'Try to make this device discoverable again',
+            onTap: () => ref.read(nodeRegistrationProvider.notifier).retry(),
+          ),
         if (PlatformUpdater.supportedOnCurrentPlatform)
           SettingsRow.action(
             key: const Key('check-for-updates-row'),

--- a/player/test/app_remote_control_init_gate_test.dart
+++ b/player/test/app_remote_control_init_gate_test.dart
@@ -68,4 +68,23 @@ void main() {
       expect(gate.shouldAttempt, isFalse);
     });
   });
+
+  group('RemoteControlInitGate after a failed attempt', () {
+    test('still allows a retry once registration succeeds', () {
+      final gate = RemoteControlInitGate();
+
+      // First attempt runs and fails before wiring a receiver.
+      expect(gate.shouldAttempt, isTrue);
+      gate.begin();
+      gate.end();
+
+      // A later registration success must be able to drive another attempt.
+      expect(gate.shouldAttempt, isTrue);
+      gate.begin();
+      gate.succeed();
+      gate.end();
+
+      expect(gate.shouldAttempt, isFalse);
+    });
+  });
 }

--- a/player/test/core/cast/cast_providers_rebuild_test.dart
+++ b/player/test/core/cast/cast_providers_rebuild_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/cast/cast_providers.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/p2p/p2p_service.dart';
+import 'package:player/native/lib.dart';
+
+import '../../test_utils/stub_graphql_client.dart';
+
+/// A P2PHost-typed value for tests. None of its methods are called: the
+/// providers under test only check `host != null` and hand it to a
+/// transport they never drive here.
+class _FakeP2PHost implements P2PHost {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('$_FakeP2PHost: ${invocation.memberName}');
+}
+
+/// A `P2pService` whose host is already up. `nodeId` is deliberately left
+/// at its default (null), which is the point of this fake: the pre-fix
+/// providers read `selfNodeId` from this getter, so a host being present
+/// here is not enough on its own to produce a backend.
+class _FakeP2pServiceWithHost extends P2pService {
+  final P2PHost _host = _FakeP2PHost();
+
+  @override
+  P2PHost? get host => _host;
+}
+
+/// Publishes a node id on demand so a test can decide when the host
+/// finishes announcing its identity, matching the pattern in
+/// `test/core/remote/node_registration_providers_test.dart`.
+class _FakeP2pStatusNotifier extends P2pStatusNotifier {
+  @override
+  P2pStatus build() => const P2pStatus.initial();
+
+  void publish(String nodeId) {
+    state = const P2pStatus.initial().copyWith(
+      isInitialized: true,
+      nodeId: nodeId,
+    );
+  }
+}
+
+void main() {
+  group('mydiaCastBackendProvider rebuild on host swap', () {
+    test(
+        'stays null until the status record carries a node id, then '
+        'rebuilds non-null once it does', () async {
+      final statusNotifier = _FakeP2pStatusNotifier();
+
+      final container = ProviderContainer(overrides: [
+        p2pServiceProvider.overrideWithValue(_FakeP2pServiceWithHost()),
+        p2pStatusNotifierProvider.overrideWith(() => statusNotifier),
+        graphqlClientProvider.overrideWith(
+          (ref) => stubClient(StubLink.responses([
+            <String, dynamic>{'__typename': 'Query'},
+          ])),
+        ),
+      ]);
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(mydiaCastBackendProvider),
+        isNull,
+        reason: 'the host is up but no node id has been published yet',
+      );
+
+      statusNotifier.publish('a' * 64);
+
+      expect(
+        container.read(mydiaCastBackendProvider),
+        isNotNull,
+        reason: 'the host and the node id are both present now, so the '
+            'provider must rebuild rather than keep handing out the '
+            'earlier null',
+      );
+    });
+  });
+
+  group('ambientTargetsProvider rebuild on host swap', () {
+    test(
+        'stays null until the status record carries a node id, then '
+        'rebuilds non-null once it does', () async {
+      final statusNotifier = _FakeP2pStatusNotifier();
+
+      final container = ProviderContainer(overrides: [
+        p2pServiceProvider.overrideWithValue(_FakeP2pServiceWithHost()),
+        p2pStatusNotifierProvider.overrideWith(() => statusNotifier),
+        graphqlClientProvider.overrideWith(
+          (ref) => stubClient(StubLink.responses([
+            <String, dynamic>{'__typename': 'Query'},
+          ])),
+        ),
+      ]);
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(ambientTargetsProvider),
+        isNull,
+        reason: 'the host is up but no node id has been published yet',
+      );
+
+      statusNotifier.publish('a' * 64);
+
+      expect(
+        container.read(ambientTargetsProvider),
+        isNotNull,
+        reason: 'the host and the node id are both present now, so the '
+            'provider must rebuild rather than keep handing out the '
+            'earlier null',
+      );
+    });
+  });
+}

--- a/player/test/core/p2p/p2p_status_test.dart
+++ b/player/test/core/p2p/p2p_status_test.dart
@@ -173,5 +173,23 @@ void main() {
         expect(defaultRelayUrl, equals('https://cae1-1.relay.mydia.dev'));
       });
     });
+
+    group('nodeId', () {
+      test('is null before the host is initialized', () {
+        expect(const P2pStatus.initial().nodeId, isNull);
+      });
+
+      test('is carried through copyWith', () {
+        final status = P2pStatus(
+          isInitialized: true,
+          isRelayConnected: true,
+          connectedPeersCount: 0,
+          nodeId: 'a' * 64,
+        );
+
+        expect(status.copyWith().nodeId, 'a' * 64);
+        expect(status.copyWith(nodeId: 'b' * 64).nodeId, 'b' * 64);
+      });
+    });
   });
 }

--- a/player/test/core/remote/node_registration_providers_test.dart
+++ b/player/test/core/remote/node_registration_providers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
@@ -57,6 +59,60 @@ void main() {
           reason: 'the late node id must drive a registration, not be missed');
       expect(container.read(nodeRegistrationProvider),
           isA<RegistrationSucceeded>());
+    });
+
+    test(
+        'a stored false resolving after a loading period does not '
+        'register', () async {
+      final sent = <String>[];
+      final statusNotifier = _FakeP2pStatus();
+      final controllableCompleter = Completer<bool>();
+
+      final container = ProviderContainer(overrides: [
+        nodeRegistrationServiceProvider.overrideWith((ref) {
+          final service = NodeRegistrationService(
+            register: (nodeId) async {
+              sent.add(nodeId);
+              return true;
+            },
+            delay: (_) async {},
+          );
+          ref.onDispose(service.dispose);
+          return service;
+        }),
+        p2pStatusNotifierProvider.overrideWith(() => statusNotifier),
+        // Never resolves until the test says so, standing in for Hive still
+        // opening its box.
+        remoteControlEnabledProvider
+            .overrideWith((ref) => controllableCompleter.future),
+        graphqlClientProvider.overrideWith(
+          (ref) => stubClient(StubLink.responses([
+            <String, dynamic>{'__typename': 'Mutation'},
+          ])),
+        ),
+      ]);
+      addTearDown(container.dispose);
+
+      // Keep the driver alive for the whole test.
+      container.listen(nodeRegistrationProvider, (_, __) {});
+      // The node id and the client are both ready; only the setting is
+      // still loading, so it alone must be what gates registration.
+      statusNotifier.publish('a' * 64);
+      await pumpEventQueue();
+
+      expect(sent, isEmpty,
+          reason: 'the setting has not resolved yet, so nothing may '
+              'register even though every other input is ready');
+      expect(
+          container.read(nodeRegistrationProvider), isA<RegistrationWaiting>());
+
+      controllableCompleter.complete(false);
+      await pumpEventQueue();
+
+      expect(sent, isEmpty,
+          reason: 'a stored false resolving after loading must not have '
+              'been treated as enabled during the loading window');
+      expect(container.read(nodeRegistrationProvider), isA<RegistrationIdle>());
     });
   });
 }

--- a/player/test/core/remote/node_registration_providers_test.dart
+++ b/player/test/core/remote/node_registration_providers_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/p2p/p2p_service.dart';
+import 'package:player/core/remote/node_registration_providers.dart';
+import 'package:player/core/remote/node_registration_service.dart';
+import 'package:player/core/remote/registration_status.dart';
+import 'package:player/core/remote/remote_control_settings.dart';
+
+import '../../test_utils/stub_graphql_client.dart';
+
+void main() {
+  group('nodeRegistrationProvider', () {
+    test('registers when the node id arrives after the first build', () async {
+      final sent = <String>[];
+      final statusNotifier = _FakeP2pStatus();
+
+      final container = ProviderContainer(overrides: [
+        nodeRegistrationServiceProvider.overrideWith((ref) {
+          final service = NodeRegistrationService(
+            register: (nodeId) async {
+              sent.add(nodeId);
+              return true;
+            },
+            delay: (_) async {},
+          );
+          ref.onDispose(service.dispose);
+          return service;
+        }),
+        p2pStatusNotifierProvider.overrideWith(() => statusNotifier),
+        remoteControlEnabledProvider.overrideWith((ref) async => true),
+        // A real GraphQLClient over a stub link. The driver only checks this
+        // for null, and the service above never reaches it, but it has to be
+        // non-null for `clientReady` to be true.
+        graphqlClientProvider.overrideWith(
+          (ref) => stubClient(StubLink.responses([
+            <String, dynamic>{'__typename': 'Mutation'},
+          ])),
+        ),
+      ]);
+      addTearDown(container.dispose);
+
+      // Keep the driver alive for the whole test.
+      container.listen(nodeRegistrationProvider, (_, __) {});
+      await container.read(remoteControlEnabledProvider.future);
+      await pumpEventQueue();
+
+      expect(sent, isEmpty,
+          reason: 'no node id yet, so there is nothing to publish');
+      expect(
+          container.read(nodeRegistrationProvider), isA<RegistrationWaiting>());
+
+      statusNotifier.publish('a' * 64);
+      await pumpEventQueue();
+
+      expect(sent, ['a' * 64],
+          reason: 'the late node id must drive a registration, not be missed');
+      expect(container.read(nodeRegistrationProvider),
+          isA<RegistrationSucceeded>());
+    });
+  });
+}
+
+/// Publishes a node id on demand so a test can decide when the host appears.
+///
+/// The single instance is deliberately captured and reused so `publish` can
+/// reach it. That is safe only because the provider is built once per test: a
+/// Riverpod `Notifier` instance cannot be mounted twice, so a test that lets
+/// this provider be disposed and rebuilt must hand `overrideWith` a factory
+/// that constructs a fresh one instead.
+class _FakeP2pStatus extends P2pStatusNotifier {
+  @override
+  P2pStatus build() => const P2pStatus.initial();
+
+  void publish(String nodeId) {
+    state = const P2pStatus.initial().copyWith(
+      isInitialized: true,
+      nodeId: nodeId,
+    );
+  }
+}

--- a/player/test/core/remote/node_registration_service_test.dart
+++ b/player/test/core/remote/node_registration_service_test.dart
@@ -200,5 +200,20 @@ void main() {
       // Disposing twice must be harmless.
       service.dispose();
     });
+
+    test('delivers later statuses to a continuous listener', () async {
+      final service = serviceWith((_) async => true);
+      addTearDown(service.dispose);
+
+      final seen = <RegistrationStatus>[];
+      final subscription = service.statuses.listen(seen.add);
+      addTearDown(subscription.cancel);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      expect(seen.last, isA<RegistrationSucceeded>(),
+          reason: 'a listener attached before update must see the outcome');
+    });
   });
 }

--- a/player/test/core/remote/node_registration_service_test.dart
+++ b/player/test/core/remote/node_registration_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/remote/node_registration_service.dart';
 import 'package:player/core/remote/registration_status.dart';
@@ -9,6 +11,18 @@ class FakeDelay {
 
   Future<void> call(Duration duration) async {
     waits.add(duration);
+  }
+}
+
+/// A delay that never resolves on its own, so a test can hold the service in
+/// a backoff wait indefinitely and observe whether something else -- namely
+/// [NodeRegistrationService.retryNow] -- is what actually moves it along.
+class ControllableDelay {
+  final List<Duration> waits = [];
+
+  Future<void> call(Duration duration) {
+    waits.add(duration);
+    return Completer<void>().future;
   }
 }
 
@@ -104,6 +118,39 @@ void main() {
       expect(service.status, isA<RegistrationSucceeded>());
     });
 
+    test('retryNow interrupts a pending backoff wait instead of waiting it out',
+        () async {
+      var calls = 0;
+      final delay = ControllableDelay();
+      final service = NodeRegistrationService(
+        register: (_) async {
+          calls += 1;
+          // Fails once, then succeeds on the retry retryNow() triggers.
+          return calls >= 2;
+        },
+        now: () => clock,
+        delay: delay.call,
+      );
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      // The first attempt failed and is now asleep in a backoff wait that
+      // this test's ControllableDelay never resolves on its own.
+      expect(calls, 1);
+      expect(service.status, isA<RegistrationFailed>());
+      expect(delay.waits, [const Duration(seconds: 2)]);
+
+      service.retryNow();
+      await pumpEventQueue();
+
+      expect(calls, 2,
+          reason: 'retryNow must interrupt the backoff wait promptly, not '
+              'leave the retry pending until the full delay elapses');
+      expect(service.status, isA<RegistrationSucceeded>());
+    });
+
     test('treats a throwing register as a retryable failure', () async {
       var calls = 0;
       final service = serviceWith((_) async {
@@ -118,6 +165,39 @@ void main() {
 
       expect(calls, 2);
       expect(service.status, isA<RegistrationSucceeded>());
+    });
+
+    test('re-registers the same node id when the client scope changes',
+        () async {
+      final sent = <String>[];
+      final service = serviceWith((nodeId) async {
+        sent.add(nodeId);
+        return true;
+      });
+      addTearDown(service.dispose);
+
+      final clientA = Object();
+      final clientB = Object();
+
+      service.update(
+        controllable: true,
+        nodeId: 'abc',
+        clientReady: true,
+        clientScope: clientA,
+      );
+      await pumpEventQueue();
+      service.update(
+        controllable: true,
+        nodeId: 'abc',
+        clientReady: true,
+        clientScope: clientB,
+      );
+      await pumpEventQueue();
+
+      expect(sent, ['abc', 'abc'],
+          reason: 'a different client scope must re-register the same node '
+              'id, because a cached confirmation only speaks for the '
+              'client that produced it');
     });
 
     test('re-registers when the node id changes', () async {

--- a/player/test/core/remote/node_registration_service_test.dart
+++ b/player/test/core/remote/node_registration_service_test.dart
@@ -164,5 +164,41 @@ void main() {
 
       expect(await service.statuses.first, isA<RegistrationSucceeded>());
     });
+
+    test('stops calling register after dispose', () async {
+      var calls = 0;
+      // Built directly rather than through serviceWith/FakeDelay: this
+      // register never succeeds, so without the dispose fix the retry loop
+      // runs forever. FakeDelay resolves through microtasks only, with no
+      // real Timer, so an unbounded chain of those would starve the event
+      // loop and pumpEventQueue (itself Timer-based) would never return,
+      // hanging the test before dispose() is even reached. A real
+      // zero-duration delay still yields to the event loop each iteration,
+      // so the loop can be observed and then actually stopped.
+      final service = NodeRegistrationService(
+        register: (_) async {
+          calls += 1;
+          return false;
+        },
+        now: () => clock,
+        delay: (_) => Future<void>.delayed(Duration.zero),
+      );
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      final callsAtDispose = calls;
+      expect(callsAtDispose, greaterThan(0));
+
+      service.dispose();
+      await pumpEventQueue();
+      await pumpEventQueue();
+
+      expect(calls, callsAtDispose,
+          reason: 'a disposed service must not keep calling register');
+
+      // Disposing twice must be harmless.
+      service.dispose();
+    });
   });
 }

--- a/player/test/core/remote/node_registration_service_test.dart
+++ b/player/test/core/remote/node_registration_service_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/remote/node_registration_service.dart';
+import 'package:player/core/remote/registration_status.dart';
+
+/// Collects every delay the service asks for instead of sleeping, so a test
+/// covering six backoff steps runs in microseconds rather than two minutes.
+class FakeDelay {
+  final List<Duration> waits = [];
+
+  Future<void> call(Duration duration) async {
+    waits.add(duration);
+  }
+}
+
+void main() {
+  final clock = DateTime(2026, 9, 1, 12);
+
+  NodeRegistrationService serviceWith(
+    RegisterNode register, {
+    FakeDelay? delay,
+  }) =>
+      NodeRegistrationService(
+        register: register,
+        now: () => clock,
+        delay: (delay ?? FakeDelay()).call,
+      );
+
+  group('NodeRegistrationService', () {
+    test('waits rather than failing when the node id is missing', () async {
+      final service = serviceWith((_) async => true);
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: null, clientReady: true);
+      await pumpEventQueue();
+
+      expect(service.status, isA<RegistrationWaiting>());
+      expect((service.status as RegistrationWaiting).dependency,
+          'this device to come online');
+    });
+
+    test('waits rather than failing when the client is not ready', () async {
+      final service = serviceWith((_) async => true);
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: false);
+      await pumpEventQueue();
+
+      expect(service.status, isA<RegistrationWaiting>());
+      expect((service.status as RegistrationWaiting).dependency,
+          'a server connection');
+    });
+
+    test('registers once every input has arrived', () async {
+      final sent = <String>[];
+      final service = serviceWith((nodeId) async {
+        sent.add(nodeId);
+        return true;
+      });
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: null, clientReady: false);
+      await pumpEventQueue();
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      expect(sent, ['abc']);
+      expect(service.status, isA<RegistrationSucceeded>());
+    });
+
+    test('does not re-register a node id the server already holds', () async {
+      var calls = 0;
+      final service = serviceWith((_) async {
+        calls += 1;
+        return true;
+      });
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      expect(calls, 1);
+    });
+
+    test('retries with growing backoff until it succeeds', () async {
+      final delay = FakeDelay();
+      var calls = 0;
+      final service = serviceWith(
+        (_) async {
+          calls += 1;
+          return calls >= 3;
+        },
+        delay: delay,
+      );
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      expect(calls, 3);
+      expect(delay.waits,
+          [const Duration(seconds: 2), const Duration(seconds: 4)]);
+      expect(service.status, isA<RegistrationSucceeded>());
+    });
+
+    test('treats a throwing register as a retryable failure', () async {
+      var calls = 0;
+      final service = serviceWith((_) async {
+        calls += 1;
+        if (calls == 1) throw StateError('transport down');
+        return true;
+      });
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      expect(calls, 2);
+      expect(service.status, isA<RegistrationSucceeded>());
+    });
+
+    test('re-registers when the node id changes', () async {
+      final sent = <String>[];
+      final service = serviceWith((nodeId) async {
+        sent.add(nodeId);
+        return true;
+      });
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+      service.update(controllable: true, nodeId: 'def', clientReady: true);
+      await pumpEventQueue();
+
+      expect(sent, ['abc', 'def']);
+    });
+
+    test('goes idle when the device opts out, and resumes when it opts in',
+        () async {
+      final sent = <String>[];
+      final service = serviceWith((nodeId) async {
+        sent.add(nodeId);
+        return true;
+      });
+      addTearDown(service.dispose);
+
+      service.update(controllable: false, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+      expect(service.status, isA<RegistrationIdle>());
+      expect(sent, isEmpty);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+      expect(sent, ['abc']);
+    });
+
+    test('replays the current status to a new listener', () async {
+      final service = serviceWith((_) async => true);
+      addTearDown(service.dispose);
+
+      service.update(controllable: true, nodeId: 'abc', clientReady: true);
+      await pumpEventQueue();
+
+      expect(await service.statuses.first, isA<RegistrationSucceeded>());
+    });
+  });
+}

--- a/player/test/core/remote/registration_status_test.dart
+++ b/player/test/core/remote/registration_status_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/remote/registration_status.dart';
+
+void main() {
+  group('RegistrationStatus.describe', () {
+    test('reads as off when idle', () {
+      expect(
+          const RegistrationIdle().describe(), 'Not advertising this device');
+    });
+
+    test('names the dependency it is waiting on', () {
+      expect(
+        const RegistrationWaiting('a server connection').describe(),
+        'Waiting for a server connection',
+      );
+    });
+
+    test('reports the attempt while in flight', () {
+      expect(
+        const RegistrationInFlight('abc', 2).describe(),
+        'Registering with the server (attempt 2)',
+      );
+    });
+
+    test('confirms success', () {
+      expect(
+        RegistrationSucceeded('abc', DateTime(2026, 9, 1)).describe(),
+        'Discoverable by your other devices',
+      );
+    });
+
+    test('surfaces the failure reason', () {
+      expect(
+        RegistrationFailed('server rejected the node id', 3, null).describe(),
+        'Not discoverable: server rejected the node id',
+      );
+    });
+  });
+}

--- a/player/test/core/remote/remote_roster_test.dart
+++ b/player/test/core/remote/remote_roster_test.dart
@@ -11,12 +11,19 @@ Map<String, dynamic> devicesResponse(List<Map<String, dynamic>> devices) => {
       'devices': devices,
     };
 
-Map<String, dynamic> device(String id, String name, String? nodeId) => {
+Map<String, dynamic> device(
+  String id,
+  String name,
+  String? nodeId, {
+  bool isRevoked = false,
+}) =>
+    {
       '__typename': 'RemoteDevice',
       'id': id,
       'deviceName': name,
       'platform': 'linux',
       'nodeId': nodeId,
+      'isRevoked': isRevoked,
     };
 
 RemoteRoster rosterWith(StubLink link, DateTime Function() now) => RemoteRoster(
@@ -105,6 +112,32 @@ void main() {
       // strangers buy at most the initial fetch plus one refetch.
       // StubLink.responses repeats its last entry, so a short script is fine.
       expect(link.requests.length, lessThanOrEqualTo(2));
+    });
+
+    test('omits revoked devices from the picker list', () async {
+      final link = StubLink.responses([
+        devicesResponse([
+          device('d1', 'Kitchen', 'a' * 64),
+          device('d2', 'Old Tablet', 'b' * 64, isRevoked: true),
+        ]),
+      ]);
+
+      final roster = rosterWith(link, () => fixedClock);
+      final entries = await roster.entries();
+
+      expect(entries.map((e) => e.id), ['d1']);
+    });
+
+    test('refuses a revoked device that tries to drive this one', () async {
+      final link = StubLink.responses([
+        devicesResponse([
+          device('d2', 'Old Tablet', 'b' * 64, isRevoked: true),
+        ]),
+      ]);
+
+      final roster = rosterWith(link, () => fixedClock);
+
+      expect(await roster.allows('b' * 64), isFalse);
     });
   });
 }

--- a/player/test/presentation/screens/settings/settings_screen_test.dart
+++ b/player/test/presentation/screens/settings/settings_screen_test.dart
@@ -11,6 +11,8 @@ import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/connection/connection_provider.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
 import 'package:player/core/p2p/p2p_service.dart';
+import 'package:player/core/remote/node_registration_providers.dart';
+import 'package:player/core/remote/registration_status.dart';
 import 'package:player/core/remote/remote_control_settings.dart';
 import 'package:player/core/update/update_provider.dart';
 import 'package:player/domain/models/user_settings.dart';
@@ -115,6 +117,20 @@ const _status = P2pStatus(
   connectedPeersCount: 0,
 );
 
+/// Publishes a fixed registration status so a widget test can drive the row
+/// without a p2p host or a server.
+class _StubRegistration extends NodeRegistrationDriver {
+  _StubRegistration(this._status);
+
+  final RegistrationStatus _status;
+
+  @override
+  RegistrationStatus build() => _status;
+
+  @override
+  void retry() {}
+}
+
 /// Resolves and reads normally, but fails the write itself — for proving
 /// `_setControllable` catches a failure from `setControllable` specifically,
 /// not just from `remoteControlSettingsProvider` failing to resolve at all
@@ -136,6 +152,7 @@ Future<void> _pump(
   bool failRemoteControlWrite = false,
   String version = '',
   Size size = const Size(1000, 1400),
+  RegistrationStatus registration = const RegistrationIdle(),
 }) async {
   await tester.binding.setSurfaceSize(size);
   addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -162,6 +179,9 @@ Future<void> _pump(
           (ref) async => failRemoteControlWrite
               ? _ThrowingRemoteControlSettings(box: _remoteControlBox)
               : RemoteControlSettings(box: _remoteControlBox),
+        ),
+        nodeRegistrationProvider.overrideWith(
+          () => _StubRegistration(registration),
         ),
       ],
       child: MaterialApp.router(
@@ -497,6 +517,32 @@ void main() {
         updateCheckSubtitle(isMacOS: false, availableVersion: null),
         "You're up to date",
       );
+    });
+  });
+
+  group('remote control registration status', () {
+    testWidgets('shows the retry row only when registration has failed',
+        (tester) async {
+      await _pump(
+        tester,
+        registration:
+            const RegistrationFailed('could not reach the server', 3, null),
+      );
+
+      expect(find.byKey(const Key('remote-control-retry-row')), findsOneWidget);
+      expect(find.text('Not discoverable: could not reach the server'),
+          findsOneWidget);
+    });
+
+    testWidgets('hides the retry row once registration succeeds',
+        (tester) async {
+      await _pump(
+        tester,
+        registration: RegistrationSucceeded('abc', DateTime(2026, 9, 1)),
+      );
+
+      expect(find.byKey(const Key('remote-control-retry-row')), findsNothing);
+      expect(find.text('Discoverable by your other devices'), findsOneWidget);
     });
   });
 }

--- a/priv/repo/migrations/20260901173000_add_client_device_id_to_remote_devices.exs
+++ b/priv/repo/migrations/20260901173000_add_client_device_id_to_remote_devices.exs
@@ -1,0 +1,24 @@
+defmodule Mydia.Repo.Migrations.AddClientDeviceIdToRemoteDevices do
+  use Ecto.Migration
+
+  @moduledoc """
+  Records the stable identifier a client generates for itself.
+
+  `remote_devices.id` is a server-side UUID, so before this column there was
+  nothing to match a returning client against and a password login had no way
+  to find its own row. Nullable because every device paired before this
+  migration has no client identifier and must keep working.
+  """
+
+  def change do
+    alter table(:remote_devices) do
+      # `:text`, never `:string`: a bare `:string` is varchar(255) on
+      # PostgreSQL and unconstrained TEXT on SQLite, so an over-long write
+      # passes in development and fails in production.
+      add :client_device_id, :text
+    end
+
+    # Scoped to the user so two accounts on one machine keep separate rows.
+    create unique_index(:remote_devices, [:user_id, :client_device_id])
+  end
+end

--- a/test/mydia/remote_access/login_device_test.exs
+++ b/test/mydia/remote_access/login_device_test.exs
@@ -1,0 +1,103 @@
+defmodule Mydia.RemoteAccess.LoginDeviceTest do
+  @moduledoc """
+  Covers `find_or_create_login_device/1`, the password-login counterpart to
+  the pairing flow. Two concurrent first-time logins for the same
+  `client_device_id` can both pass the initial lookup before either insert
+  lands; the loser used to hit the `[:user_id, :client_device_id]` unique
+  constraint and surface as "Failed to register this device" for what was a
+  legitimate login.
+
+  `async: false` is load-bearing: `Mydia.DataCase` only shares the sandboxed
+  connection across processes when the test is not async, and the concurrent
+  case below needs the spawned tasks to see each other's writes.
+  """
+  use Mydia.DataCase, async: false
+
+  alias Mydia.RemoteAccess
+  alias Mydia.RemoteAccess.RemoteDevice
+
+  describe "find_or_create_login_device/1" do
+    setup do
+      %{user: Mydia.AccountsFixtures.user_fixture()}
+    end
+
+    test "creates a device on first login", %{user: user} do
+      assert {:ok, device} =
+               RemoteAccess.find_or_create_login_device(%{
+                 user_id: user.id,
+                 client_device_id: "client-first",
+                 device_name: "Living Room",
+                 platform: "linux"
+               })
+
+      assert device.client_device_id == "client-first"
+      assert device.user_id == user.id
+    end
+
+    test "returns the same row on a returning login", %{user: user} do
+      attrs = %{
+        user_id: user.id,
+        client_device_id: "client-returning",
+        device_name: "Living Room",
+        platform: "linux"
+      }
+
+      assert {:ok, first} = RemoteAccess.find_or_create_login_device(attrs)
+      assert {:ok, second} = RemoteAccess.find_or_create_login_device(attrs)
+
+      assert first.id == second.id
+    end
+
+    test "still fails for a genuine validation error", %{user: user} do
+      assert {:error, changeset} =
+               RemoteAccess.find_or_create_login_device(%{
+                 user_id: user.id,
+                 client_device_id: "client-invalid",
+                 # Missing device_name and platform: a real validation
+                 # failure, which the unique-constraint recovery path must
+                 # not paper over.
+                 device_name: nil,
+                 platform: nil
+               })
+
+      refute changeset.valid?
+    end
+
+    test "the loser of a concurrent first login gets the winner's row instead of an error",
+         %{user: user} do
+      client_device_id = "client-concurrent-#{System.unique_integer([:positive])}"
+      attempts = 8
+
+      results =
+        1..attempts
+        |> Task.async_stream(
+          fn _ ->
+            RemoteAccess.find_or_create_login_device(%{
+              user_id: user.id,
+              client_device_id: client_device_id,
+              device_name: "Concurrent Client",
+              platform: "linux"
+            })
+          end,
+          max_concurrency: attempts,
+          timeout: :infinity
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.all?(results, &match?({:ok, %RemoteDevice{}}, &1)),
+             "every concurrent login must resolve to a device, not the unique-constraint error"
+
+      device_ids = results |> Enum.map(fn {:ok, device} -> device.id end) |> Enum.uniq()
+
+      assert device_ids == [hd(device_ids)],
+             "every concurrent login for the same client_device_id must resolve to one row"
+
+      assert Repo.aggregate(
+               from(d in RemoteDevice,
+                 where: d.user_id == ^user.id and d.client_device_id == ^client_device_id
+               ),
+               :count
+             ) == 1
+    end
+  end
+end

--- a/test/mydia/remote_access/remote_device_test.exs
+++ b/test/mydia/remote_access/remote_device_test.exs
@@ -4,12 +4,13 @@ defmodule Mydia.RemoteAccess.RemoteDeviceTest do
   alias Mydia.RemoteAccess.RemoteDevice
 
   describe "login_changeset/2" do
-    test "records the client-supplied device identifier without a token" do
+    test "records the client-supplied device identifier when a token is provided" do
       changeset =
         RemoteDevice.login_changeset(%RemoteDevice{}, %{
           client_device_id: "client-abc",
           device_name: "Test Laptop",
           platform: "macos",
+          token: "unused-generated-token",
           user_id: Ecto.UUID.generate()
         })
 
@@ -22,11 +23,46 @@ defmodule Mydia.RemoteAccess.RemoteDeviceTest do
         RemoteDevice.login_changeset(%RemoteDevice{}, %{
           device_name: "Test Laptop",
           platform: "macos",
+          token: "unused-generated-token",
           user_id: Ecto.UUID.generate()
         })
 
       refute changeset.valid?
       assert %{client_device_id: _} = errors_on(changeset)
+    end
+
+    test "requires a token, because token_hash is NOT NULL at the database level" do
+      changeset =
+        RemoteDevice.login_changeset(%RemoteDevice{}, %{
+          client_device_id: "client-abc",
+          device_name: "Test Laptop",
+          platform: "macos",
+          user_id: Ecto.UUID.generate()
+        })
+
+      refute changeset.valid?
+      assert %{token: _} = errors_on(changeset)
+    end
+
+    test "inserts successfully and hashes the token, matching the DB constraints" do
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      assert {:ok, device} =
+               %RemoteDevice{}
+               |> RemoteDevice.login_changeset(%{
+                 client_device_id: "client-abc",
+                 device_name: "Test Laptop",
+                 platform: "macos",
+                 token: "unused-generated-token",
+                 user_id: user.id
+               })
+               |> Mydia.Repo.insert()
+
+      assert device.client_device_id == "client-abc"
+      assert is_binary(device.token_hash)
+      # The plaintext is never persisted; only its hash is.
+      refute device.token_hash == "unused-generated-token"
+      assert is_nil(device.token)
     end
   end
 end

--- a/test/mydia/remote_access/remote_device_test.exs
+++ b/test/mydia/remote_access/remote_device_test.exs
@@ -1,0 +1,32 @@
+defmodule Mydia.RemoteAccess.RemoteDeviceTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.RemoteAccess.RemoteDevice
+
+  describe "login_changeset/2" do
+    test "records the client-supplied device identifier without a token" do
+      changeset =
+        RemoteDevice.login_changeset(%RemoteDevice{}, %{
+          client_device_id: "client-abc",
+          device_name: "Test Laptop",
+          platform: "macos",
+          user_id: Ecto.UUID.generate()
+        })
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :client_device_id) == "client-abc"
+    end
+
+    test "requires the client device identifier" do
+      changeset =
+        RemoteDevice.login_changeset(%RemoteDevice{}, %{
+          device_name: "Test Laptop",
+          platform: "macos",
+          user_id: Ecto.UUID.generate()
+        })
+
+      refute changeset.valid?
+      assert %{client_device_id: _} = errors_on(changeset)
+    end
+  end
+end

--- a/test/mydia_web/schema/auth_resolver_test.exs
+++ b/test/mydia_web/schema/auth_resolver_test.exs
@@ -133,6 +133,48 @@ defmodule MydiaWeb.Schema.AuthResolverTest do
         assert message =~ "Invalid"
       end
     end
+
+    test "creates one device per client device id and issues a device-scoped token",
+         %{user: user} do
+      variables = %{
+        "username" => user.username,
+        "password" => "correct-horse-battery-staple",
+        "deviceId" => "client-abc",
+        "deviceName" => "Test Laptop",
+        "platform" => "macos"
+      }
+
+      assert {:ok, %{data: %{"login" => %{"token" => token}}}} = run_query(variables)
+
+      assert {:ok, _user, claims} = Mydia.Auth.Guardian.verify_token_with_claims(token)
+      assert is_binary(claims["device_id"])
+
+      devices = Mydia.RemoteAccess.list_devices(user.id)
+      assert [device] = devices
+      assert device.client_device_id == "client-abc"
+      assert device.id == claims["device_id"]
+
+      # A second login from the same client must reuse the row, not add one.
+      assert {:ok, %{data: %{"login" => _}}} = run_query(variables, unique_caller())
+      assert length(Mydia.RemoteAccess.list_devices(user.id)) == 1
+    end
+
+    test "a different client device id gets its own device row", %{user: user} do
+      base = %{
+        "username" => user.username,
+        "password" => "correct-horse-battery-staple",
+        "deviceName" => "Test Laptop",
+        "platform" => "macos"
+      }
+
+      assert {:ok, %{data: %{"login" => _}}} =
+               run_query(Map.put(base, "deviceId", "client-abc"))
+
+      assert {:ok, %{data: %{"login" => _}}} =
+               run_query(Map.put(base, "deviceId", "client-def"), unique_caller())
+
+      assert length(Mydia.RemoteAccess.list_devices(user.id)) == 2
+    end
   end
 
   defp run_query(input, context \\ %{}) do


### PR DESCRIPTION
Two paired players on the same account could not see each other as remote control targets. Nothing appeared in the picker and no error was shown.

## What was wrong

Discovery is server-mediated: every player POSTs its iroh node ID via `registerDeviceNode`, and the roster lists only devices that have one. A device with no node ID is filtered out of every roster, so it is invisible to and unreachable from every other device on the account.

Production evidence from the reporting account:

| device | platform | node_id | last_seen |
| --- | --- | --- | --- |
| MacBook Air | macos | empty | current |
| iPhone | ios | empty | current |

Across the whole table, iOS had never registered once (0/3) and macOS 1/17, while android was 3/4 and windows 1/1. In six hours of application logs `RegisterDeviceNode` appeared **zero** times against 89 `UpdateEpisodeProgress` mutations over p2p, so the transport, the auth token and the `device_id` claim were all working. The client simply never sent the mutation.

`_initRemoteControlIfEnabled` in `player/lib/app.dart` was a one-shot awaited chain with three silent early exits (opted out, no node ID yet, GraphQL client not ready) wrapped in a catch-all `debugPrint`. Nothing retried it: the only re-entry triggers were an auth-state change and the settings switch flipping, neither of which happens in normal use. One unlucky moment during startup disabled remote control for the entire session, silently.

The tell was that `query Devices` still ran four times in those six hours while `RegisterDeviceNode` ran zero times. `mydiaCastBackendProvider` and `ambientTargetsProvider` depend on the same three inputs but are watched providers that recover when a dependency arrives. Registration was the only consumer that sampled them once.

## What changed

Registration is no longer a startup event. It is an invariant that gets reconciled.

- `P2pStatus` carries `nodeId`. That record is already broadcast on every `initialize()` and `reset()`, so it becomes the readiness signal with no new plumbing.
- `NodeRegistrationService` reconciles the desired state against the observed one: bounded exponential backoff instead of giving up, re-registration when the node ID changes (a relay switch or re-auth mints a new host, and the old undialable ID used to sit in the roster forever), and a clean stop on dispose.
- Riverpod wiring feeds it from **watched** inputs, so a dependency that arrives late recovers on its own.
- `app.dart` no longer registers inline, and a missing node ID is no longer terminal for the session.

Three related fixes came with it:

- **Settings now shows registration state** with a retry action. The original failure was completely silent, which is why it survived in production for weeks.
- **`mydiaCastBackendProvider` and `ambientTargetsProvider` rebuild when the p2p host is swapped.** `p2pServiceProvider` is a plain provider that is never invalidated, so both could capture a null or abandoned host permanently and Mydia cast discovery would stop with nothing explaining why. This was already documented as a live bug in their own dartdoc.
- **Revoked devices are excluded from `RemoteRoster`.** That class is deliberately the single source for both the picker list and the access control list, so a revoked device was still offered as a target and still permitted to drive other devices.
- **Password login creates a device.** `login_input` has always required `deviceId`, `deviceName` and `platform` as non-null, and the resolver discarded all three, minting a token with no `device_id` claim. Anyone signing in on the direct tab therefore had no device row, so `registerDeviceNode` rejected them and they could never be discovered. A new nullable `client_device_id` column lets a returning client reuse its row instead of adding one per login.

## Verification

- Player suite: 3059 passed, 7 skipped, 0 failed.
- `mix precommit` green: format, Credo, compile, database, and 9934 tests with 0 failures.
- Every commit reviewed individually as it landed, plus a whole-branch review.

Manual check once deployed: both devices should now hold a non-empty `node_id` in `remote_devices`, where both were empty before.

## Known issues, none blocking

- **Revocation over p2p is enforced client-side** via `RemoteRoster.allows()`, and `revoke_device/1` never clears `node_id`. An un-upgraded player binary will not respect a revocation until it updates. Pre-existing, and not fixable server-side given the architecture, but worth a release note.
- **A device that pairs by QR and later uses password login gets two `RemoteDevice` rows**, because pairing's `changeset/2` never casts `client_device_id`. Cosmetic duplication in the paired-devices list.
- **`find_or_create_login_device/1` has a narrow race**: two concurrent first-time logins with the same `client_device_id` can leave the loser seeing "Failed to register this device" rather than finding the winner's row. Self-healing on retry, no corruption.

## Note on the design

`remote_devices.token_hash` is `NOT NULL` with a unique index, so a login-created device needs one. Rather than a migration making the column nullable, which on SQLite requires a full table rebuild of a table with foreign key children, login-created devices get a generated token whose plaintext is hashed and discarded. The resulting hash has no known preimage, so it satisfies both constraints while being unable to authenticate anything, which is the correct semantics for a device that re-authenticates with a password.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password login now registers the signing-in device and issues a device-specific token.
  * Remote-control registration runs automatically, retries temporary failures, and supports manual retry.
  * Settings show the current registration status and retry option when needed.
  * Registration refreshes when switching accounts or servers.
* **Bug Fixes**
  * Concurrent first-time logins no longer create duplicate devices or fail unexpectedly.
  * Revoked devices are excluded from discovery and connection attempts.
  * Casting updates correctly when the device’s network identity changes.
* **Security**
  * Device tokens are securely hashed and never stored in plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->