### PR TITLE
fix(ui): align poster card bodies across every surface

### DIFF
--- a/lib/mydia_web.ex
+++ b/lib/mydia_web.ex
@@ -93,6 +93,8 @@ defmodule MydiaWeb do
       import MydiaWeb.CollectionComponents
       # Admin configuration page chrome (admin_page)
       import MydiaWeb.AdminComponents
+      # Poster card body: shared title box and bottom-pinned metadata
+      import MydiaWeb.PosterCardComponents
 
       # Common modules used in templates
       alias Phoenix.LiveView.JS

--- a/lib/mydia_web/components/collection_components.ex
+++ b/lib/mydia_web/components/collection_components.ex
@@ -8,6 +8,7 @@ defmodule MydiaWeb.CollectionComponents do
   use Phoenix.Component
 
   import MydiaWeb.CoreComponents, only: [icon: 1]
+  import MydiaWeb.PosterCardComponents, only: [poster_card_body: 1]
 
   use Phoenix.VerifiedRoutes,
     endpoint: MydiaWeb.Endpoint,
@@ -45,7 +46,7 @@ defmodule MydiaWeb.CollectionComponents do
         @class
       ]}
     >
-      <div :for={{id, collection} <- @collections} id={id}>
+      <div :for={{id, collection} <- @collections} id={id} class="h-full">
         {render_slot(@collection, collection)}
       </div>
     </div>
@@ -113,8 +114,8 @@ defmodule MydiaWeb.CollectionComponents do
 
   def collection_card(assigns) do
     ~H"""
-    <div class="relative group">
-      <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
+    <div class="relative group h-full">
+      <div class="card h-full bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
         <.link navigate={@href}>
           <figure class="relative aspect-[2/3] overflow-hidden bg-base-300">
             <.poster_collage poster_paths={@poster_paths} collection_type={@collection.type} />
@@ -159,21 +160,20 @@ defmodule MydiaWeb.CollectionComponents do
             </.link>
           <% end %>
         </div>
-        <div class="card-body p-3">
-          <h3 class="card-title text-sm line-clamp-2" title={@collection.name}>
-            {@collection.name}
-          </h3>
-          <div class="flex items-center justify-between gap-2">
-            <span class="text-xs text-base-content/70">
-              {@item_count} {if @item_count == 1, do: "item", else: "items"}
-            </span>
-            <%= if @collection.visibility == "shared" do %>
-              <span class="badge badge-xs badge-outline gap-1">
-                <.icon name="hero-globe-alt" class="w-3 h-3" /> Shared
+        <.poster_card_body title={@collection.name}>
+          <:meta>
+            <div class="flex items-center justify-between gap-2">
+              <span class="text-xs text-base-content/70">
+                {@item_count} {if @item_count == 1, do: "item", else: "items"}
               </span>
-            <% end %>
-          </div>
-        </div>
+              <%= if @collection.visibility == "shared" do %>
+                <span class="badge badge-xs badge-outline gap-1">
+                  <.icon name="hero-globe-alt" class="w-3 h-3" /> Shared
+                </span>
+              <% end %>
+            </div>
+          </:meta>
+        </.poster_card_body>
       </div>
     </div>
     """

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -6,6 +6,7 @@ defmodule MydiaWeb.DiscoverComponents do
   use Phoenix.Component
 
   import MydiaWeb.CoreComponents, only: [icon: 1, poster_figure: 1]
+  import MydiaWeb.PosterCardComponents, only: [poster_card_body: 1]
 
   alias Mydia.Metadata.ImageUrl
   alias MydiaWeb.LibraryComponents
@@ -71,7 +72,7 @@ defmodule MydiaWeb.DiscoverComponents do
 
     ~H"""
     <div class={[
-      "card bg-base-100 shadow-sm hover:shadow-md transition-shadow relative group",
+      "card bg-base-100 shadow-lg hover:shadow-xl transition-shadow relative group h-full",
       @current && "ring-2 ring-primary"
     ]}>
       <%= if (vote = Map.get(@item, :vote_average)) && vote > 0 do %>
@@ -129,26 +130,23 @@ defmodule MydiaWeb.DiscoverComponents do
             class="rounded-t-box"
           />
       <% end %>
-      <div class="card-body p-3">
-        <h3 class="font-semibold text-sm line-clamp-2" title={@item.title}>
-          {@item.title}
-        </h3>
-        <%= if @item.year do %>
-          <p class="text-xs text-base-content/60">{@item.year}</p>
-        <% end %>
-        <.trending_card_action
-          :if={not @current}
-          item={@item}
-          media_type={@media_type}
-          current_user={@current_user}
-          adding={@adding?}
-          requesting_item_id={@requesting_item_id}
-          libraries={@libraries}
-          add_event={@add_event}
-          request_event={@request_event}
-          can_add={@can_add}
-        />
-      </div>
+      <.poster_card_body title={@item.title}>
+        <:meta>
+          <p :if={@item.year} class="text-xs text-base-content/60">{@item.year}</p>
+          <.trending_card_action
+            :if={not @current}
+            item={@item}
+            media_type={@media_type}
+            current_user={@current_user}
+            adding={@adding?}
+            requesting_item_id={@requesting_item_id}
+            libraries={@libraries}
+            add_event={@add_event}
+            request_event={@request_event}
+            can_add={@can_add}
+          />
+        </:meta>
+      </.poster_card_body>
     </div>
     """
   end

--- a/lib/mydia_web/components/poster_card_components.ex
+++ b/lib/mydia_web/components/poster_card_components.ex
@@ -26,8 +26,10 @@ defmodule MydiaWeb.PosterCardComponents do
   `mt-auto` on the metadata wrapper replaces daisyUI's
   `.card-body p { flex-grow: 1 }`, which pinned Discover's action button to the
   bottom only because its year happened to be a `p`. The wrapper repeats
-  card-body's own `gap-2` so children keep the spacing they had when they were
-  direct card-body children.
+  card-body's own `gap-2` so the gap between metadata children is unchanged. Gap
+  and margin are additive, not interchangeable: a caller that also had margin
+  utilities on those children (an `mt-1` on an overview paragraph, an `mt-2` on
+  `card-actions`) must keep them, or that spacing is silently deleted.
 
   The caller's `.card` has to stretch to its row for `mt-auto` to have anything
   to push against. Where the card is nested below the grid or flex item rather

--- a/lib/mydia_web/components/poster_card_components.ex
+++ b/lib/mydia_web/components/poster_card_components.ex
@@ -1,0 +1,70 @@
+defmodule MydiaWeb.PosterCardComponents do
+  @moduledoc """
+  The body of a poster card: a title box of reserved height, and a metadata
+  block pinned to the card's bottom edge.
+
+  This exists for the same reason `poster_figure/1` does. The markup was
+  hand-copied across seven files and drifted, and the drift is visible. A long
+  title wraps to two lines while a short one takes one, so everything below the
+  title sits at a different height on each card in a row.
+
+  Three details are load-bearing.
+
+  `min-h-[2lh]` reserves two of the element's own line-heights, so the title box
+  stays correct if the type scale changes. `add_media_live` previously hardcoded
+  `h-10`, which is two lines only while the title is `text-sm`. Where `lh` is
+  unsupported the declaration is dropped and the card falls back to the
+  unreserved behaviour it had before, never to a clipped title.
+
+  `font-semibold` rather than daisyUI's `card-title`. `.card-title` is
+  `display: flex` in layer `daisyui.l1.l2.l3`, while `.line-clamp-2` is
+  `display: -webkit-box` declared directly in `utilities`. A rule declared
+  directly in a layer beats that layer's nested sublayers, so clamping wins, but
+  only by cascade accident. What `card-title` contributed here was
+  `font-weight: 600` plus flex properties that never applied.
+
+  `mt-auto` on the metadata wrapper replaces daisyUI's
+  `.card-body p { flex-grow: 1 }`, which pinned Discover's action button to the
+  bottom only because its year happened to be a `p`. The wrapper repeats
+  card-body's own `gap-2` so children keep the spacing they had when they were
+  direct card-body children.
+
+  The caller's `.card` has to stretch to its row for `mt-auto` to have anything
+  to push against. Where the card is nested below the grid or flex item rather
+  than being it, the caller adds `h-full`.
+  """
+
+  use Phoenix.Component
+
+  @doc """
+  Renders a poster card's body.
+
+  The `title` is rendered clamped to two lines and repeated in the `title`
+  attribute, so a clamped title is still readable on hover.
+
+  ## Example
+
+      <.poster_card_body title={item.title}>
+        <:meta>
+          <span class="text-xs text-base-content/70">{item.year}</span>
+        </:meta>
+      </.poster_card_body>
+  """
+  attr :title, :string, required: true
+
+  slot :meta,
+    doc: "badges, year, counts and actions, pinned to the card's bottom edge"
+
+  def poster_card_body(assigns) do
+    ~H"""
+    <div class="card-body p-3">
+      <h3 class="font-semibold text-sm line-clamp-2 min-h-[2lh]" title={@title}>
+        {@title}
+      </h3>
+      <div :if={@meta != []} class="mt-auto flex flex-col gap-2">
+        {render_slot(@meta)}
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/mydia_web/live/add_media_live/index.html.heex
+++ b/lib/mydia_web/live/add_media_live/index.html.heex
@@ -181,10 +181,10 @@
               <.poster_card_body title={result.title || result.name}>
                 <:meta>
                   <p class="text-xs text-base-content/70">{format_year(result)}</p>
-                  <p :if={result.overview} class="text-xs text-base-content/60 line-clamp-2">
+                  <p :if={result.overview} class="text-xs text-base-content/60 line-clamp-2 mt-1">
                     {result.overview}
                   </p>
-                  <div class="card-actions flex-col gap-1">
+                  <div class="card-actions flex-col gap-1 mt-2">
                     <%= if is_added do %>
                       <.link
                         navigate={~p"/media/#{media_item_id}"}

--- a/lib/mydia_web/live/add_media_live/index.html.heex
+++ b/lib/mydia_web/live/add_media_live/index.html.heex
@@ -178,65 +178,62 @@
                   <% end %>
                 </:overlay>
               </.poster_figure>
-              <div class="card-body p-3">
-                <h3 class="card-title text-sm line-clamp-2 h-10">
-                  {result.title || result.name}
-                </h3>
-                <p class="text-xs text-base-content/70">{format_year(result)}</p>
-                <%= if result.overview do %>
-                  <p class="text-xs text-base-content/60 line-clamp-2 mt-1">
+              <.poster_card_body title={result.title || result.name}>
+                <:meta>
+                  <p class="text-xs text-base-content/70">{format_year(result)}</p>
+                  <p :if={result.overview} class="text-xs text-base-content/60 line-clamp-2">
                     {result.overview}
                   </p>
-                <% end %>
-                <div class="card-actions mt-2 flex-col gap-1">
-                  <%= if is_added do %>
-                    <.link
-                      navigate={~p"/media/#{media_item_id}"}
-                      class="btn btn-primary btn-sm btn-block gap-2"
-                    >
-                      <.icon name="hero-arrow-right" class="w-4 h-4" />
-                      {if @media_type == :movie, do: "Go to Movie", else: "Go to Show"}
-                    </.link>
-                  <% else %>
-                    <%= if is_adding do %>
-                      <button class="btn btn-primary btn-sm btn-block" disabled>
-                        <span class="loading loading-spinner loading-xs"></span> Adding...
-                      </button>
+                  <div class="card-actions flex-col gap-1">
+                    <%= if is_added do %>
+                      <.link
+                        navigate={~p"/media/#{media_item_id}"}
+                        class="btn btn-primary btn-sm btn-block gap-2"
+                      >
+                        <.icon name="hero-arrow-right" class="w-4 h-4" />
+                        {if @media_type == :movie, do: "Go to Movie", else: "Go to Show"}
+                      </.link>
                     <% else %>
-                      <div class="flex gap-1 w-full">
+                      <%= if is_adding do %>
+                        <button class="btn btn-primary btn-sm btn-block" disabled>
+                          <span class="loading loading-spinner loading-xs"></span> Adding...
+                        </button>
+                      <% else %>
+                        <div class="flex gap-1 w-full">
+                          <button
+                            class="btn btn-primary btn-sm flex-1"
+                            phx-click="quick_add"
+                            phx-value-index={index}
+                            phx-value-search_on_add="false"
+                            disabled={@library_paths == []}
+                            title="Add to library"
+                          >
+                            <.icon name="hero-plus" class="w-4 h-4" /> Add
+                          </button>
+                          <button
+                            class="btn btn-ghost btn-sm"
+                            phx-click="open_config_modal"
+                            phx-value-index={index}
+                            title="Configure before adding"
+                          >
+                            <.icon name="hero-cog-6-tooth" class="w-4 h-4" />
+                          </button>
+                        </div>
                         <button
-                          class="btn btn-primary btn-sm flex-1"
+                          class="btn btn-secondary btn-sm btn-block"
                           phx-click="quick_add"
                           phx-value-index={index}
-                          phx-value-search_on_add="false"
+                          phx-value-search_on_add="true"
                           disabled={@library_paths == []}
-                          title="Add to library"
+                          title="Add to library and search for content"
                         >
-                          <.icon name="hero-plus" class="w-4 h-4" /> Add
+                          <.icon name="hero-magnifying-glass" class="w-4 h-4" /> Add + Search
                         </button>
-                        <button
-                          class="btn btn-ghost btn-sm"
-                          phx-click="open_config_modal"
-                          phx-value-index={index}
-                          title="Configure before adding"
-                        >
-                          <.icon name="hero-cog-6-tooth" class="w-4 h-4" />
-                        </button>
-                      </div>
-                      <button
-                        class="btn btn-secondary btn-sm btn-block"
-                        phx-click="quick_add"
-                        phx-value-index={index}
-                        phx-value-search_on_add="true"
-                        disabled={@library_paths == []}
-                        title="Add to library and search for content"
-                      >
-                        <.icon name="hero-magnifying-glass" class="w-4 h-4" /> Add + Search
-                      </button>
+                      <% end %>
                     <% end %>
-                  <% end %>
-                </div>
-              </div>
+                  </div>
+                </:meta>
+              </.poster_card_body>
             </div>
           <% end %>
         </div>

--- a/lib/mydia_web/live/collection_live/show.ex
+++ b/lib/mydia_web/live/collection_live/show.ex
@@ -245,7 +245,7 @@ defmodule MydiaWeb.CollectionLive.Show do
           phx-viewport-bottom={@has_more && "load_more"}
           class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 md:gap-4"
         >
-          <div :for={{id, item} <- @streams.items} id={id} class="relative group">
+          <div :for={{id, item} <- @streams.items} id={id} class="relative group h-full">
             <%!-- Remove button for manual collections --%>
             <%= if @collection.type == "manual" and can_edit?(@collection, @current_user) do %>
               <button
@@ -259,13 +259,14 @@ defmodule MydiaWeb.CollectionLive.Show do
               </button>
             <% end %>
 
-            <.link navigate={item_href(item)} class="block">
-              <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
+            <.link navigate={item_href(item)} class="block h-full">
+              <div class="card h-full bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
                 <.poster_figure src={item.poster_url} alt={item.title} />
-                <div class="card-body p-3">
-                  <h3 class="card-title text-sm line-clamp-2">{item.title}</h3>
-                  <span class="text-xs text-base-content/70">{item.year}</span>
-                </div>
+                <.poster_card_body title={item.title}>
+                  <:meta>
+                    <span class="text-xs text-base-content/70">{item.year}</span>
+                  </:meta>
+                </.poster_card_body>
               </div>
             </.link>
           </div>

--- a/lib/mydia_web/live/dashboard_live/components.ex
+++ b/lib/mydia_web/live/dashboard_live/components.ex
@@ -13,6 +13,7 @@ defmodule MydiaWeb.DashboardLive.Components do
   use MydiaWeb, :verified_routes
 
   import MydiaWeb.CoreComponents, only: [icon: 1, poster_figure: 1]
+  import MydiaWeb.PosterCardComponents, only: [poster_card_body: 1]
 
   alias MydiaWeb.Live.Helpers.MediaImages
 
@@ -39,7 +40,7 @@ defmodule MydiaWeb.DashboardLive.Components do
           id={"#{@id}-item-#{entry.media_item.id}"}
           class="snap-start flex-shrink-0 w-36"
         >
-          <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden group">
+          <div class="card h-full bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden group">
             <.link navigate={~p"/media/#{entry.media_item.id}"}>
               <.poster_figure
                 src={MediaImages.poster_url(entry.media_item, "w342")}
@@ -56,11 +57,7 @@ defmodule MydiaWeb.DashboardLive.Components do
                 </:overlay>
               </.poster_figure>
             </.link>
-            <div class="card-body p-3">
-              <h3 class="card-title text-sm line-clamp-2" title={entry.media_item.title}>
-                {entry.media_item.title}
-              </h3>
-            </div>
+            <.poster_card_body title={entry.media_item.title} />
           </div>
         </div>
       </div>

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -411,7 +411,7 @@
               />
             </button>
 
-            <div class="card bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
+            <div class="card h-full bg-base-100 shadow-lg hover:shadow-xl transition-shadow duration-200 overflow-hidden">
               <.link navigate={~p"/media/#{item.id}"}>
                 <% progress = get_progress(item) %>
                 <.poster_figure src={get_poster_url(item)} alt={item.title}>
@@ -427,38 +427,37 @@
                   </:overlay>
                 </.poster_figure>
               </.link>
-              <div class="card-body p-3">
-                <h3 class="card-title text-sm line-clamp-2" title={item.title}>
-                  {item.title}
-                </h3>
-                <%!-- Status badge and year --%>
-                <% status = get_media_item_status(item) %>
-                <div class="flex flex-col gap-1">
-                  <div class="flex items-center justify-between gap-2">
-                    <div class="flex items-center gap-1">
-                      <div class="tooltip tooltip-right" data-tip={media_status_label(status)}>
-                        <span class={["badge badge-xs", media_status_color(status)]}>
-                          <.icon name={media_status_icon(status)} class="w-3 h-3" />
-                        </span>
-                      </div>
-                      <%!-- Category badge --%>
-                      <%= if item.category do %>
-                        <div>
-                          <.category_badge
-                            category={item.category}
-                            override={item.category_override}
-                            size="xs"
-                          />
+              <% status = get_media_item_status(item) %>
+              <.poster_card_body title={item.title}>
+                <:meta>
+                  <%!-- Status badge and year --%>
+                  <div class="flex flex-col gap-1">
+                    <div class="flex items-center justify-between gap-2">
+                      <div class="flex items-center gap-1">
+                        <div class="tooltip tooltip-right" data-tip={media_status_label(status)}>
+                          <span class={["badge badge-xs", media_status_color(status)]}>
+                            <.icon name={media_status_icon(status)} class="w-3 h-3" />
+                          </span>
                         </div>
-                      <% end %>
+                        <%!-- Category badge --%>
+                        <%= if item.category do %>
+                          <div>
+                            <.category_badge
+                              category={item.category}
+                              override={item.category_override}
+                              size="xs"
+                            />
+                          </div>
+                        <% end %>
+                      </div>
+                      <span class="text-xs text-base-content/70">{format_year(item.year)}</span>
                     </div>
-                    <span class="text-xs text-base-content/70">{format_year(item.year)}</span>
+                    <%= if episode_count = format_episode_count(status) do %>
+                      <span class="text-xs text-base-content/70">{episode_count}</span>
+                    <% end %>
                   </div>
-                  <%= if episode_count = format_episode_count(status) do %>
-                    <span class="text-xs text-base-content/70">{episode_count}</span>
-                  <% end %>
-                </div>
-              </div>
+                </:meta>
+              </.poster_card_body>
             </div>
           </div>
         <% else %>

--- a/lib/mydia_web/live/media_live/index.html.heex
+++ b/lib/mydia_web/live/media_live/index.html.heex
@@ -367,7 +367,7 @@
           <%!-- Grid Card View --%>
           <div
             id={"grid-item-#{item.id}"}
-            class="relative group media-grid-item"
+            class="relative group media-grid-item h-full"
             data-selected={to_string(MapSet.member?(@selected_ids, item.id))}
             phx-click="toggle_select"
             phx-value-id={item.id}

--- a/lib/mydia_web/live/request_media_live/index.html.heex
+++ b/lib/mydia_web/live/request_media_live/index.html.heex
@@ -89,38 +89,35 @@
                   <% end %>
                 </:overlay>
               </.poster_figure>
-              <div class="card-body p-3">
-                <h3 class="card-title text-sm line-clamp-2 h-10">
-                  {result.title || result.name}
-                </h3>
-                <p class="text-xs text-base-content/70">{format_year(result)}</p>
-                <%= if result.overview do %>
-                  <p class="text-xs text-base-content/60 line-clamp-2 mt-1">
+              <.poster_card_body title={result.title || result.name}>
+                <:meta>
+                  <p class="text-xs text-base-content/70">{format_year(result)}</p>
+                  <p :if={result.overview} class="text-xs text-base-content/60 line-clamp-2">
                     {result.overview}
                   </p>
-                <% end %>
-                <div class="card-actions mt-2">
-                  <%= if is_requested do %>
-                    <button class="btn btn-success btn-sm btn-block" disabled>
-                      <.icon name="hero-check" class="w-4 h-4" /> Requested
-                    </button>
-                  <% else %>
-                    <%= if is_requesting do %>
-                      <button class="btn btn-primary btn-sm btn-block" disabled>
-                        <span class="loading loading-spinner loading-xs"></span> Requesting...
+                  <div class="card-actions">
+                    <%= if is_requested do %>
+                      <button class="btn btn-success btn-sm btn-block" disabled>
+                        <.icon name="hero-check" class="w-4 h-4" /> Requested
                       </button>
                     <% else %>
-                      <button
-                        class="btn btn-primary btn-sm btn-block"
-                        phx-click="open_request_modal"
-                        phx-value-index={index}
-                      >
-                        <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
-                      </button>
+                      <%= if is_requesting do %>
+                        <button class="btn btn-primary btn-sm btn-block" disabled>
+                          <span class="loading loading-spinner loading-xs"></span> Requesting...
+                        </button>
+                      <% else %>
+                        <button
+                          class="btn btn-primary btn-sm btn-block"
+                          phx-click="open_request_modal"
+                          phx-value-index={index}
+                        >
+                          <.icon name="hero-paper-airplane" class="w-4 h-4" /> Request
+                        </button>
+                      <% end %>
                     <% end %>
-                  <% end %>
-                </div>
-              </div>
+                  </div>
+                </:meta>
+              </.poster_card_body>
             </div>
           <% end %>
         </div>

--- a/lib/mydia_web/live/request_media_live/index.html.heex
+++ b/lib/mydia_web/live/request_media_live/index.html.heex
@@ -92,10 +92,10 @@
               <.poster_card_body title={result.title || result.name}>
                 <:meta>
                   <p class="text-xs text-base-content/70">{format_year(result)}</p>
-                  <p :if={result.overview} class="text-xs text-base-content/60 line-clamp-2">
+                  <p :if={result.overview} class="text-xs text-base-content/60 line-clamp-2 mt-1">
                     {result.overview}
                   </p>
-                  <div class="card-actions">
+                  <div class="card-actions mt-2">
                     <%= if is_requested do %>
                       <button class="btn btn-success btn-sm btn-block" disabled>
                         <.icon name="hero-check" class="w-4 h-4" /> Requested

--- a/test/mydia_web/components/poster_card_body_test.exs
+++ b/test/mydia_web/components/poster_card_body_test.exs
@@ -1,0 +1,72 @@
+defmodule MydiaWeb.PosterCardComponents.PosterCardBodyTest do
+  @moduledoc """
+  The reserved title height and the bottom pin are the assertions that matter.
+  They are the two things that were hand-copied across seven files and drifted,
+  and the only reason this component exists.
+  """
+
+  use ExUnit.Case, async: true
+  use Phoenix.Component
+
+  import Phoenix.LiveViewTest
+  import MydiaWeb.PosterCardComponents
+
+  defp with_meta(title) do
+    assigns = %{title: title}
+
+    rendered_to_string(~H"""
+    <.poster_card_body title={@title}>
+      <:meta>
+        <span class="text-xs">1994</span>
+      </:meta>
+    </.poster_card_body>
+    """)
+  end
+
+  defp without_meta(title) do
+    assigns = %{title: title}
+
+    rendered_to_string(~H"""
+    <.poster_card_body title={@title} />
+    """)
+  end
+
+  test "reserves two lines for the title regardless of its length" do
+    html = without_meta("Nine Winters")
+
+    assert html =~ "line-clamp-2"
+    assert html =~ "min-h-[2lh]"
+  end
+
+  test "carries the full title as a tooltip so a clamped title stays readable" do
+    long = "The Cartographer's Dilemma: A Very Long Subtitle That Will Clamp"
+    escaped = long |> Phoenix.HTML.html_escape() |> Phoenix.HTML.safe_to_string()
+
+    assert with_meta(long) =~ ~s(title="#{escaped}")
+  end
+
+  test "does not use daisyUI card-title, which fights line-clamp" do
+    html = without_meta("Nine Winters")
+
+    assert html =~ "font-semibold"
+    refute html =~ "card-title"
+  end
+
+  test "pins the meta slot to the bottom of the card" do
+    html = with_meta("Nine Winters")
+
+    assert html =~ "mt-auto"
+    assert html =~ "1994"
+  end
+
+  test "renders no meta wrapper when the slot is empty" do
+    refute without_meta("Nine Winters") =~ "mt-auto"
+  end
+
+  test "keeps the card-body padding every call site uses" do
+    html = without_meta("Nine Winters")
+
+    assert html =~ "card-body"
+    assert html =~ "p-3"
+  end
+end

--- a/test/mydia_web/components/poster_card_consistency_test.exs
+++ b/test/mydia_web/components/poster_card_consistency_test.exs
@@ -1,0 +1,52 @@
+defmodule MydiaWeb.PosterCardConsistencyTest do
+  @moduledoc """
+  Poster card titles were hand-copied across seven files and drifted, which is
+  what `MydiaWeb.PosterCardComponents.poster_card_body/1` exists to stop. A
+  copy that reappears looks correct in isolation and only shows up as a ragged
+  row on a page nobody thought to open.
+
+  This is the same kind of guard as
+  `test/mydia/repo/migrations/no_varchar_columns_test.exs`.
+  """
+
+  use ExUnit.Case, async: true
+
+  @source_glob "lib/mydia_web/**/*.{ex,heex}"
+
+  # Matches a class attribute in either form: class="..." or class={...}
+  @class_attr ~r/class=(?:"[^"]*"|\{[^}]*\})/
+
+  test "the source glob actually matches files" do
+    refute Path.wildcard(@source_glob) == []
+  end
+
+  test "no template hand-rolls a poster card title" do
+    offenders =
+      @source_glob
+      |> Path.wildcard()
+      |> Enum.filter(&hand_rolled_title?(File.read!(&1)))
+
+    assert offenders == [],
+           """
+           These files hand-roll a poster card title instead of using
+           MydiaWeb.PosterCardComponents.poster_card_body/1:
+
+           #{Enum.map_join(offenders, "\n", &("  " <> &1))}
+
+           A clamped title with no reserved height makes the row ragged. Use
+           <.poster_card_body title={...}> and put the rest in its :meta slot.
+           """
+  end
+
+  # Scoped to class attributes so this can't collide with prose that merely
+  # discusses both class names (e.g. a moduledoc), and so it catches both
+  # quoted classes and HEEx's `class={[...]}` list syntax regardless of the
+  # order the two classes appear in.
+  defp hand_rolled_title?(source) do
+    @class_attr
+    |> Regex.scan(source)
+    |> Enum.any?(fn [attr] ->
+      String.contains?(attr, "card-title") and String.contains?(attr, "line-clamp-2")
+    end)
+  end
+end


### PR DESCRIPTION
Reported in https://github.com/getmydia/mydia/discussions/642#discussioncomment-18233496

## The problem

Poster cards clamp their title to two lines but reserve no height for it, so a long title takes two rows and a short one takes one. Everything below the title then sits at a different height on each card, and in the Movies and TV Shows grids the cards themselves end up different heights with a ragged row bottom.

The report named the Compact and Dense views, but density is not involved. `grid_density_components.ex` only swaps the column count, so the same drift is present at Comfortable and in every rail.

Discover looked correct only by accident. Its cards are direct grid children so they stretch to equal height, and daisyUI ships `.card-body p { flex-grow: 1 }`. Discover happens to render its year as a `<p>`, so that paragraph absorbed the slack and pushed the action button to the bottom. Any surface that used a `<div>` got no alignment at all, and Discover's own year line still drifted.

## The change

A new `MydiaWeb.PosterCardComponents.poster_card_body/1` owns a title box of reserved height and a metadata block pinned to the card's bottom edge. Seven files that hand-copied the markup now call it.

Three details are load-bearing:

- `min-h-[2lh]` reserves two of the element's own line-heights, so the title box survives a change to the type scale. `add_media_live` and `request_media_live` previously hardcoded `h-10`, which is two lines only while the title is `text-sm`. Where `lh` is unsupported the declaration is dropped and the card falls back to today's behaviour rather than to a clipped title.
- `font-semibold` replaces daisyUI's `card-title`. `.card-title` is `display: flex` in layer `daisyui.l1.l2.l3` while `.line-clamp-2` is `display: -webkit-box` declared directly in `utilities`, so clamping only worked by cascade-layer accident.
- `mt-auto` on the metadata wrapper replaces the accidental `.card-body p` behaviour, so alignment no longer depends on which tag a caller picks for its year.

Cards that are nested below their grid or flex item also gain `h-full`, because `mt-auto` needs the card to stretch to its row before it has anything to push against.

Two smaller fixes ride along: Discover's card was the only one of the seven on `shadow-sm hover:shadow-md` and now matches the rest, and three call sites that had no `title` attribute on their clamped heading gain the hover tooltip the others already had.

## Verification

`mix precommit` green: 10075 tests, 0 failures, with format, credo and compile checks clean.

Measured in a real browser rather than asserted, per the rule in `lib/mydia_web/components/README.md`. With seeded data mixing one-line and two-line titles, across Movies and TV Shows at all three densities, every grid row measured one distinct card bottom, one distinct metadata bottom, and a title box of exactly 40px.

That measurement was then falsified to prove it was not vacuous. Neutralising only the reserved height and the bottom pin reproduced the reported bug exactly: title heights split into 20px and 40px, and card and metadata bottoms diverged into two values each.

The height chain was verified the same way under metadata that varies within a row, which is the condition that actually exercises it: flush with the fix, 24px ragged without it.

A guard test fails the suite if a future file hand-rolls the title again. It is scoped to `class` attributes so it cannot collide with prose, is order independent, and catches HEEx's `class={[...]}` list syntax. It was proven to fail on all three of those syntactic forms and to pass on a prose-only control.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Standardized poster cards across collections, discovery, media libraries, dashboards, and search/request views.
  - Cards now maintain consistent heights for cleaner, more even grids and rails.
  - Long titles are limited to two lines while remaining fully viewable on hover.
  - Metadata and actions are consistently aligned at the bottom of cards.
  - Preserved existing details and actions, including years, statuses, episode counts, overviews, and add/request controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->