### PR TITLE
fix(library): stop re-enrichment from silently re-enabling monitoring

### DIFF
--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -67,8 +67,12 @@ defmodule Mydia.Application do
         Mydia.Jobs.HdrBackfill.enqueue_once()
         # One-shot repair for items the metadata enricher silently re-monitored
         # before #653 was fixed. Idempotent by item state plus its own decision
-        # event, so enqueuing on every boot is harmless once the set has
-        # drained. enqueue_once/0 protects its own Oban.insert/1 call.
+        # event, but unlike HdrBackfill there is no stamp column: every boot
+        # re-queries every currently-monitored item id and its recent event
+        # history to find the (usually empty) remainder, so the cost scales
+        # with library size for the life of the deployment rather than
+        # shrinking to a cheap no-match. enqueue_once/0 protects its own
+        # Oban.insert/1 call.
         Mydia.Jobs.MonitoringRepair.enqueue_once()
         # Clean up stale HLS session directories
         cleanup_stale_hls_sessions()

--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -65,6 +65,11 @@ defmodule Mydia.Application do
         # convention DatabaseHealthCheck.run/0 and StartupSync.sync_all/0
         # already follow in this same block.
         Mydia.Jobs.HdrBackfill.enqueue_once()
+        # One-shot repair for items the metadata enricher silently re-monitored
+        # before #653 was fixed. Idempotent by item state plus its own decision
+        # event, so enqueuing on every boot is harmless once the set has
+        # drained. enqueue_once/0 protects its own Oban.insert/1 call.
+        Mydia.Jobs.MonitoringRepair.enqueue_once()
         # Clean up stale HLS session directories
         cleanup_stale_hls_sessions()
       end

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -590,7 +590,7 @@ defmodule Mydia.Events.Presentation do
     end
   end
 
-  defp field_name(%{"field" => field}), do: field
+  defp field_name(%{"field" => field}) when is_binary(field), do: field
   defp field_name(field) when is_binary(field), do: field
   defp field_name(_), do: "field"
 
@@ -624,9 +624,27 @@ defmodule Mydia.Events.Presentation do
   `MydiaWeb.ActivityLive.Index.format_change_details/1`, so the short
   summary and the expanded Activity Feed breakdown always agree on how a
   field is labeled.
+
+  `MydiaWeb.ActivityLive.Index.format_change_details/1` calls this directly
+  with a raw `"field"` value pulled out of persisted event metadata, without
+  going through `field_name/1` first. A malformed or legacy event (hand-edited,
+  or written by a version of this code with a different metadata shape) can
+  carry `nil` or a number there instead of a string. `Phoenix.Naming.humanize/1`
+  only has clauses for an atom or a binary and raises `FunctionClauseError` on
+  anything else, which would take down the whole Activity Feed and item
+  history timeline over one bad row. Guarded here so a non-binary, non-atom
+  value renders a fixed fallback label instead.
   """
-  @spec field_label(String.t()) :: String.t()
-  def field_label(field), do: Map.get(@field_labels, field, Phoenix.Naming.humanize(field))
+  @spec field_label(term()) :: String.t()
+  def field_label(field) when is_binary(field) do
+    Map.get(@field_labels, field, Phoenix.Naming.humanize(field))
+  end
+
+  def field_label(field) when is_atom(field) and not is_nil(field) do
+    Map.get(@field_labels, field, Phoenix.Naming.humanize(field))
+  end
+
+  def field_label(_field), do: "Unknown field"
 
   # Renders " S01E02" or " S01" when the metadata carries season and episode.
   defp episode_part(metadata) do

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -569,7 +569,7 @@ defmodule Mydia.Events.Presentation do
 
     simple_fields =
       changes
-      |> Map.take(["title", "original_title", "year"])
+      |> Map.take(["title", "original_title", "year", "monitored", "monitor_new_seasons"])
       |> Map.keys()
 
     case metadata_fields ++ simple_fields do

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -571,6 +571,7 @@ defmodule Mydia.Events.Presentation do
       changes
       |> Map.take(["title", "original_title", "year", "monitored", "monitor_new_seasons"])
       |> Map.keys()
+      |> Enum.map(&field_label/1)
 
     case metadata_fields ++ simple_fields do
       [] -> nil
@@ -579,7 +580,7 @@ defmodule Mydia.Events.Presentation do
   end
 
   defp summarize_fields(fields) do
-    names = fields |> Enum.take(3) |> Enum.map(&field_name/1)
+    names = fields |> Enum.take(3) |> Enum.map(&(&1 |> field_name() |> field_label()))
     remaining = length(fields) - 3
 
     if remaining > 0 do
@@ -592,6 +593,40 @@ defmodule Mydia.Events.Presentation do
   defp field_name(%{"field" => field}), do: field
   defp field_name(field) when is_binary(field), do: field
   defp field_name(_), do: "field"
+
+  # Field labels used by both renderers of a media_item.updated changeset:
+  # this module's own one-line `changes_summary/1` and the expanded
+  # breakdown in `MydiaWeb.ActivityLive.Index.format_change_details/1`. One
+  # map here keeps them from drifting apart on the same field, which is how
+  # the summary ended up rendering the raw `monitor_new_seasons` next to the
+  # expanded view's "New season monitoring" for the same event.
+  @field_labels %{
+    "title" => "Title",
+    "original_title" => "Original Title",
+    "year" => "Year",
+    "monitored" => "Monitoring",
+    "monitor_new_seasons" => "New season monitoring",
+    "overview" => "Description",
+    "poster" => "Poster",
+    "backdrop" => "Backdrop",
+    "tagline" => "Tagline",
+    "rating" => "Rating",
+    "runtime" => "Runtime",
+    "genres" => "Genres",
+    "cast" => "Cast",
+    "crew" => "Crew"
+  }
+
+  @doc """
+  Human-readable label for a `media_item.updated` changed-field name.
+
+  Shared by `changes_summary/1` here and
+  `MydiaWeb.ActivityLive.Index.format_change_details/1`, so the short
+  summary and the expanded Activity Feed breakdown always agree on how a
+  field is labeled.
+  """
+  @spec field_label(String.t()) :: String.t()
+  def field_label(field), do: Map.get(@field_labels, field, Phoenix.Naming.humanize(field))
 
   # Renders " S01E02" or " S01" when the metadata carries season and episode.
   defp episode_part(metadata) do

--- a/lib/mydia/jobs/monitoring_repair.ex
+++ b/lib/mydia/jobs/monitoring_repair.ex
@@ -1,0 +1,215 @@
+defmodule Mydia.Jobs.MonitoringRepair do
+  @moduledoc """
+  One-shot worker restoring monitoring on items the enricher silently enabled.
+
+  `Mydia.Library.MetadataEnricher` used to write `monitored: true` on the update
+  path, so any scan that re-enriched an item the operator had unmonitored turned
+  monitoring back on without recording a decision (getmydia/mydia#653). The
+  setting was destroyed but the record of it was not: the monitoring toggles
+  write `reason: "Monitoring enabled"` or `"Monitoring disabled"` into event
+  metadata, and events are retained for 90 days by default.
+
+  An item is repaired when two facts hold: it is monitored now, and the most
+  recent monitoring decision on record was a disable. Nothing else is checked,
+  because the enricher was the only writer that could produce that combination.
+  Every other path that sets `monitored` on an existing item records a decision
+  (`Media.update_media_items_monitored/3` and the LiveView toggles), and
+  approving a media request for an item already in the library links the row
+  without writing to it.
+
+  Idempotent with no stamp column. The restoration emits its own
+  `monitoring_changed` event, which becomes the item's latest decision, and the
+  item is no longer monitored, so a second pass cannot select it. A manual
+  re-enable afterwards is likewise a later decision, so this never undoes the
+  operator. That is why, unlike `Mydia.Jobs.HdrBackfill`, this needs no
+  migration.
+
+  Items whose disable predates the event retention window carry no record and
+  are left alone. They cannot be recovered.
+
+  One limitation worth knowing: `events.inserted_at` is `:utc_datetime`, so it
+  holds seconds, and `events.id` is a random UUID. Two decisions recorded in the
+  same second therefore order arbitrarily. In production a disable and an enable
+  a second apart is not a real scenario, and the worst case is that one item is
+  left monitored, which the operator can fix from the UI. The tests stamp
+  explicit timestamps rather than rely on it.
+  """
+
+  use Oban.Worker,
+    queue: :maintenance,
+    max_attempts: 3,
+    # Mirrors Mydia.Jobs.HdrBackfill: with :executing included, a restart while
+    # a pass is mid-batch cannot stack a second one on top.
+    unique: [
+      period: 300,
+      fields: [:worker],
+      states: [:suspended, :available, :scheduled, :executing, :retryable]
+    ]
+
+  import Ecto.Query
+
+  alias Mydia.Events
+  alias Mydia.Events.Event
+  alias Mydia.Media
+  alias Mydia.Media.MediaItem
+  alias Mydia.Repo
+
+  require Logger
+
+  @default_batch_size 100
+
+  # How many media item ids go into one `resource_id in (...)` list. Well under
+  # SQLite's bound-parameter ceiling, and small enough that a library with tens
+  # of thousands of items does not pull its whole event history at once.
+  @id_chunk_size 200
+
+  # See Mydia.Jobs.HdrBackfill for why the reschedule drops :executing from the
+  # worker-level states: Oban's uniqueness check has no exclusion for the row
+  # currently running this code, so the follow-up insert would match its own
+  # job and the repair would stop after one batch.
+  @reschedule_unique_states [:suspended, :available, :scheduled, :retryable]
+
+  @enable_reason "Monitoring enabled"
+  @disable_reason "Monitoring disabled"
+
+  @doc """
+  Enqueues the one-shot repair. Called once at boot.
+
+  Deliberately never raises, for the reason spelled out in
+  `Mydia.Jobs.HdrBackfill.enqueue_once/0`: `Mydia.Application.start/2` has no
+  top-level rescue, and losing the whole application to a repair job that can
+  safely run on the next boot is a bad trade for a self-hosted operator with no
+  easy way to diagnose a boot crash.
+  """
+  @spec enqueue_once() :: :ok
+  def enqueue_once do
+    %{} |> new() |> Oban.insert()
+    :ok
+  rescue
+    error ->
+      Logger.warning("Monitoring repair: failed to enqueue on boot", error: inspect(error))
+      :ok
+  end
+
+  @doc """
+  Ids of media items whose monitoring should be restored, oldest first.
+
+  The reason lives inside `Event.metadata`, which is a
+  `Mydia.Settings.JsonMapType`: a map serialized into a **text** column on both
+  SQLite and PostgreSQL. There is no portable JSON operator for it, so the query
+  narrows by type and resource and the reason match runs in Elixir.
+  """
+  @spec pending_ids(pos_integer()) :: [binary()]
+  def pending_ids(limit) do
+    MediaItem
+    |> where([m], m.monitored == true)
+    |> order_by([m], asc: m.id)
+    |> select([m], m.id)
+    |> Repo.all()
+    |> Enum.chunk_every(@id_chunk_size)
+    |> Enum.reduce_while([], fn chunk, acc ->
+      found = acc ++ disabled_in_chunk(chunk)
+
+      if length(found) >= limit do
+        {:halt, Enum.take(found, limit)}
+      else
+        {:cont, found}
+      end
+    end)
+    |> Enum.take(limit)
+  end
+
+  # One query per chunk of ids, not one per item. Chunking keeps the `in` list
+  # clear of SQLite's bound-parameter ceiling on a large library.
+  defp disabled_in_chunk(ids) do
+    Event
+    |> where([e], e.resource_type == "media_item")
+    |> where([e], e.resource_id in ^ids)
+    |> where([e], e.type in ["media_item.updated", "media_item.monitoring_changed"])
+    |> order_by([e], desc: e.inserted_at, desc: e.id)
+    |> select([e], {e.resource_id, e.type, e.metadata})
+    |> Repo.all()
+    |> Enum.group_by(fn {resource_id, _type, _metadata} -> resource_id end)
+    |> Enum.filter(fn {_resource_id, events} ->
+      # The group preserves the newest-first order of the query, so the first
+      # event that is a decision at all is the most recent one.
+      Enum.find_value(events, &decision/1) == :disable
+    end)
+    |> Enum.map(fn {resource_id, _events} -> resource_id end)
+    # Repo.all returned rows grouped arbitrarily; restore the id order the
+    # caller asked for so the batch is deterministic.
+    |> then(fn matched -> Enum.filter(ids, &(&1 in matched)) end)
+  end
+
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
+  def perform(%Oban.Job{}) do
+    batch_size = Application.get_env(:mydia, :monitoring_repair_batch_size, @default_batch_size)
+
+    case pending_ids(batch_size) do
+      [] ->
+        Logger.info("Monitoring repair complete, no items pending")
+        :ok
+
+      ids ->
+        Enum.each(ids, &repair_one/1)
+
+        Logger.info("Monitoring repair restored #{length(ids)} item(s)")
+
+        # Reschedule until the set drains. Singular insert/1, not insert_all/1,
+        # which bypasses the worker's unique constraint.
+        %{} |> new(schedule_in: 5, unique: [states: @reschedule_unique_states]) |> Oban.insert()
+        :ok
+    end
+  end
+
+  defp repair_one(id) do
+    case Repo.get(MediaItem, id) do
+      nil ->
+        :ok
+
+      item ->
+        case Media.update_media_item(item, %{monitored: false},
+               actor_type: :system,
+               actor_id: "monitoring_repair",
+               reason: "Monitoring restored after #653"
+             ) do
+          {:ok, updated} ->
+            # The explicit decision event is what makes this idempotent: it
+            # becomes the item's latest monitoring decision, so a later pass
+            # cannot select the row again.
+            Events.media_item_monitoring_changed(updated, false, :system, "monitoring_repair")
+            :ok
+
+          {:error, changeset} ->
+            Logger.warning("Monitoring repair failed for item",
+              media_item_id: id,
+              errors: inspect(changeset.errors)
+            )
+
+            :ok
+        end
+    end
+  end
+
+  # Returns :enable, :disable, or nil for a row that is not a decision.
+  # Enum.find_value/2 stops at the first non-nil, which is the most recent
+  # decision because the query ordered newest first.
+  defp decision({_resource_id, "media_item.monitoring_changed", metadata}) do
+    case Map.get(metadata, "monitored") do
+      true -> :enable
+      false -> :disable
+      _ -> nil
+    end
+  end
+
+  defp decision({_resource_id, "media_item.updated", metadata}) do
+    case Map.get(metadata, "reason") do
+      @enable_reason -> :enable
+      @disable_reason -> :disable
+      _ -> nil
+    end
+  end
+
+  defp decision(_row), do: nil
+end

--- a/lib/mydia/jobs/monitoring_repair.ex
+++ b/lib/mydia/jobs/monitoring_repair.ex
@@ -17,6 +17,15 @@ defmodule Mydia.Jobs.MonitoringRepair do
   and the LiveView toggles), and approving a media request for an item already
   in the library links the row without writing to it.
 
+  `pending_ids/1` selects a batch once per run, but the operator can act on
+  any of those items before `repair_one/1` gets to them. So the decision is
+  re-checked, via `latest_decision/1`, immediately before the write, inside
+  the same `Repo.transaction/1` as the write itself. If a newer decision
+  appeared (an operator re-enabling monitoring, most importantly) the item is
+  skipped rather than flipped, and no event is emitted for it: writing an
+  event for a skipped item would fabricate a decision that was never made and
+  corrupt the very history this worker reads.
+
   Idempotent with no stamp column. The restoration emits its own
   `monitoring_changed` event, which becomes the item's latest decision, and the
   item is no longer monitored, so a second pass cannot select it. A manual
@@ -123,15 +132,24 @@ defmodule Mydia.Jobs.MonitoringRepair do
     |> Enum.take(limit)
   end
 
-  # One query per chunk of ids, not one per item. Chunking keeps the `in` list
-  # clear of SQLite's bound-parameter ceiling on a large library.
-  defp disabled_in_chunk(ids) do
+  # Shared by the batch selection query below and by `latest_decision/1`, the
+  # single-item recheck `repair_one/1` runs immediately before it writes, so
+  # the two paths cannot drift apart on what counts as "a decision event for
+  # this item".
+  defp decision_events_query(ids) do
     Event
     |> where([e], e.resource_type == "media_item")
     |> where([e], e.resource_id in ^ids)
     |> where([e], e.type in ["media_item.updated", "media_item.monitoring_changed"])
     |> order_by([e], desc: e.inserted_at, desc: e.id)
     |> select([e], {e.resource_id, e.type, e.metadata})
+  end
+
+  # One query per chunk of ids, not one per item. Chunking keeps the `in` list
+  # clear of SQLite's bound-parameter ceiling on a large library.
+  defp disabled_in_chunk(ids) do
+    ids
+    |> decision_events_query()
     |> Repo.all()
     |> Enum.group_by(fn {resource_id, _type, _metadata} -> resource_id end)
     |> Enum.filter(fn {_resource_id, events} ->
@@ -143,6 +161,22 @@ defmodule Mydia.Jobs.MonitoringRepair do
     # Repo.all returned rows grouped arbitrarily; restore the id order the
     # caller asked for so the batch is deterministic.
     |> then(fn matched -> Enum.filter(ids, &(&1 in matched)) end)
+  end
+
+  @doc """
+  The latest monitoring decision recorded for one media item: `:enable`,
+  `:disable`, or `nil` when no decision is on record.
+
+  Used to re-check a single item immediately before `repair_one/1` writes to
+  it, so a decision recorded after `pending_ids/1` selected the batch is not
+  missed.
+  """
+  @spec latest_decision(binary()) :: :enable | :disable | nil
+  def latest_decision(id) do
+    [id]
+    |> decision_events_query()
+    |> Repo.all()
+    |> Enum.find_value(&decision/1)
   end
 
   @impl Oban.Worker
@@ -167,36 +201,71 @@ defmodule Mydia.Jobs.MonitoringRepair do
     end
   end
 
-  defp repair_one(id) do
-    case Repo.get(MediaItem, id) do
-      nil ->
+  @doc """
+  Restores monitoring on one media item, if its decision still says so.
+
+  Public (rather than the batch-only `defp` it started as) so a test can
+  drive the exact race this guards against: write a newer decision for an
+  item, then call this directly with its id, without needing real
+  concurrency to land the write in between `pending_ids/1`'s selection and
+  this function's own write.
+
+  `pending_ids/1` selects the batch from a query taken before this job
+  started running. An operator can act on any of those items before this
+  function reaches them, most importantly by re-enabling monitoring, which
+  records a fresh "enable" decision. Writing `monitored: false` without
+  looking again would silently undo that operator action, which is exactly
+  the class of bug getmydia/mydia#653 is about, so the recheck below runs
+  immediately before the write, inside the same transaction as the write.
+  """
+  @spec repair_one(binary()) :: :ok
+  def repair_one(id) do
+    case Repo.transaction(fn -> repair_one_tx(id) end) do
+      {:ok, {:updated, updated}} ->
+        # The explicit decision event is what makes this idempotent: it
+        # becomes the item's latest monitoring decision, so a later pass
+        # cannot select the row again. Only emitted when the guarded update
+        # above actually ran, so a skipped item leaves no event behind.
+        Events.media_item_monitoring_changed(updated, false, :job, "monitoring_repair")
         :ok
 
-      item ->
-        # Deliberately not Media.update_media_item/3: it always emits its own
-        # media_item.updated event, which would land right next to the
-        # explicit monitoring_changed event below and show the operator two
-        # near-duplicate entries in the Activity Feed and item history for
-        # every repaired item. Building and applying the changeset directly
-        # keeps this write to exactly the one event that makes it idempotent.
-        changeset = MediaItem.changeset(item, %{monitored: false})
+      {:ok, {:error, changeset}} ->
+        Logger.warning("Monitoring repair failed for item",
+          media_item_id: id,
+          errors: inspect(changeset.errors)
+        )
 
-        case Repo.update(changeset) do
-          {:ok, updated} ->
-            # The explicit decision event is what makes this idempotent: it
-            # becomes the item's latest monitoring decision, so a later pass
-            # cannot select the row again.
-            Events.media_item_monitoring_changed(updated, false, :job, "monitoring_repair")
-            :ok
+        :ok
 
-          {:error, changeset} ->
-            Logger.warning("Monitoring repair failed for item",
-              media_item_id: id,
-              errors: inspect(changeset.errors)
-            )
+      {:ok, :skipped} ->
+        :ok
+    end
+  end
 
-            :ok
-        end
+  defp repair_one_tx(id) do
+    with %MediaItem{} = item <- Repo.get(MediaItem, id) || :not_found,
+         :disable <- latest_decision(id) do
+      # Deliberately not Media.update_media_item/3: it always emits its own
+      # media_item.updated event, which would land right next to the
+      # explicit monitoring_changed event above and show the operator two
+      # near-duplicate entries in the Activity Feed and item history for
+      # every repaired item. Building and applying the changeset directly
+      # keeps this write to exactly the one event that makes it idempotent.
+      case Repo.update(MediaItem.changeset(item, %{monitored: false})) do
+        {:ok, updated} -> {:updated, updated}
+        {:error, changeset} -> {:error, changeset}
+      end
+    else
+      :not_found ->
+        :skipped
+
+      _newer_decision ->
+        Logger.info(
+          "Monitoring repair skipped item: a newer decision was recorded after selection",
+          media_item_id: id
+        )
+
+        :skipped
     end
   end
 

--- a/lib/mydia/jobs/monitoring_repair.ex
+++ b/lib/mydia/jobs/monitoring_repair.ex
@@ -13,9 +13,9 @@ defmodule Mydia.Jobs.MonitoringRepair do
   recent monitoring decision on record was a disable. Nothing else is checked,
   because the enricher was the only writer that could produce that combination.
   Every other path that sets `monitored` on an existing item records a decision
-  (`Media.update_media_items_monitored/3` and the LiveView toggles), and
-  approving a media request for an item already in the library links the row
-  without writing to it.
+  (`Media.update_media_items_monitored/3`, `Media.update_media_items_batch/3`,
+  and the LiveView toggles), and approving a media request for an item already
+  in the library links the row without writing to it.
 
   Idempotent with no stamp column. The restoration emits its own
   `monitoring_changed` event, which becomes the item's latest decision, and the
@@ -50,7 +50,6 @@ defmodule Mydia.Jobs.MonitoringRepair do
 
   alias Mydia.Events
   alias Mydia.Events.Event
-  alias Mydia.Media
   alias Mydia.Media.MediaItem
   alias Mydia.Repo
 
@@ -92,7 +91,12 @@ defmodule Mydia.Jobs.MonitoringRepair do
   end
 
   @doc """
-  Ids of media items whose monitoring should be restored, oldest first.
+  Ids of media items whose monitoring should be restored.
+
+  Ordered by `m.id asc`, which is deterministic but arbitrary: `id` is a
+  random UUIDv4, not a timestamp, so this is not "oldest first" or any other
+  meaningful order. Nothing depends on the order beyond it being stable across
+  the paged `disabled_in_chunk/1` calls within a single run.
 
   The reason lives inside `Event.metadata`, which is a
   `Mydia.Settings.JsonMapType`: a map serialized into a **text** column on both
@@ -169,16 +173,20 @@ defmodule Mydia.Jobs.MonitoringRepair do
         :ok
 
       item ->
-        case Media.update_media_item(item, %{monitored: false},
-               actor_type: :system,
-               actor_id: "monitoring_repair",
-               reason: "Monitoring restored after #653"
-             ) do
+        # Deliberately not Media.update_media_item/3: it always emits its own
+        # media_item.updated event, which would land right next to the
+        # explicit monitoring_changed event below and show the operator two
+        # near-duplicate entries in the Activity Feed and item history for
+        # every repaired item. Building and applying the changeset directly
+        # keeps this write to exactly the one event that makes it idempotent.
+        changeset = MediaItem.changeset(item, %{monitored: false})
+
+        case Repo.update(changeset) do
           {:ok, updated} ->
             # The explicit decision event is what makes this idempotent: it
             # becomes the item's latest monitoring decision, so a later pass
             # cannot select the row again.
-            Events.media_item_monitoring_changed(updated, false, :system, "monitoring_repair")
+            Events.media_item_monitoring_changed(updated, false, :job, "monitoring_repair")
             :ok
 
           {:error, changeset} ->

--- a/lib/mydia/jobs/monitoring_repair.ex
+++ b/lib/mydia/jobs/monitoring_repair.ex
@@ -217,16 +217,23 @@ defmodule Mydia.Jobs.MonitoringRepair do
   looking again would silently undo that operator action, which is exactly
   the class of bug getmydia/mydia#653 is about, so the recheck below runs
   immediately before the write, inside the same transaction as the write.
+
+  The decision event is written inside that same transaction, not after it
+  commits. `Events.media_item_monitoring_changed/4` calls
+  `Events.create_event_async/1`, which writes synchronously on the caller's
+  connection whenever `Repo.in_transaction?/0` is true instead of casting to
+  the async `Events.Writer`, so the update and its event commit or roll back
+  together. Writing the event after the transaction would leave a window
+  where an operator's re-enable lands between the commit and the event
+  write: the repair's disable event would then become the item's newest
+  decision while the item is actually monitored, and `pending_ids/1` would
+  select it again on the next run and undo the operator a second time. That
+  is the same bug this worker exists to fix.
   """
   @spec repair_one(binary()) :: :ok
   def repair_one(id) do
     case Repo.transaction(fn -> repair_one_tx(id) end) do
-      {:ok, {:updated, updated}} ->
-        # The explicit decision event is what makes this idempotent: it
-        # becomes the item's latest monitoring decision, so a later pass
-        # cannot select the row again. Only emitted when the guarded update
-        # above actually ran, so a skipped item leaves no event behind.
-        Events.media_item_monitoring_changed(updated, false, :job, "monitoring_repair")
+      {:ok, :updated} ->
         :ok
 
       {:ok, {:error, changeset}} ->
@@ -242,18 +249,43 @@ defmodule Mydia.Jobs.MonitoringRepair do
     end
   end
 
-  defp repair_one_tx(id) do
+  @doc """
+  The transaction body shared by `repair_one/1`: recheck, update, and (on a
+  successful update) write the decision event, all on the caller's
+  connection.
+
+  Public, like `repair_one/1`, purely for testability: a test can wrap this
+  in its own `Repo.transaction/1` and force a rollback after it returns
+  `:updated`, then assert that neither the update nor the event survived.
+  That is the cleanest deterministic way to prove the two writes are
+  atomic, since production never rolls this transaction back on the
+  success path (there is nothing to force the race in real time without
+  concurrency or a sleep). `repair_one/1` remains the only caller in
+  production code.
+  """
+  @spec repair_one_tx(binary()) :: :updated | {:error, Ecto.Changeset.t()} | :skipped
+  def repair_one_tx(id) do
     with %MediaItem{} = item <- Repo.get(MediaItem, id) || :not_found,
          :disable <- latest_decision(id) do
       # Deliberately not Media.update_media_item/3: it always emits its own
       # media_item.updated event, which would land right next to the
-      # explicit monitoring_changed event above and show the operator two
+      # explicit monitoring_changed event below and show the operator two
       # near-duplicate entries in the Activity Feed and item history for
       # every repaired item. Building and applying the changeset directly
       # keeps this write to exactly the one event that makes it idempotent.
       case Repo.update(MediaItem.changeset(item, %{monitored: false})) do
-        {:ok, updated} -> {:updated, updated}
-        {:error, changeset} -> {:error, changeset}
+        {:ok, updated} ->
+          # The explicit decision event is what makes this idempotent: it
+          # becomes the item's latest monitoring decision, so a later pass
+          # cannot select the row again. Only emitted when the guarded
+          # update above actually ran, so a skipped item leaves no event
+          # behind. Written inside this transaction (see the moduledoc and
+          # repair_one/1 above) so the update and the event are atomic.
+          Events.media_item_monitoring_changed(updated, false, :job, "monitoring_repair")
+          :updated
+
+        {:error, changeset} ->
+          {:error, changeset}
       end
     else
       :not_found ->

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -212,7 +212,7 @@ defmodule Mydia.Library.MetadataEnricher do
              ) do
           {:ok, metadata} ->
             attrs =
-              build_media_item_attrs(metadata, media_type, %{
+              build_metadata_attrs(metadata, media_type, %{
                 provider_type: provider_type,
                 exclude_id: existing_item.id
               })
@@ -275,7 +275,27 @@ defmodule Mydia.Library.MetadataEnricher do
     Metadata.fetch_by_id_cached(config, provider_id, fetch_opts)
   end
 
+  # The create path. Everything the provider owns, plus the monitoring default
+  # for an item that has no operator decision yet because it does not exist yet.
   defp build_media_item_attrs(metadata, media_type, match_result) do
+    metadata
+    |> build_metadata_attrs(media_type, match_result)
+    |> Map.put(:monitored, true)
+  end
+
+  # The update path. Strictly the fields the metadata provider owns.
+  #
+  # `:monitored` is absent on purpose and must stay absent. This function's
+  # output is written over a row the operator may have configured, and
+  # `MediaItem.changeset/2` casts `:monitored`, so putting it back here silently
+  # re-enables monitoring on every item an ordinary scan re-enriches. That was
+  # the bug in getmydia/mydia#653. `Media.upsert_episodes_from_season/3` keeps
+  # the same rule one level down for the same reason.
+  #
+  # `:monitor_new_seasons`, `:quality_profile_id` and `:library_path_id` are
+  # operator settings too. None of them is built here today. None of them
+  # should be added here later.
+  defp build_metadata_attrs(metadata, media_type, match_result) do
     provider_id = String.to_integer(to_string(metadata.provider_id))
 
     raw_provider_type = Map.get(match_result, :provider_type, metadata.provider || :tmdb)
@@ -287,8 +307,7 @@ defmodule Mydia.Library.MetadataEnricher do
       original_title: metadata.original_title,
       year: extract_year(metadata),
       imdb_id: metadata.imdb_id,
-      metadata: metadata,
-      monitored: true
+      metadata: metadata
     }
 
     # Set the id of the provider that produced the match, then add whatever

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -702,12 +702,24 @@ defmodule Mydia.Media do
   Only updates non-nil attributes. Returns `{:ok, count}` on success
   where count is the number of updated items, or `{:error, :not_found}` if
   `attrs` references a quality profile or library path that does not exist.
+
+  When `attrs` sets `:monitored`, this records a monitoring decision for every
+  affected item, exactly like `update_media_items_monitored/3` does. Without
+  that, an operator re-enabling monitoring here instead of through the
+  dedicated toggle would leave no decision on record, and
+  `Mydia.Jobs.MonitoringRepair` would read the item's last recorded decision
+  as the earlier disable and undo the re-enable on the next boot
+  (getmydia/mydia#653). A batch that does not touch `:monitored` emits nothing.
+
+  ## Options
+    - `:actor_type` - The type of actor (:user, :system, :job) - defaults to :system
+    - `:actor_id` - The ID of the actor (user_id, job name, etc.)
   """
-  @spec update_media_items_batch([binary()], map()) ::
+  @spec update_media_items_batch([binary()], map(), keyword()) ::
           {:ok, non_neg_integer()} | {:error, :not_found | term()}
-  def update_media_items_batch(ids, attrs) when is_list(ids) and is_map(attrs) do
+  def update_media_items_batch(ids, attrs, opts \\ []) when is_list(ids) and is_map(attrs) do
     if referenced_foreign_keys_exist?(attrs) do
-      do_update_media_items_batch(ids, attrs)
+      do_update_media_items_batch(ids, attrs, opts)
     else
       {:error, :not_found}
     end
@@ -732,7 +744,7 @@ defmodule Mydia.Media do
     Ecto.Query.CastError -> false
   end
 
-  defp do_update_media_items_batch(ids, attrs) do
+  defp do_update_media_items_batch(ids, attrs, opts) do
     Repo.transaction(fn ->
       # Build the update list, only including non-nil values
       updates =
@@ -743,15 +755,49 @@ defmodule Mydia.Media do
 
       if map_size(updates) > 1 do
         # More than just updated_at
-        MediaItem
-        |> where([m], m.id in ^ids)
-        |> Repo.update_all(set: Map.to_list(updates))
-        |> elem(0)
+
+        # Fetch media items before the update, but only when the batch
+        # touches :monitored: a quality-profile-only batch has nothing to
+        # record and should pay no extra query.
+        media_items =
+          if Map.has_key?(updates, :monitored) do
+            MediaItem
+            |> where([m], m.id in ^ids)
+            |> Repo.all()
+          else
+            []
+          end
+
+        {count, _} =
+          MediaItem
+          |> where([m], m.id in ^ids)
+          |> Repo.update_all(set: Map.to_list(updates))
+
+        unless media_items == [] do
+          monitored = normalize_monitored(Map.fetch!(updates, :monitored))
+          actor_type = Keyword.get(opts, :actor_type, :system)
+          actor_id = Keyword.get(opts, :actor_id, "media_context")
+
+          Enum.each(media_items, fn media_item ->
+            Events.media_item_monitoring_changed(media_item, monitored, actor_type, actor_id)
+          end)
+        end
+
+        count
       else
         0
       end
     end)
   end
+
+  # The batch edit form in the LiveView posts "true"/"false" strings; direct
+  # callers (tests, other contexts) pass real booleans. Repo.update_all casts
+  # either shape fine for the write itself, but the monitoring_changed event's
+  # metadata must carry an actual boolean, not the literal string "true".
+  defp normalize_monitored(true), do: true
+  defp normalize_monitored(false), do: false
+  defp normalize_monitored("true"), do: true
+  defp normalize_monitored("false"), do: false
 
   @doc """
   Deletes multiple media items in a transaction.

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -410,7 +410,12 @@ defmodule Mydia.Media do
 
     simple_changes =
       changes
-      |> Map.take([:title, :original_title, :year])
+      # :monitored and :monitor_new_seasons are operator settings, not metadata.
+      # They are here so that a write of either lands in the item's history with
+      # its old and new value, whichever caller made it. Without that, the
+      # enricher's silent re-enable in getmydia/mydia#653 was indistinguishable
+      # from an ordinary "Metadata enriched" update for three weeks.
+      |> Map.take([:title, :original_title, :year, :monitored, :monitor_new_seasons])
       |> Enum.map(fn {field, new_value} ->
         old_value = Map.get(original, field)
         {field, %{old: old_value, new: new_value}}

--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -435,21 +435,10 @@ defmodule MydiaWeb.ActivityLive.Index do
     simple_changes ++ metadata_changes
   end
 
-  defp humanize_field_name("overview"), do: "Description"
-  defp humanize_field_name("poster"), do: "Poster"
-  defp humanize_field_name("backdrop"), do: "Backdrop"
-  defp humanize_field_name("tagline"), do: "Tagline"
-  defp humanize_field_name("rating"), do: "Rating"
-  defp humanize_field_name("runtime"), do: "Runtime"
-  defp humanize_field_name("genres"), do: "Genres"
-  defp humanize_field_name("cast"), do: "Cast"
-  defp humanize_field_name("crew"), do: "Crew"
-  defp humanize_field_name("title"), do: "Title"
-  defp humanize_field_name("original_title"), do: "Original Title"
-  defp humanize_field_name("year"), do: "Year"
-  defp humanize_field_name("monitored"), do: "Monitoring"
-  defp humanize_field_name("monitor_new_seasons"), do: "New season monitoring"
-  defp humanize_field_name(field), do: Phoenix.Naming.humanize(field)
+  # Delegates to Presentation.field_label/1, the single source of truth for
+  # these labels, so this expanded breakdown cannot drift from the one-line
+  # summary rendered by Presentation.detail/1 for the same event.
+  defp humanize_field_name(field), do: Presentation.field_label(field)
 
   defp format_change_value("monitored", true), do: "monitored"
   defp format_change_value("monitored", false), do: "not monitored"

--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -405,7 +405,7 @@ defmodule MydiaWeb.ActivityLive.Index do
   defp format_change_details(changes) do
     simple_changes =
       changes
-      |> Map.take(["title", "original_title", "year"])
+      |> Map.take(["title", "original_title", "year", "monitored", "monitor_new_seasons"])
       |> Enum.map(fn {field, change} ->
         %{
           field: humanize_field_name(field),
@@ -447,8 +447,14 @@ defmodule MydiaWeb.ActivityLive.Index do
   defp humanize_field_name("title"), do: "Title"
   defp humanize_field_name("original_title"), do: "Original Title"
   defp humanize_field_name("year"), do: "Year"
+  defp humanize_field_name("monitored"), do: "Monitoring"
+  defp humanize_field_name("monitor_new_seasons"), do: "New season monitoring"
   defp humanize_field_name(field), do: Phoenix.Naming.humanize(field)
 
+  defp format_change_value("monitored", true), do: "monitored"
+  defp format_change_value("monitored", false), do: "not monitored"
+  defp format_change_value("monitor_new_seasons", "all"), do: "all seasons"
+  defp format_change_value("monitor_new_seasons", "none"), do: "no seasons"
   defp format_change_value(_field, nil), do: "none"
   defp format_change_value(_field, value), do: to_string(value)
 

--- a/test/mydia/events/presentation_test.exs
+++ b/test/mydia/events/presentation_test.exs
@@ -146,6 +146,40 @@ defmodule Mydia.Events.PresentationTest do
       assert detail == "Arrival, metadata refresh (title)"
     end
 
+    test "updated includes a monitored change in the summary" do
+      detail =
+        Presentation.detail(
+          event(
+            type: "media_item.updated",
+            metadata: %{
+              "title" => "Arrival",
+              "reason" => "Monitoring disabled",
+              "changes" => %{"monitored" => %{"old" => true, "new" => false}}
+            }
+          )
+        )
+
+      assert detail == "Arrival, monitoring disabled (monitored)"
+    end
+
+    test "updated includes a monitor_new_seasons change in the summary" do
+      detail =
+        Presentation.detail(
+          event(
+            type: "media_item.updated",
+            metadata: %{
+              "title" => "Severance",
+              "reason" => "Updated",
+              "changes" => %{
+                "monitor_new_seasons" => %{"old" => "all", "new" => "none"}
+              }
+            }
+          )
+        )
+
+      assert detail == "Severance, updated (monitor_new_seasons)"
+    end
+
     test "updated degrades to the title alone" do
       assert Presentation.detail(
                event(type: "media_item.updated", metadata: %{"title" => "Arrival"})

--- a/test/mydia/events/presentation_test.exs
+++ b/test/mydia/events/presentation_test.exs
@@ -228,6 +228,50 @@ defmodule Mydia.Events.PresentationTest do
                )
              ) == "Severance, 9 episodes"
     end
+
+    test "updated does not raise on a metadata_fields entry with a malformed field name" do
+      # A hand-edited or legacy row could carry anything under "field". This
+      # must render, not crash the whole Activity Feed over one bad event.
+      detail =
+        Presentation.detail(
+          event(
+            type: "media_item.updated",
+            metadata: %{
+              "title" => "Arrival",
+              "reason" => "Metadata refreshed",
+              "changes" => %{
+                "metadata_fields" => [
+                  %{"field" => nil, "old" => "a", "new" => "b"},
+                  %{"field" => 42, "old" => "c", "new" => "d"}
+                ]
+              }
+            }
+          )
+        )
+
+      assert is_binary(detail)
+      assert detail =~ "Arrival"
+    end
+  end
+
+  describe "field_label/1" do
+    test "maps a known field to its curated label" do
+      assert Presentation.field_label("monitored") == "Monitoring"
+    end
+
+    test "humanizes an unknown but well-formed string field" do
+      assert Presentation.field_label("release_year") == "Release year"
+    end
+
+    test "falls back to a fixed label for nil, instead of raising" do
+      assert Presentation.field_label(nil) == "Unknown field"
+    end
+
+    test "falls back to a fixed label for a non-string, non-atom value" do
+      assert Presentation.field_label(42) == "Unknown field"
+      assert Presentation.field_label(%{"not" => "a field name"}) == "Unknown field"
+      assert Presentation.field_label(["nope"]) == "Unknown field"
+    end
   end
 
   describe "detail/1 media_file.*" do

--- a/test/mydia/events/presentation_test.exs
+++ b/test/mydia/events/presentation_test.exs
@@ -143,7 +143,7 @@ defmodule Mydia.Events.PresentationTest do
           )
         )
 
-      assert detail == "Arrival, metadata refresh (title)"
+      assert detail == "Arrival, metadata refresh (Title)"
     end
 
     test "updated includes a monitored change in the summary" do
@@ -159,7 +159,10 @@ defmodule Mydia.Events.PresentationTest do
           )
         )
 
-      assert detail == "Arrival, monitoring disabled (monitored)"
+      # Matches the label the expanded Activity Feed breakdown uses for the
+      # same field (MydiaWeb.ActivityLive.Index.humanize_field_name/1), both
+      # sourced from Presentation.field_label/1.
+      assert detail == "Arrival, monitoring disabled (Monitoring)"
     end
 
     test "updated includes a monitor_new_seasons change in the summary" do
@@ -177,7 +180,7 @@ defmodule Mydia.Events.PresentationTest do
           )
         )
 
-      assert detail == "Severance, updated (monitor_new_seasons)"
+      assert detail == "Severance, updated (New season monitoring)"
     end
 
     test "updated degrades to the title alone" do

--- a/test/mydia/jobs/monitoring_repair_test.exs
+++ b/test/mydia/jobs/monitoring_repair_test.exs
@@ -1,0 +1,245 @@
+defmodule Mydia.Jobs.MonitoringRepairTest do
+  # Drives an isolated Oban instance, so these run serially.
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Ecto.Query
+  import Mydia.MediaFixtures
+
+  alias Mydia.Events
+  alias Mydia.Events.Event
+  alias Mydia.Jobs.MonitoringRepair
+  alias Mydia.Media.MediaItem
+
+  # perform/1 reschedules itself whenever it processes at least one row. The app
+  # skips Oban in test (engine: false), so that insert needs a locally started
+  # instance; mirrors the setup in hdr_backfill_test.exs.
+  setup do
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+    :ok
+  end
+
+  # events.inserted_at is :utc_datetime (second precision) and events.id is a
+  # random UUID, so two events written in the same second tie on the timestamp
+  # and the desc: e.id tiebreak is not chronological. Every helper here stamps
+  # an explicit time so ordering is deterministic instead of a coin flip.
+  defp stamp(event, seconds_ago), do: stamp_at(event, -seconds_ago)
+
+  defp stamp_forward(event, seconds_ahead), do: stamp_at(event, seconds_ahead)
+
+  defp stamp_at(event, offset_seconds) do
+    at =
+      DateTime.utc_now()
+      |> DateTime.add(offset_seconds, :second)
+      |> DateTime.truncate(:second)
+
+    {1, _} =
+      from(e in Event, where: e.id == ^event.id)
+      |> Repo.update_all(set: [inserted_at: at])
+
+    event
+  end
+
+  # Writes an event directly. The production reason strings come from the
+  # LiveView toggles in media_live/index.ex and show/episode_events.ex.
+  defp record_update(item, reason, seconds_ago) do
+    {:ok, event} =
+      Events.create_event(%{
+        category: "media",
+        type: "media_item.updated",
+        actor_type: :user,
+        actor_id: "test-operator",
+        resource_type: "media_item",
+        resource_id: item.id,
+        metadata: %{"title" => item.title, "media_type" => item.type, "reason" => reason}
+      })
+
+    stamp(event, seconds_ago)
+  end
+
+  defp record_monitoring_changed(item, monitored, seconds_ago) do
+    :ok = Events.media_item_monitoring_changed(item, monitored, :user, "test-operator")
+
+    [event] =
+      Events.list_events(
+        type: "media_item.monitoring_changed",
+        resource_type: "media_item",
+        resource_id: item.id
+      )
+
+    stamp(event, seconds_ago)
+  end
+
+  defp monitored?(id), do: Repo.get!(MediaItem, id).monitored
+
+  describe "pending_ids/1" do
+    test "selects a monitored item whose last decision was a disable" do
+      item = media_item_fixture(%{title: "Halloway Bend", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+
+      assert MonitoringRepair.pending_ids(10) == [item.id]
+    end
+
+    test "ignores an item whose last decision was an enable" do
+      item = media_item_fixture(%{title: "Ashgrove Lane", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+      record_update(item, "Monitoring enabled", 120)
+
+      assert MonitoringRepair.pending_ids(10) == []
+    end
+
+    test "ignores an item with no monitoring decision on record" do
+      item = media_item_fixture(%{title: "Pemberton Row", monitored: true})
+      record_update(item, "Metadata enriched", 300)
+
+      assert MonitoringRepair.pending_ids(10) == []
+    end
+
+    test "ignores an item with no events at all" do
+      _item = media_item_fixture(%{title: "Ellery Crossing", monitored: true})
+
+      assert MonitoringRepair.pending_ids(10) == []
+    end
+
+    test "ignores an item that is already unmonitored" do
+      item = media_item_fixture(%{title: "Cobbler's Rest", monitored: false})
+      record_update(item, "Monitoring disabled", 300)
+
+      assert MonitoringRepair.pending_ids(10) == []
+    end
+
+    # This is the case the design's dropped third condition would have missed.
+    test "selects an item with unrelated events after the disable" do
+      item = media_item_fixture(%{title: "Winterhold Mill", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+      record_update(item, "Metadata enriched", 200)
+      record_update(item, "Metadata refreshed", 100)
+
+      assert MonitoringRepair.pending_ids(10) == [item.id]
+    end
+
+    test "reads a monitoring_changed event as a decision" do
+      item = media_item_fixture(%{title: "Salter's Cross", monitored: true})
+      record_monitoring_changed(item, false, 300)
+
+      assert MonitoringRepair.pending_ids(10) == [item.id]
+    end
+
+    test "a monitoring_changed enable outranks an earlier disable" do
+      item = media_item_fixture(%{title: "Thistledown Way", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+      record_monitoring_changed(item, true, 120)
+
+      assert MonitoringRepair.pending_ids(10) == []
+    end
+
+    test "honours the limit" do
+      items =
+        for n <- 1..3 do
+          item = media_item_fixture(%{title: "Batch Item #{n}", monitored: true})
+          record_update(item, "Monitoring disabled", 300)
+          item
+        end
+
+      assert length(items) == 3
+      assert length(MonitoringRepair.pending_ids(2)) == 2
+    end
+  end
+
+  describe "perform/1" do
+    test "restores the item and records the restoration" do
+      item = media_item_fixture(%{title: "Merrow Quay", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+
+      assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
+
+      refute monitored?(item.id)
+
+      assert [event] =
+               Events.list_events(
+                 type: "media_item.monitoring_changed",
+                 resource_type: "media_item",
+                 resource_id: item.id
+               )
+
+      assert event.metadata["monitored"] == false
+      assert event.actor_id == "monitoring_repair"
+    end
+
+    test "leaves an item whose last decision was an enable alone" do
+      item = media_item_fixture(%{title: "Bramble Court", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+      record_update(item, "Monitoring enabled", 120)
+
+      assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
+
+      assert monitored?(item.id)
+    end
+
+    test "a second run changes nothing" do
+      item = media_item_fixture(%{title: "Fallow Green", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+
+      assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
+      refute monitored?(item.id)
+
+      assert MonitoringRepair.pending_ids(10) == []
+      assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
+
+      refute monitored?(item.id)
+
+      # One restoration, not two.
+      assert length(
+               Events.list_events(
+                 type: "media_item.monitoring_changed",
+                 resource_type: "media_item",
+                 resource_id: item.id
+               )
+             ) == 1
+    end
+
+    test "a manual re-enable after the repair is not undone" do
+      item = media_item_fixture(%{title: "Otterly Vale", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+
+      assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
+      refute monitored?(item.id)
+
+      # The repair's own monitoring_changed event was written just now, so the
+      # manual re-enable has to be stamped later than it to be the newest
+      # decision at second precision.
+      {:ok, reenabled} =
+        Mydia.Media.update_media_item(Repo.get!(MediaItem, item.id), %{monitored: true},
+          reason: "Monitoring enabled"
+        )
+
+      # Selected by reason, not by position: the repair wrote its own
+      # media_item.updated event in the same second, so "newest first" cannot
+      # tell the two apart.
+      enable_event =
+        Events.list_events(
+          type: "media_item.updated",
+          resource_type: "media_item",
+          resource_id: item.id
+        )
+        |> Enum.find(&(&1.metadata["reason"] == "Monitoring enabled"))
+
+      assert enable_event
+      stamp_forward(enable_event, 60)
+
+      assert reenabled.monitored
+      assert MonitoringRepair.pending_ids(10) == []
+
+      assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
+      assert monitored?(item.id)
+    end
+  end
+
+  describe "enqueue_once/0" do
+    test "returns :ok and inserts one job" do
+      assert :ok = MonitoringRepair.enqueue_once()
+      assert_enqueued(worker: MonitoringRepair)
+    end
+  end
+end

--- a/test/mydia/jobs/monitoring_repair_test.exs
+++ b/test/mydia/jobs/monitoring_repair_test.exs
@@ -195,6 +195,40 @@ defmodule Mydia.Jobs.MonitoringRepairTest do
     test "returns :ok for an id that no longer exists" do
       assert :ok = MonitoringRepair.repair_one(Ecto.UUID.generate())
     end
+
+    test "the update and its decision event commit or roll back together" do
+      item = media_item_fixture(%{title: "Wrenfield Close", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+
+      # repair_one/1 is just `Repo.transaction(fn -> repair_one_tx(id) end)`.
+      # Driving repair_one_tx/1 through our own transaction here is
+      # equivalent, and lets the test force a rollback right after the
+      # write instead of relying on real concurrency or a sleep to land one
+      # mid-transaction.
+      result =
+        Repo.transaction(fn ->
+          case MonitoringRepair.repair_one_tx(item.id) do
+            :updated -> Repo.rollback(:forced_for_test)
+            other -> other
+          end
+        end)
+
+      assert result == {:error, :forced_for_test}
+
+      # The update did not survive the rollback.
+      assert monitored?(item.id)
+
+      # Nor did the decision event. If the two writes were not part of the
+      # same transaction, this event would still be here even though the
+      # update it describes never happened, and it would become the item's
+      # newest "decision" on the very next pending_ids/1 run: the same
+      # class of self-inflicted bug getmydia/mydia#653 is about.
+      assert Events.list_events(
+               type: "media_item.monitoring_changed",
+               resource_type: "media_item",
+               resource_id: item.id
+             ) == []
+    end
   end
 
   describe "perform/1" do

--- a/test/mydia/jobs/monitoring_repair_test.exs
+++ b/test/mydia/jobs/monitoring_repair_test.exs
@@ -147,6 +147,56 @@ defmodule Mydia.Jobs.MonitoringRepairTest do
     end
   end
 
+  describe "repair_one/1" do
+    test "does not flip an item whose decision became an enable after selection" do
+      item = media_item_fixture(%{title: "Quietwood Fen", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+
+      # This is exactly what pending_ids/1 selects on.
+      assert MonitoringRepair.pending_ids(10) == [item.id]
+
+      # Simulates the race directly: an operator re-enables monitoring,
+      # recording a newer decision, between selection and repair_one/1's
+      # write. No sleeps or concurrent processes needed, since repair_one/1
+      # re-reads the decision itself immediately before writing.
+      record_update(item, "Monitoring enabled", 120)
+
+      assert :ok = MonitoringRepair.repair_one(item.id)
+
+      assert monitored?(item.id)
+
+      # No monitoring_changed event was fabricated for a write that never
+      # happened; that would corrupt the decision history this worker reads.
+      assert Events.list_events(
+               type: "media_item.monitoring_changed",
+               resource_type: "media_item",
+               resource_id: item.id
+             ) == []
+    end
+
+    test "flips an item whose latest decision is still a disable" do
+      item = media_item_fixture(%{title: "Amberfield Row", monitored: true})
+      record_update(item, "Monitoring disabled", 300)
+
+      assert :ok = MonitoringRepair.repair_one(item.id)
+
+      refute monitored?(item.id)
+
+      assert [event] =
+               Events.list_events(
+                 type: "media_item.monitoring_changed",
+                 resource_type: "media_item",
+                 resource_id: item.id
+               )
+
+      assert event.metadata["monitored"] == false
+    end
+
+    test "returns :ok for an id that no longer exists" do
+      assert :ok = MonitoringRepair.repair_one(Ecto.UUID.generate())
+    end
+  end
+
   describe "perform/1" do
     test "restores the item and records the restoration" do
       item = media_item_fixture(%{title: "Merrow Quay", monitored: true})

--- a/test/mydia/jobs/monitoring_repair_test.exs
+++ b/test/mydia/jobs/monitoring_repair_test.exs
@@ -165,6 +165,10 @@ defmodule Mydia.Jobs.MonitoringRepairTest do
 
       assert event.metadata["monitored"] == false
       assert event.actor_id == "monitoring_repair"
+      # :job routes through format_job_name/1 in the Activity Feed ("Monitoring
+      # Repair"); :system would collapse to a generic "System" label and
+      # discard the actor id entirely.
+      assert event.actor_type == :job
     end
 
     test "leaves an item whose last decision was an enable alone" do
@@ -181,22 +185,30 @@ defmodule Mydia.Jobs.MonitoringRepairTest do
       item = media_item_fixture(%{title: "Fallow Green", monitored: true})
       record_update(item, "Monitoring disabled", 300)
 
+      events_before_repair =
+        Events.list_events(resource_type: "media_item", resource_id: item.id)
+
       assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
       refute monitored?(item.id)
+
+      # The repair must write exactly ONE event (the explicit
+      # monitoring_changed decision), not that event plus a second
+      # media_item.updated from going through Media.update_media_item/3. A
+      # count scoped to `type: "media_item.monitoring_changed"` would not
+      # catch the second event, since it is a different type.
+      events_after_first_run =
+        Events.list_events(resource_type: "media_item", resource_id: item.id)
+
+      assert length(events_after_first_run) == length(events_before_repair) + 1
 
       assert MonitoringRepair.pending_ids(10) == []
       assert :ok = MonitoringRepair.perform(%Oban.Job{args: %{}})
 
       refute monitored?(item.id)
 
-      # One restoration, not two.
-      assert length(
-               Events.list_events(
-                 type: "media_item.monitoring_changed",
-                 resource_type: "media_item",
-                 resource_id: item.id
-               )
-             ) == 1
+      # One restoration, not two: the second run adds nothing at all.
+      assert length(Events.list_events(resource_type: "media_item", resource_id: item.id)) ==
+               length(events_after_first_run)
     end
 
     test "a manual re-enable after the repair is not undone" do

--- a/test/mydia/library/metadata_enricher_test.exs
+++ b/test/mydia/library/metadata_enricher_test.exs
@@ -972,6 +972,185 @@ defmodule Mydia.Library.MetadataEnricherTest do
     |> Enum.map(&{&1.season_number, &1.episode_count})
   end
 
+  describe "monitored on the update path" do
+    setup do
+      bypass = Bypass.open()
+
+      config = %{
+        type: :metadata_relay,
+        base_url: "http://localhost:#{bypass.port}",
+        options: %{language: "en-US", include_adult: false}
+      }
+
+      %{bypass: bypass, config: config}
+    end
+
+    test "an unmonitored movie is still unmonitored after re-enrichment",
+         %{bypass: bypass, config: config} do
+      id = System.unique_integer([:positive])
+
+      item =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Quiet Harbour",
+          year: 2019,
+          tmdb_id: id,
+          monitored: false
+        })
+        |> backdate()
+
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/tmdb/movies/#{id}",
+        &respond_json(&1, movie_body(id, "Quiet Harbour"))
+      )
+
+      match = %{
+        provider_id: to_string(id),
+        provider_type: :tmdb,
+        title: "Quiet Harbour",
+        metadata: %{media_type: :movie}
+      }
+
+      assert {:ok, updated} =
+               MetadataEnricher.enrich(match, config: config, fetch_episodes: false)
+
+      assert updated.id == item.id
+      refute updated.monitored
+      refute Repo.get!(MediaItem, item.id).monitored
+    end
+
+    test "an unmonitored show is still unmonitored after re-enrichment",
+         %{bypass: bypass, config: config} do
+      id = System.unique_integer([:positive])
+
+      item =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Lanternwick",
+          tmdb_id: id,
+          metadata_source: :tmdb,
+          monitored: false
+        })
+        |> backdate()
+
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/tmdb/tv/shows/#{id}",
+        &respond_json(&1, tv_body(id, "Lanternwick"))
+      )
+
+      match = tv_match(id, :tmdb, "Lanternwick")
+
+      assert {:ok, updated} =
+               MetadataEnricher.enrich(match, config: config, fetch_episodes: false)
+
+      assert updated.id == item.id
+      refute updated.monitored
+    end
+
+    test "a monitored item stays monitored after re-enrichment",
+         %{bypass: bypass, config: config} do
+      id = System.unique_integer([:positive])
+
+      item =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Copperline",
+          year: 2019,
+          tmdb_id: id,
+          monitored: true
+        })
+        |> backdate()
+
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/tmdb/movies/#{id}",
+        &respond_json(&1, movie_body(id, "Copperline"))
+      )
+
+      match = %{
+        provider_id: to_string(id),
+        provider_type: :tmdb,
+        title: "Copperline",
+        metadata: %{media_type: :movie}
+      }
+
+      assert {:ok, updated} =
+               MetadataEnricher.enrich(match, config: config, fetch_episodes: false)
+
+      assert updated.id == item.id
+      assert updated.monitored
+    end
+
+    # Guards the other direction: Part 1 must not narrow the update attrs so far
+    # that the enricher stops doing its actual job.
+    test "the update still writes the metadata fields it owns",
+         %{bypass: bypass, config: config} do
+      id = System.unique_integer([:positive])
+
+      item =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Stale Title",
+          year: 1999,
+          tmdb_id: id,
+          monitored: false
+        })
+        |> backdate()
+
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/tmdb/movies/#{id}",
+        &respond_json(&1, movie_body(id, "Marrowfield"))
+      )
+
+      match = %{
+        provider_id: to_string(id),
+        provider_type: :tmdb,
+        title: "Marrowfield",
+        metadata: %{media_type: :movie}
+      }
+
+      assert {:ok, updated} =
+               MetadataEnricher.enrich(match, config: config, fetch_episodes: false)
+
+      assert updated.id == item.id
+      assert updated.title == "Marrowfield"
+      # movie_body/2 hardcodes a 2019-01-01 release date.
+      assert updated.year == 2019
+      refute updated.monitored
+    end
+
+    test "a brand new item is created monitored",
+         %{bypass: bypass, config: config} do
+      id = System.unique_integer([:positive])
+
+      Bypass.stub(
+        bypass,
+        "GET",
+        "/tmdb/movies/#{id}",
+        &respond_json(&1, movie_body(id, "Ninebark"))
+      )
+
+      match = %{
+        provider_id: to_string(id),
+        provider_type: :tmdb,
+        title: "Ninebark",
+        metadata: %{media_type: :movie}
+      }
+
+      assert {:ok, created} =
+               MetadataEnricher.enrich(match, config: config, fetch_episodes: false)
+
+      assert created.monitored
+    end
+  end
+
   defp tv_match(id, provider_type, title) do
     %{
       provider_id: to_string(id),

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -1,6 +1,7 @@
 defmodule Mydia.MediaTest do
   use Mydia.DataCase
 
+  alias Mydia.Events
   alias Mydia.Media
 
   describe "media_items" do
@@ -3431,6 +3432,54 @@ defmodule Mydia.MediaTest do
         })
 
       assert Mydia.Media.episode_bounds(show.id) == {2, 10}
+    end
+  end
+
+  describe "update_media_item/3 change tracking" do
+    import Mydia.MediaFixtures
+
+    test "records a monitored change in the event" do
+      item = media_item_fixture(%{monitored: true})
+
+      assert {:ok, _updated} =
+               Media.update_media_item(item, %{monitored: false}, reason: "Monitoring disabled")
+
+      event =
+        Events.list_events(
+          type: "media_item.updated",
+          resource_type: "media_item",
+          resource_id: item.id
+        )
+        |> List.first()
+
+      assert event
+      assert event.metadata["reason"] == "Monitoring disabled"
+      assert event.metadata["changes"]["monitored"] == %{"old" => true, "new" => false}
+    end
+
+    # monitor_new_seasons is an Ecto.Enum over [:all, :none], not a boolean.
+    # Atom values pass through serialize_change_value/1 unchanged and Jason
+    # encodes them as strings, so they read back as "all" and "none".
+    test "records a monitor_new_seasons change in the event" do
+      item = media_item_fixture(%{type: "tv_show", monitor_new_seasons: :all})
+
+      assert {:ok, _updated} =
+               Media.update_media_item(item, %{monitor_new_seasons: :none})
+
+      event =
+        Events.list_events(
+          type: "media_item.updated",
+          resource_type: "media_item",
+          resource_id: item.id
+        )
+        |> List.first()
+
+      assert event
+
+      assert event.metadata["changes"]["monitor_new_seasons"] == %{
+               "old" => "all",
+               "new" => "none"
+             }
     end
   end
 end

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -306,6 +306,48 @@ defmodule Mydia.MediaTest do
 
       assert Media.get_media_item!(media_item.id).quality_profile_id == profile.id
     end
+
+    test "update_media_items_batch/2 records a monitoring decision per item when it sets monitored" do
+      item_a = media_item_fixture(%{type: "movie", monitored: false})
+      item_b = media_item_fixture(%{type: "movie", monitored: false})
+
+      assert {:ok, 2} =
+               Media.update_media_items_batch([item_a.id, item_b.id], %{monitored: true})
+
+      assert Media.get_media_item!(item_a.id).monitored
+      assert Media.get_media_item!(item_b.id).monitored
+
+      for item <- [item_a, item_b] do
+        assert [event] =
+                 Events.list_events(
+                   type: "media_item.monitoring_changed",
+                   resource_type: "media_item",
+                   resource_id: item.id
+                 )
+
+        assert event.metadata["monitored"] == true
+      end
+    end
+
+    # This is the regression: a batch re-enable through this path used to set
+    # `monitored` with a bare Repo.update_all and no event, which is
+    # indistinguishable from Mydia.Library.MetadataEnricher's silent flip
+    # (getmydia/mydia#653) to Mydia.Jobs.MonitoringRepair.
+    test "update_media_items_batch/2 emits no monitoring event for a quality-profile-only batch" do
+      media_item = media_item_fixture(%{type: "movie"})
+      profile = quality_profile_fixture()
+
+      assert {:ok, 1} =
+               Media.update_media_items_batch([media_item.id], %{
+                 quality_profile_id: profile.id
+               })
+
+      assert Events.list_events(
+               type: "media_item.monitoring_changed",
+               resource_type: "media_item",
+               resource_id: media_item.id
+             ) == []
+    end
   end
 
   # Nested describe is invalid in ExUnit. These live as siblings of "media_items"

--- a/test/mydia_web/live/activity_live/index_test.exs
+++ b/test/mydia_web/live/activity_live/index_test.exs
@@ -374,6 +374,47 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
 
       assert html =~ "Plugin update available: tmdb-art 1.0.0 to 1.2.0"
     end
+
+    test "expands a monitored change with humanized field and values", %{conn: conn} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "media",
+          type: "media_item.updated",
+          actor_type: :system,
+          actor_id: "media_context",
+          metadata: %{
+            "title" => "Nightfall Station",
+            "reason" => "Monitoring disabled",
+            "changes" => %{"monitored" => %{"old" => true, "new" => false}}
+          }
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      assert html =~ "Monitoring"
+      assert html =~ "not monitored"
+    end
+
+    test "expands a monitor_new_seasons change with humanized field and values", %{conn: conn} do
+      {:ok, _} =
+        Events.create_event(%{
+          category: "media",
+          type: "media_item.updated",
+          actor_type: :system,
+          actor_id: "media_context",
+          metadata: %{
+            "title" => "Nightfall Station",
+            "reason" => "Updated",
+            "changes" => %{"monitor_new_seasons" => %{"old" => "all", "new" => "none"}}
+          }
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      assert html =~ "New season monitoring"
+      assert html =~ "all seasons"
+      assert html =~ "no seasons"
+    end
   end
 
   describe "Activity feed as a guest" do

--- a/test/mydia_web/live/activity_live/index_test.exs
+++ b/test/mydia_web/live/activity_live/index_test.exs
@@ -415,6 +415,35 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
       assert html =~ "all seasons"
       assert html =~ "no seasons"
     end
+
+    test "renders a metadata_fields change whose field name is malformed", %{conn: conn} do
+      # format_change_details/1 passes field_change["field"] straight to
+      # Presentation.field_label/1. A hand-edited or legacy row can carry
+      # nil (or any other non-string) there, and that used to raise
+      # FunctionClauseError out of Phoenix.Naming.humanize/1, crashing the
+      # whole Activity Feed render over one bad event.
+      {:ok, _} =
+        Events.create_event(%{
+          category: "media",
+          type: "media_item.updated",
+          actor_type: :system,
+          actor_id: "media_context",
+          metadata: %{
+            "title" => "Nightfall Station",
+            "reason" => "Metadata refreshed",
+            "changes" => %{
+              "metadata_fields" => [
+                %{"field" => nil, "old" => "a", "new" => "b"}
+              ]
+            }
+          }
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/activity")
+
+      assert html =~ "Nightfall Station"
+      assert html =~ "Unknown field"
+    end
   end
 
   describe "Activity feed as a guest" do

--- a/test/mydia_web/live/media_live/index_test.exs
+++ b/test/mydia_web/live/media_live/index_test.exs
@@ -959,6 +959,68 @@ defmodule MydiaWeb.MediaLive.IndexTest do
     end
   end
 
+  describe "batch edit" do
+    setup %{conn: conn} do
+      %{conn: log_in_user(conn, admin_user_fixture())}
+    end
+
+    # getmydia/mydia#653 regression: a batch re-enable through this modal used
+    # to write `monitored` with a bare Repo.update_all and record no decision,
+    # indistinguishable to Mydia.Jobs.MonitoringRepair from the metadata
+    # enricher's silent flip.
+    test "setting monitored records a decision for every selected item", %{conn: conn} do
+      movie_a = media_item_fixture(%{title: "Harrowgate Signal", type: "movie", monitored: false})
+      movie_b = media_item_fixture(%{title: "Pallid Meridian", type: "movie", monitored: false})
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      render_click(view, "toggle_selection_mode", %{})
+      render_click(view, "toggle_select", %{"id" => movie_a.id})
+      render_click(view, "toggle_select", %{"id" => movie_b.id})
+
+      render_click(view, "show_batch_edit", %{})
+      render_submit(view, "batch_edit_submit", %{"batch_edit" => %{"monitored" => "true"}})
+
+      assert Mydia.Media.get_media_item!(movie_a.id).monitored
+      assert Mydia.Media.get_media_item!(movie_b.id).monitored
+
+      for item <- [movie_a, movie_b] do
+        assert [event] =
+                 Mydia.Events.list_events(
+                   type: "media_item.monitoring_changed",
+                   resource_type: "media_item",
+                   resource_id: item.id
+                 )
+
+        assert event.metadata["monitored"] == true
+      end
+    end
+
+    test "a quality-profile-only batch emits no monitoring event", %{conn: conn} do
+      profile = Mydia.SettingsFixtures.quality_profile_fixture()
+      movie = media_item_fixture(%{title: "Quiet Aftermath", type: "movie"})
+
+      {:ok, view, _html} = live(conn, ~p"/movies")
+
+      render_click(view, "toggle_selection_mode", %{})
+      render_click(view, "toggle_select", %{"id" => movie.id})
+
+      render_click(view, "show_batch_edit", %{})
+
+      render_submit(view, "batch_edit_submit", %{
+        "batch_edit" => %{"quality_profile_id" => profile.id, "monitored" => "no_change"}
+      })
+
+      assert Mydia.Media.get_media_item!(movie.id).quality_profile_id == profile.id
+
+      assert Mydia.Events.list_events(
+               type: "media_item.monitoring_changed",
+               resource_type: "media_item",
+               resource_id: movie.id
+             ) == []
+    end
+  end
+
   describe "poster badge stack" do
     setup %{conn: conn} do
       admin = admin_user_fixture()


### PR DESCRIPTION
Fixes the self-enabling monitoring reported in https://github.com/getmydia/mydia/issues/653#issuecomment-5501654427: an operator disabled monitoring on a movie, and 22 days later it read Monitored again with nothing in its history recording the change.

This is independent of the re-scan trashing in the body of #653, which is a separate defect with its own fix.

## Cause

`MetadataEnricher.build_media_item_attrs/3` built one attrs map and handed it to two callers with opposite needs: the create path, and the update path for an item already in the library. The map hardcoded `monitored: true`, and `MediaItem.changeset/2` casts `:monitored`, so every re-enrichment overwrote the operator's choice. The only thing in the way was `recently_enriched?/1`, whose window is one hour, so any scan promoting a file for an item last touched longer ago than that rewrote the flag.

It went unseen because `extract_meaningful_changes/2` recorded only title, original_title and year. The write left a `media_item.updated` event whose sole mark was `reason: "Metadata enriched"`. The history was never empty; it just never mentioned monitoring.

The same defect had already been fixed one level down: `Media.upsert_episodes_from_season/3` takes `monitor_new?` through `Keyword.fetch!` with the comment *"A default here is what let the scanner and enricher drift into monitoring everything regardless of the show's intent"*, and its update branch omits `monitored` deliberately. The episode level was hardened; the media item level was missed.

## What changed

**Split the enricher's attrs builder** (`a99ce7c`). The create path keeps `monitored: true`; the update path gets a builder returning only what the metadata provider owns. The update attrs now have no `:monitored` key, and by construction no `:monitor_new_seasons`, `:quality_profile_id` or `:library_path_id` either, so the next field added to the builder cannot leak the same way.

**Record monitoring changes in history** (`828e3cf`, `dbb8794`). `:monitored` and `:monitor_new_seasons` are added to `extract_meaningful_changes/2`, and both presentation layers that render an event's changes were widened to match. Without the second commit the change reached the database but appeared nowhere a person looks: `Presentation.changes_summary/1` and `ActivityLive.format_change_details/1` each hardcoded their own three-field list.

**Restore the already-flipped items** (`67a5769`). `Mydia.Jobs.MonitoringRepair`, a one-shot Oban worker on the `HdrBackfill` pattern, enqueued once at boot. The bug destroyed the setting but not the record of it: the toggles write `reason: "Monitoring enabled"` / `"Monitoring disabled"` into event metadata, retained 90 days by default. An item is restored when two facts hold, that it is monitored now and its most recent recorded monitoring decision was a disable.

It is idempotent with no stamp column and therefore no migration: the restoration emits its own `monitoring_changed` event, which becomes the item's latest decision, and the item is no longer monitored, so a second pass cannot select it. A manual re-enable afterwards is likewise a later decision, so it never undoes the operator.

`Event.metadata` is a map serialized into a TEXT column on both SQLite and PostgreSQL, so there is no portable JSON operator for it. The query narrows by type and resource in chunks of 200 ids; the reason match runs in Elixir.

**Closed a second silent path** (`544a30d`). Found by review, not by the original design. `Media.update_media_items_batch/2`, reached from the Batch Edit modal, set `monitored` through a bare `Repo.update_all` with no event at all, the same silent shape as the enricher bug. That falsified the premise the repair worker rests on: an operator who disabled an item with the single toggle and later re-enabled it via Batch Edit would leave exactly the state the worker treats as evidence of the bug, and the repair would have undone their deliberate re-enable. `update_media_items_batch/3` now records one `monitoring_changed` event per affected item when, and only when, the batch sets `monitored`.

## Limits worth knowing

Items whose disable predates the 90 day event retention window carry no record and are left alone. They cannot be recovered, and operators should re-check anything they unmonitored longer ago than that.

`events.inserted_at` is second-precision and `events.id` is a random UUID, so two decisions recorded in the same second order arbitrarily. Not a real production scenario, and the worst case is one item left monitored, fixable from the UI.

Unlike `HdrBackfill`, this worker has no stamp column, so its per-boot cost does not fall to zero once the backlog drains. It re-derives the candidate set each boot. Cheap on a typical self-hosted library; documented honestly in the boot comment rather than borrowing `HdrBackfill`'s "harmless once drained" claim, which does not hold here.

## Testing

Full suite green on this branch: 13 doctests, 10103 tests, 0 failures, 44 skipped.

New coverage: an unmonitored item survives re-enrichment unmonitored (movie and show), a new item is still created monitored, the update still writes the fields it owns; monitored changes appear in event change details and render in the Activity Feed; the repair worker's selection rule across seven cases including idempotency and a manual re-enable; batch edit emits one decision per item when it sets monitored and none otherwise.

## Follow-up, not in this PR

`Media.set_monitor_new_seasons/2` writes via `Repo.update_all` and calls `Events.media_item_updated/5` with no changes argument, so `changes["monitor_new_seasons"]` never populates from the real call path. The rendering added here for that field is currently unreachable by user action. Harmless, but worth closing separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Re-enriching media no longer unintentionally re-enables monitoring settings.
  - Existing items with incorrect monitoring states are automatically corrected without overriding newer manual decisions.
  - Monitoring decisions are now consistently recorded in activity history.
  - Newly added media continues to receive the appropriate default monitoring setting.

- **Improvements**
  - Batch monitoring changes generate clear per-item activity events.
  - Activity details now show readable monitoring and new-season monitoring changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->