### PR TITLE
fix(collections): preselect stored smart rule values in the edit dialog

### DIFF
--- a/lib/mydia/collections/smart_rules_fields.ex
+++ b/lib/mydia/collections/smart_rules_fields.ex
@@ -136,6 +136,17 @@ defmodule Mydia.Collections.SmartRulesFields do
     end
   end
 
+  @multi_value_operators ~w(in not_in contains_any)
+
+  @doc """
+  Whether an operator takes a list of values rather than a single one.
+
+  Rules store a list for these operators and a scalar for the rest, so the
+  editor has to render a multi-select for them - a single select can never
+  hold, or give back, more than one of the stored values.
+  """
+  def multi_value_operator?(operator), do: to_string(operator) in @multi_value_operators
+
   @doc """
   Returns operator labels for display.
   """

--- a/lib/mydia_web/live/collection_live/components.ex
+++ b/lib/mydia_web/live/collection_live/components.ex
@@ -32,6 +32,28 @@ defmodule MydiaWeb.CollectionLive.Components do
     assign_new(socket, :rules_value_options, fn -> SmartRulesFields.value_options() end)
   end
 
+  @doc """
+  Normalizes a condition value into the list form the multi-value operators store.
+
+  Accepts both shapes the editor deals in: the list a `<select multiple>`
+  submits, and the comma-joined string every text input round-trips through.
+  """
+  def value_list(nil), do: []
+
+  def value_list(value) when is_list(value),
+    do: value |> Enum.map(&to_string/1) |> trim_present()
+
+  def value_list(value), do: value |> to_string() |> String.split(",") |> trim_present()
+
+  @doc """
+  Collapses a condition value to the single string the scalar inputs expect.
+  """
+  def value_string(nil), do: ""
+  def value_string(value) when is_list(value), do: Enum.join(value, ", ")
+  def value_string(value), do: to_string(value)
+
+  defp trim_present(values), do: values |> Enum.map(&String.trim/1) |> Enum.reject(&(&1 == ""))
+
   # Smart rules editor component
   attr :conditions, :list, required: true
   attr :match_type, :string, required: true
@@ -276,17 +298,34 @@ defmodule MydiaWeb.CollectionLive.Components do
 
   # Enum fields - options are loaded once when the dialog opens, never in render
   defp render_value_input(assigns, %{type: :enum}) do
-    assigns = assign(assigns, :options, Map.get(assigns.value_options, assigns.field, []))
+    multi? = SmartRulesFields.multi_value_operator?(assigns.operator)
+    stored = value_list(assigns.value)
+
+    # Switching an operator from multi-value to scalar leaves the old list behind
+    # for one change event. A single select can only carry one value, so narrow to
+    # the first rather than marking several options selected at once.
+    selected = if multi?, do: stored, else: Enum.take(stored, 1)
+
+    assigns =
+      assigns
+      |> assign(:multi, multi?)
+      |> assign(:selected, selected)
+      |> assign(
+        :options,
+        with_stored_values(Map.get(assigns.value_options, assigns.field, []), selected)
+      )
 
     ~H"""
     <select
-      name={"conditions[#{@index}][value]"}
+      name={if @multi, do: "conditions[#{@index}][value][]", else: "conditions[#{@index}][value]"}
+      multiple={@multi}
+      size={@multi && 4}
       class="select select-sm select-bordered flex-1 min-w-0 bg-base-100"
     >
-      <option value="">Select...</option>
-      <%= for {val, label} <- @options do %>
-        <option value={val} selected={@value == val or @value == to_string(val)}>{label}</option>
-      <% end %>
+      <option :if={not @multi} value="">Select...</option>
+      <option :for={{val, label} <- @options} value={val} selected={to_string(val) in @selected}>
+        {label}
+      </option>
     </select>
     """
   end
@@ -378,6 +417,17 @@ defmodule MydiaWeb.CollectionLive.Components do
       placeholder={value_placeholder(@operator)}
     />
     """
+  end
+
+  # A saved rule can name a value the library does not currently produce: a genre
+  # every matching item has since lost, or one that never matched anything. The
+  # options come from a scan of what is in the library, so such a value has no
+  # option to be selected on - and because this select is a live form field, the
+  # next change event would post the empty placeholder back and quietly erase the
+  # rule. Appending the stored value keeps it both visible and round-trippable.
+  defp with_stored_values(options, selected) do
+    known = MapSet.new(options, fn {val, _label} -> to_string(val) end)
+    options ++ for val <- selected, not MapSet.member?(known, val), do: {val, val}
   end
 
   defp format_date_value(nil), do: ""

--- a/lib/mydia_web/live/collection_live/index.ex
+++ b/lib/mydia_web/live/collection_live/index.ex
@@ -13,7 +13,8 @@ defmodule MydiaWeb.CollectionLive.Index do
   alias Mydia.Collections
   alias Mydia.Collections.Collection
 
-  import MydiaWeb.CollectionLive.Components, only: [smart_rules_editor: 1, load_value_options: 1]
+  import MydiaWeb.CollectionLive.Components,
+    only: [smart_rules_editor: 1, load_value_options: 1, value_list: 1, value_string: 1]
 
   @default_condition %{"field" => "", "operator" => "eq", "value" => ""}
 
@@ -407,7 +408,7 @@ defmodule MydiaWeb.CollectionLive.Index do
             %{
               "field" => cond["field"] || "",
               "operator" => cond["operator"] || "eq",
-              "value" => cond["value"] || ""
+              "value" => value_string(cond["value"])
             }
           end)
       end
@@ -492,11 +493,13 @@ defmodule MydiaWeb.CollectionLive.Index do
   end
 
   defp parse_condition_value(value, operator) when operator in ["in", "not_in", "contains_any"] do
-    # Split comma-separated values into a list
-    value
-    |> String.split(",")
-    |> Enum.map(&String.trim/1)
-    |> Enum.filter(&(&1 != ""))
+    value_list(value)
+  end
+
+  # A multi-select's list can outlive a switch to a scalar operator by one change
+  # event, so collapse it before the scalar clauses below try to parse it.
+  defp parse_condition_value(value, operator) when is_list(value) do
+    parse_condition_value(value_string(value), operator)
   end
 
   defp parse_condition_value(value, "between") do

--- a/lib/mydia_web/live/collection_live/index.ex
+++ b/lib/mydia_web/live/collection_live/index.ex
@@ -497,9 +497,10 @@ defmodule MydiaWeb.CollectionLive.Index do
   end
 
   # A multi-select's list can outlive a switch to a scalar operator by one change
-  # event, so collapse it before the scalar clauses below try to parse it.
+  # event. The editor narrows that list to its first entry, so parse the same one
+  # rather than a joined string, which would match nothing.
   defp parse_condition_value(value, operator) when is_list(value) do
-    parse_condition_value(value_string(value), operator)
+    value |> value_list() |> List.first("") |> parse_condition_value(operator)
   end
 
   defp parse_condition_value(value, "between") do

--- a/lib/mydia_web/live/collection_live/show.ex
+++ b/lib/mydia_web/live/collection_live/show.ex
@@ -15,7 +15,8 @@ defmodule MydiaWeb.CollectionLive.Show do
   alias Mydia.Collections.Collection
   alias Mydia.Media
 
-  import MydiaWeb.CollectionLive.Components, only: [smart_rules_editor: 1, load_value_options: 1]
+  import MydiaWeb.CollectionLive.Components,
+    only: [smart_rules_editor: 1, load_value_options: 1, value_list: 1, value_string: 1]
 
   @items_per_page 50
   @default_condition %{"field" => "", "operator" => "eq", "value" => ""}
@@ -95,12 +96,9 @@ defmodule MydiaWeb.CollectionLive.Show do
     %{
       "field" => Map.get(cond, "field", ""),
       "operator" => Map.get(cond, "operator", "eq"),
-      "value" => format_condition_value(Map.get(cond, "value", ""))
+      "value" => value_string(Map.get(cond, "value", ""))
     }
   end
-
-  defp format_condition_value(value) when is_list(value), do: Enum.join(value, ", ")
-  defp format_condition_value(value), do: to_string(value)
 
   @impl true
   def handle_params(params, _url, socket) do
@@ -945,7 +943,7 @@ defmodule MydiaWeb.CollectionLive.Show do
               %{
                 "field" => new_field,
                 "operator" => cond["operator"] || old_cond["operator"] || "eq",
-                "value" => cond["value"] || ""
+                "value" => value_string(cond["value"])
               }
             end
           end)
@@ -1046,11 +1044,13 @@ defmodule MydiaWeb.CollectionLive.Show do
 
   defp parse_condition_value(_field, value, operator)
        when operator in ["in", "not_in", "contains_any"] do
-    # Split comma-separated values into a list
-    value
-    |> String.split(",")
-    |> Enum.map(&String.trim/1)
-    |> Enum.filter(&(&1 != ""))
+    value_list(value)
+  end
+
+  # A multi-select's list can outlive a switch to a scalar operator by one change
+  # event, so collapse it before the scalar clauses below try to parse it.
+  defp parse_condition_value(field, value, operator) when is_list(value) do
+    parse_condition_value(field, value_string(value), operator)
   end
 
   defp parse_condition_value(_field, value, "between") do

--- a/lib/mydia_web/live/collection_live/show.ex
+++ b/lib/mydia_web/live/collection_live/show.ex
@@ -1048,9 +1048,10 @@ defmodule MydiaWeb.CollectionLive.Show do
   end
 
   # A multi-select's list can outlive a switch to a scalar operator by one change
-  # event, so collapse it before the scalar clauses below try to parse it.
+  # event. The editor narrows that list to its first entry, so parse the same one
+  # rather than a joined string, which would match nothing.
   defp parse_condition_value(field, value, operator) when is_list(value) do
-    parse_condition_value(field, value_string(value), operator)
+    parse_condition_value(field, value |> value_list() |> List.first(""), operator)
   end
 
   defp parse_condition_value(_field, value, "between") do

--- a/test/mydia_web/live/collection_live/smart_rules_dialog_test.exs
+++ b/test/mydia_web/live/collection_live/smart_rules_dialog_test.exs
@@ -132,4 +132,124 @@ defmodule MydiaWeb.CollectionLive.SmartRulesDialogTest do
       assert html =~ "Drama"
     end
   end
+
+  defp smart_collection!(user, name, condition) do
+    {:ok, collection} =
+      Collections.create_collection(user, %{
+        name: name,
+        type: "smart",
+        visibility: "private",
+        smart_rules: Jason.encode!(%{"match_type" => "all", "conditions" => [condition]})
+      })
+
+    collection
+  end
+
+  # The values the first condition's value input reports as selected. A single
+  # select yields at most one; a multi-select yields one per stored value.
+  defp selected_values(html) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find(~s(select[name^="conditions[0][value]"] option[selected]))
+    |> Floki.attribute("value")
+  end
+
+  describe "edit dialog preselects the stored condition value" do
+    test "a genre some library item actually has", %{conn: conn, user: user} do
+      collection =
+        smart_collection!(user, "Dramas", %{
+          "field" => "metadata.genres",
+          "operator" => "contains",
+          "value" => "Drama"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}?edit=true")
+
+      assert selected_values(render(view)) == ["Drama"]
+    end
+
+    test "a genre no library item currently has", %{conn: conn, user: user} do
+      collection =
+        smart_collection!(user, "Documentaries", %{
+          "field" => "metadata.genres",
+          "operator" => "contains",
+          "value" => "Documentary"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}?edit=true")
+
+      assert selected_values(render(view)) == ["Documentary"]
+    end
+
+    test "every value of a multi-value category rule", %{conn: conn, user: user} do
+      collection =
+        smart_collection!(user, "Anime", %{
+          "field" => "category",
+          "operator" => "in",
+          "value" => ["anime_movie", "anime_series"]
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}?edit=true")
+
+      assert selected_values(render(view)) == ["anime_movie", "anime_series"]
+    end
+  end
+
+  describe "saving the edit dialog back preserves the rule" do
+    # The edit form only renders the visibility select for admins, and
+    # Collection.changeset/2 requires visibility, so only an admin submit
+    # actually reaches the database.
+    setup %{conn: conn} do
+      admin = admin_user_fixture()
+      %{conn: log_in_user(conn, admin), user: admin}
+    end
+
+    defp saved_conditions(user, collection) do
+      user
+      |> Collections.get_collection(collection.id)
+      |> Map.fetch!(:smart_rules)
+      |> Jason.decode!()
+      |> Map.fetch!("conditions")
+    end
+
+    # Renaming proves the submit actually landed, so a preserved rule cannot be
+    # confused with a rejected save that simply left the old one in place.
+    defp submit_rename(view) do
+      view
+      |> form("#edit-collection-form", collection: %{name: "Renamed"})
+      |> render_submit()
+    end
+
+    test "a genre no library item currently has", %{conn: conn, user: user} do
+      condition = %{
+        "field" => "metadata.genres",
+        "operator" => "contains",
+        "value" => "Documentary"
+      }
+
+      collection = smart_collection!(user, "Documentaries", condition)
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}?edit=true")
+      submit_rename(view)
+
+      assert Collections.get_collection(user, collection.id).name == "Renamed"
+      assert saved_conditions(user, collection) == [condition]
+    end
+
+    test "a multi-value category rule", %{conn: conn, user: user} do
+      condition = %{
+        "field" => "category",
+        "operator" => "in",
+        "value" => ["anime_movie", "anime_series"]
+      }
+
+      collection = smart_collection!(user, "Anime", condition)
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}?edit=true")
+      submit_rename(view)
+
+      assert Collections.get_collection(user, collection.id).name == "Renamed"
+      assert saved_conditions(user, collection) == [condition]
+    end
+  end
 end

--- a/test/mydia_web/live/collection_live/smart_rules_dialog_test.exs
+++ b/test/mydia_web/live/collection_live/smart_rules_dialog_test.exs
@@ -251,5 +251,46 @@ defmodule MydiaWeb.CollectionLive.SmartRulesDialogTest do
       assert Collections.get_collection(user, collection.id).name == "Renamed"
       assert saved_conditions(user, collection) == [condition]
     end
+
+    test "a list left over from an operator that just turned scalar", %{conn: conn, user: user} do
+      collection =
+        smart_collection!(user, "Anime", %{
+          "field" => "category",
+          "operator" => "in",
+          "value" => ["anime_movie", "anime_series"]
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/collections/#{collection.id}?edit=true")
+
+      # Saving before the change event swaps the multi-select out posts a scalar
+      # operator alongside the list the old input still held. The editor shows the
+      # first value as selected, so that is the one the save has to keep.
+      view
+      |> element("#edit-collection-form")
+      |> render_submit(%{
+        "collection" => %{
+          "name" => "Renamed",
+          "description" => "",
+          "visibility" => "private"
+        },
+        "match_type" => "all",
+        "conditions" => %{
+          "0" => %{
+            "field" => "category",
+            "operator" => "eq",
+            "value" => ["anime_movie", "anime_series"]
+          }
+        },
+        "sort_field" => "",
+        "sort_direction" => "desc",
+        "limit" => ""
+      })
+
+      assert Collections.get_collection(user, collection.id).name == "Renamed"
+
+      assert saved_conditions(user, collection) == [
+               %{"field" => "category", "operator" => "eq", "value" => "anime_movie"}
+             ]
+    end
   end
 end


### PR DESCRIPTION
Editing a smart collection showed `Select...` instead of the value the rule
stores. Reproduced against galactica's live data, where all three smart
collections hit it:

| Collection | Stored rule | Why nothing was selected |
|---|---|---|
| Anime, Cartoons | `category in ["anime_movie","anime_series"]` | list joined to `"anime_movie, anime_series"`, compared against one option at a time |
| Documentaries | `metadata.genres contains "Documentary"` | options come from a scan of the library, which has 0 items with that genre |

Two independent causes, same symptom:

**Multi-value operators.** `in`, `not_in` and `contains_any` store a list, and
`normalize_condition/1` joins it for the editor. The enum branch rendered a
single `<select>` and tested `@value == val`, which a joined string can never
satisfy — and a single select could not have held both values anyway. It now
renders a multi-select for those operators and accepts the list posted back.

**Values absent from the option list.** Options come from scanning
`media_items.metadata`, so a value nothing currently has — a genre every
matching item lost, or one that never matched — has no option to be selected
on. Any stored value the scan did not produce is now appended.

### This was destructive, not cosmetic

The select is a live form field, so opening the dialog and saving posted the
empty placeholder back and rewrote the rule to `""` (or `[]` for a list),
emptying the collection with no error — `SmartRules.validate/1` accepts both
shapes. The new round-trip tests fail on master with
`%{"field" => "category", "operator" => "in", "value" => []}`.

### Tests

Four tests, all failing before and passing after. The control case (a genre the
library does have) passes both ways, which pins the mechanism. The round-trip
tests rename the collection in the same submit so a preserved rule cannot be
confused with a rejected save.

`181 tests, 0 failures` across the collections and collection/section LiveView suites.

### Noticed, not fixed

The edit form renders the `visibility` select only for admins, but
`Collection.changeset/2` has `validate_required([..., :visibility])` — so a
non-admin submitting the edit dialog always fails the changeset and silently
saves nothing. That is why the round-trip tests use `admin_user_fixture/0`.
Separate from this bug; happy to file it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Smart collection rules now support selecting multiple values for applicable conditions.
  - Existing selections remain available and preselected when editing rules, including values not currently found in the library.
  - Condition values are displayed and saved consistently between list-based and text-based inputs.

- **Bug Fixes**
  - Fixed smart-rule editing so multi-value conditions and saved values are preserved when submitting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->