### PR TITLE
fix(player): match the home loading skeleton to the content it stands in for

### DIFF
--- a/player/lib/core/layout/rail_metrics.dart
+++ b/player/lib/core/layout/rail_metrics.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/widgets.dart';
+
+import 'breakpoints.dart';
+
+/// The geometry of one horizontal poster rail, resolved for the current
+/// screen width.
+///
+/// `ContentRail` and the `ShimmerRail` that stands in for it while data loads
+/// both read this, so a change to rail geometry cannot land in one and miss
+/// the other. The two carried independent copies of these numbers until
+/// 2026-09-01 and every one of them had drifted: the skeleton drew 120px cards
+/// against the rail's 130 to 160, with its own spacing, padding, rail height
+/// and corner radius. `test/test_utils/rail_parity.dart` is the trip-wire.
+///
+/// Tier thresholds are not repeated here. Every dimension delegates to
+/// [Breakpoints], which stays the single place a breakpoint is written down.
+@immutable
+class RailMetrics {
+  const RailMetrics({
+    required this.cardSize,
+    required this.cardSpacing,
+    required this.horizontalPadding,
+    required this.railHeight,
+    required this.headerTopPadding,
+    required this.headerBottomPadding,
+    required this.headerBottomCollapsed,
+  });
+
+  /// Resolves the metrics for [context]'s current width.
+  factory RailMetrics.of(BuildContext context) {
+    // Two thresholds, deliberately read separately. `Breakpoints.isDesktop` is
+    // true from 900 (`Breakpoints.tablet`), while `Breakpoints.desktop` is
+    // 1200. Card size, spacing, side padding and rail height switch at both;
+    // the header paddings, which were written in terms of `isDesktop`, switch
+    // only at 900. Collapsing these into one branch is the mistake this
+    // comment exists to prevent.
+    final isDesktop = Breakpoints.isDesktop(context);
+
+    return RailMetrics(
+      cardSize: Breakpoints.getCardSize(context),
+      cardSpacing: Breakpoints.getCardSpacing(context),
+      horizontalPadding: Breakpoints.getHorizontalPadding(context),
+      railHeight: Breakpoints.getRailHeight(context),
+      headerTopPadding: isDesktop ? 32 : 24,
+      headerBottomPadding: isDesktop ? 20 : 16,
+      headerBottomCollapsed: isDesktop ? 10 : 8,
+    );
+  }
+
+  /// Poster dimensions for one card.
+  final CardSize cardSize;
+
+  /// Gap between two adjacent cards.
+  final double cardSpacing;
+
+  /// Space to the left of the first card and to the right of the last.
+  final double horizontalPadding;
+
+  /// Height of the strip the cards scroll in. Exceeds [cardSize]'s height by
+  /// enough to hold a card's title and subtitle beneath its poster.
+  final double railHeight;
+
+  /// Space above a rail's title. This is also what separates one rail from the
+  /// rail above it: rails carry no inter-rail spacer, and neither does the
+  /// skeleton.
+  final double headerTopPadding;
+
+  /// Space below the title of an open rail.
+  final double headerBottomPadding;
+
+  /// Space below the title of a collapsed rail, where the title sits directly
+  /// above whatever follows rather than above a strip of posters.
+  ///
+  /// Rail-only; the skeleton never collapses. It lives here because it and
+  /// [headerBottomPadding] are two halves of one decision, and separating them
+  /// is how the next divergence starts.
+  final double headerBottomCollapsed;
+
+  /// Gap between a card's poster and its title. Mirrors `MediaCard`.
+  static const double labelGap = 10;
+
+  /// Gap between a card's title and its subtitle. Mirrors `MediaCard`.
+  static const double subtitleGap = 4;
+}

--- a/player/lib/presentation/screens/home/home_loading_skeleton.dart
+++ b/player/lib/presentation/screens/home/home_loading_skeleton.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/layout/breakpoints.dart';
+import '../../../core/theme/colors.dart';
+import '../../widgets/shimmer_card.dart';
+
+/// The home screen's loading state.
+///
+/// Shaped to the loaded layout rather than to a generic placeholder: a hero
+/// and three rails at the sizes and offsets `HomeScreen`'s `data` branch will
+/// use, so nothing moves when the two swap.
+///
+/// It lives in its own file so a test can pump it directly. In place, checking
+/// this geometry meant holding a code-generated Riverpod `StreamNotifier` in
+/// `AsyncLoading`, which is a lot of scaffolding to assert a padding value.
+class HomeLoadingSkeleton extends StatelessWidget {
+  const HomeLoadingSkeleton({super.key});
+
+  /// Test handle for the hero block.
+  static const heroKey = ValueKey<String>('home-skeleton-hero');
+
+  @override
+  Widget build(BuildContext context) {
+    // No top padding, and no spacers between the rails.
+    //
+    // The `data` branch is a `CustomScrollView` with neither, under a Scaffold
+    // with `extendBodyBehindAppBar: true`, so its hero starts at y=0 and
+    // renders under the glass app bar. A top padding here pushed the
+    // placeholder hero below the app bar and cost roughly 80 to 100px of jump
+    // on load. Rails are separated by `RailMetrics.headerTopPadding` alone,
+    // exactly as `ContentRail` is.
+    return ListView(
+      children: const [
+        _ShimmerHero(key: HomeLoadingSkeleton.heroKey),
+        ShimmerRail(),
+        ShimmerRail(),
+        ShimmerRail(),
+      ],
+    );
+  }
+}
+
+class _ShimmerHero extends StatelessWidget {
+  const _ShimmerHero({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final size = MediaQuery.of(context).size;
+    final isDesktop = Breakpoints.isDesktop(context);
+    // Match the responsive hero height from _HeroSection
+    final heroHeight = isDesktop
+        ? (size.height * 0.45).clamp(300.0, 450.0)
+        : size.height * 0.5;
+    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
+
+    return Container(
+      width: size.width,
+      height: heroHeight,
+      color: AppColors.surface,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    AppColors.background.withValues(alpha: 0.4),
+                    Colors.transparent,
+                    AppColors.background.withValues(alpha: 0.9),
+                    AppColors.background,
+                  ],
+                  stops: const [0.0, 0.3, 0.7, 1.0],
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: horizontalPadding,
+            right: horizontalPadding,
+            bottom: isDesktop ? 32 : 24,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 80,
+                  height: 20,
+                  decoration: BoxDecoration(
+                    color: AppColors.shimmerBase,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Container(
+                  width: 200,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: AppColors.shimmerBase,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  width: 120,
+                  height: 20,
+                  decoration: BoxDecoration(
+                    color: AppColors.shimmerBase,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Container(
+                      width: 100,
+                      height: 44,
+                      decoration: BoxDecoration(
+                        color: AppColors.shimmerBase,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Container(
+                      width: 120,
+                      height: 44,
+                      decoration: BoxDecoration(
+                        color: AppColors.shimmerBase,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/player/lib/presentation/screens/home_screen.dart
+++ b/player/lib/presentation/screens/home_screen.dart
@@ -13,7 +13,7 @@ import '../widgets/content_rail.dart';
 import 'continue_watching/continue_watching_actions.dart' as cw_actions;
 import '../widgets/freshness_header.dart';
 import '../widgets/glass_surface.dart';
-import '../widgets/shimmer_card.dart';
+import 'home/home_loading_skeleton.dart';
 import '../../core/layout/breakpoints.dart';
 import '../../core/layout/dock_insets.dart';
 import '../../core/theme/colors.dart';
@@ -164,7 +164,7 @@ class HomeScreen extends ConsumerWidget {
                 loading: () {
                   // No hero pick yet -> calm static fallback.
                   publishBackdropSource(ref, BackdropSource.none);
-                  return _buildShimmerLoading(context);
+                  return const HomeLoadingSkeleton();
                 },
                 error: (error, stackTrace) {
                   publishBackdropSource(ref, BackdropSource.none);
@@ -267,24 +267,6 @@ class HomeScreen extends ConsumerWidget {
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildShimmerLoading(BuildContext context) {
-    final isDesktop = Breakpoints.isDesktop(context);
-    final safeAreaTop = MediaQuery.of(context).padding.top;
-    return ListView(
-      padding:
-          EdgeInsets.only(top: isDesktop ? 0 : safeAreaTop + kToolbarHeight),
-      children: [
-        const _ShimmerHero(),
-        SizedBox(height: isDesktop ? 32 : 24),
-        const ShimmerRail(count: 5),
-        SizedBox(height: isDesktop ? 24 : 16),
-        const ShimmerRail(count: 5),
-        SizedBox(height: isDesktop ? 24 : 16),
-        const ShimmerRail(count: 5),
-      ],
     );
   }
 
@@ -610,107 +592,6 @@ class _HeroSection extends StatelessWidget {
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(10),
                         ),
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _ShimmerHero extends StatelessWidget {
-  const _ShimmerHero();
-
-  @override
-  Widget build(BuildContext context) {
-    final size = MediaQuery.of(context).size;
-    final isDesktop = Breakpoints.isDesktop(context);
-    // Match the responsive hero height from _HeroSection
-    final heroHeight = isDesktop
-        ? (size.height * 0.45).clamp(300.0, 450.0)
-        : size.height * 0.5;
-    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-
-    return Container(
-      width: size.width,
-      height: heroHeight,
-      color: AppColors.surface,
-      child: Stack(
-        children: [
-          // Shimmer effect
-          Positioned.fill(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    AppColors.background.withValues(alpha: 0.4),
-                    Colors.transparent,
-                    AppColors.background.withValues(alpha: 0.9),
-                    AppColors.background,
-                  ],
-                  stops: const [0.0, 0.3, 0.7, 1.0],
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            left: horizontalPadding,
-            right: horizontalPadding,
-            bottom: isDesktop ? 32 : 24,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  width: 80,
-                  height: 20,
-                  decoration: BoxDecoration(
-                    color: AppColors.shimmerBase,
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                ),
-                const SizedBox(height: 12),
-                Container(
-                  width: 200,
-                  height: 32,
-                  decoration: BoxDecoration(
-                    color: AppColors.shimmerBase,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Container(
-                  width: 120,
-                  height: 20,
-                  decoration: BoxDecoration(
-                    color: AppColors.shimmerBase,
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Row(
-                  children: [
-                    Container(
-                      width: 100,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        color: AppColors.shimmerBase,
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                    ),
-                    const SizedBox(width: 12),
-                    Container(
-                      width: 120,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        color: AppColors.shimmerBase,
-                        borderRadius: BorderRadius.circular(10),
                       ),
                     ),
                   ],

--- a/player/lib/presentation/widgets/content_rail.dart
+++ b/player/lib/presentation/widgets/content_rail.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollCacheExtent;
-import '../../core/layout/breakpoints.dart';
+import '../../core/layout/rail_metrics.dart';
 import '../../core/player/input_capabilities.dart';
 import '../../core/theme/colors.dart';
 import '../../domain/models/continue_watching_item.dart';
@@ -111,15 +111,12 @@ class _ContentRailState extends State<ContentRail> {
       return const SizedBox.shrink();
     }
 
-    final railHeight = Breakpoints.getRailHeight(context);
-    final horizontalPadding = Breakpoints.getHorizontalPadding(context);
-    final cardSpacing = Breakpoints.getCardSpacing(context);
-    final isDesktop = Breakpoints.isDesktop(context);
+    final metrics = RailMetrics.of(context);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        _buildHeader(context, horizontalPadding, isDesktop),
+        _buildHeader(context, metrics),
 
         // Scrollable content with fade edges. A collapsed rail builds none of
         // it, so a hidden rail costs no cards and no poster fetches.
@@ -129,8 +126,8 @@ class _ContentRailState extends State<ContentRail> {
           alignment: Alignment.topCenter,
           child: _expanded
               ? SizedBox(
-                  height: railHeight,
-                  child: _buildRailBody(horizontalPadding, cardSpacing),
+                  height: metrics.railHeight,
+                  child: _buildRailBody(metrics),
                 )
               : const SizedBox(width: double.infinity, height: 0),
         ),
@@ -140,22 +137,18 @@ class _ContentRailState extends State<ContentRail> {
 
   /// The header line. When [ContentRail.collapsible] it doubles as the
   /// disclosure control for the strip below it.
-  Widget _buildHeader(
-    BuildContext context,
-    double horizontalPadding,
-    bool isDesktop,
-  ) {
+  Widget _buildHeader(BuildContext context, RailMetrics metrics) {
     // Closed, the title sits directly above whatever follows it, so it keeps
     // only enough room to read as its own line rather than the gap that an
     // open rail needs above its posters.
     final bottomPadding =
-        _expanded ? (isDesktop ? 20.0 : 16.0) : (isDesktop ? 10.0 : 8.0);
+        _expanded ? metrics.headerBottomPadding : metrics.headerBottomCollapsed;
 
     final header = Padding(
       padding: EdgeInsets.fromLTRB(
-        horizontalPadding,
-        isDesktop ? 32 : 24,
-        horizontalPadding,
+        metrics.horizontalPadding,
+        metrics.headerTopPadding,
+        metrics.horizontalPadding,
         bottomPadding,
       ),
       child: Row(
@@ -210,7 +203,7 @@ class _ContentRailState extends State<ContentRail> {
     );
   }
 
-  Widget _buildRailBody(double horizontalPadding, double cardSpacing) {
+  Widget _buildRailBody(RailMetrics metrics) {
     return Stack(
       children: [
         // Main scrollable list. The wrapper is what makes a plain mouse wheel
@@ -224,17 +217,19 @@ class _ContentRailState extends State<ContentRail> {
             scrollCacheExtent: InputCapabilities.directionalPrimary
                 ? const ScrollCacheExtent.pixels(_directionalCacheExtent)
                 : null,
-            padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
+            padding:
+                EdgeInsets.symmetric(horizontal: metrics.horizontalPadding),
             itemCount: widget.items.length,
             itemBuilder: (context, index) {
               final item = widget.items[index];
               return Padding(
                 key: _keyFor(item, index),
                 padding: EdgeInsets.only(
-                  right: index < widget.items.length - 1 ? cardSpacing : 0,
+                  right:
+                      index < widget.items.length - 1 ? metrics.cardSpacing : 0,
                 ),
                 child: RailFocusScroller(
-                  child: _buildCard(context, item),
+                  child: _buildCard(context, item, metrics),
                 ),
               );
             },
@@ -300,8 +295,8 @@ class _ContentRailState extends State<ContentRail> {
     return ValueKey('rail-$index');
   }
 
-  Widget _buildCard(BuildContext context, dynamic item) {
-    final cardSize = Breakpoints.getCardSize(context);
+  Widget _buildCard(BuildContext context, dynamic item, RailMetrics metrics) {
+    final cardSize = metrics.cardSize;
 
     if (item is ContinueWatchingItem) {
       final target = MediaContextTarget(

--- a/player/lib/presentation/widgets/shimmer_card.dart
+++ b/player/lib/presentation/widgets/shimmer_card.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:shimmer/shimmer.dart';
+import '../../core/layout/rail_metrics.dart';
 import '../../core/theme/colors.dart';
 import '../../core/theme/app_theme.dart';
+import '../../core/theme/depth_tokens.dart';
 
 class ShimmerCard extends StatelessWidget {
   final double width;
@@ -30,53 +32,162 @@ class ShimmerCard extends StatelessWidget {
   }
 }
 
+/// The loading stand-in for one [ContentRail].
+///
+/// Every dimension comes from [RailMetrics], the same object the real rail
+/// reads, so the two cannot hold different numbers.
+/// `test/test_utils/rail_parity.dart` asserts that at each breakpoint, and is
+/// the reason this widget must not grow a hardcoded size.
 class ShimmerRail extends StatelessWidget {
-  final double cardWidth;
-  final double cardHeight;
-  final int count;
+  const ShimmerRail({super.key, this.count});
 
-  const ShimmerRail({
-    super.key,
-    this.cardWidth = 120,
-    this.cardHeight = 180,
-    this.count = 5,
-  });
+  /// How many placeholder cards to draw.
+  ///
+  /// Null derives a count that overflows the viewport, so the rail has no
+  /// empty tail that fills in when real cards arrive. A fixed five left the
+  /// right third of a desktop rail blank.
+  final int? count;
+
+  /// Test handle for the header's title bar.
+  static const headerKey = ValueKey<String>('shimmer-rail-header');
+
+  /// Test handle for the placeholder poster block of card [index].
+  static ValueKey<String> posterKeyAt(int index) =>
+      ValueKey<String>('shimmer-rail-poster-$index');
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          child: Shimmer.fromColors(
-            baseColor: AppColors.shimmerBase,
-            highlightColor: AppColors.shimmerHighlight,
-            child: Container(
+    final metrics = RailMetrics.of(context);
+    final textTheme = Theme.of(context).textTheme;
+    final cardCount = count ??
+        (MediaQuery.sizeOf(context).width /
+                    (metrics.cardSize.width + metrics.cardSpacing))
+                .ceil() +
+            1;
+
+    // One shimmer for the whole rail rather than one per card, so the
+    // highlight travels across the row as a single motion and the tree carries
+    // one ShaderMask instead of N.
+    return Shimmer.fromColors(
+      baseColor: AppColors.shimmerBase,
+      highlightColor: AppColors.shimmerHighlight,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              metrics.horizontalPadding,
+              metrics.headerTopPadding,
+              metrics.horizontalPadding,
+              metrics.headerBottomPadding,
+            ),
+            child: _TextBar(
+              key: ShimmerRail.headerKey,
+              style: textTheme.headlineSmall,
               width: 150,
-              height: 20,
-              decoration: BoxDecoration(
-                color: AppColors.shimmerBase,
-                borderRadius: BorderRadius.circular(AppTheme.radiusButton),
+            ),
+          ),
+          SizedBox(
+            height: metrics.railHeight,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              // A skeleton has nothing to scroll to.
+              physics: const NeverScrollableScrollPhysics(),
+              padding:
+                  EdgeInsets.symmetric(horizontal: metrics.horizontalPadding),
+              itemCount: cardCount,
+              itemBuilder: (context, index) => Padding(
+                padding: EdgeInsets.only(
+                  right: index < cardCount - 1 ? metrics.cardSpacing : 0,
+                ),
+                child: _ShimmerRailCard(metrics: metrics, index: index),
               ),
             ),
           ),
-        ),
-        SizedBox(
-          height: cardHeight + 40,
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: count,
-            itemBuilder: (context, index) {
-              return Padding(
-                padding: const EdgeInsets.only(right: 12),
-                child: ShimmerCard(width: cardWidth, height: cardHeight),
-              );
-            },
-          ),
-        ),
-      ],
+        ],
+      ),
     );
+  }
+}
+
+/// One placeholder card, mirroring `MediaCard`'s column: a poster, then the
+/// title and subtitle lines beneath it.
+class _ShimmerRailCard extends StatelessWidget {
+  const _ShimmerRailCard({required this.metrics, required this.index});
+
+  final RailMetrics metrics;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return SizedBox(
+      width: metrics.cardSize.width,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            key: ShimmerRail.posterKeyAt(index),
+            width: metrics.cardSize.width,
+            height: metrics.cardSize.height,
+            child: const DecoratedBox(
+              decoration: BoxDecoration(
+                color: AppColors.shimmerBase,
+                borderRadius: BorderRadius.all(
+                  Radius.circular(DepthTokens.radiusPoster),
+                ),
+                boxShadow: DepthTokens.posterResting,
+              ),
+            ),
+          ),
+          const SizedBox(height: RailMetrics.labelGap),
+          _TextBar(style: textTheme.bodyMedium, widthFactor: 1),
+          const SizedBox(height: RailMetrics.subtitleGap),
+          _TextBar(style: textTheme.bodySmall, widthFactor: 0.6),
+        ],
+      ),
+    );
+  }
+}
+
+/// A shimmering bar exactly one line of [style] tall.
+///
+/// The height comes from a zero-width space rendered in the real text style
+/// rather than from a hardcoded pixel value, so the bars follow a theme change
+/// without a tuning pass. Pass [width] for a fixed width or [widthFactor] for
+/// a fraction of the available one.
+class _TextBar extends StatelessWidget {
+  const _TextBar({
+    super.key,
+    required this.style,
+    this.width,
+    this.widthFactor,
+  });
+
+  final TextStyle? style;
+  final double? width;
+  final double? widthFactor;
+
+  @override
+  Widget build(BuildContext context) {
+    final bar = DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppColors.shimmerBase,
+        borderRadius: BorderRadius.circular(AppTheme.radiusButton),
+      ),
+      // U+200B, a zero-width space: no glyph, full line height.
+      child: Text('​', style: style),
+    );
+
+    if (width != null) return SizedBox(width: width, child: bar);
+    if (widthFactor != null) {
+      return FractionallySizedBox(
+        alignment: Alignment.centerLeft,
+        widthFactor: widthFactor,
+        child: bar,
+      );
+    }
+    return bar;
   }
 }

--- a/player/test/core/layout/rail_metrics_test.dart
+++ b/player/test/core/layout/rail_metrics_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/rail_metrics.dart';
+
+/// Resolves `RailMetrics` at a given viewport by pumping a widget that reads
+/// it. `RailMetrics.of` needs a `BuildContext`, so there is no way to call it
+/// from a plain unit test.
+Future<RailMetrics> metricsAt(WidgetTester tester, Size size) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  late RailMetrics captured;
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) {
+          captured = RailMetrics.of(context);
+          return const SizedBox.shrink();
+        },
+      ),
+    ),
+  );
+  return captured;
+}
+
+void main() {
+  group('RailMetrics.of', () {
+    testWidgets('resolves the mobile tier below 900', (tester) async {
+      final m = await metricsAt(tester, const Size(599, 800));
+
+      expect(m.cardSize.width, 130);
+      expect(m.cardSize.height, 195);
+      expect(m.cardSpacing, 16);
+      expect(m.horizontalPadding, 20);
+      expect(m.railHeight, 260);
+      expect(m.headerTopPadding, 24);
+      expect(m.headerBottomPadding, 16);
+      expect(m.headerBottomCollapsed, 8);
+    });
+
+    testWidgets('resolves the tablet tier between 900 and 1199',
+        (tester) async {
+      final m = await metricsAt(tester, const Size(1000, 800));
+
+      expect(m.cardSize.width, 145);
+      expect(m.cardSize.height, 218);
+      expect(m.cardSpacing, 20);
+      expect(m.horizontalPadding, 24);
+      expect(m.railHeight, 300);
+    });
+
+    testWidgets('resolves the desktop tier from 1200', (tester) async {
+      final m = await metricsAt(tester, const Size(1400, 900));
+
+      expect(m.cardSize.width, 160);
+      expect(m.cardSize.height, 240);
+      expect(m.cardSpacing, 24);
+      expect(m.horizontalPadding, 32);
+      expect(m.railHeight, 340);
+      expect(m.headerTopPadding, 32);
+      expect(m.headerBottomPadding, 20);
+      expect(m.headerBottomCollapsed, 10);
+    });
+
+    testWidgets('header padding switches at 900 and card size at 1200',
+        (tester) async {
+      // The trap this class exists to survive. `Breakpoints.isDesktop` is true
+      // from 900 while `Breakpoints.desktop` is 1200, so at 1000 the header is
+      // already on its wide padding while the cards are still tablet-sized. An
+      // implementation that collapsed the two thresholds into one branch would
+      // pass at 599 and 1400 and fail only here.
+      final m = await metricsAt(tester, const Size(1000, 800));
+
+      expect(m.headerTopPadding, 32, reason: 'isDesktop is true from 900');
+      expect(m.cardSize.width, 145, reason: 'desktop cards start at 1200');
+    });
+
+    testWidgets('card and label gaps are the MediaCard values', (tester) async {
+      expect(RailMetrics.labelGap, 10);
+      expect(RailMetrics.subtitleGap, 4);
+    });
+  });
+}

--- a/player/test/presentation/screens/home/home_loading_skeleton_test.dart
+++ b/player/test/presentation/screens/home/home_loading_skeleton_test.dart
@@ -1,0 +1,69 @@
+// The loading state's own geometry, as distinct from the rails inside it
+// (which `rail_parity.dart` covers).
+//
+// Both assertions here pin a real defect fixed on 2026-09-01. The skeleton
+// list carried a top padding of `safeAreaTop + kToolbarHeight` while the
+// loaded `CustomScrollView` carried none under a Scaffold with
+// `extendBodyBehindAppBar: true`, so the hero jumped up by roughly 80 to 100px
+// on load. The skeleton also inserted spacers between its rails that the
+// loaded layout does not have.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/home/home_loading_skeleton.dart';
+import 'package:player/presentation/widgets/shimmer_card.dart';
+
+Future<void> _pump(WidgetTester tester, Size size) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    const MaterialApp(home: Scaffold(body: HomeLoadingSkeleton())),
+  );
+  // Never pumpAndSettle: ShimmerRail animates forever.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}
+
+void main() {
+  group('HomeLoadingSkeleton', () {
+    testWidgets('the hero starts at the top of the scroll view',
+        (tester) async {
+      await _pump(tester, const Size(390, 844));
+
+      // .first: ShimmerRail's horizontal card strip is itself a ListView, so
+      // the finder is ambiguous once a rail is built. The outer, vertical one
+      // is first in traversal order.
+      final listTop = tester.getTopLeft(find.byType(ListView).first).dy;
+      final heroTop =
+          tester.getTopLeft(find.byKey(HomeLoadingSkeleton.heroKey)).dy;
+
+      expect(heroTop, listTop,
+          reason: 'the loaded CustomScrollView has no top padding either');
+    });
+
+    testWidgets('no spacer sits between the rails', (tester) async {
+      await _pump(tester, const Size(390, 844));
+
+      final rails = find.byType(ShimmerRail);
+      expect(rails, findsAtLeastNWidgets(2));
+
+      expect(
+        tester.getTopLeft(rails.at(1)).dy,
+        tester.getBottomLeft(rails.at(0)).dy,
+        reason: 'rails are separated by headerTopPadding alone',
+      );
+    });
+
+    testWidgets('draws a hero and three rails', (tester) async {
+      // Tall enough that the hero and all three rails land inside the
+      // sliver's default cache extent; 900 leaves the third rail unbuilt at
+      // this breakpoint's sizes, which is a viewport artifact, not a defect.
+      await _pump(tester, const Size(1400, 3000));
+
+      expect(find.byKey(HomeLoadingSkeleton.heroKey), findsOneWidget);
+      expect(find.byType(ShimmerRail), findsNWidgets(3));
+    });
+  });
+}

--- a/player/test/presentation/widgets/content_rail_test.dart
+++ b/player/test/presentation/widgets/content_rail_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/rail_metrics.dart';
 import 'package:player/domain/models/continue_watching_item.dart';
 import 'package:player/domain/models/media_file.dart';
 import 'package:player/domain/models/progress.dart';
@@ -19,6 +20,7 @@ import 'package:player/domain/models/watch_status.dart';
 import 'package:player/presentation/widgets/content_rail.dart';
 import 'package:player/presentation/widgets/media_card.dart';
 import 'package:player/presentation/widgets/media_context_menu.dart';
+import 'package:player/presentation/widgets/poster_frame.dart';
 import 'package:player/presentation/widgets/progress_overlay.dart';
 import 'package:player/presentation/widgets/watch_indicator.dart';
 
@@ -521,6 +523,52 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(ProgressOverlay), findsNothing);
+    });
+  });
+
+  group('ContentRail geometry', () {
+    testWidgets('matches RailMetrics at the mobile tier', (tester) async {
+      tester.view.physicalSize = const Size(599, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _host(ContentRail(title: 'Recently Added', items: _items(5))),
+      );
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(ContentRail));
+      final metrics = RailMetrics.of(context);
+      final railTop = tester.getTopLeft(find.byType(ContentRail));
+      final firstPoster = tester.getRect(find.byType(PosterFrame).first);
+
+      expect(firstPoster.left - railTop.dx, metrics.horizontalPadding);
+      expect(firstPoster.width, metrics.cardSize.width);
+      expect(firstPoster.height, metrics.cardSize.height);
+    });
+
+    testWidgets('matches RailMetrics at the desktop tier', (tester) async {
+      tester.view.physicalSize = const Size(1400, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        _host(ContentRail(title: 'Recently Added', items: _items(5))),
+      );
+      await tester.pumpAndSettle();
+
+      final context = tester.element(find.byType(ContentRail));
+      final metrics = RailMetrics.of(context);
+      final railTop = tester.getTopLeft(find.byType(ContentRail));
+      final second = tester.getRect(find.byType(PosterFrame).at(1));
+
+      expect(
+        second.left - railTop.dx,
+        metrics.horizontalPadding +
+            metrics.cardSize.width +
+            metrics.cardSpacing,
+      );
+      expect(second.width, metrics.cardSize.width);
     });
   });
 }

--- a/player/test/presentation/widgets/shimmer_rail_test.dart
+++ b/player/test/presentation/widgets/shimmer_rail_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/layout/rail_metrics.dart';
+import 'package:player/core/theme/depth_tokens.dart';
+import 'package:player/presentation/widgets/shimmer_card.dart';
+import 'package:shimmer/shimmer.dart';
+
+import '../../test_utils/rail_parity.dart';
+
+Future<void> _pumpSkeleton(WidgetTester tester, Size size) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    const MaterialApp(home: Scaffold(body: ShimmerRail())),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}
+
+void main() {
+  runRailSkeletonParity();
+
+  group('ShimmerRail', () {
+    testWidgets('rounds its posters at the shared poster radius',
+        (tester) async {
+      await _pumpSkeleton(tester, const Size(1400, 900));
+
+      final box = tester.widget<DecoratedBox>(
+        find.descendant(
+          of: find.byKey(ShimmerRail.posterKeyAt(0)),
+          matching: find.byType(DecoratedBox),
+        ),
+      );
+      final decoration = box.decoration as BoxDecoration;
+
+      expect(
+        decoration.borderRadius,
+        const BorderRadius.all(Radius.circular(DepthTokens.radiusPoster)),
+      );
+    });
+
+    testWidgets('runs one shimmer for the whole rail, not one per card',
+        (tester) async {
+      await _pumpSkeleton(tester, const Size(1400, 900));
+
+      expect(find.byType(Shimmer), findsOneWidget);
+    });
+
+    testWidgets('fills the viewport to its right edge', (tester) async {
+      const size = Size(1400, 900);
+      await _pumpSkeleton(tester, size);
+
+      final context = tester.element(find.byType(ShimmerRail));
+      final metrics = RailMetrics.of(context);
+      final perCard = metrics.cardSize.width + metrics.cardSpacing;
+      final lastOnScreen = (size.width / perCard).ceil() - 1;
+
+      // The card straddling the right edge must exist and must cross it. A
+      // fixed count of five left the right third of a desktop rail blank until
+      // real cards arrived, which is the same jump on the other axis.
+      final last =
+          tester.getRect(find.byKey(ShimmerRail.posterKeyAt(lastOnScreen)));
+
+      expect(
+        last.right,
+        greaterThan(size.width),
+        reason: 'the rail must run past the viewport, leaving no empty tail',
+      );
+    });
+
+    testWidgets('an explicit count overrides the derived one', (tester) async {
+      tester.view.physicalSize = const Size(1400, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: ShimmerRail(count: 2))),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.byKey(ShimmerRail.posterKeyAt(1)), findsOneWidget);
+      expect(find.byKey(ShimmerRail.posterKeyAt(2)), findsNothing);
+    });
+  });
+}

--- a/player/test/test_utils/rail_parity.dart
+++ b/player/test/test_utils/rail_parity.dart
@@ -1,0 +1,173 @@
+// Rail skeleton parity.
+//
+// `ContentRail` and `ShimmerRail` are separate widgets that must lay out
+// identically, so the home screen does not resize when data replaces the
+// placeholder. They held independent copies of their geometry until
+// 2026-09-01 and every number had drifted. Both now read `RailMetrics`; this
+// suite is what keeps them reading the same one.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/domain/models/recently_added_item.dart';
+import 'package:player/presentation/widgets/content_rail.dart';
+import 'package:player/presentation/widgets/poster_frame.dart';
+import 'package:player/presentation/widgets/shimmer_card.dart';
+
+/// The title the real rail under test carries. Also the finder for its header
+/// text, which is why it is a constant rather than a literal in two places.
+const railParityTitle = 'Recently Added';
+
+/// One viewport per `Breakpoints` tier.
+///
+/// 1000x800 is load-bearing rather than a third sample for its own sake.
+/// `Breakpoints.isDesktop` flips at 900 and the card size at 1200, so 1000 is
+/// the only width where the header is on its wide padding while the cards are
+/// still tablet-sized. A `RailMetrics` that collapsed the two thresholds would
+/// pass at 599 and 1400 and fail only here.
+const railParityViewports = <Size>[
+  Size(599, 800),
+  Size(1000, 800),
+  Size(1400, 900),
+];
+
+List<RecentlyAddedItem> _items(int n) => List<RecentlyAddedItem>.generate(
+      n,
+      (i) => RecentlyAddedItem(
+        id: 'parity-$i',
+        type: 'movie',
+        title: 'The Lantern Wastes $i',
+        year: 2019 + i,
+      ),
+    );
+
+Future<void> _pump(WidgetTester tester, Widget rail, Size size) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [rail],
+          ),
+        ),
+      ),
+    ),
+  );
+
+  // Never pumpAndSettle here. `ShimmerRail` animates forever, so settling
+  // times out. Two fixed pumps clear the rail's 220ms AnimatedSize.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 300));
+}
+
+Future<void> _pumpReal(WidgetTester tester, Size size) => _pump(
+      tester,
+      ContentRail(title: railParityTitle, items: _items(8)),
+      size,
+    );
+
+Future<void> _pumpSkeleton(WidgetTester tester, Size size) =>
+    _pump(tester, const ShimmerRail(), size);
+
+/// [target]'s rect expressed relative to [ancestor]'s top-left, so the two
+/// rails can be compared without depending on where each was placed.
+Rect _relativeRect(WidgetTester tester, Finder ancestor, Finder target) =>
+    tester.getRect(target).shift(-tester.getTopLeft(ancestor));
+
+/// Compares two rects component by component.
+///
+/// Tolerant to half a pixel rather than exact, because the poster's `top`
+/// depends on the header text's measured line height and font metrics round.
+/// The smallest genuine drift this suite must catch is 4px, so half a pixel
+/// leaves the assertions sharp.
+void _expectRect(Rect actual, Rect expected) {
+  expect(actual.left, moreOrLessEquals(expected.left, epsilon: 0.5));
+  expect(actual.top, moreOrLessEquals(expected.top, epsilon: 0.5));
+  expect(actual.width, moreOrLessEquals(expected.width, epsilon: 0.5));
+  expect(actual.height, moreOrLessEquals(expected.height, epsilon: 0.5));
+}
+
+/// Asserts that `ShimmerRail` and `ContentRail` lay out identically at every
+/// breakpoint.
+void runRailSkeletonParity() {
+  group('rail skeleton parity', () {
+    for (final size in railParityViewports) {
+      final label = '${size.width.toInt()}x${size.height.toInt()}';
+
+      testWidgets('$label: both rails are the same height', (tester) async {
+        await _pumpReal(tester, size);
+        final real = tester.getSize(find.byType(ContentRail)).height;
+
+        await _pumpSkeleton(tester, size);
+        final skeleton = tester.getSize(find.byType(ShimmerRail)).height;
+
+        expect(skeleton, moreOrLessEquals(real, epsilon: 0.5));
+      });
+
+      testWidgets('$label: the first poster occupies the same rect',
+          (tester) async {
+        await _pumpReal(tester, size);
+        final real = _relativeRect(
+          tester,
+          find.byType(ContentRail),
+          find.byType(PosterFrame).at(0),
+        );
+
+        await _pumpSkeleton(tester, size);
+        final skeleton = _relativeRect(
+          tester,
+          find.byType(ShimmerRail),
+          find.byKey(ShimmerRail.posterKeyAt(0)),
+        );
+
+        _expectRect(skeleton, real);
+      });
+
+      testWidgets('$label: the second poster occupies the same rect',
+          (tester) async {
+        // Card 1 alone cannot see a wrong `cardSpacing`. Card 2 can.
+        await _pumpReal(tester, size);
+        final real = _relativeRect(
+          tester,
+          find.byType(ContentRail),
+          find.byType(PosterFrame).at(1),
+        );
+
+        await _pumpSkeleton(tester, size);
+        final skeleton = _relativeRect(
+          tester,
+          find.byType(ShimmerRail),
+          find.byKey(ShimmerRail.posterKeyAt(1)),
+        );
+
+        _expectRect(skeleton, real);
+      });
+
+      testWidgets('$label: the header sits on the same line', (tester) async {
+        await _pumpReal(tester, size);
+        final real = _relativeRect(
+          tester,
+          find.byType(ContentRail),
+          find.text(railParityTitle),
+        );
+
+        await _pumpSkeleton(tester, size);
+        final skeleton = _relativeRect(
+          tester,
+          find.byType(ShimmerRail),
+          find.byKey(ShimmerRail.headerKey),
+        );
+
+        // Top and height only. The real header is as wide as its title text
+        // and the placeholder bar is a fixed 150, which is deliberate.
+        expect(skeleton.top, moreOrLessEquals(real.top, epsilon: 0.5));
+        expect(skeleton.height, moreOrLessEquals(real.height, epsilon: 0.5));
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Problem

The home screen's loading skeleton is visibly smaller than the content it stands in for. Posters arrive wider than the placeholder blocks that preceded them and the whole rail resizes as data lands.

`ContentRail` derived every dimension from `Breakpoints`; `ShimmerRail` hardcoded its own. Every number disagreed:

| | skeleton | mobile (<900) | tablet (900-1199) | desktop (>=1200) |
| --- | --- | --- | --- | --- |
| card width | 120 | 130 | 145 | 160 |
| poster height | 180 | 195 | 218 | 240 |
| gap between cards | 12 | 16 | 20 | 24 |
| rail side padding | 16 | 20 | 24 | 32 |
| rail body height | 220 | 260 | 300 | 340 |
| header top padding | 8 | 24 | 32 | 32 |
| poster corner radius | 14 | 8 | 8 | 8 |

Posters were 8% wider than their skeleton on a phone and 33% wider on a desktop.

A second, larger defect turned up while tracing it. The loading branch was a `ListView` with `padding: EdgeInsets.only(top: safeAreaTop + kToolbarHeight)` on mobile, while the loaded branch is a `CustomScrollView` with no top padding under a Scaffold with `extendBodyBehindAppBar: true`. The real hero starts at y=0 and renders under the glass app bar; the skeleton hero was pushed below it, costing roughly 80 to 100px of vertical jump on load.

## Change

`RailMetrics` (`player/lib/core/layout/rail_metrics.dart`) becomes the single source for one rail's geometry, delegating tier thresholds to `Breakpoints` rather than restating them. `ContentRail` and `ShimmerRail` both read it, so the two cannot hold different numbers.

The skeleton is rebuilt to mirror `MediaCard`'s column: a poster at the real card size rounded at `DepthTokens.radiusPoster`, then title and subtitle bars whose heights come from the actual `TextStyle` via a zero-width-space `Text` rather than hardcoded pixels. One `Shimmer` now wraps the whole rail instead of one per card, and the card count derives from viewport width so no empty tail is left for real cards to fill in.

The loading branch moves into `HomeLoadingSkeleton`, which makes it testable without holding a code-generated Riverpod `StreamNotifier` in `AsyncLoading`, and drops both the top padding and the inter-rail spacers the loaded layout does not have.

`ContentRail`'s rendered geometry is unchanged; a characterization test pins it across the refactor.

## Tests

`test/test_utils/rail_parity.dart` pumps both rails at 599x800, 1000x800 and 1400x900 and asserts equal rail heights, equal poster rects for cards 1 and 2, and an equal header line.

The 1000x800 viewport is load-bearing rather than a third sample: `Breakpoints.isDesktop` flips at 900 while card size flips at 1200, so it is the only width where the header is on its wide padding while cards are still tablet-sized. A regression keyed off the wrong threshold passes at 599 and 1400 and fails only there.

Full suite: 3093 passing, 0 failures.

## Not covered by tests

The top-padding fix was reasoned from source rather than measured on a device. Worth eyeballing the loading-to-loaded transition on a phone before this is relied on. The skeleton only appears on a cold or stale start, since `selectFetchPolicy` picks `networkOnly` only when there is no fetch-log entry or the cache is older than `kFreshnessThreshold`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a responsive home-screen loading experience with a hero placeholder and three content-rail skeletons.
  - Loading placeholders now adapt to mobile, tablet, and desktop screen sizes.
- **Bug Fixes**
  - Improved visual consistency between loaded content rails and their loading placeholders.
  - Updated rail spacing, card sizing, padding, and heights to remain aligned across screen sizes.
  - Improved shimmer rendering with consistent card styling and viewport-based item counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->