### PR TITLE
fix(ui): hide the mobile dock while the drawer is open

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -231,3 +231,20 @@
 .changelog-entry[open] > summary .hero-chevron-right {
   transform: rotate(90deg);
 }
+
+/* The mobile dock is `fixed` at z-50, above the drawer sidebar (z-40), so it
+   floats over the sidebar at every scroll offset. While the drawer is open the
+   dock's links are redundant with the sidebar nav and it completely covers the
+   sidebar's user menu, so fade it out and take it out of the hit test.
+
+   `pointer-events: none` is what lets taps reach the menu underneath.
+   `visibility: hidden` also drops the dock from the tab order and the
+   accessibility tree. Deliberately not `display: none`: the DockNav hook reads
+   getBoundingClientRect() of the active link on every LiveView patch to place
+   #dock-indicator, and a display:none rect is all zeros, which would strand the
+   indicator in the viewport corner. */
+#main-drawer:checked ~ .drawer-content #mobile-dock {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}

--- a/lib/mydia_web/components/layouts.ex
+++ b/lib/mydia_web/components/layouts.ex
@@ -415,7 +415,7 @@ defmodule MydiaWeb.Layouts do
             </button>
 
             <div class="dropdown dropdown-top dropdown-end w-full">
-              <label tabindex="0" class="btn btn-ghost w-full justify-start">
+              <label id="sidebar-user-menu" tabindex="0" class="btn btn-ghost w-full justify-start">
                 <div class="avatar placeholder">
                   <div class="bg-neutral text-neutral-content rounded-full w-8">
                     <span class="text-xs">
@@ -595,6 +595,7 @@ defmodule MydiaWeb.Layouts do
         "bottom-[calc(0.75rem+env(safe-area-inset-bottom,0px))]",
         "flex items-center justify-around",
         "rounded-2xl px-2 py-2",
+        "transition-[opacity,visibility] duration-200 ease-out",
         "bg-base-100/60 backdrop-blur-3xl backdrop-saturate-150",
         "border border-white/20",
         "shadow-[0_8px_32px_rgba(0,0,0,0.12),inset_0_1px_0_rgba(255,255,255,0.2)]"

--- a/test/mydia_web/features/dock_nav_test.exs
+++ b/test/mydia_web/features/dock_nav_test.exs
@@ -76,5 +76,69 @@ defmodule MydiaWeb.Features.DockNavTest do
 
       assert Wallaby.Browser.has_css?(session, "[data-phx-main].phx-connected")
     end
+
+    @tag :feature
+    test "the sidebar user menu is tappable while the drawer is open",
+         %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> resize_window(390, 844)
+      |> visit("/")
+      |> wait_for_liveview()
+
+      # The hamburger is `<label for="main-drawer">` (layouts.ex). A real click
+      # on a label toggles its associated checkbox, which is the only thing
+      # daisyUI's drawer is driven by.
+      session
+      |> click(Query.css(~s(label[for="main-drawer"])))
+
+      # Two separate transitions run here and only one of them is visibility.
+      # `.drawer-side` flips computed visibility to "visible" at the end of a
+      # 0.1s delay, but the sidebar slides in independently: daisyUI puts
+      # `transition: translate .3s ease-out` with no delay on
+      # `.drawer-side > :not(.drawer-overlay)`, animating `translate: -100%` to
+      # `0%`. Waiting on visibility alone therefore probes mid-slide, with the
+      # sidebar still partly off screen to the left. Wait on the geometry the
+      # assertions below actually depend on.
+      eventually(
+        fn ->
+          script = """
+          var aside = document.querySelector('.drawer-side > :not(.drawer-overlay)');
+          if (!aside) { return '__missing__'; }
+          if (window.getComputedStyle(aside).visibility !== 'visible') { return 'hidden'; }
+          return aside.getBoundingClientRect().left;
+          """
+
+          case eval_js(session, script) do
+            left when is_number(left) and left >= -0.5 -> {:ok, :open}
+            _ -> :error
+          end
+        end,
+        description: "the drawer sidebar finishing its slide-in"
+      )
+
+      # The sidebar scrolls: scrollHeight runs past the viewport once the
+      # admin nav section renders. The user menu only reaches the bottom edge
+      # of the screen, where the dock floats, when it is scrolled all the way
+      # down, so probe that worst case rather than the initial position.
+      scroll_bottom = """
+      var side = document.querySelector('.drawer-side');
+      if (!side) { return '__missing__'; }
+      side.scrollTop = side.scrollHeight;
+      return side.scrollTop;
+      """
+
+      refute eval_js(session, scroll_bottom) == "__missing__",
+             "expected a .drawer-side element to scroll"
+
+      # `refute_covered/2` skips sample points that fall outside the viewport
+      # (elementFromPoint returns null there), so an off-screen element would
+      # pass vacuously. Assert the rect is on screen first, so the cover check
+      # cannot silently no-op.
+      session
+      |> assert_in_viewport("#sidebar-user-menu")
+      |> refute_covered("#sidebar-user-menu")
+    end
   end
 end


### PR DESCRIPTION
The dock is `fixed` at z-50 and the drawer sidebar is z-40, so on mobile
the dock painted over the bottom of the open sidebar at every scroll
offset. At a 390x700 viewport the dock rect fully contained the user
avatar row, and a hit-test grid over that row returned #mobile-dock at
every sample: the Settings / Logout menu was unreachable, not merely
hard to hit.

While the drawer is open the dock duplicates the sidebar nav, so fade it
out and drop it from the hit test and the tab order. Not display:none,
which would zero the rect DockNav reads to place its indicator.

Adds a Wallaby geometry test that opens the drawer, scrolls the sidebar
to the bottom and asserts the user menu is on screen and unobstructed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation behavior by hiding the dock while the sidebar drawer is open.
  * Ensured the sidebar user menu remains tappable and visible when the drawer is expanded.
  * Added a smooth fade transition for the mobile dock’s visibility.

* **Tests**
  * Added coverage for accessing the sidebar user menu on mobile devices while the drawer is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->