### PR TITLE
fix(sections): repair four sidebar-section defects

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -11,6 +11,13 @@
    scanner can see. Safelist them so they're always built. */
 @source inline("status-{success,error,warning,info,neutral}");
 
+/* Sidebar section icons are chosen at runtime from collections.sidebar_icon,
+   and the allowlist that defines them lives in lib/mydia/collections/, which is
+   outside the @source globs above. Without this, an icon that happens not to be
+   used anywhere in lib/mydia_web gets no CSS at all and renders as a blank box.
+   test/mydia/collections/sidebar_icon_safelist_test.exs keeps the two in sync. */
+@source inline("hero-{sparkles,film,tv,star,bolt,fire,globe-alt,face-smile,rocket-launch,squares-2x2,book-open,beaker}");
+
 /* A Tailwind plugin that makes "hero-#{ICON}" classes available.
    The heroicons installation itself is managed by your mix.exs */
 @plugin "../vendor/heroicons";

--- a/assets/css/mydiaTheme.ts
+++ b/assets/css/mydiaTheme.ts
@@ -64,7 +64,7 @@ export default plugin(
         "--color-neutral": "oklch(29.72% 0.013 257.29)", // #1f2937 (Gray-800)
         "--color-neutral-content": "oklch(98.04% 0.003 247.86)", // #f9fafb (Gray-50)
 
-        "--color-info": "oklch(62.8% 0.2515 258.34)", // #3b82f6 (Blue-500)
+        "--color-info": "oklch(50% 0.119 242.8)", // #0369a1 (Sky-700)
         "--color-info-content": "oklch(100% 0 0)", // #ffffff
 
         "--color-success": "oklch(68.3% 0.1686 163.14)", // #10b981 (Emerald-500)
@@ -161,7 +161,7 @@ export default plugin(
         "--color-neutral": "oklch(95.76% 0.006 252.37)", // #f1f5f9 (Slate-100)
         "--color-neutral-content": "oklch(25.33% 0.016 252.42)", // #0f172a (Slate-900)
 
-        "--color-info": "oklch(62.8% 0.2515 258.34)", // #3b82f6 (Blue-500)
+        "--color-info": "oklch(50% 0.119 242.8)", // #0369a1 (Sky-700)
         "--color-info-content": "oklch(100% 0 0)", // #ffffff
 
         "--color-success": "oklch(68.3% 0.1686 163.14)", // #10b981 (Emerald-500)

--- a/lib/mydia/collections.ex
+++ b/lib/mydia/collections.ex
@@ -100,6 +100,21 @@ defmodule Mydia.Collections do
   def claimed_categories(sections) when is_list(sections) do
     sections
     |> Enum.filter(& &1.exclusive)
+    |> pinned_categories()
+  end
+
+  @doc """
+  Returns the category names covered by every pinned section, whether or not
+  that section is exclusive.
+
+  `claimed_categories/1` answers "what has been taken away from Movies and TV".
+  This answers the broader "does a section for these categories already exist",
+  which is what decides whether to stop suggesting the user create one. A
+  non-exclusive section is still a section the user made on purpose.
+  """
+  @spec pinned_categories([Collection.t()]) :: [binary()]
+  def pinned_categories(sections) when is_list(sections) do
+    sections
     |> Enum.flat_map(&section_categories/1)
     |> Enum.uniq()
   end

--- a/lib/mydia/collections/section_presets.ex
+++ b/lib/mydia/collections/section_presets.ex
@@ -22,7 +22,7 @@ defmodule Mydia.Collections.SectionPresets do
     %{
       key: "anime",
       name: "Anime",
-      icon: "hero-sparkles",
+      icon: "hero-bolt",
       description: "Japanese animation, movies and series, out of Movies and TV.",
       rules: %{
         "conditions" => [

--- a/lib/mydia_web/components/layouts.ex
+++ b/lib/mydia_web/components/layouts.ex
@@ -104,7 +104,7 @@ defmodule MydiaWeb.Layouts do
               </span>
             </div>
             <div class="flex items-center gap-2">
-              <.link navigate={~p"/changelog"} class="btn btn-sm btn-primary">
+              <.link navigate={~p"/changelog"} class="btn btn-sm btn-neutral">
                 See what's new
               </.link>
               <button

--- a/lib/mydia_web/live/admin_import_lists_live/index.html.heex
+++ b/lib/mydia_web/live/admin_import_lists_live/index.html.heex
@@ -55,7 +55,7 @@
     <%!-- Active Lists Section --%>
     <div>
       <h2 class="text-xl font-semibold mb-4 flex items-center gap-2">
-        <.icon name="hero-list-bullet" class="w-5 h-5 text-info" /> Active Lists
+        <.icon name="hero-list-bullet" class="w-5 h-5 text-primary" /> Active Lists
         <span class="badge badge-ghost">{length(@import_lists)}</span>
       </h2>
 
@@ -433,7 +433,7 @@
               class="card-body p-4 text-left w-full"
             >
               <div class="flex items-start gap-3">
-                <.icon name="hero-eye" class="w-6 h-6 text-info flex-shrink-0 mt-0.5" />
+                <.icon name="hero-eye" class="w-6 h-6 text-primary flex-shrink-0 mt-0.5" />
                 <div>
                   <h4 class="font-semibold">No, I'll review first</h4>
                   <p class="text-sm text-base-content/60 mt-1">

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -983,7 +983,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   defp media_server_type_bg_class(_), do: "bg-base-300"
 
   defp media_server_type_icon_class(:plex), do: "text-warning"
-  defp media_server_type_icon_class(:jellyfin), do: "text-info"
+  defp media_server_type_icon_class(:jellyfin), do: "text-primary"
   defp media_server_type_icon_class(_), do: "text-base-content/60"
 
   defp media_server_type_label(:plex), do: "Plex"

--- a/lib/mydia_web/live/admin_remote_access_live/components.ex
+++ b/lib/mydia_web/live/admin_remote_access_live/components.ex
@@ -258,7 +258,7 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Components do
             <div class="divider my-1"></div>
 
             <div class="alert bg-info/10 border-info/20 py-2.5">
-              <.icon name="hero-light-bulb" class="w-5 h-5 text-info" />
+              <.icon name="hero-light-bulb" class="w-5 h-5 text-primary" />
               <div class="text-xs">
                 <span class="font-semibold">Tip:</span>
                 Use
@@ -271,7 +271,7 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Components do
                   Tailscale
                 </a>
                 for secure access anywhere. Add your Tailscale address, e.g.
-                <code class="bg-info/20 px-1.5 py-0.5 rounded font-mono text-info">
+                <code class="bg-info/20 px-1.5 py-0.5 rounded font-mono text-primary">
                   http://mydia.tail1234.ts.net:4000
                 </code>
               </div>
@@ -391,6 +391,6 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Components do
 
   defp connection_type_class("direct"), do: "text-success font-medium"
   defp connection_type_class("relay"), do: "text-warning font-medium"
-  defp connection_type_class("mixed"), do: "text-info font-medium"
+  defp connection_type_class("mixed"), do: "text-primary font-medium"
   defp connection_type_class(_), do: ""
 end

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -116,11 +116,11 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
         id="tracked-errors-link"
         class="stat hover:bg-base-300 transition-colors cursor-pointer"
       >
-        <div class="stat-figure text-info">
+        <div class="stat-figure text-primary">
           <.icon name="hero-magnifying-glass" class="w-8 h-8" />
         </div>
         <div class="stat-title">Tracked</div>
-        <div class="stat-value text-info">
+        <div class="stat-value text-primary">
           {@stats.tracked_errors}
           <span class="text-base font-normal">
             {if @stats.tracked_errors == 1, do: "error", else: "errors"}

--- a/lib/mydia_web/live/downloads_live/index.html.heex
+++ b/lib/mydia_web/live/downloads_live/index.html.heex
@@ -554,7 +554,7 @@
         <div>
           <div class="flex items-center justify-between mb-3">
             <h3 class="text-lg font-semibold flex items-center gap-2">
-              <.icon name="hero-document-magnifying-glass" class="w-5 h-5 text-info" />
+              <.icon name="hero-document-magnifying-glass" class="w-5 h-5 text-primary" />
               Unresolved Files
               <%= if @issues_counts.unresolved > 0 do %>
                 <span class="badge badge-info badge-sm">{@issues_counts.unresolved}</span>

--- a/lib/mydia_web/live/import_media_live/components.ex
+++ b/lib/mydia_web/live/import_media_live/components.ex
@@ -219,7 +219,7 @@ defmodule MydiaWeb.ImportMediaLive.Components do
           <% @band == :ignored -> %>
             <button
               id="restore-selected"
-              class="btn btn-sm btn-primary"
+              class="btn btn-sm btn-neutral"
               disabled={@count == 0}
               phx-click="restore_selected"
             >
@@ -240,7 +240,7 @@ defmodule MydiaWeb.ImportMediaLive.Components do
           <% true -> %>
             <button
               id="accept-selected"
-              class="btn btn-sm btn-primary"
+              class="btn btn-sm btn-neutral"
               disabled={@count == 0}
               phx-click="accept_selected"
             >

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -135,10 +135,11 @@ defmodule MydiaWeb.MediaLive.Index do
   defp anime_nudge?(socket) do
     user = socket.assigns.current_user
     anime = Enum.map(Mydia.Media.MediaCategory.anime_categories(), &Atom.to_string/1)
+    pinned = Collections.pinned_categories(socket.assigns[:sections] || [])
 
     cond do
-      Enum.any?(anime, &(&1 in (socket.assigns[:excluded_categories] || []))) -> false
       Accounts.anime_nudge_dismissed?(user) -> false
+      Enum.any?(anime, &(&1 in pinned)) -> false
       true -> Media.count_media_items(category_in: anime) >= @anime_nudge_threshold
     end
   end
@@ -707,6 +708,7 @@ defmodule MydiaWeb.MediaLive.Index do
              sidebar_icon: preset.icon,
              exclusive: preset.exclusive
            ) do
+      Accounts.dismiss_anime_nudge(user)
       {:noreply, push_navigate(socket, to: ~p"/sections/#{pinned.id}")}
     else
       {:error, _changeset} ->

--- a/lib/mydia_web/live/media_live/index.ex
+++ b/lib/mydia_web/live/media_live/index.ex
@@ -60,8 +60,6 @@ defmodule MydiaWeb.MediaLive.Index do
      |> assign(:section_owned?, false)
      |> assign(:section_query, nil)
      |> assign(:section_error, false)
-     |> assign(:excluded_count, 0)
-     |> assign(:claiming_sections, [])
      |> assign(:show_section_settings, false)
      |> assign(:section_form, nil)
      |> assign(:section_exclusive_eligible, false)
@@ -81,8 +79,6 @@ defmodule MydiaWeb.MediaLive.Index do
     socket
     |> assign(:page_title, "Movies")
     |> assign(:filter_type, "movie")
-    |> assign(:excluded_count, excluded_count(socket, "movie"))
-    |> assign(:claiming_sections, claiming_sections(socket))
     |> assign(:show_anime_nudge, anime_nudge?(socket))
     |> load_media_items(reset: true)
   end
@@ -91,8 +87,6 @@ defmodule MydiaWeb.MediaLive.Index do
     socket
     |> assign(:page_title, "TV Shows")
     |> assign(:filter_type, "tv_show")
-    |> assign(:excluded_count, excluded_count(socket, "tv_show"))
-    |> assign(:claiming_sections, claiming_sections(socket))
     |> assign(:show_anime_nudge, anime_nudge?(socket))
     |> load_media_items(reset: true)
   end
@@ -147,24 +141,6 @@ defmodule MydiaWeb.MediaLive.Index do
       Accounts.anime_nudge_dismissed?(user) -> false
       true -> Media.count_media_items(category_in: anime) >= @anime_nudge_threshold
     end
-  end
-
-  defp excluded_count(socket, type) do
-    case socket.assigns[:excluded_categories] || [] do
-      [] ->
-        0
-
-      categories ->
-        Media.count_media_items(type: type, category_in: categories)
-    end
-  end
-
-  # The sections claiming categories away from this page, so the excluded
-  # items notice can name the one responsible instead of staying anonymous.
-  # `@sections` is already the current user's own pinned sections (the nav
-  # hook scopes it that way), so filtering it is enough without another query.
-  defp claiming_sections(socket) do
-    Enum.filter(socket.assigns[:sections] || [], & &1.exclusive)
   end
 
   @impl true

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -246,7 +246,7 @@
         <button
           id="accept-anime-nudge"
           phx-click="accept_anime_nudge"
-          class="btn btn-sm btn-primary"
+          class="btn btn-sm btn-neutral"
         >
           Create Anime section
         </button>

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -238,7 +238,7 @@
     </div>
 
     <div :if={@show_anime_nudge} id="anime-nudge" class="alert alert-info mb-4">
-      <.icon name="hero-sparkles" class="w-5 h-5" />
+      <.icon name="hero-bolt" class="w-5 h-5" />
       <span>
         You have a fair bit of anime mixed in here. Want it in its own sidebar section?
       </span>

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -260,24 +260,6 @@
       </div>
     </div>
 
-    <div
-      :if={@excluded_count > 0 and is_nil(@section)}
-      id="excluded-notice"
-      class="alert alert-info mb-4"
-    >
-      <.icon name="hero-information-circle" class="w-5 h-5" />
-      <span>
-        <%= case @claiming_sections do %>
-          <% [section] -> %>
-            {@excluded_count} {if(@excluded_count == 1, do: "item is", else: "items are")} in your
-            <.link navigate={~p"/sections/#{section.id}"} class="link link-primary font-semibold">{section.name}</.link>
-            section.
-          <% _ -> %>
-            {@excluded_count} {if(@excluded_count == 1, do: "item is", else: "items are")} in your pinned sections.
-        <% end %>
-      </span>
-    </div>
-
     <%!-- Empty state (shown when no items) --%>
     <%= if @media_items_empty? do %>
       <div class="flex flex-col items-center justify-center py-16">

--- a/lib/mydia_web/live/media_live/show/season_order_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_order_components.ex
@@ -56,7 +56,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonOrderComponents do
             <button
               type="button"
               id="season-order-accept"
-              class="btn btn-sm btn-primary"
+              class="btn btn-sm btn-neutral"
               phx-click="change_season_order"
               phx-value-order="dvd"
             >

--- a/lib/mydia_web/live/search_live/index.html.heex
+++ b/lib/mydia_web/live/search_live/index.html.heex
@@ -16,7 +16,7 @@
         <.icon name="hero-information-circle" class="w-5 h-5" />
         <span>
           No indexers configured.
-          <a href="/admin/config" class="link link-primary font-semibold">Configure indexers</a>
+          <a href="/admin/config" class="link font-semibold">Configure indexers</a>
           to enable searching.
         </span>
       </div>
@@ -649,7 +649,7 @@
                 <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
                 <span class="text-sm">
                   No library paths configured.
-                  <a href="/admin/config" class="link link-primary">Configure library paths</a>
+                  <a href="/admin/config" class="link">Configure library paths</a>
                   to enable downloads.
                 </span>
               </div>

--- a/lib/mydia_web/live/search_live/index.html.heex
+++ b/lib/mydia_web/live/search_live/index.html.heex
@@ -520,10 +520,10 @@
                 </div>
               </div>
               <div class="flex items-center gap-3 bg-base-200 rounded-lg p-4">
-                <.icon name="hero-arrow-down" class="w-8 h-8 text-info" />
+                <.icon name="hero-arrow-down" class="w-8 h-8 text-primary" />
                 <div>
                   <div class="text-xs text-base-content/70">Leechers</div>
-                  <div class="text-2xl font-bold text-info">{@selected_result.leechers}</div>
+                  <div class="text-2xl font-bold text-primary">{@selected_result.leechers}</div>
                 </div>
               </div>
             </div>

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -380,4 +380,20 @@ defmodule Mydia.Collections.SectionsTest do
       assert Collections.claimed_categories(sections) == ["anime_series"]
     end
   end
+
+  describe "section presets" do
+    test "the anime preset uses an icon with no AI connotation" do
+      preset = Mydia.Collections.SectionPresets.get("anime")
+
+      assert preset.icon == "hero-bolt"
+      assert preset.icon in Collection.valid_sidebar_icons()
+    end
+
+    test "every preset icon is allowlisted" do
+      for preset <- Mydia.Collections.SectionPresets.all() do
+        assert preset.icon in Collection.valid_sidebar_icons(),
+               "#{preset.key} uses #{preset.icon}, which is not allowlisted"
+      end
+    end
+  end
 end

--- a/test/mydia/collections/sections_test.exs
+++ b/test/mydia/collections/sections_test.exs
@@ -337,4 +337,47 @@ defmodule Mydia.Collections.SectionsTest do
       assert is_nil(SectionPresets.get("nope"))
     end
   end
+
+  describe "pinned_categories/1" do
+    test "returns categories from every pinned section, exclusive or not" do
+      user = user_fixture()
+
+      {:ok, _exclusive} =
+        Collections.create_collection(user, %{
+          name: "Anime",
+          type: "smart",
+          visibility: "private",
+          smart_rules:
+            Jason.encode!(%{
+              "conditions" => [
+                %{"field" => "category", "operator" => "in", "value" => ["anime_series"]}
+              ]
+            }),
+          pinned_position: 0,
+          exclusive: true
+        })
+
+      {:ok, _plain} =
+        Collections.create_collection(user, %{
+          name: "Toons",
+          type: "smart",
+          visibility: "private",
+          smart_rules:
+            Jason.encode!(%{
+              "conditions" => [
+                %{"field" => "category", "operator" => "in", "value" => ["cartoon_series"]}
+              ]
+            }),
+          pinned_position: 1,
+          exclusive: false
+        })
+
+      sections = Collections.list_pinned_sections(user)
+
+      assert Enum.sort(Collections.pinned_categories(sections)) ==
+               ["anime_series", "cartoon_series"]
+
+      assert Collections.claimed_categories(sections) == ["anime_series"]
+    end
+  end
 end

--- a/test/mydia/collections/sidebar_icon_safelist_test.exs
+++ b/test/mydia/collections/sidebar_icon_safelist_test.exs
@@ -1,0 +1,40 @@
+defmodule Mydia.Collections.SidebarIconSafelistTest do
+  # Guards a cross-file invariant, in the spirit of
+  # test/mydia/repo/migrations/no_varchar_columns_test.exs.
+  #
+  # Sidebar icons are chosen at runtime from collections.sidebar_icon, so the
+  # class name never appears in anything Tailwind scans. The allowlist that
+  # defines them lives in lib/mydia/, which is outside the @source globs in
+  # app.css. An icon that is offered in the UI but absent from the safelist
+  # gets no CSS and renders as a blank box, with no error anywhere.
+  use ExUnit.Case, async: true
+
+  alias Mydia.Collections.Collection
+
+  @app_css "assets/css/app.css"
+
+  test "every allowlisted sidebar icon is safelisted in app.css" do
+    css = File.read!(@app_css)
+
+    safelisted =
+      case Regex.run(~r/@source inline\("hero-\{([^}]+)\}"\)/, css) do
+        [_full, names] ->
+          names
+          |> String.split(",")
+          |> Enum.map(&"hero-#{String.trim(&1)}")
+
+        nil ->
+          []
+      end
+
+    missing = Collection.valid_sidebar_icons() -- safelisted
+
+    assert missing == [],
+           """
+           These sidebar icons are offered in the UI but never emitted by
+           Tailwind, so they render as blank boxes: #{inspect(missing)}
+
+           Add them to the @source inline("hero-{...}") safelist in #{@app_css}.
+           """
+  end
+end

--- a/test/mydia/collections/sidebar_icon_safelist_test.exs
+++ b/test/mydia/collections/sidebar_icon_safelist_test.exs
@@ -13,7 +13,7 @@ defmodule Mydia.Collections.SidebarIconSafelistTest do
 
   @app_css "assets/css/app.css"
 
-  test "every allowlisted sidebar icon is safelisted in app.css" do
+  test "the sidebar icon allowlist and the app.css safelist agree exactly" do
     css = File.read!(@app_css)
 
     safelisted =
@@ -27,14 +27,22 @@ defmodule Mydia.Collections.SidebarIconSafelistTest do
           []
       end
 
-    missing = Collection.valid_sidebar_icons() -- safelisted
+    expected = Collection.valid_sidebar_icons()
+    missing = expected -- safelisted
+    stale = safelisted -- expected
 
-    assert missing == [],
+    assert missing == [] and stale == [],
            """
-           These sidebar icons are offered in the UI but never emitted by
-           Tailwind, so they render as blank boxes: #{inspect(missing)}
+           The sidebar icon allowlist and the #{@app_css} safelist have drifted.
 
-           Add them to the @source inline("hero-{...}") safelist in #{@app_css}.
+           Offered in the UI but never emitted by Tailwind, so they render as
+           blank boxes: #{inspect(missing)}
+
+           Safelisted but no longer offered, so the safelist is carrying dead
+           entries: #{inspect(stale)}
+
+           The allowlist is @sidebar_icons in lib/mydia/collections/collection.ex;
+           the safelist is the @source inline("hero-{...}") line in #{@app_css}.
            """
   end
 end

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -184,29 +184,19 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       assert has_element?(view, "#nav-tv-count", "1")
     end
 
-    test "the page explains where the hidden items went", %{conn: conn} do
-      {:ok, view, _html} = live(conn, ~p"/tv")
+    test "the claimed items are absent and no banner explains them", %{
+      conn: conn,
+      anime: anime,
+      live: live
+    } do
+      {:ok, view, html} = live(conn, ~p"/tv")
 
-      assert has_element?(view, "#excluded-notice")
+      assert html =~ live.title
+      refute html =~ anime.title
+      refute has_element?(view, "#excluded-notice")
     end
 
-    test "the notice names the single claiming section and links to it", %{
-      conn: conn,
-      section: section
-    } do
-      {:ok, view, _html} = live(conn, ~p"/tv")
-
-      assert has_element?(
-               view,
-               ~s(#excluded-notice a[href="/sections/#{section.id}"]),
-               "Anime"
-             )
-    end
-
-    test "the notice falls back to aggregate wording when more than one section claims", %{
-      conn: conn,
-      user: user
-    } do
+    test "a second claiming section still shows no banner", %{conn: conn, user: user} do
       {:ok, _other} =
         Collections.create_collection(user, %{
           name: "Retro",
@@ -224,8 +214,7 @@ defmodule MydiaWeb.MediaLive.SectionTest do
 
       {:ok, view, _html} = live(conn, ~p"/tv")
 
-      assert has_element?(view, "#excluded-notice", "in your pinned sections")
-      refute has_element?(view, "#excluded-notice a")
+      refute has_element?(view, "#excluded-notice")
     end
 
     test "the sidebar shows the pinned section", %{conn: conn, section: section} do

--- a/test/mydia_web/live/media_live/section_test.exs
+++ b/test/mydia_web/live/media_live/section_test.exs
@@ -453,5 +453,48 @@ defmodule MydiaWeb.MediaLive.SectionTest do
       assert created.name == "Anime"
       assert path == "/sections/#{created.id}"
     end
+
+    test "accepting silences the nudge even after the section is removed", %{
+      conn: conn,
+      user: user
+    } do
+      for n <- 1..10 do
+        categorized_media_item_fixture(
+          %{title: "Signal Garden #{n}", type: "tv_show"},
+          :anime_series
+        )
+      end
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      {:error, {:live_redirect, %{to: _path}}} =
+        view |> element("#accept-anime-nudge") |> render_click()
+
+      [created] = Collections.list_pinned_sections(user)
+      {:ok, _unpinned} = Collections.unpin_section(user, created)
+
+      {:ok, view2, _html} = live(conn, ~p"/tv")
+
+      refute has_element?(view2, "#anime-nudge")
+    end
+
+    test "a non-exclusive anime section silences the nudge", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      for n <- 1..10 do
+        categorized_media_item_fixture(
+          %{title: "Signal Garden #{n}", type: "tv_show"},
+          :anime_series
+        )
+      end
+
+      {:ok, _} = Collections.pin_section(user, section, exclusive: false)
+
+      {:ok, view, _html} = live(conn, ~p"/tv")
+
+      refute has_element?(view, "#anime-nudge")
+    end
   end
 end

--- a/test/mydia_web/live/section_live/new_test.exs
+++ b/test/mydia_web/live/section_live/new_test.exs
@@ -37,7 +37,7 @@ defmodule MydiaWeb.SectionLive.NewTest do
     assert [section] = Collections.list_pinned_sections(user)
     assert section.name == "Anime"
     assert section.exclusive
-    assert section.sidebar_icon == "hero-sparkles"
+    assert section.sidebar_icon == "hero-bolt"
     assert path == "/sections/#{section.id}"
   end
 


### PR DESCRIPTION
Four defects in the sidebar sections feature, all reported from a running instance.

## The permanent excluded-items banner

Pinning an exclusive Anime section left `/movies` and `/tv` carrying an undismissable `alert-info` reading "8 items are in your Anime section." on every visit. It restated a setting the user chose on purpose, and the sidebar already names the section and carries its count.

Removed outright, along with its two assigns and two private helpers. `@excluded_categories` survives; only the banner goes. Two `count_media_items/1` queries drop off every Movies and TV page load.

## The anime nudge forgot that you accepted it

`accept_anime_nudge` created the section, pinned it, and navigated away without recording a decision. Only "No thanks" wrote the preference, so suppression rested on `excluded_categories` — derived state that evaporates the moment the section is unpinned, deleted, or pinned non-exclusively. Someone who did exactly what the banner asked got nagged again.

Both buttons now record the decision, and any pinned section covering an anime category suppresses the nudge regardless of its `exclusive` flag. `Collections.pinned_categories/1` is extracted for that, with `claimed_categories/1` redefined in terms of it.

The existing accept test asserted creation and stopped there, which is the gap that let this ship. The new test accepts, unpins, remounts, and asserts the nudge stays away.

## Three sidebar icons rendered as blank boxes

`app.css` scans `lib/mydia_web` only, but the icon allowlist and the preset catalog live in `lib/mydia`, so Tailwind never saw a reference to a class chosen at runtime from `collections.sidebar_icon`. `hero-face-smile` (the Cartoons preset), `hero-fire` and `hero-rocket-launch` got no CSS at all. The other nine worked by coincidence, each happening to be used somewhere in the web layer.

Safelisted all twelve following the `status-` precedent already in the file, plus a test so the allowlist and the safelist cannot drift apart. The Anime preset also moves off `hero-sparkles`, which now reads as an AI affordance; sparkles stays allowlisted as a choice for a custom section, so existing sections that stored it are unaffected.

## `info` and `primary` were the same colour

`--color-info` and `--color-primary` were both `oklch(62.8% 0.2515 258.34)` in both theme blocks, so a `link-primary` inside a filled `alert-info` was painted in the alert's own background: 1:1 contrast, invisible, in both themes rather than just dark.

`--color-info` moves to Sky-700, which also lifts the alerts' own white body text from 3.68:1 to 5.93:1, over the 4.5:1 AA bar it had never cleared.

Two things worth calling out for review:

- Re-hueing `info` does not by itself make a primary-coloured *control* readable on it — even at Sky-700 that pairing is 1.61:1. The five affected buttons move to `btn-neutral`, including the changelog banner that appears after every upgrade and the import bulk bar.
- Darkening `info` regressed `text-info` used as foreground on dark surfaces (3.98:1 to 2.47:1). Since `text-info` and `text-primary` were identical colours before this branch, the 11 affected call sites move to `text-primary`, restoring their exact previous appearance.

## Verification

`mix precommit` green: 10043 tests, 0 failures, credo --strict clean. No migrations, so nothing to run on upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Categories are now recognized from all pinned sections.
  - Anime recommendations remain dismissed after acceptance, even if the section is later unpinned.
  - Runtime-selected sidebar icons now display reliably.

- **Bug Fixes**
  - Removed misleading excluded-item notices from built-in media pages.

- **Style**
  - Refined button, link, icon, and information colors across the application.
  - Updated the Anime section icon and improved theme contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->