### PR TITLE
feat(web): dismissible player banner and a hide-the-player setting

### DIFF
--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -444,6 +444,21 @@ defmodule Mydia.Accounts do
   end
 
   @doc """
+  Records that the user closed the dashboard player banner.
+
+  Idempotent: a second call rewrites the same value. Separate from the
+  `hide_player` preference, so dismissing the banner never touches the
+  navigation and turning that setting off never brings a dismissed banner back.
+  """
+  @spec dismiss_player_banner(User.t()) ::
+          {:ok, UserPreference.t()} | {:error, Ecto.Changeset.t()}
+  def dismiss_player_banner(%User{} = user) do
+    user
+    |> get_user_preference!()
+    |> update_preference(%{"player_banner_dismissed" => true})
+  end
+
+  @doc """
   The newest changelog version this user has seen, or `nil`.
 
   `nil` means the user has never been shown the changelog, which includes every

--- a/lib/mydia/accounts/user_preference.ex
+++ b/lib/mydia/accounts/user_preference.ex
@@ -19,7 +19,9 @@ defmodule Mydia.Accounts.UserPreference do
     "theme" => "system",
     "close_manual_search_after_grab" => false,
     "grid_density" => "comfortable",
-    "recommendations_expanded" => false
+    "recommendations_expanded" => false,
+    "hide_player" => false,
+    "player_banner_dismissed" => false
   }
 
   # Valid values for each preference
@@ -95,6 +97,34 @@ defmodule Mydia.Accounts.UserPreference do
   end
 
   @doc """
+  Whether the player's navigation entry points should be hidden.
+
+  Covers the sidebar pill, the mobile dock tab, the dashboard banner and the
+  Devices "Web" tile. Play buttons on individual movies and episodes are not
+  affected, and `/player` stays reachable: this is a preference, not access
+  control.
+
+  The `== true` comparison is deliberate. `preferences` is a free-form map and
+  `validate_preferences/1` only runs on writes, so a hand-edited row could hold
+  the string "true". Returning that string would reach `not @hide_player` in a
+  template, where `not "true"` raises ArgumentError and breaks every render.
+  """
+  def hide_player?(%__MODULE__{preferences: prefs}) do
+    Map.get(prefs, "hide_player", @defaults["hide_player"]) == true
+  end
+
+  @doc """
+  Whether the user closed the dashboard player banner.
+
+  Independent of `hide_player?/1`: closing the banner never touches the
+  navigation, and turning the hide setting off never brings a dismissed banner
+  back.
+  """
+  def player_banner_dismissed?(%__MODULE__{preferences: prefs}) do
+    Map.get(prefs, "player_banner_dismissed", @defaults["player_banner_dismissed"]) == true
+  end
+
+  @doc """
   Changeset for creating or updating user preferences.
 
   The `preferences` param should be a map with string keys, e.g.:
@@ -131,6 +161,8 @@ defmodule Mydia.Accounts.UserPreference do
     |> validate_preference_value("close_manual_search_after_grab", [true, false])
     |> validate_preference_value("grid_density", @valid_densities)
     |> validate_preference_value("recommendations_expanded", [true, false])
+    |> validate_preference_value("hide_player", [true, false])
+    |> validate_preference_value("player_banner_dismissed", [true, false])
   end
 
   defp validate_preference_value(changeset, key, valid_values) do

--- a/lib/mydia_web/components/layouts.ex
+++ b/lib/mydia_web/components/layouts.ex
@@ -57,6 +57,10 @@ defmodule MydiaWeb.Layouts do
     default: nil,
     doc: "unread release notes, as %{version: String.t(), older_count: non_neg_integer()}"
 
+  attr :hide_player, :boolean,
+    default: false,
+    doc: "when true, suppress the player entry points in the sidebar and mobile dock"
+
   attr :current_path, :string,
     default: nil,
     doc: "the current request path for active nav highlighting"
@@ -120,7 +124,11 @@ defmodule MydiaWeb.Layouts do
           </div>
           {render_slot(@inner_block)}
         </main>
-        <.mobile_dock current_user={@current_user} current_path={@current_path} />
+        <.mobile_dock
+          current_user={@current_user}
+          current_path={@current_path}
+          hide_player={@hide_player}
+        />
       </div>
 
       <!-- Sidebar -->
@@ -136,6 +144,8 @@ defmodule MydiaWeb.Layouts do
                 <h1 class="text-2xl font-bold">Mydia</h1>
               </div>
               <a
+                :if={!@hide_player}
+                id="sidebar-player-link"
                 href="/player"
                 class="btn btn-primary btn-sm gap-1.5 rounded-full shadow-sm hover:shadow-md transition-shadow"
                 title="Open Player"
@@ -571,6 +581,10 @@ defmodule MydiaWeb.Layouts do
   attr :current_user, :map, default: nil, doc: "the currently authenticated user"
   attr :current_path, :string, default: nil, doc: "the current request path"
 
+  attr :hide_player, :boolean,
+    default: false,
+    doc: "when true, omit the Player tab from the dock"
+
   def mobile_dock(assigns) do
     ~H"""
     <nav
@@ -629,6 +643,8 @@ defmodule MydiaWeb.Layouts do
           label="Downloads"
         />
         <a
+          :if={!@hide_player}
+          id="dock-player-link"
           href="/player"
           data-dock-link
           class="flex flex-col items-center justify-center min-w-[52px] py-1.5 rounded-xl text-primary hover:bg-primary/10 transition-[color,opacity] duration-300 ease-in-out relative z-10"

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.DashboardLive.Index do
 
   require Logger
 
+  alias Mydia.Accounts
   alias Mydia.Media
   alias Mydia.Media.RecentlyAdded
   alias Mydia.Library
@@ -137,6 +138,16 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   @impl true
+  def handle_event("dismiss_player_banner", _params, socket) do
+    case Accounts.dismiss_player_banner(socket.assigns.current_user) do
+      {:ok, _preference} ->
+        {:noreply, assign(socket, :player_banner_dismissed, true)}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not dismiss that. Please try again.")}
+    end
+  end
+
   def handle_event("open_library_picker", params, socket) do
     {:noreply, MediaAddHelpers.put_library_picker(socket, params)}
   end

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -7,25 +7,40 @@
   </div>
 
   <!-- Player CTA Banner -->
-  <a
-    href="/player"
-    class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow mb-6 md:mb-8"
+  <div
+    :if={!@hide_player and !@player_banner_dismissed}
+    id="player-cta-banner"
+    class="card bg-base-100 shadow-sm mb-6 md:mb-8"
   >
     <div class="card-body flex-col sm:flex-row sm:items-center gap-4">
-      <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
-        <.icon name="hero-play-circle-solid" class="w-6 h-6 text-primary" />
-      </div>
-      <div class="flex-1 min-w-0">
-        <h3 class="font-semibold">Open the Mydia Player</h3>
-        <p class="text-sm text-base-content/60">
-          Watch your library right here — no separate app needed.
-        </p>
-      </div>
-      <span class="btn btn-primary btn-sm self-start sm:self-center shrink-0">
-        Launch Player <.icon name="hero-arrow-right" class="w-4 h-4" />
-      </span>
+      <a
+        href="/player"
+        class="flex-1 flex flex-col sm:flex-row sm:items-center gap-4 min-w-0 group"
+      >
+        <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+          <.icon name="hero-play-circle-solid" class="w-6 h-6 text-primary" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="font-semibold">Open the Mydia Player</h3>
+          <p class="text-sm text-base-content/60">
+            Watch your library right here, no separate app needed.
+          </p>
+        </div>
+        <span class="btn btn-primary btn-sm self-start sm:self-center shrink-0 group-hover:shadow-md transition-shadow">
+          Launch Player <.icon name="hero-arrow-right" class="w-4 h-4" />
+        </span>
+      </a>
+      <button
+        id="dismiss-player-banner"
+        type="button"
+        phx-click="dismiss_player_banner"
+        class="btn btn-sm btn-ghost btn-square self-start sm:self-center shrink-0"
+        aria-label="Dismiss"
+      >
+        <.icon name="hero-x-mark" class="w-4 h-4" />
+      </button>
     </div>
-  </a>
+  </div>
 
   <!-- Stats Cards -->
   <% admin? = @current_user && @current_user.role == "admin" %>

--- a/lib/mydia_web/live/devices_live/components.ex
+++ b/lib/mydia_web/live/devices_live/components.ex
@@ -241,6 +241,10 @@ defmodule MydiaWeb.DevicesLive.Components do
     %{id: "linux", name: "Linux tarball", icon: "hero-archive-box", label: "Download .tar.gz"}
   ]
 
+  attr :hide_player, :boolean,
+    default: false,
+    doc: "when true, omit the browser player tile from the download list"
+
   def download_card(assigns) do
     assigns = assign(assigns, :downloads, @downloads)
 
@@ -277,6 +281,7 @@ defmodule MydiaWeb.DevicesLive.Components do
           </a>
 
           <.link
+            :if={!@hide_player}
             id="download-web"
             navigate={~p"/player"}
             class="flex items-center gap-3 p-4 rounded-xl border border-base-300 hover:border-primary/40 hover:shadow-md transition-all"

--- a/lib/mydia_web/live/devices_live/index.html.heex
+++ b/lib/mydia_web/live/devices_live/index.html.heex
@@ -32,7 +32,7 @@
         device_to_delete={@device_to_delete}
       />
 
-      <MydiaWeb.DevicesLive.Components.download_card />
+      <MydiaWeb.DevicesLive.Components.download_card hide_player={@hide_player} />
     </div>
   </div>
 </Layouts.app>

--- a/lib/mydia_web/live/profile_live/index.ex
+++ b/lib/mydia_web/live/profile_live/index.ex
@@ -132,6 +132,22 @@ defmodule MydiaWeb.ProfileLive.Index do
     end
   end
 
+  @impl true
+  def handle_event("toggle_hide_player", _params, socket) do
+    hidden = !socket.assigns.hide_player
+
+    case Accounts.update_preference(socket.assigns.preference, %{"hide_player" => hidden}) do
+      {:ok, preference} ->
+        {:noreply,
+         socket
+         |> assign(:preference, preference)
+         |> assign(:hide_player, hidden)}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Failed to update the player setting")}
+    end
+  end
+
   ## Private Helpers
 
   defp password_changeset(params \\ %{}) do

--- a/lib/mydia_web/live/profile_live/index.html.heex
+++ b/lib/mydia_web/live/profile_live/index.html.heex
@@ -140,6 +140,26 @@
                 <% end %>
               </div>
             </div>
+
+            <div class="divider my-2"></div>
+
+            <div class="form-control w-full">
+              <span class="label-text font-medium">Player</span>
+              <p class="text-sm text-base-content/60 mb-3">
+                Takes the player shortcuts out of the sidebar, the mobile dock and the dashboard.
+                Play buttons on movies and episodes keep working, and the player itself stays
+                available if you open it directly.
+              </p>
+              <.input
+                type="checkbox"
+                id="hide-player-toggle"
+                name="hide_player"
+                label="Hide the player"
+                class="toggle toggle-primary"
+                checked={@hide_player}
+                phx-click="toggle_hide_player"
+              />
+            </div>
           </div>
         </div>
 

--- a/lib/mydia_web/live/user_auth.ex
+++ b/lib/mydia_web/live/user_auth.ex
@@ -136,6 +136,7 @@ defmodule MydiaWeb.Live.UserAuth do
       |> assign(:show_feedback_modal, false)
       |> assign(:feedback_form, build_feedback_form(%{}))
       |> assign_changelog_notice()
+      |> assign_player_ui()
       |> attach_hook(:changelog_hook, :handle_event, &handle_changelog_event/3)
       |> attach_hook(:jobs_status_hook, :handle_info, &handle_jobs_status/2)
       |> attach_hook(:feedback_hook, :handle_event, &handle_feedback_event/3)
@@ -243,6 +244,30 @@ defmodule MydiaWeb.Live.UserAuth do
 
       _ ->
         assign(socket, :changelog_notice, nil)
+    end
+  end
+
+  # Player entry-point visibility, read once per mount.
+  #
+  # No connected?/1 gate: unlike assign_changelog_notice/1 this only reads, so
+  # there is no write to defer to the connected render. This on_mount covers the
+  # whole of live_session :authenticated, so every role gets the assigns.
+  defp assign_player_ui(socket) do
+    case socket.assigns do
+      %{current_user: %Mydia.Accounts.User{} = user} ->
+        pref = Mydia.Accounts.get_user_preference!(user)
+
+        socket
+        |> assign(:hide_player, Mydia.Accounts.UserPreference.hide_player?(pref))
+        |> assign(
+          :player_banner_dismissed,
+          Mydia.Accounts.UserPreference.player_banner_dismissed?(pref)
+        )
+
+      _ ->
+        socket
+        |> assign(:hide_player, false)
+        |> assign(:player_banner_dismissed, false)
     end
   end
 

--- a/test/mydia/accounts/player_visibility_preference_test.exs
+++ b/test/mydia/accounts/player_visibility_preference_test.exs
@@ -1,0 +1,95 @@
+defmodule Mydia.Accounts.PlayerVisibilityPreferenceTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
+
+  test "both keys default to false" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    refute UserPreference.hide_player?(pref)
+    refute UserPreference.player_banner_dismissed?(pref)
+  end
+
+  test "defaults to false for a row that predates the keys" do
+    user = user_fixture()
+
+    legacy =
+      user
+      |> Accounts.get_user_preference!()
+      |> Ecto.Changeset.change(preferences: %{"theme" => "dark"})
+      |> Repo.update!()
+
+    refute UserPreference.hide_player?(legacy)
+    refute UserPreference.player_banner_dismissed?(legacy)
+  end
+
+  test "dismiss_player_banner/1 sets the key" do
+    user = user_fixture()
+
+    {:ok, _} = Accounts.dismiss_player_banner(user)
+
+    assert UserPreference.player_banner_dismissed?(Accounts.get_user_preference!(user))
+  end
+
+  test "dismiss_player_banner/1 is idempotent" do
+    user = user_fixture()
+
+    {:ok, _} = Accounts.dismiss_player_banner(user)
+    {:ok, _} = Accounts.dismiss_player_banner(user)
+
+    assert UserPreference.player_banner_dismissed?(Accounts.get_user_preference!(user))
+  end
+
+  test "hide_player persists via update_preference/2" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    {:ok, _} = Accounts.update_preference(pref, %{"hide_player" => true})
+
+    assert UserPreference.hide_player?(Accounts.get_user_preference!(user))
+  end
+
+  test "rejects a non-boolean for either key" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    assert {:error, hide_changeset} = Accounts.update_preference(pref, %{"hide_player" => "yes"})
+    assert %{preferences: [_ | _]} = errors_on(hide_changeset)
+
+    assert {:error, dismiss_changeset} =
+             Accounts.update_preference(pref, %{"player_banner_dismissed" => "yes"})
+
+    assert %{preferences: [_ | _]} = errors_on(dismiss_changeset)
+  end
+
+  test "a stored string reads back as false" do
+    user = user_fixture()
+
+    corrupted =
+      user
+      |> Accounts.get_user_preference!()
+      |> Ecto.Changeset.change(
+        preferences: %{"hide_player" => "true", "player_banner_dismissed" => "true"}
+      )
+      |> Repo.update!()
+
+    refute UserPreference.hide_player?(corrupted)
+    refute UserPreference.player_banner_dismissed?(corrupted)
+  end
+
+  test "leaves other preferences intact" do
+    user = user_fixture()
+    pref = Accounts.get_user_preference!(user)
+
+    {:ok, pref} = Accounts.update_preference(pref, %{"theme" => "dark"})
+    {:ok, _} = Accounts.update_preference(pref, %{"hide_player" => true})
+
+    reloaded = Accounts.get_user_preference!(user)
+    assert UserPreference.theme(reloaded) == "dark"
+    assert UserPreference.hide_player?(reloaded)
+  end
+end

--- a/test/mydia_web/live/player_visibility_test.exs
+++ b/test/mydia_web/live/player_visibility_test.exs
@@ -113,4 +113,45 @@ defmodule MydiaWeb.PlayerVisibilityTest do
     refute has_element?(view, "#download-web")
     assert has_element?(view, "#download-card")
   end
+
+  test "the toggle turns the setting on and hides the sidebar pill in the same render", %{
+    conn: conn,
+    user: user
+  } do
+    {:ok, view, _html} = live(conn, ~p"/profile")
+    assert has_element?(view, "#sidebar-player-link")
+
+    view |> element("#hide-player-toggle") |> render_click()
+
+    refute has_element?(view, "#sidebar-player-link")
+    assert UserPreference.hide_player?(Accounts.get_user_preference!(user))
+  end
+
+  test "the toggle turns the setting back off", %{conn: conn, user: user} do
+    :ok = hide_player(user)
+
+    {:ok, view, _html} = live(conn, ~p"/profile")
+    refute has_element?(view, "#sidebar-player-link")
+
+    view |> element("#hide-player-toggle") |> render_click()
+
+    assert has_element?(view, "#sidebar-player-link")
+    refute UserPreference.hide_player?(Accounts.get_user_preference!(user))
+  end
+
+  test "turning the setting off does not bring back a dismissed banner", %{
+    conn: conn,
+    user: user
+  } do
+    {:ok, _} = Accounts.dismiss_player_banner(user)
+    :ok = hide_player(user)
+
+    {:ok, profile, _html} = live(conn, ~p"/profile")
+    profile |> element("#hide-player-toggle") |> render_click()
+
+    {:ok, dashboard, _html} = live(conn, ~p"/")
+
+    refute has_element?(dashboard, "#player-cta-banner")
+    assert has_element?(dashboard, "#sidebar-player-link")
+  end
 end

--- a/test/mydia_web/live/player_visibility_test.exs
+++ b/test/mydia_web/live/player_visibility_test.exs
@@ -1,0 +1,58 @@
+defmodule MydiaWeb.PlayerVisibilityTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
+  import Mydia.MetadataCacheHelpers
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Accounts
+
+  setup %{conn: conn} do
+    # DashboardLive.Index loads both trending rails on connected mount.
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+
+    user = admin_user_fixture()
+
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  defp hide_player(user) do
+    {:ok, _} =
+      user
+      |> Accounts.get_user_preference!()
+      |> Accounts.update_preference(%{"hide_player" => true})
+
+    :ok
+  end
+
+  test "the sidebar pill and dock tab render by default", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#sidebar-player-link")
+    assert has_element?(view, "#dock-player-link")
+  end
+
+  test "hide_player removes the sidebar pill and dock tab", %{conn: conn, user: user} do
+    :ok = hide_player(user)
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    refute has_element?(view, "#sidebar-player-link")
+    refute has_element?(view, "#dock-player-link")
+  end
+
+  test "hide_player leaves the movie Play button alone", %{conn: conn, user: user} do
+    :ok = hide_player(user)
+
+    _library = library_path_fixture(%{type: "movies"})
+    item = media_item_fixture(%{type: "movie", title: "Quiet Harbour", year: 2024})
+    _file = media_file_fixture(%{media_item_id: item.id})
+
+    {:ok, view, _html} = live(conn, ~p"/movies/#{item.id}")
+
+    assert has_element?(view, ~s{a[href^="/player/#/player/movie/"]})
+  end
+end

--- a/test/mydia_web/live/player_visibility_test.exs
+++ b/test/mydia_web/live/player_visibility_test.exs
@@ -8,6 +8,7 @@ defmodule MydiaWeb.PlayerVisibilityTest do
   import Mydia.SettingsFixtures
 
   alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
 
   setup %{conn: conn} do
     # DashboardLive.Index loads both trending rails on connected mount.
@@ -54,5 +55,44 @@ defmodule MydiaWeb.PlayerVisibilityTest do
     {:ok, view, _html} = live(conn, ~p"/movies/#{item.id}")
 
     assert has_element?(view, ~s{a[href^="/player/#/player/movie/"]})
+  end
+
+  test "the banner renders by default", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert has_element?(view, "#player-cta-banner")
+  end
+
+  test "dismissing removes the banner and persists", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+    assert has_element?(view, "#player-cta-banner")
+
+    view |> element("#dismiss-player-banner") |> render_click()
+
+    refute has_element?(view, "#player-cta-banner")
+
+    {:ok, remounted, _html} = live(conn, ~p"/")
+    refute has_element?(remounted, "#player-cta-banner")
+  end
+
+  test "dismissing leaves the sidebar pill and dock tab in place", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    view |> element("#dismiss-player-banner") |> render_click()
+
+    assert has_element?(view, "#sidebar-player-link")
+    assert has_element?(view, "#dock-player-link")
+  end
+
+  test "hide_player removes the banner even when it was never dismissed", %{
+    conn: conn,
+    user: user
+  } do
+    :ok = hide_player(user)
+    refute UserPreference.player_banner_dismissed?(Accounts.get_user_preference!(user))
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    refute has_element?(view, "#player-cta-banner")
   end
 end

--- a/test/mydia_web/live/player_visibility_test.exs
+++ b/test/mydia_web/live/player_visibility_test.exs
@@ -95,4 +95,22 @@ defmodule MydiaWeb.PlayerVisibilityTest do
 
     refute has_element?(view, "#player-cta-banner")
   end
+
+  test "the Devices web tile renders by default", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/devices")
+
+    assert has_element?(view, "#download-web")
+  end
+
+  test "hide_player removes the Devices web tile but keeps the native downloads", %{
+    conn: conn,
+    user: user
+  } do
+    :ok = hide_player(user)
+
+    {:ok, view, _html} = live(conn, ~p"/devices")
+
+    refute has_element?(view, "#download-web")
+    assert has_element?(view, "#download-card")
+  end
 end


### PR DESCRIPTION
Lets a user close the player CTA banner on the dashboard, and adds a preference that takes the player's navigation entry points out of the web UI.

## Two independent preferences

Both are boolean keys on the existing `UserPreference` free-form map column, so there is no migration.

- `player_banner_dismissed` records that the user closed the dashboard banner.
- `hide_player` records that the user wants the UI to stop offering the player.

Neither implies the other. Closing the banner never rearranges the navigation, and turning the setting back off does not bring a dismissed banner back. There is a test for exactly that.

## What the setting hides

| Surface | Hidden |
| --- | --- |
| Dashboard player CTA banner | yes |
| Sidebar header Player pill | yes |
| Mobile dock Player tab | yes |
| Devices page "Web" tile | yes |
| Play buttons on movies, episodes and file rows | no |
| Collection "Play all" | no |

Play buttons act on an item the user already picked rather than advertising the player, so they stay. `/player` also stays routed and reachable by URL: this is a preference, not access control, and another user on the same install still gets the player.

Note this is unrelated to the existing instance-wide `ENABLE_PLAYBACK` switch, which gates play buttons for the whole deployment.

## Implementation

`assign_player_ui/1` reads both keys once per mount in the `:load_navigation_data` on_mount, beside `assign_changelog_notice/1`, so every LiveView in `live_session :authenticated` has them. No `connected?/1` gate, because unlike the changelog helper this only reads.

The getters coerce with `== true` rather than returning `Map.get/3` directly. `preferences` is a free-form map and `validate_preferences/1` only runs on writes, so a hand-edited row holding the string `"true"` would reach `not @hide_player` in a template, where `not "true"` raises `ArgumentError` and breaks every render.

The dashboard banner was a single `<a>`, and a `<button>` cannot nest inside an anchor, so the card body becomes a flex row with the anchor as `flex-1` and the dismiss button as its sibling. Its hover shadow moved onto the Launch pill as `group-hover`, since a card-wide hover no longer matches where clicking navigates.

Both event handlers only flip their assign on a successful write and flash on failure, rather than hiding optimistically and reappearing on the next page load.

## Tests

20 new tests across two files, following the existing per-preference pattern:

- `test/mydia/accounts/player_visibility_preference_test.exs` covers defaults, rows that predate the keys, idempotent dismissal, non-boolean rejection, and the stored-string case.
- `test/mydia_web/live/player_visibility_test.exs` covers all four surfaces by element id, dismissal persisting across a remount, the two preferences staying independent, and a regression test pinning that the movie Play button survives `hide_player`.

`mix precommit` passes: 10025 tests, 0 failures, plus `format --check-formatted` and `credo --strict`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Profile setting to hide the Player interface.
  * Added a dismissible Player banner on the dashboard.
  * Player links, tabs, and download options now respect the visibility setting.
  * Banner dismissal and visibility preferences persist across sessions.

* **Bug Fixes**
  * Preserved other player controls and native download options when Player visibility is changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->