### PR TITLE
fix(test): bind promotion ownership pids from the tasks, not arrival order

### DIFF
--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -315,28 +315,56 @@ extra query per LiveView mount, can expose a latent one without being its cause.
 ### Both adapters at once
 
 The green-SQLite / red-Postgres split is the usual shape, so a test failing on
-**both** jobs in the same run reads as a real regression. One known case is not.
+**both** jobs in the same run reads as a real regression. Trust that reading: the
+one entry filed here as an exception turned out to be a genuine test bug, and
+carrying it as a flake for a day bought nothing but re-runs.
 
 **`Mydia.Library.CandidatePromotionTest`, "separate database connections
 serialize competing promotions at ownership"**
-(`test/mydia/library/candidate_promotion_test.exs`). Seen 2026-08-31 on PR #631,
-failing on `Test` (1 failure out of 9773) and `Test / PostgreSQL` (1 out of 9774)
-in the same run, and again hours later on #634 (1 out of 9774 on `Test`) whose
-diff was **this file and `.github/README.md` only**. Two sightings the same day
-on diffs that cannot reach Elixir code, so budget a re-run rather than
-investigating.
+(`test/mydia/library/candidate_promotion_test.exs`). **Fixed 2026-09-01. It was
+never a flake; it was a bug in the test.** Kept here because it was catalogued
+as timing noise for a day and cost re-runs, and because the shape recurs.
 
-It is not adapter-related because the test deliberately escapes the sandbox: it
-wraps setup in `Ecto.Adapters.SQL.Sandbox.unboxed_run/2` and races real
-connections to prove promotion serialises at the ownership boundary. Real
-connections on a loaded runner are timing-sensitive by construction, and the
-SQLite log carries `(Exqlite.Error) database is locked` and
-`DBConnection.OwnershipError: cannot find ownership process` alongside it.
+The test starts two tasks that each check out a real connection and report it,
+then bound the two roles out of the mailbox:
 
-Triage as usual: #631's diff was a single workflow YAML file, which cannot reach
-Elixir code, and master's `ci.yml` was green on the three preceding commits. The
-test is young, added with the import-pipeline work, so treat timing-shaped
-failures in that file as flake-first once master is confirmed green.
+```elixir
+assert_receive {:connection_ready, first_pid}
+assert_receive {:connection_ready, second_pid}
+```
+
+but drove the tasks through the `Task` structs (`send(first.pid, ...)`). Which
+task wins the checkout is a coin flip, so roughly half the time `first_pid` was
+`second.pid`: the test then started `first.pid` and waited on messages from the
+other task, and the next `assert_receive` timed out with a mailbox full of
+correctly-delivered messages from the pid it was not looking for. That mailbox
+dump is the tell, and it is what distinguishes this from a genuine timeout:
+
+```
+code: assert_receive {:ownership_attempt, ^first_pid}
+mailbox:
+  value: {:ownership_attempt, #PID<0.40175.0>}
+  value: {:ownership_boundary, #PID<0.40175.0>}
+```
+
+with `first_pid` bound to a *different* pid than every message in the mailbox.
+The fix is to bind the pids from the `Task` structs and pin them in every
+`assert_receive`, which is order-independent because `assert_receive` scans the
+whole mailbox for a match. The sibling ownership race in `file_ingest_test.exs`
+already did this (`winner_pid = winner.pid`); this test did not.
+
+Seen on PR #631 (`Test` 1/9773 and `Test / PostgreSQL` 1/9774 in the same run),
+on #634, and on master at `731282dc` on 2026-09-01. Failing on **both** adapters
+was read as evidence it could not be a code defect, since the test escapes the
+sandbox via `Ecto.Adapters.SQL.Sandbox.unboxed_run/2` and races real
+connections. It is the opposite: a coin flip in the test body is exactly what
+fails on both adapters at once. Runner load only changes how often the coin
+lands the wrong way.
+
+**Generalise from this.** Whenever concurrent processes report themselves to the
+test, bind their identities from what spawned them, never from arrival order.
+An `assert_receive` timeout whose mailbox dump shows the awaited message present
+under a different pid is this bug, not load.
 
 Note its `on_exit` deletes rows through another `unboxed_run`, so a failed run
 can leave real rows behind in the shared SQLite test database.

--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -340,7 +340,7 @@ other task, and the next `assert_receive` timed out with a mailbox full of
 correctly-delivered messages from the pid it was not looking for. That mailbox
 dump is the tell, and it is what distinguishes this from a genuine timeout:
 
-```
+```text
 code: assert_receive {:ownership_attempt, ^first_pid}
 mailbox:
   value: {:ownership_attempt, #PID<0.40175.0>}

--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -369,6 +369,38 @@ under a different pid is this bug, not load.
 Note its `on_exit` deletes rows through another `unboxed_run`, so a failed run
 can leave real rows behind in the shared SQLite test database.
 
+**`Mydia.Library.FileIngestTest`, "a losing promotion failure cannot resurrect
+the winner's deleted candidate"** (`file_ingest_test.exs:178`). **Fixed
+2026-09-01, same day, and it was a timeout budget, not load.** Fails as
+`** (exit) exited in: Task.await(...)` at `assert {:promoted, [_]} =
+Task.await(winner, @ownership_await)`, SQLite job only.
+
+The budget was the bug. While the winner holds the writer lock the loser is
+parked in `BEGIN IMMEDIATE` retrying, and `config/test.exs` sets
+`busy_timeout: 30_000`, so one contended statement may legitimately block for
+thirty full seconds. `@ownership_await` was **also** `30_000`. At any value at
+or below `busy_timeout`, a single ordinary lock wait exhausts the whole budget
+and `Task.await` gives up on a test that was never stuck.
+
+The rate is what proves it. The budget was raised from `2_000` to `30_000`
+precisely to stop this, and the failure rate did not move: roughly two runs in
+three before, and it still failed twice consecutively afterwards, including a
+`gh run rerun --failed`. Ordinary slowness would have improved fifteenfold.
+A bounded thirty-second lock wait would not improve at all, which is what was
+observed.
+
+Raised to `90_000`, above Ecto's own `timeout: 60_000`, so a genuinely stuck
+query raises a `DBConnection` timeout with a stacktrace before the budget
+expires, and a `Task.await` timeout here means a hang again.
+
+**Generalise from this too.** A timeout budget must exceed the longest wait the
+system is allowed to impose, or it measures the lock manager rather than the
+code. Compare any `Task.await`/`assert_receive` budget against `busy_timeout`,
+`pool_timeout` and `timeout` in `config/test.exs` before calling it generous. A
+budget equal to one of them is not a generous budget, it is a coin flip. And
+when raising a budget does not move a failure rate, stop raising it: that is
+evidence the wait is bounded by configuration, not by load.
+
 ### Postgres job
 
 **`CrashReporter.TowerReporterTest`**, high rate, roughly 3 in 5 runs. Fails

--- a/test/mydia/library/candidate_promotion_test.exs
+++ b/test/mydia/library/candidate_promotion_test.exs
@@ -434,10 +434,18 @@ defmodule Mydia.Library.CandidatePromotionTest do
 
     first = Task.async(promote)
     second = Task.async(promote)
+    first_pid = first.pid
+    second_pid = second.pid
 
-    assert_receive {:connection_ready, first_pid}, @ownership_receive
-    assert_receive {:connection_ready, second_pid}, @ownership_receive
-    refute first_pid == second_pid
+    # Take the pids from the Task structs, never from the order the
+    # :connection_ready messages arrive in. Which task checks out its real
+    # connection first is a coin flip, and binding them from the mailbox
+    # swapped the two roles whenever the second one won: the test then drove
+    # first.pid while waiting on messages from the other task, and every
+    # later assert_receive timed out. Pinning here is order-independent
+    # because assert_receive scans the whole mailbox for a match.
+    assert_receive {:connection_ready, ^first_pid}, @ownership_receive
+    assert_receive {:connection_ready, ^second_pid}, @ownership_receive
 
     send(first.pid, {:start_promotion, ref})
     assert_receive {:ownership_attempt, ^first_pid}, @ownership_receive

--- a/test/mydia/library/candidate_promotion_test.exs
+++ b/test/mydia/library/candidate_promotion_test.exs
@@ -365,12 +365,14 @@ defmodule Mydia.Library.CandidatePromotionTest do
     end
   end
 
-  # Same reasoning as the ownership race in file_ingest_test.exs: this escapes
-  # the sandbox and waits on real connections being scheduled, so its budgets
-  # measure runner load rather than anything it computes. It was caught twice
-  # in .github/ci-flakes.md at the old one and two second values, on both
-  # adapters, and runs in a fraction of a second locally.
-  @ownership_await 30_000
+  # Same reasoning as the ownership race in file_ingest_test.exs, including why
+  # `@ownership_await` has to clear SQLite's `busy_timeout: 30_000` rather than
+  # sit exactly on it: while one promotion holds the writer lock the other is
+  # parked in `BEGIN IMMEDIATE` retrying, so a single contended statement can
+  # legitimately block for the full thirty seconds. See that file for the
+  # detail. This test escapes the sandbox too and runs in a fraction of a
+  # second locally.
+  @ownership_await 90_000
   @ownership_receive 10_000
 
   test "separate database connections serialize competing promotions at ownership" do

--- a/test/mydia/library/file_ingest_test.exs
+++ b/test/mydia/library/file_ingest_test.exs
@@ -168,11 +168,22 @@ defmodule Mydia.Library.FileIngestTest do
   # Timeouts here are generous on purpose. This test escapes the sandbox and
   # races two real connections through the SQLite write lock, so every wait is
   # for another OS process to be scheduled rather than for anything this test
-  # computes. It runs in well under a second locally and still timed out on
-  # two of three CI runs at the two second budget it used to carry, which is a
-  # loaded runner, not a regression. The numbers below are large enough that
-  # only a genuine hang reaches them; a real failure still fails, just later.
-  @ownership_await 30_000
+  # computes. It runs in well under a second locally.
+  #
+  # `@ownership_await` must stay clear of SQLite's busy handler. While the
+  # winner works, the loser is parked in `BEGIN IMMEDIATE` retrying, and
+  # `config/test.exs` sets `busy_timeout: 30_000`, so a single contended
+  # statement may legitimately block for thirty full seconds. This budget was
+  # once 2_000 and then 30_000, the latter landing exactly on `busy_timeout`:
+  # at any value at or below it, one ordinary lock wait exhausts the budget and
+  # `Task.await` gives up on a test that was never stuck. That is why raising
+  # 2_000 to 30_000 did not move the failure rate, which stayed around two runs
+  # in three -- evidence against "slow runner" and for a bounded lock wait.
+  #
+  # 90_000 is above Ecto's own `timeout: 60_000`, so a query that really is
+  # stuck now raises a DBConnection timeout with a stacktrace before this
+  # budget expires. A `Task.await` timeout here once again means a hang.
+  @ownership_await 90_000
   @ownership_receive 10_000
 
   test "a losing promotion failure cannot resurrect the winner's deleted candidate" do


### PR DESCRIPTION
Master's `Test / PostgreSQL` job went red at `731282dc` with a single failure out of 10006: `Mydia.Library.CandidatePromotionTest`, "separate database connections serialize competing promotions at ownership". It is not a flake. It is a coin flip written into the test.

## The bug

The test starts two tasks that each check out a real (`sandbox: false`) connection and report themselves, and it bound the two roles out of its own mailbox:

```elixir
assert_receive {:connection_ready, first_pid}
assert_receive {:connection_ready, second_pid}
```

but then drove them through the `Task` structs:

```elixir
send(first.pid, {:start_promotion, ref})
assert_receive {:ownership_attempt, ^first_pid}
```

Which task wins the checkout is not ordered. Whenever the second one won, `first_pid` was bound to `second.pid`, so the test started one task and waited on messages from the other. Every later `assert_receive` then timed out, with a mailbox holding exactly the messages it wanted under the pid it was not looking for:

```
code: assert_receive {:ownership_attempt, ^first_pid}
   first_pid = #PID<0.40176.0>
mailbox:
   value: {:ownership_attempt, #PID<0.40175.0>}
   value: {:ownership_boundary, #PID<0.40175.0>}
```

`0.40175.0` is the lower pid, so it is the first-spawned task, and `first_pid` was bound to the second. That mailbox dump is the signature, and it is what separates this from a genuine timeout.

## The fix

Bind both pids from the `Task` structs and pin them in every `assert_receive`. Pinning is order-independent because `assert_receive` scans the whole mailbox for a match, so either checkout order now works. The sibling ownership race in `file_ingest_test.exs` already did exactly this (`winner_pid = winner.pid`); this test was the one that did not. The `refute first_pid == second_pid` line is dropped, since two distinct tasks always have distinct pids and it never proved anything.

## Verification

I forced the losing order by sleeping in the first task before it reports `:connection_ready`, which makes the swap deterministic:

- old binding + forced swap: reproduces CI's failure exactly, same two-message mailbox dump under the lower pid
- new binding + forced swap: passes
- `candidate_promotion_test.exs` alone, 10 consecutive runs: green
- `candidate_promotion_test.exs` + `file_ingest_test.exs`: 22 tests, 0 failures

That instrumentation was only a probe and is not in the diff.

## The catalogue entry

`.github/ci-flakes.md` carried this as timing noise to budget a re-run past, on two arguments: the test escapes the sandbox and races real connections, so it must be load-sensitive, and it failed on **both** adapters in one run, which was read as ruling out a code defect.

Both were wrong, and the second inverted the right signal. A coin flip in the test body is precisely the thing that fails on both adapters at once; load only changed how often the coin landed badly. The entry is rewritten to record the real cause, the mailbox signature to match on, and the general rule: when concurrent processes report themselves to a test, bind their identities from what spawned them, never from arrival order. The section preamble no longer advertises an exception to "both adapters means a real regression".

---

## Second commit: a second defect of the same family

CI surfaced a different failure in the sibling ownership race, `FileIngestTest` "a losing promotion failure cannot resurrect the winner's deleted candidate", which exits on `Task.await(winner, @ownership_await)` on the SQLite job. It is not load, and it is not caused by the first commit: it predates this branch, and `test/mydia/library/` is byte-identical between this branch's base and master.

**The budget was the bug.** While the winner holds the writer lock, the loser sits in `BEGIN IMMEDIATE` retrying, and `config/test.exs` sets `busy_timeout: 30_000` — so a single contended statement may legitimately block for thirty full seconds. `@ownership_await` was **also** `30_000`. At any value at or below `busy_timeout`, one ordinary lock wait consumes the entire budget and `Task.await` gives up on a test that was never stuck.

The failure rate is what distinguishes this from a slow runner. 9f1b6fd46 raised the budget from `2_000` to `30_000` specifically to stop this, and the rate did not move: roughly two runs in three before, and it still failed twice consecutively afterwards, the second under `gh run rerun --failed`. Ordinary slowness would have improved fifteenfold. A wait bounded by configuration improves not at all, which is what was observed.

Both ownership tests go to `90_000`, above Ecto's own `timeout: 60_000`, so a query that really is stuck raises a `DBConnection` timeout with a stacktrace before the budget expires, and a `Task.await` timeout means a hang again. The comment claiming the old numbers were "large enough that only a genuine hang reaches them" is corrected — one full busy wait reached them with nothing hung.

I checked the obvious alternative first and discarded it: I hypothesised a deadlock where the winner's post-commit work blocks on the lock the loser just took, and disproved it by widening that handoff window to 400ms with a temporary probe, which still passed. That probe is not in the diff.

Full SQLite suite locally on this branch: **10068 tests, 0 failures**.

The catalogue gains this entry and the general rule: compare a timeout budget against `busy_timeout`, `pool_timeout` and `timeout` in `config/test.exs` before calling it generous — a budget equal to one of them is a coin flip, not headroom — and when raising a budget does not move a failure rate, stop raising it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency checks by matching connection events to their originating tasks rather than message arrival order.
  * Reduced intermittent failures in file-ingestion and promotion checks by allowing sufficient time for database contention and long-running operations.

* **Documentation**
  * Expanded CI troubleshooting guidance with failure signatures, root causes, and recommended timeout configuration.
  * Improved readability of diagnostic output with clearer formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->