### PR TITLE
fix: stop re-scan trashing media that is still on disk

### DIFF
--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -1761,27 +1761,42 @@ defmodule Mydia.Jobs.MediaImport do
         {:ok, media_file}
 
       {:error, changeset} ->
-        # Check if this is a library type mismatch error
-        if has_library_type_mismatch_error?(changeset) do
-          media_type = if episode, do: "TV show", else: "movie"
+        cond do
+          # A concurrent import (this job racing its own retry, or two
+          # workers racing the same season pack) can lose the create/1 race
+          # after this process already decided the path was free: another
+          # insert won and the unique index on (library_path_id,
+          # relative_path) for active rows (migration 20260901234336) turns
+          # the loser's insert into a changeset error instead of a second
+          # row. Adopt the row that won instead of failing the import --
+          # the same "someone already put this here" reuse this function
+          # already does before attempting to place the file (see "Reusing
+          # existing media file" above) and the `{:existing, path}` branch
+          # of resolve_conflict_path/2, just caught one step later.
+          duplicate_active_path_error?(changeset) ->
+            adopt_duplicate_active_path(library_path.id, relative_path, path)
 
-          Logger.error("Library type mismatch during import",
-            path: path,
-            media_type: media_type,
-            download_id: download.id,
-            media_item_id: download.media_item_id,
-            episode_id: episode && episode.id,
-            errors: format_changeset_errors(changeset)
-          )
+          has_library_type_mismatch_error?(changeset) ->
+            media_type = if episode, do: "TV show", else: "movie"
 
-          {:error, :library_type_mismatch}
-        else
-          Logger.error("Failed to create media file record",
-            path: path,
-            errors: inspect(changeset.errors)
-          )
+            Logger.error("Library type mismatch during import",
+              path: path,
+              media_type: media_type,
+              download_id: download.id,
+              media_item_id: download.media_item_id,
+              episode_id: episode && episode.id,
+              errors: format_changeset_errors(changeset)
+            )
 
-          {:error, :database_error}
+            {:error, :library_type_mismatch}
+
+          true ->
+            Logger.error("Failed to create media file record",
+              path: path,
+              errors: inspect(changeset.errors)
+            )
+
+            {:error, :database_error}
         end
     end
   end
@@ -1891,6 +1906,42 @@ defmodule Mydia.Jobs.MediaImport do
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, _key, ""), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  # Matches the specific violation `guard_unique_active_path/1` in
+  # MediaFile attaches to :relative_path (declared under two constraint
+  # names there because ecto_sqlite3 reports a convention-derived name
+  # rather than the real one for a partial index) -- never a genuine
+  # validation failure, which must still surface as an error.
+  defp duplicate_active_path_error?(changeset) do
+    Enum.any?(changeset.errors, fn {field, {_message, opts}} ->
+      field == :relative_path and Keyword.get(opts, :constraint) == :unique
+    end)
+  end
+
+  # Looks up the row that won the race and adopts it. A miss here (the
+  # constraint fired but no active row exists for this path) means it was
+  # trashed or deleted between the insert and this read -- nothing to adopt,
+  # so report the original failure and let the caller retry.
+  defp adopt_duplicate_active_path(library_path_id, relative_path, path) do
+    case Library.get_media_file_by_relative_path(library_path_id, relative_path) do
+      nil ->
+        Logger.error("Duplicate-path constraint hit but no active row found to adopt",
+          path: path,
+          library_path_id: library_path_id,
+          relative_path: relative_path
+        )
+
+        {:error, :database_error}
+
+      existing ->
+        Logger.info("Reusing existing media file after a duplicate-path race",
+          path: path,
+          id: existing.id
+        )
+
+        {:ok, existing}
+    end
+  end
 
   # Checks if a changeset has a library type mismatch error
   defp has_library_type_mismatch_error?(changeset) do

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -651,13 +651,22 @@ defmodule Mydia.Library do
   present could not be moved. A row marked trashed while its file sits in the
   library is precisely the inconsistency this move exists to remove, so the two
   are kept in step or neither changes.
+
+  ## Options
+
+  Passed straight through to `Mydia.Library.TrashStore.store/2`; see its docs.
+  Notably `:move` (default `true`) - `move: false` refuses to move a file that
+  is present on disk instead of trashing it, leaving the row untouched. The
+  three re-scan functions in this module pass it: a file the diff called
+  missing but that has since reappeared must never be moved out of the
+  library.
   """
-  @spec trash_media_file(MediaFile.t()) ::
+  @spec trash_media_file(MediaFile.t(), keyword()) ::
           {:ok, MediaFile.t()} | {:error, Ecto.Changeset.t()} | {:error, term()}
-  def trash_media_file(%MediaFile{} = media_file) do
+  def trash_media_file(%MediaFile{} = media_file, opts \\ []) do
     media_file = Repo.preload(media_file, :library_path)
 
-    case TrashStore.store(media_file) do
+    case TrashStore.store(media_file, opts) do
       {:ok, outcome} ->
         media_file
         |> Ecto.Changeset.change(
@@ -683,7 +692,9 @@ defmodule Mydia.Library do
 
   # The directory diff in the three re-scan paths proposes files as missing by
   # comparing path strings against a scan of one inferred directory. This is
-  # the only thing allowed to confirm it.
+  # the operator-facing check that confirms it: it names the path in a
+  # warning log so a wrongly-called-missing row is visible, and it keeps the
+  # re-scan from even attempting a trash that would now fail anyway.
   #
   # A row the diff called missing whose file is nevertheless sitting on disk is
   # not missing: it is a row whose stored path did not match the scan for some
@@ -692,8 +703,17 @@ defmodule Mydia.Library do
   # extension is outside Scanner's list. Trashing it moves bytes out of the
   # library, which is how #653 emptied people's libraries.
   #
+  # This check and trash_media_file/2's `move: false` run at different
+  # times, so a file that reappears on disk in the gap between them (a
+  # reconnecting mount, a concurrent import) can still slip past this
+  # function. The `move: false` option the three re-scan callers pass is the
+  # backstop for that: it refuses to move a file TrashStore finds present at
+  # the moment it actually acts, no matter what this function saw earlier.
+  # This function stays first because it is the only one of the two that can
+  # name the path in a warning log.
+  #
   # A row with no resolvable path is kept in the list. There is nothing to
-  # check, and TrashStore.store/1 has nothing to move for it either.
+  # check, and TrashStore.store/2 has nothing to move for it either.
   @spec reject_files_still_on_disk([MediaFile.t()]) :: [MediaFile.t()]
   defp reject_files_still_on_disk(candidates) do
     Enum.reject(candidates, fn media_file ->
@@ -1248,7 +1268,9 @@ defmodule Mydia.Library do
               trashed_count =
                 missing_files
                 |> reject_files_still_on_disk()
-                |> Enum.count(fn file -> match?({:ok, _}, trash_media_file(file)) end)
+                |> Enum.count(fn file ->
+                  match?({:ok, _}, trash_media_file(file, move: false))
+                end)
 
               Logger.info("Found new files during re-scan",
                 new_file_count: length(new_files),
@@ -1421,7 +1443,9 @@ defmodule Mydia.Library do
               trashed_count =
                 missing_files
                 |> reject_files_still_on_disk()
-                |> Enum.count(fn file -> match?({:ok, _}, trash_media_file(file)) end)
+                |> Enum.count(fn file ->
+                  match?({:ok, _}, trash_media_file(file, move: false))
+                end)
 
               Logger.info("Found new files for season during re-scan",
                 season: season_number,
@@ -1577,7 +1601,9 @@ defmodule Mydia.Library do
               trashed_count =
                 missing_files
                 |> reject_files_still_on_disk()
-                |> Enum.count(fn file -> match?({:ok, _}, trash_media_file(file)) end)
+                |> Enum.count(fn file ->
+                  match?({:ok, _}, trash_media_file(file, move: false))
+                end)
 
               Logger.info("Found new files during movie re-scan",
                 new_file_count: length(new_files),

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -681,6 +681,42 @@ defmodule Mydia.Library do
     end
   end
 
+  # The directory diff in the three re-scan paths proposes files as missing by
+  # comparing path strings against a scan of one inferred directory. This is
+  # the only thing allowed to confirm it.
+  #
+  # A row the diff called missing whose file is nevertheless sitting on disk is
+  # not missing: it is a row whose stored path did not match the scan for some
+  # other reason. A second row for the same file, a path that normalises
+  # differently, a scan that could not read the directory, a file whose
+  # extension is outside Scanner's list. Trashing it moves bytes out of the
+  # library, which is how #653 emptied people's libraries.
+  #
+  # A row with no resolvable path is kept in the list. There is nothing to
+  # check, and TrashStore.store/1 has nothing to move for it either.
+  @spec reject_files_still_on_disk([MediaFile.t()]) :: [MediaFile.t()]
+  defp reject_files_still_on_disk(candidates) do
+    Enum.reject(candidates, fn media_file ->
+      case MediaFile.absolute_path(media_file) do
+        nil ->
+          false
+
+        path ->
+          present? = File.exists?(path)
+
+          if present? do
+            Logger.warning(
+              "Re-scan called a file missing that is still on disk; refusing to trash it",
+              media_file_id: media_file.id,
+              path: path
+            )
+          end
+
+          present?
+      end
+    end)
+  end
+
   @doc """
   Restores a trashed media file: the file moves back to its library path and
   `trashed_at` is cleared.
@@ -1210,9 +1246,9 @@ defmodule Mydia.Library do
                 end)
 
               trashed_count =
-                Enum.count(missing_files, fn file ->
-                  match?({:ok, _}, trash_media_file(file))
-                end)
+                missing_files
+                |> reject_files_still_on_disk()
+                |> Enum.count(fn file -> match?({:ok, _}, trash_media_file(file)) end)
 
               Logger.info("Found new files during re-scan",
                 new_file_count: length(new_files),
@@ -1395,9 +1431,9 @@ defmodule Mydia.Library do
                 end)
 
               trashed_count =
-                Enum.count(missing_files, fn file ->
-                  match?({:ok, _}, trash_media_file(file))
-                end)
+                missing_files
+                |> reject_files_still_on_disk()
+                |> Enum.count(fn file -> match?({:ok, _}, trash_media_file(file)) end)
 
               Logger.info("Found new files for season during re-scan",
                 season: season_number,
@@ -1581,9 +1617,9 @@ defmodule Mydia.Library do
                 end)
 
               trashed_count =
-                Enum.count(missing_files, fn file ->
-                  match?({:ok, _}, trash_media_file(file))
-                end)
+                missing_files
+                |> reject_files_still_on_disk()
+                |> Enum.count(fn file -> match?({:ok, _}, trash_media_file(file)) end)
 
               Logger.info("Found new files during movie re-scan",
                 new_file_count: length(new_files),

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -1291,34 +1291,22 @@ defmodule Mydia.Library do
                  new_files: created_count,
                  deleted_files: trashed_count,
                  matched: matched_count,
-                 errors: create_errors
+                 errors: create_errors,
+                 scan_errors: scan_result.errors
                }}
 
             {:error, :not_found} ->
-              # Directory no longer exists — trash all files for the series
-              existing_files =
-                get_media_files_for_item(media_item_id,
-                  preload: [:library_path],
-                  include_extras: true
-                )
-
-              trashed_count =
-                Enum.count(existing_files, fn file ->
-                  match?({:ok, _}, trash_media_file(file))
-                end)
-
-              Logger.info("Series directory missing, trashed all files",
+              # A base directory that will not resolve is a failed scan, not
+              # proof the library is empty. This branch used to trash every
+              # file for the item, which physically moved the bytes of any
+              # file that was still there: an unmounted share or a renamed
+              # folder emptied the item (#653).
+              Logger.error("Re-scan base directory could not be read",
                 media_item_id: media_item_id,
-                trashed_files: trashed_count
+                directory: base_directory
               )
 
-              {:ok,
-               %{
-                 new_files: 0,
-                 deleted_files: trashed_count,
-                 matched: 0,
-                 errors: []
-               }}
+              {:error, :scan_failed}
 
             {:error, reason} ->
               Logger.error("Failed to scan directory",
@@ -1480,50 +1468,20 @@ defmodule Mydia.Library do
                  new_files: created_count,
                  deleted_files: trashed_count,
                  matched: matched_count,
-                 errors: create_errors
+                 errors: create_errors,
+                 scan_errors: scan_result.errors
                }}
 
             {:error, :not_found} ->
-              # Directory no longer exists — trash all season files
-              existing_files =
-                get_media_files_for_item(media_item_id,
-                  preload: [:library_path, :episode],
-                  include_extras: true
-                )
-
-              season_existing =
-                Enum.filter(existing_files, fn file ->
-                  cond do
-                    file.episode && file.episode.season_number == season_number ->
-                      true
-
-                    is_nil(file.episode) ->
-                      parsed = FileParser.parse(Path.basename(file.relative_path || ""))
-                      parsed.season == season_number
-
-                    true ->
-                      false
-                  end
-                end)
-
-              trashed_count =
-                Enum.count(season_existing, fn file ->
-                  match?({:ok, _}, trash_media_file(file))
-                end)
-
-              Logger.info("Season directory missing, trashed season files",
+              # See rescan_series/1: a directory that will not resolve is a
+              # failed scan, never a reason to trash the season's files (#653).
+              Logger.error("Season re-scan base directory could not be read",
                 media_item_id: media_item_id,
                 season: season_number,
-                trashed_files: trashed_count
+                directory: base_directory
               )
 
-              {:ok,
-               %{
-                 new_files: 0,
-                 deleted_files: trashed_count,
-                 matched: 0,
-                 errors: []
-               }}
+              {:error, :scan_failed}
 
             {:error, reason} ->
               Logger.error("Failed to scan directory for season",
@@ -1642,33 +1600,19 @@ defmodule Mydia.Library do
                %{
                  new_files: created_count,
                  deleted_files: trashed_count,
-                 errors: create_errors
+                 errors: create_errors,
+                 scan_errors: scan_result.errors
                }}
 
             {:error, :not_found} ->
-              # Directory no longer exists — trash all files for the movie
-              existing_files =
-                get_media_files_for_item(media_item_id,
-                  preload: [:library_path],
-                  include_extras: true
-                )
-
-              trashed_count =
-                Enum.count(existing_files, fn file ->
-                  match?({:ok, _}, trash_media_file(file))
-                end)
-
-              Logger.info("Movie directory missing, trashed all files",
+              # See rescan_series/1: a directory that will not resolve is a
+              # failed scan, never a reason to trash the movie's files (#653).
+              Logger.error("Movie re-scan base directory could not be read",
                 media_item_id: media_item_id,
-                trashed_files: trashed_count
+                directory: base_directory
               )
 
-              {:ok,
-               %{
-                 new_files: 0,
-                 deleted_files: trashed_count,
-                 errors: []
-               }}
+              {:error, :scan_failed}
 
             {:error, reason} ->
               Logger.error("Failed to scan directory",

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -1301,7 +1301,7 @@ defmodule Mydia.Library do
               # file for the item, which physically moved the bytes of any
               # file that was still there: an unmounted share or a renamed
               # folder emptied the item (#653).
-              Logger.error("Re-scan base directory could not be read",
+              Logger.error("Series re-scan base directory could not be read",
                 media_item_id: media_item_id,
                 directory: base_directory
               )

--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -306,6 +306,7 @@ defmodule Mydia.Library.MediaFile do
       name: :media_files_has_parent,
       message: "must belong to a media item or episode"
     )
+    |> guard_unique_active_path()
     |> foreign_key_constraint(:media_item_id)
     |> foreign_key_constraint(:episode_id)
     |> foreign_key_constraint(:quality_profile_id)
@@ -363,10 +364,35 @@ defmodule Mydia.Library.MediaFile do
       name: :media_files_has_parent,
       message: "must belong to a media item or episode"
     )
+    |> guard_unique_active_path()
     |> foreign_key_constraint(:media_item_id)
     |> foreign_key_constraint(:episode_id)
     |> foreign_key_constraint(:quality_profile_id)
     |> foreign_key_constraint(:library_path_id)
+  end
+
+  # Two names for one guarantee: on Postgres the constraint violation reports
+  # the real index name. SQLite's driver never gets an index name back from a
+  # partial-unique violation (just "UNIQUE constraint failed: <table>.<col>,
+  # <table>.<col>"), so ecto_sqlite3 guesses "<table>_<col>_<col>_index"
+  # instead, which happens to collide with the plain (non-unique,
+  # non-partial) index of that same conventional name created by
+  # add_import_scale_indexes. Declaring both lets either adapter's error
+  # resolve to the same changeset error. Kept as one shared function so the
+  # two names never drift out of sync between changeset/2 and
+  # scan_changeset/2.
+  defp guard_unique_active_path(changeset) do
+    changeset
+    |> unique_constraint([:library_path_id, :relative_path],
+      name: :media_files_active_library_path_relative_path_index,
+      error_key: :relative_path,
+      message: "already tracked at this library path"
+    )
+    |> unique_constraint([:library_path_id, :relative_path],
+      name: :media_files_library_path_id_relative_path_index,
+      error_key: :relative_path,
+      message: "already tracked at this library path"
+    )
   end
 
   # Ensure either media_item_id or episode_id is set, but not both

--- a/lib/mydia/library/structs/file_metadata.ex
+++ b/lib/mydia/library/structs/file_metadata.ex
@@ -23,6 +23,10 @@ defmodule Mydia.Library.Structs.FileMetadata do
 
   alias Mydia.Library.Structs.StreamInfo
 
+  # See StreamInfo: the file details modal encodes this struct directly.
+  # `streams` holds StreamInfo structs, which derive the protocol too.
+  @derive Jason.Encoder
+
   defstruct [
     # Core technical
     :duration,

--- a/lib/mydia/library/structs/stream_info.ex
+++ b/lib/mydia/library/structs/stream_info.ex
@@ -19,6 +19,10 @@ defmodule Mydia.Library.Structs.StreamInfo do
   names reach the Flutter player verbatim through GraphQL codegen.
   """
 
+  # The file details modal renders this as JSON. Without an encoder,
+  # Jason.encode!/2 raises Protocol.UndefinedError and takes the modal with it.
+  @derive Jason.Encoder
+
   defstruct [
     # common
     :index,

--- a/lib/mydia/library/trash_store.ex
+++ b/lib/mydia/library/trash_store.ex
@@ -94,18 +94,39 @@ defmodule Mydia.Library.TrashStore do
 
   Returns `{:error, reason}` when a file that is present could not be moved.
   The caller must not mark the row trashed in that case.
+
+  ## Options
+
+    * `:move` - defaults to `true`. With `move: false`, a present file is
+      never touched: `do_store/2` (the actual `File.rename/2`/`File.cp/2`)
+      is never called, and the function returns `{:error, :file_present}`
+      instead. An absent file still returns `{:ok, :missing}`, exactly as
+      with the default.
+
+      This exists for callers that only ever want to record a file as
+      missing, never move bytes - a re-scan's "this row's file is gone"
+      path, in particular. `Library.reject_files_still_on_disk/1` already
+      checks `File.exists?` before a re-scan calls this, but that check and
+      this one happen at different times; a file that reappears on disk in
+      between (a reconnecting mount, a concurrent import) must not be moved
+      into the trash out from under whatever put it there. `move: false`
+      makes that structurally impossible rather than merely unlikely: there
+      is no code path from "file present" to a move.
   """
-  @spec store(MediaFile.t()) :: {:ok, {:moved, String.t()} | :missing} | {:error, term()}
-  def store(%MediaFile{} = media_file) do
+  @spec store(MediaFile.t(), keyword()) ::
+          {:ok, {:moved, String.t()} | :missing} | {:error, term()}
+  def store(%MediaFile{} = media_file, opts \\ []) do
+    move? = Keyword.get(opts, :move, true)
+
     case MediaFile.absolute_path(media_file) do
       nil ->
         {:ok, :missing}
 
       source ->
-        if File.exists?(source) do
-          do_store(media_file, source)
-        else
-          {:ok, :missing}
+        cond do
+          not File.exists?(source) -> {:ok, :missing}
+          move? -> do_store(media_file, source)
+          true -> {:error, :file_present}
         end
     end
   end

--- a/lib/mydia/media/README.md
+++ b/lib/mydia/media/README.md
@@ -65,21 +65,34 @@ Fixtures for component tests should be real structs in production shape.
 
 `media_files_path_index` does not exist on master, on either adapter.
 `20251115185757_make_media_files_path_nullable.exs` dropped it deliberately when
-`path` became nullable. It was not lost in a SQLite table rebuild.
-
-Adding it back turns `test/mydia/jobs/media_import_test.exs` from 57 tests / 0
-failures into 57 / 2 on both adapters. `duplicate_media_file_scenario/1` (around
-line 1580) creates two `media_files` rows with the same `relative_path` in a
-`for _ <- 1..2` loop on purpose, and `media_file_fixture/1` derives `path` from
-`relative_path`, so both rows collide. Constructing that duplicate is the point
-of the test. The index also guards nothing in production, since `path` is nil
-everywhere.
+`path` became nullable. It was not lost in a SQLite table rebuild. The index
+would also guard nothing in production, since `path` is nil everywhere.
 
 If a `media_files` migration ever rebuilds the table on SQLite, recreate the
 other indexes and leave this one out. And when a test failure implicates a schema
 constraint, verify against an actual `origin/master` worktree. `git stash` cannot
 detect this, because stashing application code leaves the migration already
 applied to the test database.
+
+`20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs`
+added a real, narrower guarantee: a partial `unique_index(:media_files,
+[:library_path_id, :relative_path], where: "trashed_at IS NULL")`. Two active
+rows at one path are no longer constructible at all, through any changeset path
+(`MediaFile.changeset/2` and `scan_changeset/2` both call the shared
+`guard_unique_active_path/1`) -- not the `for _ <- 1..2` loop this section used
+to describe in `test/mydia/jobs/media_import_test.exs`, which built the same
+duplicate for `path`'s benefit and collided on the new index first once it
+landed. That helper is now `partial_import_error_scenario/1`, and it reaches a
+still-real partial-import failure (a squatted destination directory) instead.
+The new index is still partial, though: it does not compare two `NULL`
+`library_path_id` values equal, so a legacy orphaned row (see "media_files.path
+is nil on every row" above) can still collide with another one, and a trashed
+row can still share a path with a live one. `Mydia.Library.Prune.Eligibility`'s
+`:duplicate_registration` check and `Mydia.Jobs.ImportRun`'s
+`owned_path?/2` (via `list_media_files_by_relative_path/3`) exist for exactly
+those two residual cases -- see `eligibility_test.exs`'s
+`orphaned_duplicate_group/0` and `import_run_job_test.exs`'s "tolerates an
+active and a trashed row" test for how to construct them now.
 
 ## Every "does this item have files" query counts every media_file
 

--- a/lib/mydia_web/live/media_live/show/file_events.ex
+++ b/lib/mydia_web/live/media_live/show/file_events.ex
@@ -376,7 +376,11 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
     do: "Media file removed from library, file kept on disk"
 
   def show_file_details(%{"file-id" => file_id}, socket) do
-    file = Library.get_media_file!(file_id)
+    # Without the preload, MediaFile.absolute_path/1 hits its
+    # Ecto.Association.NotLoaded clause, logs a warning and returns nil, and
+    # display_path/1 falls back to the relative path. This modal is the one
+    # surface that is supposed to show the full path.
+    file = Library.get_media_file!(file_id, preload: [:library_path])
 
     {:noreply,
      socket

--- a/lib/mydia_web/live/media_live/show/file_events.ex
+++ b/lib/mydia_web/live/media_live/show/file_events.ex
@@ -769,6 +769,13 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
 
     parts = parts ++ ["refreshed metadata for #{refreshed} file(s)"]
 
+    scan_errors = Map.get(scan_result, :scan_errors, [])
+
+    parts =
+      if Enum.empty?(scan_errors),
+        do: parts,
+        else: parts ++ ["#{length(scan_errors)} file(s) could not be read"]
+
     parts =
       if Enum.empty?(scan_result.errors),
         do: parts,

--- a/priv/repo/README.md
+++ b/priv/repo/README.md
@@ -206,3 +206,31 @@ would have reached the screen.
 It survived because the ordering test gave every entry the same air date and
 exercised only the tiebreaks. A sort test whose fixtures share one date cannot
 catch this. Make the fixtures cross a month boundary.
+
+## ecto_sqlite3 guesses the wrong name on a partial unique index violation
+
+A `unique_constraint/3` keyed only to a partial index's real name silently
+never fires on SQLite: the insert raises `Exqlite.Error` instead of returning
+a changeset error, even though the identical code correctly returns
+`{:error, changeset}` on PostgreSQL.
+
+PostgreSQL's driver reports the actual index name in the constraint
+violation, so `unique_constraint(:field, name: :the_real_index_name)` matches
+it directly. SQLite's driver gets nothing back from a partial-unique
+violation beyond `UNIQUE constraint failed: <table>.<col>, ...`, so
+`ecto_sqlite3` falls back to guessing a name from Ecto's naming convention
+(`<table>_<col>_..._index`) — a name that a deliberately-named partial index
+never has.
+
+The fix is to declare the same `unique_constraint/3` twice: once under the
+index's real name (matches on PostgreSQL) and once under Ecto's conventional
+guess (matches on SQLite). Both point at the same underlying index, so
+exactly one of the two ever matches on a given adapter. Keep both
+declarations in one shared private function so the two names cannot drift
+apart when the index is renamed later.
+
+Two in-repo examples: `guard_unique_active_path/1` in
+`lib/mydia/library/media_file.ex` (the partial unique index on
+`(library_path_id, relative_path) WHERE trashed_at IS NULL`) and
+`guard_single_active_run/1` in `lib/mydia/library/import_run.ex` (the
+partial unique index enforcing one active import run per library path).

--- a/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
+++ b/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
@@ -1,0 +1,167 @@
+defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness do
+  use Ecto.Migration
+
+  require Logger
+
+  alias Mydia.Repo.Migrations.Helpers
+
+  # Nothing ever stopped two media_files rows describing one physical file.
+  # The original unique_index(:media_files, [:path]) went away when `path` was
+  # superseded and was deliberately not restored, and import_candidates got a
+  # unique index on (library_path_id, relative_path) while media_files never
+  # did. The re-scan then read the extra row as a file missing from disk and
+  # trashed it, which physically moved the bytes out of the library (#653).
+  #
+  # Rows are grouped by canonical absolute path rather than by the index
+  # columns, so two library paths over the same tree (a bind mount, a symlink,
+  # a trailing slash) fold together even though the index cannot express that.
+  #
+  # Losers are deleted outright rather than marked trashed.
+  # Library.purge_old_trashed_media_files/1 treats a trashed row carrying
+  # neither "trashed_path" nor "trashed_missing" in its metadata as legacy and
+  # deletes the file at its library path once retention expires, so soft
+  # trashing here would schedule the operator's real files for deletion 30
+  # days out. Deleting the row touches no bytes at all.
+
+  # Dependents of media_files, each with the columns its unique index carries
+  # alongside media_file_id. Moving a loser's dependent onto the winner
+  # collides where the winner already holds that key, so every UPDATE is
+  # guarded and whatever could not move is deleted with the loser.
+  #
+  # transcode_jobs is unique on (media_file_id, resolution) only WHERE
+  # type = 'download'. Guarding on (resolution, type) is stricter than the
+  # index, which at worst drops a non-download job that could have moved.
+  @dependents [
+    {"subtitles", ["subtitle_hash"]},
+    {"media_hashes", []},
+    {"subtitle_track_settings", ["track_ref"]},
+    {"transcode_jobs", ["resolution", "type"]},
+    {"media_segments", ["type"]},
+    {"media_file_match_candidates", ["rank"]}
+  ]
+
+  def up do
+    fold_duplicates()
+  end
+
+  # The fold is not reversible: the losing rows are gone. Rolling back only
+  # lifts the constraint.
+  def down, do: :ok
+
+  defp fold_duplicates do
+    %{rows: rows} =
+      repo().query!(
+        """
+        SELECT mf.id, lp.path, mf.relative_path, mf.inserted_at
+        FROM media_files mf
+        JOIN library_paths lp ON lp.id = mf.library_path_id
+        WHERE mf.trashed_at IS NULL AND mf.relative_path IS NOT NULL
+        """,
+        []
+      )
+
+    # A relative library root cannot be canonicalized without knowing the
+    # working directory the migration happened to run in, and folding on a
+    # guessed path would delete rows for files that are not actually the same
+    # file. Rows whose root is not absolute are excluded from folding
+    # entirely rather than trusted; nothing in
+    # lib/mydia/settings/library_path.ex enforces that library_paths.path is
+    # absolute, so this cannot be assumed away.
+    {foldable, skipped} =
+      Enum.split_with(rows, fn [_id, library_root, _relative_path, _inserted_at] ->
+        Path.type(library_root) == :absolute
+      end)
+
+    if skipped != [] do
+      Logger.warning(
+        "fold_duplicate_media_files_and_enforce_path_uniqueness: skipped #{length(skipped)} " <>
+          "media_files row(s) whose library_paths.path is not absolute; they were not " <>
+          "considered for duplicate folding"
+      )
+    end
+
+    foldable
+    |> Enum.group_by(fn [_id, library_root, relative_path, _inserted_at] ->
+      Path.expand(Path.join(library_root, relative_path))
+    end)
+    |> Enum.each(fn
+      {_canonical, [_only_one]} -> :ok
+      {_canonical, duplicates} -> fold_group(duplicates)
+    end)
+  end
+
+  defp fold_group(duplicates) do
+    [{winner_id, _, _} | losers] =
+      duplicates
+      |> Enum.map(fn [id, _library_root, _relative_path, inserted_at] ->
+        {id, dependent_count(id), to_string(inserted_at)}
+      end)
+      |> Enum.sort_by(fn {id, count, inserted_at} -> {-count, inserted_at, id} end)
+
+    Enum.each(losers, fn {loser_id, _count, _inserted_at} ->
+      Enum.each(@dependents, fn dependent -> repoint(dependent, loser_id, winner_id) end)
+
+      exec("""
+      UPDATE media_files SET supersedes_media_file_id = #{lit(winner_id)}
+      WHERE supersedes_media_file_id = #{lit(loser_id)}
+      """)
+
+      exec("DELETE FROM media_files WHERE id = #{lit(loser_id)}")
+    end)
+  end
+
+  # Total attached rows decide; oldest row wins a tie; id makes it total.
+  defp dependent_count(media_file_id) do
+    Enum.reduce(@dependents, 0, fn {table, _keys}, acc ->
+      %{rows: [[count]]} =
+        repo().query!(
+          "SELECT count(*) FROM #{table} WHERE media_file_id = #{lit(media_file_id)}",
+          []
+        )
+
+      acc + count
+    end)
+  end
+
+  # No unique key beyond media_file_id itself, so the winner either has a row
+  # or it does not.
+  defp repoint({table, []}, loser_id, winner_id) do
+    exec("""
+    UPDATE #{table} SET media_file_id = #{lit(winner_id)}
+    WHERE media_file_id = #{lit(loser_id)}
+      AND NOT EXISTS (
+        SELECT 1 FROM #{table} w WHERE w.media_file_id = #{lit(winner_id)}
+      )
+    """)
+
+    exec("DELETE FROM #{table} WHERE media_file_id = #{lit(loser_id)}")
+  end
+
+  defp repoint({table, keys}, loser_id, winner_id) do
+    # `w.k = t.k OR (w.k IS NULL AND t.k IS NULL)` rather than
+    # IS NOT DISTINCT FROM, which SQLite does not have. The update target is
+    # referenced by table name, not an alias, because UPDATE ... AS is not
+    # portable either.
+    conditions =
+      Enum.map_join(keys, " AND ", fn key ->
+        "(w.#{key} = #{table}.#{key} OR (w.#{key} IS NULL AND #{table}.#{key} IS NULL))"
+      end)
+
+    exec("""
+    UPDATE #{table} SET media_file_id = #{lit(winner_id)}
+    WHERE media_file_id = #{lit(loser_id)}
+      AND NOT EXISTS (
+        SELECT 1 FROM #{table} w
+        WHERE w.media_file_id = #{lit(winner_id)} AND #{conditions}
+      )
+    """)
+
+    exec("DELETE FROM #{table} WHERE media_file_id = #{lit(loser_id)}")
+  end
+
+  defp exec(query), do: repo().query!(query, [])
+
+  # SQLite binds with `?` and PostgreSQL with `$1`, so migrations here inline
+  # escaped literals instead. See Mydia.Repo.Migrations.Helpers.
+  defp lit(value), do: Helpers.to_db_value(value)
+end

--- a/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
+++ b/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
@@ -15,6 +15,10 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness 
   # Rows are grouped by canonical absolute path rather than by the index
   # columns, so two library paths over the same tree (a bind mount, a symlink,
   # a trailing slash) fold together even though the index cannot express that.
+  # Rows whose library root is not absolute cannot be canonicalized this way,
+  # so they get a second, narrower pass keyed on the literal
+  # (library_path_id, relative_path) pair instead, exactly what the index
+  # enforces. See fold_duplicates/0.
   #
   # Losers are deleted outright rather than marked trashed.
   # Library.purge_old_trashed_media_files/1 treats a trashed row carrying
@@ -42,17 +46,26 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness 
 
   def up do
     fold_duplicates()
+
+    create unique_index(:media_files, [:library_path_id, :relative_path],
+             where: "trashed_at IS NULL",
+             name: :media_files_active_library_path_relative_path_index
+           )
   end
 
   # The fold is not reversible: the losing rows are gone. Rolling back only
   # lifts the constraint.
-  def down, do: :ok
+  def down do
+    drop unique_index(:media_files, [:library_path_id, :relative_path],
+           name: :media_files_active_library_path_relative_path_index
+         )
+  end
 
   defp fold_duplicates do
     %{rows: rows} =
       repo().query!(
         """
-        SELECT mf.id, lp.path, mf.relative_path, mf.inserted_at
+        SELECT mf.id, mf.library_path_id, lp.path, mf.relative_path, mf.inserted_at
         FROM media_files mf
         JOIN library_paths lp ON lp.id = mf.library_path_id
         WHERE mf.trashed_at IS NULL AND mf.relative_path IS NOT NULL
@@ -63,37 +76,63 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness 
     # A relative library root cannot be canonicalized without knowing the
     # working directory the migration happened to run in, and folding on a
     # guessed path would delete rows for files that are not actually the same
-    # file. Rows whose root is not absolute are excluded from folding
-    # entirely rather than trusted; nothing in
-    # lib/mydia/settings/library_path.ex enforces that library_paths.path is
-    # absolute, so this cannot be assumed away.
+    # file. Rows whose root is not absolute are excluded from this canonical
+    # pass rather than trusted; nothing in lib/mydia/settings/library_path.ex
+    # enforces that library_paths.path is absolute, so this cannot be assumed
+    # away. They still go through fold_skipped/1 below.
     {foldable, skipped} =
-      Enum.split_with(rows, fn [_id, library_root, _relative_path, _inserted_at] ->
-        Path.type(library_root) == :absolute
+      Enum.split_with(rows, fn
+        [_id, _library_path_id, library_root, _relative_path, _inserted_at] ->
+          Path.type(library_root) == :absolute
       end)
 
     if skipped != [] do
       Logger.warning(
-        "fold_duplicate_media_files_and_enforce_path_uniqueness: skipped #{length(skipped)} " <>
-          "media_files row(s) whose library_paths.path is not absolute; they were not " <>
-          "considered for duplicate folding"
+        "fold_duplicate_media_files_and_enforce_path_uniqueness: #{length(skipped)} " <>
+          "media_files row(s) have a library_paths.path that is not absolute; they were " <>
+          "folded on the literal (library_path_id, relative_path) pair only, not the " <>
+          "canonicalized path"
       )
     end
 
     foldable
-    |> Enum.group_by(fn [_id, library_root, relative_path, _inserted_at] ->
+    |> Enum.group_by(fn [_id, _library_path_id, library_root, relative_path, _inserted_at] ->
       Path.expand(Path.join(library_root, relative_path))
     end)
-    |> Enum.each(fn
-      {_canonical, [_only_one]} -> :ok
-      {_canonical, duplicates} -> fold_group(duplicates)
+    |> fold_groups()
+
+    fold_skipped(skipped)
+  end
+
+  # The unique index this migration creates is keyed on the literal
+  # (library_path_id, relative_path) pair, not a canonicalized path. Rows
+  # that fold_duplicates/0 could not canonicalize never went through that
+  # fold, so two of them can still share the literal pair and would make the
+  # index impossible to create. The pair is unambiguous no matter whether the
+  # library root is absolute, so it is safe to fold on directly here. The
+  # join and WHERE clause in fold_duplicates/0 already guarantee every row
+  # reaching this function has a non-nil library_path_id and relative_path.
+  defp fold_skipped(skipped) do
+    skipped
+    |> Enum.group_by(fn [_id, library_path_id, _library_root, relative_path, _inserted_at] ->
+      {library_path_id, relative_path}
+    end)
+    |> fold_groups()
+  end
+
+  defp fold_groups(groups) do
+    Enum.each(groups, fn
+      {_key, [_only_one]} -> :ok
+      {_key, duplicates} -> fold_group(duplicates)
     end)
   end
 
   defp fold_group(duplicates) do
     [{winner_id, _, _} | losers] =
       duplicates
-      |> Enum.map(fn [id, _library_root, _relative_path, inserted_at] ->
+      |> Enum.map(fn row ->
+        id = List.first(row)
+        inserted_at = List.last(row)
         {id, dependent_count(id), to_string(inserted_at)}
       end)
       |> Enum.sort_by(fn {id, count, inserted_at} -> {-count, inserted_at, id} end)

--- a/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
+++ b/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
@@ -140,9 +140,26 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness 
     Enum.each(losers, fn {loser_id, _count, _inserted_at} ->
       Enum.each(@dependents, fn dependent -> repoint(dependent, loser_id, winner_id) end)
 
+      # Excludes the winner itself. Without the guard, a winner whose own
+      # supersedes_media_file_id already pointed at the loser it is absorbing
+      # would be repointed onto its own id. Upgrades.superseded_file/1 does a
+      # plain Repo.get(MediaFile, id) on that pointer and returns whatever
+      # untrashed row comes back with no self-reference check, so
+      # finalize_comparison/2 would compare the winner against itself and the
+      # upgrade branch could then trash the very file it just decided to
+      # keep. The winner's own pointer is cleared instead, in the second
+      # statement below, which is what Upgrades.superseded_file/1 already
+      # treats as "nothing to compare against" (the :orphaned outcome).
       exec("""
       UPDATE media_files SET supersedes_media_file_id = #{lit(winner_id)}
       WHERE supersedes_media_file_id = #{lit(loser_id)}
+        AND id <> #{lit(winner_id)}
+      """)
+
+      exec("""
+      UPDATE media_files SET supersedes_media_file_id = NULL
+      WHERE id = #{lit(winner_id)}
+        AND supersedes_media_file_id = #{lit(loser_id)}
       """)
 
       exec("DELETE FROM media_files WHERE id = #{lit(loser_id)}")

--- a/test/mydia/jobs/import_run_job_test.exs
+++ b/test/mydia/jobs/import_run_job_test.exs
@@ -144,7 +144,7 @@ defmodule Mydia.Jobs.ImportRunJobTest do
       assert Library.get_import_run(run.id).files_discovered == 2
     end
 
-    test "tolerates duplicate parented rows for one path without crashing, and still skips it",
+    test "tolerates an active and a trashed row sharing one path without crashing, and skips it",
          %{run: run, library_path: lp} do
       # The data anomaly that used to strand a run: two builds of the scanner
       # (or a scanner racing the import coordinator) created two rows for the
@@ -153,19 +153,42 @@ defmodule Mydia.Jobs.ImportRunJobTest do
       # retries, leaving the run row :running forever -- this is why phase 1
       # checks ownership with the duplicate-safe
       # `list_media_files_by_relative_path/3` instead.
+      #
+      # Two ACTIVE rows for one path are no longer reachable this way:
+      # migration 20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness
+      # added a partial unique index on (library_path_id, relative_path)
+      # scoped `WHERE trashed_at IS NULL`, and `Library.create_media_file/1`
+      # now refuses the second insert. The index does not reach a trashed
+      # row, though, so a live row and a trashed row can still share a path
+      # -- a file gets trashed, then the same path is re-imported or
+      # rediscovered -- and `owned_path?/2` in import_run.ex deliberately
+      # queries `list_media_files_by_relative_path/3` with
+      # `include_trashed: true` to see both. That is what still exercises
+      # the duplicate-safe read this test guards.
       relative_path = "Season 01/Bluey.S01E01.mkv"
       show = media_item_fixture(%{type: "tv_show"})
       episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
 
-      for _ <- 1..2 do
-        {:ok, _} =
-          Library.create_media_file(%{
-            library_path_id: lp.id,
-            relative_path: relative_path,
-            episode_id: episode.id,
-            size: 1_000
-          })
-      end
+      {:ok, trashed} =
+        Library.create_media_file(%{
+          library_path_id: lp.id,
+          relative_path: relative_path,
+          episode_id: episode.id,
+          size: 1_000
+        })
+
+      {:ok, _trashed} =
+        trashed
+        |> Ecto.Changeset.change(trashed_at: DateTime.utc_now() |> DateTime.truncate(:second))
+        |> Repo.update()
+
+      {:ok, _active} =
+        Library.create_media_file(%{
+          library_path_id: lp.id,
+          relative_path: relative_path,
+          episode_id: episode.id,
+          size: 1_000
+        })
 
       assert :ok = ImportRunJob.run_scan_phase(Library.get_import_run(run.id))
 

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -1533,9 +1533,8 @@ defmodule Mydia.Jobs.MediaImportTest do
       # Regression for the production incident where season-pack imports
       # failed with only the generic "Some files could not be imported. Check
       # library path permissions and available disk space." while the real
-      # cause was duplicate media_files rows making Repo.one/1 raise
-      # "expected at most one result" on the reuse-existing-file path.
-      {download, download_dir} = duplicate_media_file_scenario(tmp_dir)
+      # cause was a per-file error being swallowed into that generic hint.
+      {download, download_dir} = partial_import_error_scenario(tmp_dir)
 
       assert {:error, _reason} =
                perform_job(MediaImport, %{
@@ -1551,7 +1550,7 @@ defmodule Mydia.Jobs.MediaImportTest do
       # ...but the human message must name the real underlying error, not
       # just the generic permissions/disk-space hint.
       assert updated.import_last_error =~ "Some files could not be imported"
-      assert updated.import_last_error =~ "First error: expected at most one result"
+      assert updated.import_last_error =~ "First error: {:destination_not_accessible"
       refute updated.import_last_error =~ "Check library path permissions"
     end
 
@@ -1563,7 +1562,7 @@ defmodule Mydia.Jobs.MediaImportTest do
       # must match the tuple too — otherwise an unfixable partial import falls
       # through to the catch-all, never cancels, and re-walks the whole
       # download for all 1000 of Oban's attempts.
-      {download, download_dir} = duplicate_media_file_scenario(tmp_dir)
+      {download, download_dir} = partial_import_error_scenario(tmp_dir)
 
       assert {:cancel, {:partial_import, _reason}} =
                perform_job(
@@ -1573,43 +1572,48 @@ defmodule Mydia.Jobs.MediaImportTest do
                )
     end
 
-    # Builds the production shape: a two-episode season pack where S01E01's
-    # destination already exists and carries TWO media_files rows for the same
-    # (library_path_id, relative_path), so the reuse-existing-file path raises
-    # while S01E02 imports cleanly — i.e. a genuine partial import.
-    defp duplicate_media_file_scenario(tmp_dir) do
+    # Builds a genuine partial import: a two-episode pack spanning two seasons
+    # where season 1's destination directory is squatted by a plain file, so
+    # `File.mkdir_p/1` fails with :enotdir when the importer tries to create
+    # it, while season 2 is left clear. One file imports cleanly and the
+    # other fails with a real filesystem error.
+    #
+    # This used to build the same shape by giving one path two live
+    # media_files rows, so the reuse-existing-file lookup raised
+    # `Ecto.MultipleResultsError`. Migration
+    # 20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness
+    # folds any such duplicates and adds a partial unique index on
+    # (library_path_id, relative_path) for active rows, and every insert now
+    # goes through a changeset that enforces it, so two live rows sharing a
+    # path can no longer be constructed at all — not even directly through
+    # `media_file_fixture/1`, which now fails on the second call. The
+    # behavior these two tests guard (a per-file failure inside a partial
+    # import surfaces its real reason, and the tagged `{:partial_import,
+    # reason}` is still treated as terminal) does not depend on *how* the
+    # per-file failure happens, so a filesystem error stands in for the
+    # now-unreachable duplicate-row crash.
+    defp partial_import_error_scenario(tmp_dir) do
       library_path = create_test_library_path(tmp_dir, :series, auto_rename: false)
 
       download_dir = Path.join(tmp_dir, "downloads")
       File.mkdir_p!(download_dir)
 
       File.write!(Path.join(download_dir, "Mystery.Show.S01E01.mkv"), "fake video 1")
-      File.write!(Path.join(download_dir, "Mystery.Show.S01E02.mkv"), "fake video 2")
+      File.write!(Path.join(download_dir, "Mystery.Show.S02E01.mkv"), "fake video 2")
 
       media_item = media_item_fixture(%{type: "tv_show", title: "Mystery Show"})
 
-      ep_s1e1 =
+      _ep_s1e1 =
         episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 1})
 
-      _ep_s1e2 =
-        episode_fixture(%{media_item_id: media_item.id, season_number: 1, episode_number: 2})
+      _ep_s2e1 =
+        episode_fixture(%{media_item_id: media_item.id, season_number: 2, episode_number: 1})
 
-      dest_dir =
-        Path.join(MediaImport.build_series_base_path(media_item, library_path), "Season 01")
-
-      File.mkdir_p!(dest_dir)
-      dest_file = Path.join(dest_dir, "Mystery.Show.S01E01.mkv")
-      File.write!(dest_file, "existing video")
-      relative_path = Path.relative_to(dest_file, library_path.path)
-
-      existing_files =
-        for _ <- 1..2 do
-          media_file_fixture(%{
-            library_path_id: library_path.id,
-            episode_id: ep_s1e1.id,
-            relative_path: relative_path
-          })
-        end
+      base_dir = MediaImport.build_series_base_path(media_item, library_path)
+      File.mkdir_p!(base_dir)
+      # Squat season 1's destination directory with a plain file so the
+      # importer's `File.mkdir_p/1` fails with :enotdir. Season 2 stays free.
+      File.write!(Path.join(base_dir, "Season 01"), "not a directory")
 
       {:ok, _} =
         Settings.create_download_client_config(%{
@@ -1633,12 +1637,7 @@ defmodule Mydia.Jobs.MediaImportTest do
           metadata: %{
             "season_pack" => true,
             "season_number" => 1,
-            # Marked as an upgrade so the already-filed-episode skip does not
-            # intercept this file. Upgrades are exempt from that skip by design,
-            # since they target episodes that already have files, which makes
-            # this the path where a duplicate-row Repo.one crash is still
-            # reachable and therefore still worth surfacing properly.
-            "upgrade_target_media_file_id" => hd(existing_files).id
+            "episode_count" => 2
           }
         })
 

--- a/test/mydia/jobs/media_import_test.exs
+++ b/test/mydia/jobs/media_import_test.exs
@@ -1717,6 +1717,109 @@ defmodule Mydia.Jobs.MediaImportTest do
     end
   end
 
+  describe "duplicate active path race" do
+    @tag :tmp_dir
+    test "adopts the row that already occupies the destination instead of failing the import",
+         %{tmp_dir: tmp_dir} do
+      # Migration 20260901234336 added a partial unique index on
+      # (library_path_id, relative_path) WHERE trashed_at IS NULL, so a
+      # concurrent insert that lands on a path this job also resolves to now
+      # surfaces as a changeset error instead of silently creating a second
+      # row. duplicate_active_path_error?/1 and adopt_duplicate_active_path/3
+      # catch that specific violation and adopt the row that won the race —
+      # nothing exercised that path before this test.
+      #
+      # auto_rename: false pins the destination filename to the source
+      # filename, so the exact (library_path_id, relative_path) pair this
+      # import will hit is known up front and can be pre-occupied by another
+      # row.
+      library_path = create_test_library_path(tmp_dir, :movies, auto_rename: false)
+
+      download_dir = Path.join(tmp_dir, "downloads")
+      File.mkdir_p!(download_dir)
+      source_name = "Umbra.Vale.2015.1080p.BluRay.x264-FICTION.mkv"
+      File.write!(Path.join(download_dir, source_name), "the freshly downloaded copy")
+
+      media_item = media_item_fixture(%{type: "movie", title: "Umbra Vale", year: 2015})
+
+      relative_path = "Umbra Vale (2015)/#{source_name}"
+      dest_path = Path.join(library_path.path, relative_path)
+
+      # Pre-existing active row at the exact (library_path_id, relative_path)
+      # pair the import will resolve to — standing in for the row a
+      # concurrent import already committed. Its physical file is
+      # deliberately never written, which is what forces the code past the
+      # `File.exists?(dest_path)` reuse branch in
+      # import_file_to_existing_dir/6 (media_import.ex:1478) — that earlier
+      # branch would short-circuit the whole test if the file existed,
+      # without ever reaching create_media_file_record/5's insert.
+      existing =
+        media_file_fixture(%{
+          library_path_id: library_path.id,
+          media_item_id: media_item.id,
+          relative_path: relative_path
+        })
+
+      refute File.exists?(dest_path),
+             "setup must leave the destination unwritten so the import reaches the insert " <>
+               "instead of the earlier File.exists? reuse branch"
+
+      {:ok, _} =
+        Settings.create_download_client_config(%{
+          name: "RaceClient",
+          type: :qbittorrent,
+          host: "nonexistent.invalid",
+          port: 9999,
+          username: "test",
+          password: "test",
+          enabled: true,
+          priority: 1
+        })
+
+      download =
+        download_fixture(%{
+          media_item_id: media_item.id,
+          status: "completed",
+          completed_at: DateTime.utc_now(),
+          download_client: "RaceClient",
+          download_client_id: "race-1"
+        })
+
+      args = %{"download_id" => download.id, "save_path" => download_dir}
+
+      # The pre-existing row above is active (trashed_at nil), so the partial
+      # unique index unconditionally rejects any insert at this
+      # (library_path_id, relative_path) pair — this is not a race that
+      # might not fire, it fires every time. The only way perform_job/1 can
+      # return {:ok, :imported} here rather than crash the job (a raised
+      # Exqlite/Postgrex error, if the changeset's unique_constraint names
+      # did not match the driver's reported constraint) or return an
+      # {:error, ...} tuple (a mismatch caught by duplicate_active_path_error?/1
+      # that fell through to the generic :database_error branch) is for
+      # duplicate_active_path_error?/1 to recognize the violation and
+      # adopt_duplicate_active_path/3 to look up and return the row that was
+      # already there. There is no other branch in create_media_file_record/5
+      # that produces this outcome.
+      assert {:ok, :imported} = perform_job(MediaImport, args)
+
+      assert File.exists?(dest_path),
+             "the file placement that races the insert must still have happened"
+
+      rows =
+        Repo.all(
+          from(f in Library.MediaFile,
+            where: f.library_path_id == ^library_path.id and f.relative_path == ^relative_path
+          )
+        )
+
+      assert [%{id: id}] = rows,
+             "the unique index must prevent a second row from ever existing at this path"
+
+      assert id == existing.id,
+             "the surviving row must be the one that already existed, not a fresh insert"
+    end
+  end
+
   describe "download client removed from configuration" do
     # A download whose `download_client` no longer resolves to any configured
     # client cannot self-heal: every retry re-reads the same config and gets the

--- a/test/mydia/library/media_file_uniqueness_test.exs
+++ b/test/mydia/library/media_file_uniqueness_test.exs
@@ -1,0 +1,42 @@
+defmodule Mydia.Library.MediaFileUniquenessTest do
+  use Mydia.DataCase
+
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library
+  alias Mydia.MediaFixtures
+
+  test "a second active row at the same path is a changeset error, not an exception" do
+    library_path = library_path_fixture(%{type: "movies"})
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+    attrs = %{
+      relative_path: "Pale Orchard (2018)/Pale.Orchard.2018.1080p.mkv",
+      library_path_id: library_path.id,
+      media_item_id: movie.id,
+      size: 1024
+    }
+
+    assert {:ok, _} = Library.create_media_file(attrs)
+    assert {:error, changeset} = Library.create_media_file(attrs)
+
+    assert %{relative_path: ["already tracked at this library path"]} = errors_on(changeset)
+  end
+
+  test "a trashed row does not block a new active row at the same path" do
+    library_path = library_path_fixture(%{type: "movies"})
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+    attrs = %{
+      relative_path: "Harrow Bay (2011)/Harrow.Bay.2011.1080p.mkv",
+      library_path_id: library_path.id,
+      media_item_id: movie.id,
+      size: 1024
+    }
+
+    {:ok, first} = Library.create_media_file(attrs)
+    {:ok, _trashed} = Library.trash_media_file(first)
+
+    assert {:ok, _second} = Library.create_media_file(attrs)
+  end
+end

--- a/test/mydia/library/prune/eligibility_test.exs
+++ b/test/mydia/library/prune/eligibility_test.exs
@@ -31,16 +31,66 @@ defmodule Mydia.Library.Prune.EligibilityTest do
 
   defp duration(seconds), do: %{"container" => "mkv", "duration" => seconds}
 
+  # Builds a group with two rows sharing the same (library_path_id,
+  # relative_path) key. Two ACTIVE rows genuinely at the same library path
+  # and relative path are no longer reachable: migration
+  # 20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness
+  # added a partial unique index on (library_path_id, relative_path) scoped
+  # `WHERE trashed_at IS NULL`, and every insert goes through a changeset
+  # that enforces it (confirmed nothing in lib/ bypasses it with a raw
+  # insert) -- `media_file_fixture/1` itself now fails on the second call
+  # for a duplicate active path.
+  #
+  # The index does not reach a row with a nil library_path_id, though, and
+  # `populate_media_file_relative_paths` leaves a file sitting outside every
+  # configured library path with both `relative_path` and `library_path_id`
+  # nil (see lib/mydia/media/README.md, "media_files.path is nil on every
+  # row") rather than clearing it. Two such orphaned rows attached to the
+  # same subject collide on that shared `{nil, nil}` key at the Elixir
+  # equality this check uses, even though SQL uniqueness never compares two
+  # NULLs equal -- so `:duplicate_registration` still guards a real state,
+  # just this narrower one now. Bypass the changeset with `Repo.update_all/2`
+  # (`validate_required([:relative_path, :library_path_id])` would otherwise
+  # refuse to create the row at all) to reach it, the same way
+  # `backdate_media_file/2` bypasses the changeset for `inserted_at`.
+  defp orphaned_duplicate_group do
+    movie = media_item_fixture(%{type: "movie", title: "Muppets Most Wanted", year: 2014})
+    lp = library_path_fixture(%{type: "movies"})
+
+    files =
+      for path <- ["Muppets/Muppets.1.mkv", "Muppets/Muppets.2.mkv"] do
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: path,
+          metadata: duration(6000.0)
+        })
+      end
+
+    ids = Enum.map(files, & &1.id)
+
+    Mydia.Repo.update_all(
+      from(f in Mydia.Library.MediaFile, where: f.id in ^ids),
+      set: [library_path_id: nil, relative_path: nil]
+    )
+
+    files = Enum.map(files, &Mydia.Repo.reload!/1)
+
+    %Group{
+      subject_type: :movie,
+      subject_id: movie.id,
+      subject: movie,
+      media_item: Mydia.Repo.preload(movie, :episodes),
+      files: Mydia.Repo.preload(files, :library_path)
+    }
+  end
+
   describe "check/1 duplicate registration" do
-    test "refuses two rows sharing library_path_id and relative_path" do
-      group =
-        movie_group([
-          %{relative_path: "Muppets/Muppets.mkv", metadata: duration(6000.0)},
-          %{relative_path: "Muppets/Muppets.mkv", metadata: duration(6000.0)}
-        ])
+    test "refuses two orphaned rows sharing a nil library_path_id and relative_path" do
+      group = orphaned_duplicate_group()
 
       assert {:refused, :duplicate_registration, detail} = Eligibility.check(group)
-      assert detail.path == "Muppets/Muppets.mkv"
+      assert detail.path == nil
     end
   end
 
@@ -128,11 +178,7 @@ defmodule Mydia.Library.Prune.EligibilityTest do
     test "reports duplicate_registration ahead of duration agreement" do
       # Identical rows trivially agree on duration. The scanner bug is the
       # more actionable reason, so it must win.
-      group =
-        movie_group([
-          %{relative_path: "same.mkv", metadata: duration(6000.0)},
-          %{relative_path: "same.mkv", metadata: duration(6000.0)}
-        ])
+      group = orphaned_duplicate_group()
 
       assert {:refused, :duplicate_registration, _} = Eligibility.check(group)
     end

--- a/test/mydia/library/rescan_scan_failure_test.exs
+++ b/test/mydia/library/rescan_scan_failure_test.exs
@@ -1,0 +1,90 @@
+defmodule Mydia.Library.RescanScanFailureTest do
+  use Mydia.DataCase
+
+  import Ecto.Query, only: [from: 2]
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library
+  alias Mydia.Library.MediaFile
+  alias Mydia.MediaFixtures
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "mydia_rescan_failure_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    %{tmp: tmp, library_path: library_path_fixture(%{path: tmp, type: "movies"})}
+  end
+
+  defp add_file(tmp, lib, movie, relative_path) do
+    absolute = Path.join(tmp, relative_path)
+    File.mkdir_p!(Path.dirname(absolute))
+    contents = "contents of #{relative_path}"
+    File.write!(absolute, contents)
+
+    {:ok, media_file} =
+      Library.create_media_file(%{
+        relative_path: relative_path,
+        library_path_id: lib.id,
+        media_item_id: movie.id,
+        size: byte_size(contents)
+      })
+
+    media_file
+  end
+
+  defp active_count(movie) do
+    Repo.one(
+      from(f in MediaFile,
+        where: f.media_item_id == ^movie.id and is_nil(f.trashed_at),
+        select: count(f.id)
+      )
+    )
+  end
+
+  test "a base directory that no longer exists fails instead of emptying the item", %{
+    tmp: tmp,
+    library_path: lib
+  } do
+    # A renamed folder, or an unmounted share, used to reach the
+    # {:error, :not_found} branch, which trashed every row for the item and
+    # physically moved whichever files were still readable: #653.
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+    add_file(tmp, lib, movie, "Harrow Bay (2011)/Harrow.Bay.2011.1080p.mkv")
+    add_file(tmp, lib, movie, "Harrow Bay (2011)/Harrow.Bay.2011.2160p.mkv")
+
+    File.rename!(Path.join(tmp, "Harrow Bay (2011)"), Path.join(tmp, "Harrow Bay (2011) renamed"))
+
+    assert {:error, :scan_failed} = Library.rescan_movie(movie.id)
+
+    assert active_count(movie) == 2
+
+    assert File.exists?(Path.join(tmp, "Harrow Bay (2011) renamed/Harrow.Bay.2011.1080p.mkv"))
+  end
+
+  test "entries the scanner cannot read are reported rather than swallowed", %{
+    tmp: tmp,
+    library_path: lib
+  } do
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+    add_file(tmp, lib, movie, "Pale Orchard (2018)/Pale.Orchard.2018.1080p.mkv")
+
+    # A dangling symlink makes Scanner.process_entry/6 record a
+    # :symlink_resolution_error. The re-scan used to drop scan_result.errors on
+    # the floor and report a clean sweep.
+    File.ln_s!(
+      "/nonexistent/Pale.Orchard.2018.2160p.mkv",
+      Path.join(tmp, "Pale Orchard (2018)/Pale.Orchard.2018.2160p.mkv")
+    )
+
+    assert {:ok, result} = Library.rescan_movie(movie.id)
+
+    assert result.deleted_files == 0
+    assert [%{type: :symlink_resolution_error}] = result.scan_errors
+    assert active_count(movie) == 1
+  end
+end

--- a/test/mydia/library/rescan_trash_guard_test.exs
+++ b/test/mydia/library/rescan_trash_guard_test.exs
@@ -1,0 +1,95 @@
+defmodule Mydia.Library.RescanTrashGuardTest do
+  use Mydia.DataCase
+
+  import Ecto.Query, only: [from: 2]
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library
+  alias Mydia.Library.MediaFile
+  alias Mydia.MediaFixtures
+
+  setup do
+    tmp =
+      Path.join(System.tmp_dir!(), "mydia_rescan_guard_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(tmp)
+    on_exit(fn -> File.rm_rf(tmp) end)
+
+    %{tmp: tmp, library_path: library_path_fixture(%{path: tmp, type: "movies"})}
+  end
+
+  defp add_file(tmp, lib, movie, relative_path) do
+    absolute = Path.join(tmp, relative_path)
+    File.mkdir_p!(Path.dirname(absolute))
+    contents = "contents of #{relative_path}"
+    File.write!(absolute, contents)
+
+    {:ok, media_file} =
+      Library.create_media_file(%{
+        relative_path: relative_path,
+        library_path_id: lib.id,
+        media_item_id: movie.id,
+        size: byte_size(contents)
+      })
+
+    media_file
+  end
+
+  defp active_count(movie) do
+    Repo.one(
+      from(f in MediaFile,
+        where: f.media_item_id == ^movie.id and is_nil(f.trashed_at),
+        select: count(f.id)
+      )
+    )
+  end
+
+  test "does not trash a row whose file is on disk outside the scanned directory", %{
+    tmp: tmp,
+    library_path: lib
+  } do
+    # The re-scan picks one base directory by voting on Path.dirname across
+    # the item's rows, so the two rows under "Silver Harbour (2019)" win and
+    # the third directory is never scanned. Before the guard, that third row
+    # was classified missing and TrashStore moved its bytes out of the
+    # library: #653.
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+    relative_paths = [
+      "Silver Harbour (2019)/Silver.Harbour.2019.1080p.mkv",
+      "Silver Harbour (2019)/Silver.Harbour.2019.2160p.mkv",
+      "Silver Harbour (2019) [dupe]/Silver.Harbour.2019.1080p.mkv"
+    ]
+
+    for relative_path <- relative_paths, do: add_file(tmp, lib, movie, relative_path)
+
+    assert {:ok, result} = Library.rescan_movie(movie.id)
+    assert result.deleted_files == 0
+
+    for relative_path <- relative_paths do
+      assert File.exists?(Path.join(tmp, relative_path)),
+             "#{relative_path} was moved off disk by the re-scan"
+    end
+
+    assert active_count(movie) == 3
+  end
+
+  test "still trashes a row whose file is genuinely gone", %{tmp: tmp, library_path: lib} do
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+
+    kept = "Cinder Lantern (2014)/Cinder.Lantern.2014.1080p.mkv"
+    removed = "Cinder Lantern (2014)/Cinder.Lantern.2014.720p.mkv"
+
+    add_file(tmp, lib, movie, kept)
+    removed_file = add_file(tmp, lib, movie, removed)
+
+    File.rm!(Path.join(tmp, removed))
+
+    assert {:ok, result} = Library.rescan_movie(movie.id)
+    assert result.deleted_files == 1
+
+    assert Repo.reload!(removed_file).trashed_at
+    assert active_count(movie) == 1
+    assert File.exists?(Path.join(tmp, kept))
+  end
+end

--- a/test/mydia/library/rescan_trash_guard_test.exs
+++ b/test/mydia/library/rescan_trash_guard_test.exs
@@ -74,6 +74,31 @@ defmodule Mydia.Library.RescanTrashGuardTest do
     assert active_count(movie) == 3
   end
 
+  test "leaves the row active and the bytes in place when the file reappears after the guard checked",
+       %{tmp: tmp, library_path: lib} do
+    # reject_files_still_on_disk/1's File.exists? check and the trash call
+    # that follows it happen at different times. A file that reappears in
+    # that gap - a reconnecting mount, a concurrent import restoring it -
+    # must not be moved. The three re-scan sites now call
+    # Library.trash_media_file/2 with `move: false`, which is what actually
+    # closes the window: TrashStore.store/2 refuses to move a present file
+    # no matter what an earlier check saw. This calls that same function the
+    # same way the re-scan sites do, directly on a file that is on disk, to
+    # prove the backstop holds even when a row reaches it despite being
+    # present.
+    movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+    relative_path = "Hollow Vale (2016)/Hollow.Vale.2016.1080p.mkv"
+    media_file = add_file(tmp, lib, movie, relative_path)
+    absolute = Path.join(tmp, relative_path)
+
+    assert {:error, _reason} = Library.trash_media_file(media_file, move: false)
+
+    assert File.exists?(absolute)
+    assert File.read!(absolute) == "contents of #{relative_path}"
+    assert is_nil(Repo.reload!(media_file).trashed_at)
+    assert active_count(movie) == 1
+  end
+
   test "still trashes a row whose file is genuinely gone", %{tmp: tmp, library_path: lib} do
     movie = MediaFixtures.media_item_fixture(%{type: "movie"})
 

--- a/test/mydia/library/trash_store_test.exs
+++ b/test/mydia/library/trash_store_test.exs
@@ -99,6 +99,33 @@ defmodule Mydia.Library.TrashStoreTest do
     end
   end
 
+  # CodeRabbit finding: reject_files_still_on_disk/1 and this module's own
+  # File.exists?/1 check happen at different times, leaving a window where a
+  # file that reappears between them (a reconnecting mount, a concurrent
+  # import) still gets moved into the trash. `move: false` closes that
+  # structurally: it is the one option that guarantees do_store/2 - the only
+  # function in this module that calls File.rename/2 or File.cp/2 - is never
+  # reached for a file that is present.
+  describe "store/2 with move: false" do
+    @tag :tmp_dir
+    test "refuses and does not move a file that is present", %{tmp_dir: tmp_dir} do
+      {_root, media_file, path} = library_with_file(tmp_dir)
+
+      assert TrashStore.store(media_file, move: false) == {:error, :file_present}
+
+      assert File.exists?(path)
+      assert File.read!(path) == "video bytes"
+    end
+
+    @tag :tmp_dir
+    test "still reports a genuinely missing file as :missing", %{tmp_dir: tmp_dir} do
+      {_root, media_file, path} = library_with_file(tmp_dir)
+      File.rm!(path)
+
+      assert TrashStore.store(media_file, move: false) == {:ok, :missing}
+    end
+  end
+
   # The end-to-end cross-filesystem move needs a second filesystem, but the
   # contract that matters is in this one two-argument function: it is the only
   # place in the trash path that can delete the copy that just succeeded.

--- a/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
+++ b/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
@@ -132,6 +132,71 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesTest do
   end
 
   @tag :tmp_dir
+  test "folds a three-way duplicate group onto the strictly richest row" do
+    build_pre_migration_schema()
+
+    seed_library_path("lib-plain", "/media/movies")
+    seed_media_item("item-1")
+
+    # Three active rows at one path. Dependent counts are made strictly
+    # decreasing (winner 4, loser1 2, loser2 1) so the winner is unambiguous
+    # from the primary "most dependents" signal alone and the outcome never
+    # rests on the {inserted_at, id} tiebreak.
+    seed_media_file("winner", "lib-plain", "Marrow Hollow (2015)/Marrow.Hollow.mkv", "item-1")
+    seed_media_file("loser1", "lib-plain", "Marrow Hollow (2015)/Marrow.Hollow.mkv", "item-1")
+    seed_media_file("loser2", "lib-plain", "Marrow Hollow (2015)/Marrow.Hollow.mkv", "item-1")
+
+    # winner: 4 dependents (1 media_hashes + 2 subtitles + 1 subtitle_track_settings)
+    sql!("INSERT INTO media_hashes (media_file_id, opensubtitles_hash) VALUES ('winner', 'aaa')")
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s-w1', 'winner', 'h1')"
+    )
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s-w2', 'winner', 'h2')"
+    )
+
+    sql!(
+      "INSERT INTO subtitle_track_settings (id, media_file_id, track_ref) VALUES ('trk1', 'winner', 'trk-w')"
+    )
+
+    # loser1: 2 dependents, one colliding with the winner (dropped) and one
+    # that moves across untouched.
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s-l1-h2', 'loser1', 'h2')"
+    )
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s-l1-h3', 'loser1', 'h3')"
+    )
+
+    # loser2: 1 dependent, no counterpart on the winner, so it moves across.
+    sql!(
+      "INSERT INTO transcode_jobs (id, media_file_id, resolution, type) VALUES ('tj1', 'loser2', '1080p', 'download')"
+    )
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert %{rows: [["winner"]]} = sql!("SELECT id FROM media_files")
+
+    # s-l1-h2 collided with the winner's own h2 and was dropped; s-l1-h3 had
+    # no counterpart and moved onto the winner alongside its original rows.
+    assert %{rows: [["s-l1-h3", "h3"], ["s-w1", "h1"], ["s-w2", "h2"]]} =
+             sql!("SELECT id, subtitle_hash FROM subtitles ORDER BY id")
+
+    assert %{rows: [["winner", "aaa"]]} =
+             sql!("SELECT media_file_id, opensubtitles_hash FROM media_hashes")
+
+    assert %{rows: [["trk1", "winner", "trk-w"]]} =
+             sql!("SELECT id, media_file_id, track_ref FROM subtitle_track_settings")
+
+    # loser2's transcode_jobs row had no counterpart on the winner and moved.
+    assert %{rows: [["tj1", "winner", "1080p", "download"]]} =
+             sql!("SELECT id, media_file_id, resolution, type FROM transcode_jobs")
+  end
+
+  @tag :tmp_dir
   test "rejects a second active row at the same library path and relative path" do
     build_pre_migration_schema()
 

--- a/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
+++ b/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
@@ -197,6 +197,59 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesTest do
   end
 
   @tag :tmp_dir
+  test "clears the winner's own supersedes pointer instead of pointing it at itself" do
+    build_pre_migration_schema()
+
+    seed_library_path("lib-plain", "/media/movies")
+    seed_media_item("item-1")
+
+    # winner was imported as an upgrade over loser (supersedes_media_file_id
+    # points at loser), and loser is also the duplicate row this group folds
+    # away. A plain repoint (UPDATE ... WHERE supersedes_media_file_id =
+    # loser) would land on the winner too, since the winner's own pointer
+    # matches the WHERE clause, leaving it pointing at itself.
+    seed_media_file("winner", "lib-plain", "Amber Foundry (2013)/Amber.Foundry.mkv", "item-1")
+    seed_media_file("loser", "lib-plain", "Amber Foundry (2013)/Amber.Foundry.mkv", "item-1")
+
+    sql!("UPDATE media_files SET supersedes_media_file_id = 'loser' WHERE id = 'winner'")
+
+    # Give the winner strictly more dependents so it is the unambiguous
+    # winner regardless of the tiebreak.
+    sql!("INSERT INTO media_hashes (media_file_id, opensubtitles_hash) VALUES ('winner', 'aaa')")
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert %{rows: [["winner", nil]]} =
+             sql!("SELECT id, supersedes_media_file_id FROM media_files")
+  end
+
+  @tag :tmp_dir
+  test "repoints a third row's supersedes pointer off the loser onto the winner" do
+    build_pre_migration_schema()
+
+    seed_library_path("lib-plain", "/media/movies")
+    seed_media_item("item-1")
+
+    seed_media_file("winner", "lib-plain", "Marrow Hollow (2015)/Marrow.Hollow.mkv", "item-1")
+    seed_media_file("loser", "lib-plain", "Marrow Hollow (2015)/Marrow.Hollow.mkv", "item-1")
+
+    seed_media_file(
+      "newer",
+      "lib-plain",
+      "Marrow Hollow (2015) [newer]/Marrow.Hollow.mkv",
+      "item-1"
+    )
+
+    sql!("UPDATE media_files SET supersedes_media_file_id = 'loser' WHERE id = 'newer'")
+    sql!("INSERT INTO media_hashes (media_file_id, opensubtitles_hash) VALUES ('winner', 'aaa')")
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert %{rows: [["newer", "winner"], ["winner", nil]]} =
+             sql!("SELECT id, supersedes_media_file_id FROM media_files ORDER BY id")
+  end
+
+  @tag :tmp_dir
   test "rejects a second active row at the same library path and relative path" do
     build_pre_migration_schema()
 

--- a/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
+++ b/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
@@ -1,0 +1,226 @@
+defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesTest do
+  use Mydia.MigrationCase
+
+  Code.require_file(
+    "priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs"
+  )
+
+  alias Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness
+
+  @version 20_260_901_234_336
+
+  @tag :tmp_dir
+  test "folds two active rows for one canonical path onto the row with more dependents" do
+    build_pre_migration_schema()
+
+    # Two library paths over the same tree, one with a trailing slash. Both
+    # rows resolve to /media/movies/Cinder Lantern (2014)/Cinder.Lantern.mkv.
+    seed_library_path("lib-plain", "/media/movies")
+    seed_library_path("lib-slash", "/media/movies/")
+    seed_media_item("item-1")
+
+    seed_media_file("winner", "lib-plain", "Cinder Lantern (2014)/Cinder.Lantern.mkv", "item-1")
+    seed_media_file("loser", "lib-slash", "Cinder Lantern (2014)/Cinder.Lantern.mkv", "item-1")
+
+    sql!("INSERT INTO media_hashes (media_file_id, opensubtitles_hash) VALUES ('winner', 'aaa')")
+    sql!("INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s1', 'loser', 'h1')")
+    sql!("INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s2', 'winner', 'h1')")
+    sql!("INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s3', 'loser', 'h2')")
+    sql!("INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('s4', 'winner', 'h3')")
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert %{rows: [["winner"]]} = sql!("SELECT id FROM media_files")
+
+    # s3 had no counterpart on the winner and moved across. s1 collided with
+    # s2 on (media_file_id, subtitle_hash) and was dropped.
+    assert %{rows: [["s2", "h1"], ["s3", "h2"], ["s4", "h3"]]} =
+             sql!("SELECT id, subtitle_hash FROM subtitles ORDER BY id")
+  end
+
+  @tag :tmp_dir
+  test "leaves a trashed duplicate and a lone row alone" do
+    build_pre_migration_schema()
+
+    seed_library_path("lib-plain", "/media/movies")
+    seed_media_item("item-1")
+
+    seed_media_file("active", "lib-plain", "Harrow Bay (2011)/Harrow.Bay.mkv", "item-1")
+    seed_media_file("trashed", "lib-plain", "Harrow Bay (2011)/Harrow.Bay.mkv", "item-1")
+    sql!("UPDATE media_files SET trashed_at = '2026-08-01 00:00:00' WHERE id = 'trashed'")
+
+    seed_media_file("solo", "lib-plain", "Pale Orchard (2018)/Pale.Orchard.mkv", "item-1")
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert %{rows: [["active"], ["solo"], ["trashed"]]} =
+             sql!("SELECT id FROM media_files ORDER BY id")
+  end
+
+  @tag :tmp_dir
+  test "repoints or drops media_hashes, the only dependent with no key beyond media_file_id" do
+    build_pre_migration_schema()
+
+    seed_library_path("lib-plain", "/media/movies")
+    seed_media_item("item-1")
+
+    # Group A: both winner_a and loser_a already carry a media_hashes row, so
+    # the winner's row must survive untouched and the loser's must be
+    # dropped rather than merged. winner_a is strictly richer (3 dependents
+    # to 2) so the outcome rests on the primary signal, not a tie-break.
+    seed_media_file("winner_a", "lib-plain", "Amber Foundry (2013)/Amber.Foundry.mkv", "item-1")
+    seed_media_file("loser_a", "lib-plain", "Amber Foundry (2013)/Amber.Foundry.mkv", "item-1")
+
+    sql!(
+      "INSERT INTO media_hashes (media_file_id, opensubtitles_hash) VALUES ('winner_a', 'hash-winner-a')"
+    )
+
+    sql!(
+      "INSERT INTO media_hashes (media_file_id, opensubtitles_hash) VALUES ('loser_a', 'hash-loser-a')"
+    )
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('a1', 'winner_a', 'h1')"
+    )
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('a2', 'winner_a', 'h2')"
+    )
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('a3', 'loser_a', 'h3')"
+    )
+
+    # Group B: only loser_b carries a media_hashes row, so it must move onto
+    # winner_b rather than being dropped. winner_b is still strictly richer
+    # (2 dependents to 1) so this again rests on the primary signal.
+    seed_media_file("winner_b", "lib-plain", "Quiet Ledger (2017)/Quiet.Ledger.mkv", "item-1")
+    seed_media_file("loser_b", "lib-plain", "Quiet Ledger (2017)/Quiet.Ledger.mkv", "item-1")
+
+    sql!(
+      "INSERT INTO media_hashes (media_file_id, opensubtitles_hash) VALUES ('loser_b', 'hash-loser-b')"
+    )
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('b1', 'winner_b', 'h1')"
+    )
+
+    sql!(
+      "INSERT INTO subtitles (id, media_file_id, subtitle_hash) VALUES ('b2', 'winner_b', 'h2')"
+    )
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert %{rows: [["winner_a"], ["winner_b"]]} =
+             sql!("SELECT id FROM media_files ORDER BY id")
+
+    # Collision: winner_a's own hash survives; loser_a's hash is gone, not
+    # merged onto the winner.
+    assert %{rows: [["winner_a", "hash-winner-a"]]} =
+             sql!(
+               "SELECT media_file_id, opensubtitles_hash FROM media_hashes WHERE media_file_id = 'winner_a'"
+             )
+
+    assert %{rows: []} =
+             sql!("SELECT 1 FROM media_hashes WHERE opensubtitles_hash = 'hash-loser-a'")
+
+    # Move: loser_b's hash now belongs to winner_b.
+    assert %{rows: [["winner_b", "hash-loser-b"]]} =
+             sql!(
+               "SELECT media_file_id, opensubtitles_hash FROM media_hashes WHERE opensubtitles_hash = 'hash-loser-b'"
+             )
+  end
+
+  defp build_pre_migration_schema do
+    sql!("CREATE TABLE library_paths (id TEXT PRIMARY KEY, path TEXT NOT NULL)")
+    sql!("CREATE TABLE media_items (id TEXT PRIMARY KEY)")
+
+    sql!("""
+    CREATE TABLE media_files (
+      id TEXT PRIMARY KEY,
+      media_item_id TEXT REFERENCES media_items(id) ON DELETE CASCADE,
+      episode_id TEXT,
+      library_path_id TEXT REFERENCES library_paths(id) ON DELETE CASCADE,
+      supersedes_media_file_id TEXT REFERENCES media_files(id) ON DELETE SET NULL,
+      relative_path TEXT,
+      trashed_at TEXT,
+      inserted_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+    """)
+
+    sql!("""
+    CREATE TABLE subtitles (
+      id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE,
+      subtitle_hash TEXT
+    )
+    """)
+
+    sql!("CREATE UNIQUE INDEX subtitles_mf_hash ON subtitles (media_file_id, subtitle_hash)")
+
+    sql!("""
+    CREATE TABLE media_hashes (
+      media_file_id TEXT PRIMARY KEY REFERENCES media_files(id) ON DELETE CASCADE,
+      opensubtitles_hash TEXT
+    )
+    """)
+
+    sql!("""
+    CREATE TABLE subtitle_track_settings (
+      id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE,
+      track_ref TEXT
+    )
+    """)
+
+    sql!("""
+    CREATE TABLE transcode_jobs (
+      id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE,
+      resolution TEXT,
+      type TEXT
+    )
+    """)
+
+    sql!("""
+    CREATE TABLE media_segments (
+      id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE,
+      type TEXT
+    )
+    """)
+
+    sql!("""
+    CREATE TABLE media_file_match_candidates (
+      id TEXT PRIMARY KEY,
+      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE,
+      rank INTEGER
+    )
+    """)
+  end
+
+  defp seed_library_path(id, path) do
+    sql!("INSERT INTO library_paths (id, path) VALUES ('#{id}', '#{path}')")
+  end
+
+  defp seed_media_item(id) do
+    sql!("INSERT INTO media_items (id) VALUES ('#{id}')")
+  end
+
+  defp seed_media_file(id, library_path_id, relative_path, media_item_id, opts \\ []) do
+    trashed_at =
+      case Keyword.get(opts, :trashed_at) do
+        nil -> "NULL"
+        value -> "'#{value}'"
+      end
+
+    sql!("""
+    INSERT INTO media_files
+      (id, media_item_id, library_path_id, relative_path, trashed_at, inserted_at, updated_at)
+    VALUES
+      ('#{id}', '#{media_item_id}', '#{library_path_id}', '#{relative_path}', #{trashed_at},
+       '2026-01-01 00:00:00', '2026-01-01 00:00:00')
+    """)
+  end
+end

--- a/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
+++ b/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
@@ -131,6 +131,63 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesTest do
              )
   end
 
+  @tag :tmp_dir
+  test "rejects a second active row at the same library path and relative path" do
+    build_pre_migration_schema()
+
+    seed_library_path("lib-plain", "/media/movies")
+    seed_media_item("item-1")
+    seed_media_file("first", "lib-plain", "Silver Harbour (2019)/Silver.Harbour.mkv", "item-1")
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert_raise Exqlite.Error, fn ->
+      seed_media_file("second", "lib-plain", "Silver Harbour (2019)/Silver.Harbour.mkv", "item-1")
+    end
+
+    # A trashed row at the same path is outside the partial index.
+    seed_media_file("third", "lib-plain", "Silver Harbour (2019)/Silver.Harbour.mkv", "item-1",
+      trashed_at: "2026-08-01 00:00:00"
+    )
+
+    assert %{rows: [[2]]} = sql!("SELECT count(*) FROM media_files")
+  end
+
+  @tag :tmp_dir
+  test "folds two active rows sharing a path under a non-absolute library root" do
+    build_pre_migration_schema()
+
+    seed_library_path("lib-relative", "media/movies")
+    seed_media_item("item-1")
+
+    seed_media_file(
+      "first",
+      "lib-relative",
+      "Quiet Ledger (2017)/Quiet.Ledger.mkv",
+      "item-1"
+    )
+
+    seed_media_file(
+      "second",
+      "lib-relative",
+      "Quiet Ledger (2017)/Quiet.Ledger.mkv",
+      "item-1"
+    )
+
+    run_migration!(FoldDuplicateMediaFilesAndEnforcePathUniqueness, @version)
+
+    assert %{rows: [[1]]} = sql!("SELECT count(*) FROM media_files")
+
+    assert_raise Exqlite.Error, fn ->
+      seed_media_file(
+        "third",
+        "lib-relative",
+        "Quiet Ledger (2017)/Quiet.Ledger.mkv",
+        "item-1"
+      )
+    end
+  end
+
   defp build_pre_migration_schema do
     sql!("CREATE TABLE library_paths (id TEXT PRIMARY KEY, path TEXT NOT NULL)")
     sql!("CREATE TABLE media_items (id TEXT PRIMARY KEY)")

--- a/test/mydia_web/live/media_live/show/file_details_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/file_details_modal_test.exs
@@ -1,0 +1,62 @@
+defmodule MydiaWeb.MediaLive.Show.FileDetailsModalTest do
+  # Connected LiveView tests cannot be async under the PostgreSQL sandbox.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Structs.FileMetadata
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Repo
+
+  setup %{conn: conn} do
+    {conn, user} = register_and_log_in_user(conn)
+    %{conn: conn, user: user}
+  end
+
+  setup do
+    library_path = library_path_fixture(%{type: "movies"})
+    item = media_item_fixture(%{type: "movie", title: "Cinder Lantern"})
+
+    file =
+      %MediaFile{}
+      |> MediaFile.changeset(%{
+        media_item_id: item.id,
+        library_path_id: library_path.id,
+        relative_path: "Cinder Lantern (2014)/Cinder.Lantern.2014.1080p.mkv",
+        size: 1024,
+        metadata: %FileMetadata{
+          duration: 5400.0,
+          container: "matroska",
+          width: 1920,
+          height: 1080,
+          streams: [%StreamInfo{index: 0, type: "video", codec: "h264"}]
+        }
+      })
+      |> Repo.insert!()
+
+    # ExUnit's context already reserves the key :file for the test's own
+    # source file, so the setup result uses :media_file instead.
+    %{item: item, media_file: file, library_path: library_path}
+  end
+
+  test "opens for a file with populated metadata and shows the absolute path", %{
+    conn: conn,
+    item: item,
+    media_file: file,
+    library_path: library_path
+  } do
+    {:ok, view, _html} = live(conn, ~p"/media/#{item.id}")
+
+    html =
+      view
+      |> element("#version-#{file.id} button[phx-click='show_file_details']")
+      |> render_click()
+
+    assert html =~ "Media File Details"
+    assert html =~ Path.join(library_path.path, file.relative_path)
+    assert html =~ "matroska"
+  end
+end


### PR DESCRIPTION
Closes #653.

"Re-scan files" decided a media file was gone by scanning one inferred directory and diffing path strings, then handed every unmatched row to `trash_media_file/1`. That calls `TrashStore.store/1`, which checks `File.exists?` and, finding the file present, physically moves the bytes out of the library. Operators lost media, and the toast reported a clean sweep while doing it.

Three separate conditions reached that code with a false "missing" verdict: a base directory chosen by voting on `Path.dirname` across the item's rows, a scan whose own `errors` list was never read, and an explicit branch that trashed every file for an item whenever the directory would not resolve.

## The fixes

- A shared `reject_files_still_on_disk/1` guard in `Mydia.Library`, called by all three re-scan paths. A row the directory diff calls missing but whose own file is on disk is logged and skipped, never trashed. This closes the data loss regardless of which condition produced the false verdict.
- The three mass-trash-on-missing-directory branches now return `{:error, :scan_failed}` and write nothing. A directory that will not resolve is a failed scan, not evidence the library is empty. All three async handlers already had catch-all error clauses, so this surfaces as a failure flash rather than a success toast.
- `scan_errors` is carried out of the re-scan functions and into the toast, so a scan that could not read the files stops reporting "Found 0 new file(s)" with no further explanation.
- A migration folds duplicate `media_files` rows onto one row per physical file, grouping by canonical absolute path so duplicates reached through different library paths (a bind mount, a symlink, a trailing slash) fold together. Dependents across seven tables are repointed onto the survivor, with each guarded update followed by an explicit delete rather than relying on `ON DELETE CASCADE`, since some connection setups run with `PRAGMA foreign_keys=off`. Losing rows are deleted, not soft-trashed: `purge_old_trashed_media_files/1` treats a trashed row with no trash metadata as legacy and deletes the file at its library path once retention expires, so soft-trashing would have scheduled real files for deletion 30 days out.
- Rows whose library root is not absolute are excluded from the canonical fold, because `Path.expand/1` would otherwise resolve them against the working directory, and are folded separately on their literal `(library_path_id, relative_path)` pair. Since every row sharing a `library_path_id` shares one root and therefore one classification, the two folds partition cleanly and jointly guarantee the unique index can always be created. A migration that cannot create its index is a boot failure on every install, because `application.ex` starts `Ecto.Migrator` in the supervision tree.
- A partial unique index on `media_files (library_path_id, relative_path) WHERE trashed_at IS NULL`, with matching changeset constraints. `media_files` lost its uniqueness when `path` was superseded and never got it back, while the sibling `import_candidates` table gained one; that gap is what let two rows describe one file.
- The file details modal called `Jason.encode!` on a `FileMetadata` struct with no `Jason.Encoder` implementation, so it raised for every analyzed file. `FileMetadata` and `StreamInfo` now derive the protocol, and `show_file_details/2` preloads `library_path` so the modal shows the full path instead of falling back to the relative one.
- `media_import.ex` adopts an existing row when it hits the new constraint, instead of reporting `:database_error` and retrying. Re-running an import, or retrying after a partial failure, should reuse the row already there; the file already did this via `get_media_file_by_path/2` and the `{:existing, path}` conflict branch, and the constraint violation now lands in the same place.

## Notes

The prune `:duplicate_registration` check and the import-run duplicate-tolerance path were both kept rather than deleted. The index is partial in two ways: it does not cover rows with a NULL `library_path_id`, and it excludes trashed rows. Both guarded states remain reachable, through two orphaned rows in the first case and one active plus one trashed row at the same path in the second.

`priv/repo/README.md` gains a note on an `ecto_sqlite3` trap found here: a violation of a custom-named partial unique index is reported under a convention-derived name, so a `unique_constraint` keyed only to the real name never fires on SQLite and the insert raises instead of returning a changeset error. It has to be declared under both names.

`mix precommit` passes: 10082 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate media imports from creating conflicting records; existing active files are reused safely.
  * Rescans no longer trash files when scanning fails or when files remain on disk but are outside the scanned directory.
  * Rescans now report files that could not be read instead of silently ignoring them.
  * Improved handling of duplicate and trashed media-file paths.

* **Improvements**
  * File details now display the complete absolute file path and expanded metadata in the details modal.
  * Improved reliability when importing files concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->