### PR TITLE
feat(ui): hold the grid shape while poster grids load

### DIFF
--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -15,6 +15,51 @@ defmodule MydiaWeb.DiscoverComponents do
     router: MydiaWeb.Router,
     statics: MydiaWeb.static_paths()
 
+  # A TMDB page. Both Metadata.trending_movies/0 and Metadata.discover/2 return
+  # a provider page uncapped, so a skeleton grid of this size is replaced
+  # one-for-one by real cards and the grid does not resize when they land.
+  @skeleton_count 20
+
+  @doc """
+  Renders a grid of placeholder cards shaped like `trending_card/1`.
+
+  Sits beside `trending_card/1` rather than in a generic module because the two
+  have to keep the same shape, and co-location is the only thing that makes a
+  drift visible in review.
+
+  `columns` is a parameter because the consumers genuinely differ: Discover
+  drives columns from `GridDensityComponents.grid_columns_class/1` across three
+  density levels, while the Dashboard trending rows hardcode a 2/3/4/5 grid.
+  Each caller passes the same string its real grid uses, so the placeholder and
+  the results lay out identically.
+
+  Reduced motion needs no handling here. daisyUI gates the shimmer behind
+  `prefers-reduced-motion: no-preference` and leaves a flat base-300 fill
+  otherwise.
+  """
+  attr :id, :string, default: nil
+  attr :count, :integer, default: @skeleton_count
+  attr :columns, :string, required: true
+  attr :gap, :string, default: "gap-4 md:gap-5"
+
+  def poster_card_grid_skeleton(assigns) do
+    ~H"""
+    <div id={@id} class={["grid", @gap, @columns]} role="status" aria-label="Loading titles">
+      <div :for={_ <- 1..@count} class="card bg-base-100 shadow-sm">
+        <div class="skeleton aspect-[2/3] rounded-t-box rounded-b-none"></div>
+        <div class="card-body p-3">
+          <div class="skeleton h-4 w-full"></div>
+          <div class="skeleton h-4 w-2/3"></div>
+          <div class="mt-auto flex flex-col gap-2">
+            <div class="skeleton h-3 w-10"></div>
+            <div class="skeleton h-8 w-full"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
   @doc """
   Renders a trending media card with poster, status badge, title, year,
   and an action button (Add to Library / Request / Go to Movie/Show).

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -50,8 +50,8 @@ defmodule MydiaWeb.DiscoverComponents do
         <div class="card-body p-3">
           <div class="skeleton h-4 w-full"></div>
           <div class="skeleton h-4 w-2/3"></div>
-          <div class="mt-auto flex flex-col gap-2">
-            <div class="skeleton h-3 w-10"></div>
+          <div class="mt-auto flex flex-col gap-4">
+            <div class="skeleton h-4 w-10"></div>
             <div class="skeleton h-8 w-full"></div>
           </div>
         </div>

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -16,51 +16,6 @@ defmodule MydiaWeb.DiscoverComponents do
     router: MydiaWeb.Router,
     statics: MydiaWeb.static_paths()
 
-  # A TMDB page. Both Metadata.trending_movies/0 and Metadata.discover/2 return
-  # a provider page uncapped, so a skeleton grid of this size is replaced
-  # one-for-one by real cards and the grid does not resize when they land.
-  @skeleton_count 20
-
-  @doc """
-  Renders a grid of placeholder cards shaped like `trending_card/1`.
-
-  Sits beside `trending_card/1` rather than in a generic module because the two
-  have to keep the same shape, and co-location is the only thing that makes a
-  drift visible in review.
-
-  `columns` is a parameter because the consumers genuinely differ: Discover
-  drives columns from `GridDensityComponents.grid_columns_class/1` across three
-  density levels, while the Dashboard trending rows hardcode a 2/3/4/5 grid.
-  Each caller passes the same string its real grid uses, so the placeholder and
-  the results lay out identically.
-
-  Reduced motion needs no handling here. daisyUI gates the shimmer behind
-  `prefers-reduced-motion: no-preference` and leaves a flat base-300 fill
-  otherwise.
-  """
-  attr :id, :string, default: nil
-  attr :count, :integer, default: @skeleton_count
-  attr :columns, :string, required: true
-  attr :gap, :string, default: "gap-4 md:gap-5"
-
-  def poster_card_grid_skeleton(assigns) do
-    ~H"""
-    <div id={@id} class={["grid", @gap, @columns]} role="status" aria-label="Loading titles">
-      <div :for={_ <- 1..@count} class="card bg-base-100 shadow-sm">
-        <div class="skeleton aspect-[2/3] rounded-t-box rounded-b-none"></div>
-        <div class="card-body p-3">
-          <div class="skeleton h-4 w-full"></div>
-          <div class="skeleton h-4 w-2/3"></div>
-          <div class="mt-auto flex flex-col gap-4">
-            <div class="skeleton h-4 w-10"></div>
-            <div class="skeleton h-8 w-full"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    """
-  end
-
   @doc """
   Renders a trending media card with poster, status badge, title, year,
   and an action button (Add to Library / Request / Go to Movie/Show).

--- a/lib/mydia_web/components/poster_card_components.ex
+++ b/lib/mydia_web/components/poster_card_components.ex
@@ -69,4 +69,49 @@ defmodule MydiaWeb.PosterCardComponents do
     </div>
     """
   end
+
+  # A TMDB page. Both Metadata.trending_movies/0 and Metadata.discover/2 return
+  # a provider page uncapped, so a skeleton grid of this size is replaced
+  # one-for-one by real cards and the grid does not resize when they land.
+  @skeleton_count 20
+
+  @doc """
+  Renders a grid of placeholder cards shaped like a `poster_card_body/1` card.
+
+  Sits beside `poster_card_body/1` rather than in a generic module because the
+  two have to keep the same shape, and co-location is the only thing that
+  makes a drift visible in review.
+
+  `columns` is a parameter because the consumers genuinely differ: Discover
+  drives columns from `GridDensityComponents.grid_columns_class/1` across three
+  density levels, while the Dashboard trending rows hardcode a 2/3/4/5 grid.
+  Each caller passes the same string its real grid uses, so the placeholder and
+  the results lay out identically.
+
+  Reduced motion needs no handling here. daisyUI gates the shimmer behind
+  `prefers-reduced-motion: no-preference` and leaves a flat base-300 fill
+  otherwise.
+  """
+  attr :id, :string, default: nil
+  attr :count, :integer, default: @skeleton_count
+  attr :columns, :string, required: true
+  attr :gap, :string, default: "gap-4 md:gap-5"
+
+  def poster_card_grid_skeleton(assigns) do
+    ~H"""
+    <div id={@id} class={["grid", @gap, @columns]} role="status" aria-label="Loading titles">
+      <div :for={_ <- 1..@count} class="card bg-base-100 shadow-lg h-full">
+        <div class="skeleton aspect-[2/3] rounded-t-box rounded-b-none"></div>
+        <div class="card-body p-3">
+          <div class="skeleton h-4 w-full"></div>
+          <div class="skeleton h-4 w-2/3"></div>
+          <div class="mt-auto flex flex-col gap-4">
+            <div class="skeleton h-4 w-10"></div>
+            <div class="skeleton h-8 w-full"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
 end

--- a/lib/mydia_web/components/poster_card_components.ex
+++ b/lib/mydia_web/components/poster_card_components.ex
@@ -100,12 +100,22 @@ defmodule MydiaWeb.PosterCardComponents do
   def poster_card_grid_skeleton(assigns) do
     ~H"""
     <div id={@id} class={["grid", @gap, @columns]} role="status" aria-label="Loading titles">
-      <div :for={_ <- 1..@count} class="card bg-base-100 shadow-lg h-full">
+      <%!-- 1..@count//1 rather than 1..@count: with an implicit step, Elixir
+            infers -1 whenever @count < 1, so 1..0 is [1, 0] and count: 0 would
+            render two stray cards instead of none. The explicit ascending
+            step makes 0 and negative counts render zero cards. --%>
+      <div :for={_ <- 1..@count//1} class="card bg-base-100 shadow-lg h-full">
         <div class="skeleton aspect-[2/3] rounded-t-box rounded-b-none"></div>
         <div class="card-body p-3">
           <div class="skeleton h-4 w-full"></div>
           <div class="skeleton h-4 w-2/3"></div>
+          <%!-- gap-4, not poster_card_body's gap-2 above: every real action
+                element (badges, add button) also carries its own mt-2 on top
+                of card-body's gap, so real cards space these by 16px total. --%>
           <div class="mt-auto flex flex-col gap-4">
+            <%!-- h-4, not h-3: text-xs line-height is 1rem/16px and is not
+                  derived from its 0.75rem font-size, so h-4 matches the real
+                  year bar's rendered height. --%>
             <div class="skeleton h-4 w-10"></div>
             <div class="skeleton h-8 w-full"></div>
           </div>

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -20,6 +20,12 @@ defmodule MydiaWeb.DashboardLive.Index do
 
   @unsupported_media_type "That media type is not supported."
 
+  # How many trending items each rail keeps after a successful fetch (see the
+  # Enum.take/2 calls below). The skeleton grid's `count` must match this or
+  # the placeholder no longer reserves the same height as the settled row,
+  # reintroducing the layout shift this feature exists to prevent.
+  @trending_rail_limit 10
+
   @impl true
   def mount(_params, _session, socket) do
     socket =
@@ -31,6 +37,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:trending_tv_loading, true)
         |> assign(:trending_movies, [])
         |> assign(:trending_tv, [])
+        |> assign(:trending_rail_limit, @trending_rail_limit)
         |> assign(:library_status_map, %{})
         |> assign(:adding_item_ids, MapSet.new())
         |> assign(:requesting_item_id, nil)
@@ -48,6 +55,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:trending_tv_loading, false)
         |> assign(:trending_movies, [])
         |> assign(:trending_tv, [])
+        |> assign(:trending_rail_limit, @trending_rail_limit)
         |> assign(:movie_count, 0)
         |> assign(:tv_show_count, 0)
         |> assign(:active_downloads_count, 0)
@@ -239,7 +247,7 @@ defmodule MydiaWeb.DashboardLive.Index do
       {:ok, movies} ->
         enriched_movies =
           movies
-          |> Enum.take(10)
+          |> Enum.take(@trending_rail_limit)
           |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
           |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
@@ -261,7 +269,7 @@ defmodule MydiaWeb.DashboardLive.Index do
       {:ok, shows} ->
         enriched_shows =
           shows
-          |> Enum.take(10)
+          |> Enum.take(@trending_rail_limit)
           |> MediaAddHelpers.enrich_with_library_status(socket.assigns.library_status_map)
           |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
@@ -335,6 +343,12 @@ defmodule MydiaWeb.DashboardLive.Index do
     Logger.warning("Unhandled message in DashboardLive.Index: #{inspect(msg)}")
     {:noreply, socket}
   end
+
+  @doc false
+  # Exposes @trending_rail_limit so the regression test can assert the
+  # skeleton's placeholder count against the same value this module uses,
+  # rather than duplicating the literal in both places.
+  def trending_rail_limit, do: @trending_rail_limit
 
   ## Private Helpers
 

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -214,8 +214,10 @@
 
     <%= cond do %>
       <% @trending_movies_loading -> %>
+        <%!-- count matches the Enum.take(10) in index.ex's :load_trending_movies handler --%>
         <.poster_card_grid_skeleton
           id="trending-movies-skeleton"
+          count={10}
           columns="grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
           gap="gap-3 md:gap-4"
         />
@@ -252,8 +254,10 @@
 
     <%= cond do %>
       <% @trending_tv_loading -> %>
+        <%!-- count matches the Enum.take(10) in index.ex's :load_trending_tv handler --%>
         <.poster_card_grid_skeleton
           id="trending-tv-skeleton"
+          count={10}
           columns="grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
           gap="gap-3 md:gap-4"
         />

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -214,10 +214,12 @@
 
     <%= cond do %>
       <% @trending_movies_loading -> %>
-        <%!-- count matches the Enum.take(10) in index.ex's :load_trending_movies handler --%>
+        <%!-- count is @trending_rail_limit, the same limit index.ex's
+              :load_trending_movies handler passes to Enum.take/2, so the
+              placeholder always matches the settled row count --%>
         <.poster_card_grid_skeleton
           id="trending-movies-skeleton"
-          count={10}
+          count={@trending_rail_limit}
           columns="grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
           gap="gap-3 md:gap-4"
         />
@@ -254,10 +256,12 @@
 
     <%= cond do %>
       <% @trending_tv_loading -> %>
-        <%!-- count matches the Enum.take(10) in index.ex's :load_trending_tv handler --%>
+        <%!-- count is @trending_rail_limit, the same limit index.ex's
+              :load_trending_tv handler passes to Enum.take/2, so the
+              placeholder always matches the settled row count --%>
         <.poster_card_grid_skeleton
           id="trending-tv-skeleton"
-          count={10}
+          count={@trending_rail_limit}
           columns="grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
           gap="gap-3 md:gap-4"
         />

--- a/lib/mydia_web/live/dashboard_live/index.html.heex
+++ b/lib/mydia_web/live/dashboard_live/index.html.heex
@@ -214,9 +214,11 @@
 
     <%= cond do %>
       <% @trending_movies_loading -> %>
-        <div class="flex items-center justify-center py-12">
-          <span class="loading loading-spinner loading-lg"></span>
-        </div>
+        <.poster_card_grid_skeleton
+          id="trending-movies-skeleton"
+          columns="grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+          gap="gap-3 md:gap-4"
+        />
       <% @trending_movies == [] -> %>
         <div class="alert alert-info">
           <.icon name="hero-information-circle" class="w-5 h-5" />
@@ -250,9 +252,11 @@
 
     <%= cond do %>
       <% @trending_tv_loading -> %>
-        <div class="flex items-center justify-center py-12">
-          <span class="loading loading-spinner loading-lg"></span>
-        </div>
+        <.poster_card_grid_skeleton
+          id="trending-tv-skeleton"
+          columns="grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
+          gap="gap-3 md:gap-4"
+        />
       <% @trending_tv == [] -> %>
         <div class="alert alert-info">
           <.icon name="hero-information-circle" class="w-5 h-5" />

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -130,12 +130,11 @@
     <%!-- Results --%>
     <%= cond do %>
       <% @loading -> %>
-        <div class="flex flex-col items-center justify-center py-16 gap-3">
-          <span class="loading loading-spinner loading-lg text-primary"></span>
-          <p class="text-sm text-base-content/60">
-            Loading {if @media_type == :movie, do: "movies", else: "TV shows"}...
-          </p>
-        </div>
+        <.poster_card_grid_skeleton
+          id="discover-grid-skeleton"
+          columns={grid_columns_class(@grid_density)}
+          gap="gap-4 md:gap-5"
+        />
       <% @load_error != nil and @items == [] -> %>
         <div class="flex flex-col items-center justify-center py-16 gap-4">
           <div class="bg-error/10 rounded-full p-6">

--- a/test/mydia_web/components/poster_card_grid_skeleton_test.exs
+++ b/test/mydia_web/components/poster_card_grid_skeleton_test.exs
@@ -10,7 +10,7 @@ defmodule MydiaWeb.PosterCardGridSkeletonTest do
 
   import Phoenix.LiveViewTest
 
-  alias MydiaWeb.DiscoverComponents
+  alias MydiaWeb.PosterCardComponents
 
   defp render_skeleton(overrides \\ %{}) do
     assigns =
@@ -19,7 +19,7 @@ defmodule MydiaWeb.PosterCardGridSkeletonTest do
         overrides
       )
 
-    render_component(&DiscoverComponents.poster_card_grid_skeleton/1, assigns)
+    render_component(&PosterCardComponents.poster_card_grid_skeleton/1, assigns)
     |> LazyHTML.from_fragment()
   end
 

--- a/test/mydia_web/components/poster_card_grid_skeleton_test.exs
+++ b/test/mydia_web/components/poster_card_grid_skeleton_test.exs
@@ -35,6 +35,15 @@ defmodule MydiaWeb.PosterCardGridSkeletonTest do
     assert doc |> LazyHTML.query("div.card") |> Enum.count() == 20
   end
 
+  # 1..0 has an implicit step of -1 in Elixir, so a naive `1..@count` would
+  # render two stray cards ([1, 0]) instead of none. Guards the explicit
+  # ascending step in poster_card_grid_skeleton/1 against regressing.
+  test "renders zero placeholder cards for a count of zero" do
+    doc = render_skeleton(%{count: 0})
+
+    assert doc |> LazyHTML.query("div.card") |> Enum.count() == 0
+  end
+
   test "applies the caller's column and gap classes to the grid" do
     doc = render_skeleton(%{columns: "grid-cols-4 xl:grid-cols-12", gap: "gap-3 md:gap-4"})
 

--- a/test/mydia_web/components/poster_card_grid_skeleton_test.exs
+++ b/test/mydia_web/components/poster_card_grid_skeleton_test.exs
@@ -1,0 +1,81 @@
+defmodule MydiaWeb.PosterCardGridSkeletonTest do
+  @moduledoc """
+  The card count and the passed-through column class are what the call sites
+  depend on. The internal bar shapes are asserted loosely on purpose: they are
+  tuned against a measured real card in Task 4, and pinning exact heights here
+  would turn that tuning into a test failure.
+  """
+
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias MydiaWeb.DiscoverComponents
+
+  defp render_skeleton(overrides \\ %{}) do
+    assigns =
+      Map.merge(
+        %{id: "grid-skeleton", columns: "grid-cols-2 lg:grid-cols-5"},
+        overrides
+      )
+
+    render_component(&DiscoverComponents.poster_card_grid_skeleton/1, assigns)
+    |> LazyHTML.from_fragment()
+  end
+
+  test "renders one placeholder card per count" do
+    doc = render_skeleton(%{count: 7})
+
+    assert doc |> LazyHTML.query("div.card") |> Enum.count() == 7
+  end
+
+  test "defaults to twenty cards, matching a provider page" do
+    doc = render_skeleton()
+
+    assert doc |> LazyHTML.query("div.card") |> Enum.count() == 20
+  end
+
+  test "applies the caller's column and gap classes to the grid" do
+    doc = render_skeleton(%{columns: "grid-cols-4 xl:grid-cols-12", gap: "gap-3 md:gap-4"})
+
+    [class] = doc |> LazyHTML.filter("#grid-skeleton") |> LazyHTML.attribute("class")
+
+    assert class =~ "grid-cols-4"
+    assert class =~ "xl:grid-cols-12"
+    assert class =~ "gap-3"
+    assert class =~ "md:gap-4"
+  end
+
+  test "announces itself as a loading region" do
+    doc = render_skeleton(%{count: 1})
+
+    [role] = doc |> LazyHTML.filter("#grid-skeleton") |> LazyHTML.attribute("role")
+    [label] = doc |> LazyHTML.filter("#grid-skeleton") |> LazyHTML.attribute("aria-label")
+
+    assert role == "status"
+    assert label == "Loading titles"
+  end
+
+  # daisyUI's .skeleton sets border-radius on all four corners. The real
+  # poster_figure gets rounded-t-box from card_poster, so without the override
+  # the placeholder poster rounds its bottom corners inside the card.
+  test "the poster placeholder squares off its bottom corners" do
+    doc = render_skeleton(%{count: 1})
+
+    [class] =
+      doc
+      |> LazyHTML.query("div.card > div.skeleton")
+      |> LazyHTML.attribute("class")
+
+    assert class =~ "aspect-[2/3]"
+    assert class =~ "rounded-t-box"
+    assert class =~ "rounded-b-none"
+  end
+
+  test "each card carries a body with placeholder bars" do
+    doc = render_skeleton(%{count: 3})
+
+    assert doc |> LazyHTML.query("div.card > div.card-body") |> Enum.count() == 3
+    refute doc |> LazyHTML.query("div.card-body div.skeleton") |> Enum.empty?()
+  end
+end

--- a/test/mydia_web/features/discover_skeleton_height_parity_test.exs
+++ b/test/mydia_web/features/discover_skeleton_height_parity_test.exs
@@ -1,0 +1,179 @@
+defmodule MydiaWeb.Features.DiscoverSkeletonHeightParityTest do
+  @moduledoc """
+  Regression guard for the loading-skeleton height parity fixed in 8034abf67.
+
+  `poster_card_grid_skeleton/1` (poster_card_components.ex) exists only
+  because a placeholder card shorter than a real card makes the page collapse
+  then re-expand once results land. That premise was verified once by hand in
+  a browser; nothing in the committed suite checked it, so a future edit that
+  reintroduces a shortfall would pass every existing test. This file is that
+  check.
+
+  The skeleton is transient: Discover shows it only until its async data
+  fetch resolves, so racing it with a timer would be flaky. Discover's
+  DISCONNECTED render always contains the skeleton grid, because
+  `DiscoverLive.Index.mount/3` sets `@loading` to `true` outside any
+  `connected?/1` check, and `handle_params/3`'s disconnected branch never
+  flips it (discover_live/index.ex). That means a plain, cookie-authenticated
+  GET of `/discover`, issued from this already-settled, connected page,
+  returns a fresh disconnected render containing `#discover-grid-skeleton` -
+  a brand-new HTTP response, not a snapshot of transient client state, so
+  there is no race to lose.
+
+  The GET runs as a synchronous XMLHttpRequest rather than `fetch`, because
+  `Wallaby.Browser.execute_script/4` (`eval_js/3`) evaluates its script
+  synchronously and does not await a returned Promise; a plain `fetch` here
+  would hand back the Promise itself, not the response.
+
+  The fetched skeleton markup is spliced into the live DOM as a sibling of
+  the real `#discover-grid`, under a distinct id
+  (`#injected-skeleton-grid`) so it can never be confused with a skeleton
+  the live page itself might render. Both elements then exist in the same
+  document, theme, and container width at the same instant: no timing race,
+  no separate viewport, no separate CSS load.
+  """
+
+  use MydiaWeb.FeatureCase, async: false
+
+  @moduletag :feature
+
+  # Long enough to wrap to (at least) two lines at any column width the
+  # comfortable-density Discover grid renders in a test browser window, which
+  # is the case the original 12px shortfall was calibrated against (a
+  # one-line title legitimately measures one line-height shorter).
+  @long_title "Whispering Lighthouse of the Furthest Northern Coastline"
+
+  setup do
+    # MydiaWeb.FeatureCase's own setup already ran warm_trending_cache(:movie,
+    # []) before this callback, populating "trending_movies" and
+    # "curated:trending:movie:1" with an empty result. Mydia.Metadata.Cache.fetch/3
+    # returns an unexpired cached value without calling the fallback, so
+    # warming the same keys again below would silently discard this item and
+    # never even reach its own Bypass. Clearing them first forces a real
+    # refetch against this call's Bypass instance.
+    Mydia.Metadata.Cache.delete("trending_movies")
+    Mydia.Metadata.Cache.delete("curated:trending:movie:1")
+
+    Mydia.MetadataCacheHelpers.warm_trending_cache(:movie, [
+      %{
+        "id" => 900_555_001,
+        "title" => @long_title,
+        "release_date" => "2024-03-14",
+        "poster_path" => "/fictional-poster.jpg",
+        "vote_average" => 7.4
+      }
+    ])
+
+    # DiscoverLive.Index.handle_params/3's connected branch fetches genres
+    # whenever @genres is still empty (#530), which it always is on first
+    # mount. Left unwarmed, that reaches the live relay through
+    # Mydia.RelayGuard, which blocks it and forces the suite to a nonzero
+    # exit even though every assertion in this file passes.
+    Mydia.MetadataCacheHelpers.warm_genre_cache(:movie, [])
+
+    :ok
+  end
+
+  @tag :feature
+  test "an injected disconnected-render skeleton card matches a real card's height",
+       %{session: session} do
+    session
+    |> login_as_admin()
+    |> visit("/discover")
+    |> wait_for_liveview()
+
+    wait_for_real_card(session)
+
+    assert inject_skeleton(session) == "ok"
+
+    assert_same_height(session, "#injected-skeleton-grid .card", "#discover-grid .card")
+  end
+
+  @tag :feature
+  test "the guard actually fails when the skeleton card falls short", %{session: session} do
+    session
+    |> login_as_admin()
+    |> visit("/discover")
+    |> wait_for_liveview()
+
+    wait_for_real_card(session)
+
+    assert inject_skeleton(session) == "ok"
+
+    # Deliberately shrink the injected skeleton card by more than the 1px
+    # default tolerance, proving the guard can actually fail rather than
+    # silently measuring nothing and passing vacuously - exactly the failure
+    # mode this whole test exists to rule out. Restored to its natural size
+    # below so this test does not leave a mutated DOM behind for the next
+    # assertion in the same session.
+    shrink_by_px = 12
+
+    eval_js(session, """
+      var el = document.querySelector('#injected-skeleton-grid .card');
+      el.dataset.originalHeight = el.getBoundingClientRect().height;
+      el.style.height = (el.getBoundingClientRect().height - #{shrink_by_px}) + 'px';
+    """)
+
+    error =
+      assert_raise ExUnit.AssertionError, fn ->
+        assert_same_height(session, "#injected-skeleton-grid .card", "#discover-grid .card")
+      end
+
+    assert error.message =~ "injected-skeleton-grid"
+    assert error.message =~ "discover-grid .card"
+    assert error.message =~ "delta #{shrink_by_px}px"
+
+    eval_js(session, """
+      var el = document.querySelector('#injected-skeleton-grid .card');
+      el.style.height = el.dataset.originalHeight + 'px';
+    """)
+
+    assert_same_height(session, "#injected-skeleton-grid .card", "#discover-grid .card")
+  end
+
+  # `warm_trending_cache/2` makes the data available, but the connected mount
+  # still fetches it asynchronously via `send(self(), :load_data)`, so the
+  # real grid is not guaranteed to exist the instant the socket connects.
+  defp wait_for_real_card(session) do
+    eventually(
+      fn ->
+        case eval_js(
+               session,
+               "return document.querySelectorAll('#discover-grid .card').length;"
+             ) do
+          n when is_number(n) and n > 0 -> {:ok, n}
+          _ -> :error
+        end
+      end,
+      description: "the real Discover grid to render at least one card"
+    )
+  end
+
+  defp inject_skeleton(session) do
+    eval_js(session, """
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', '/discover', false);
+
+      try {
+        xhr.send(null);
+      } catch (e) {
+        return 'xhr_error: ' + e;
+      }
+
+      if (xhr.status !== 200) { return 'xhr_status_' + xhr.status; }
+
+      var doc = new DOMParser().parseFromString(xhr.responseText, 'text/html');
+      var skeleton = doc.querySelector('#discover-grid-skeleton');
+      if (!skeleton) { return 'no_skeleton_in_disconnected_render'; }
+
+      var realGrid = document.querySelector('#discover-grid');
+      if (!realGrid || !realGrid.parentElement) { return 'no_real_grid_in_live_dom'; }
+
+      var imported = document.importNode(skeleton, true);
+      imported.id = 'injected-skeleton-grid';
+      realGrid.parentElement.insertBefore(imported, realGrid);
+
+      return 'ok';
+    """)
+  end
+end

--- a/test/mydia_web/features/discover_skeleton_height_parity_test.exs
+++ b/test/mydia_web/features/discover_skeleton_height_parity_test.exs
@@ -121,7 +121,16 @@ defmodule MydiaWeb.Features.DiscoverSkeletonHeightParityTest do
 
     assert error.message =~ "injected-skeleton-grid"
     assert error.message =~ "discover-grid .card"
-    assert error.message =~ "delta #{shrink_by_px}px"
+
+    # Asserted as a range rather than the exact shrink amount. The card's real
+    # height is sub-pixel (343.48px here), so shrinking it by a whole number of
+    # pixels leaves a delta near, but not exactly on, that number. Pinning the
+    # literal only worked while the message rounded the delta to one decimal
+    # place, and it broke the moment that rounding was made finer. What this
+    # test exists to prove is that the guard fails and names a delta of roughly
+    # the size it was given, not that a browser reports whole pixels.
+    delta = extract_delta_px(error.message)
+    assert_in_delta delta, shrink_by_px, 0.5
 
     eval_js(session, """
       var el = document.querySelector('#injected-skeleton-grid .card');
@@ -175,5 +184,22 @@ defmodule MydiaWeb.Features.DiscoverSkeletonHeightParityTest do
 
       return 'ok';
     """)
+  end
+
+  # Pulls the numeric delta out of assert_same_height/4's failure message so the
+  # test can assert its magnitude rather than its exact rendering. Flunks rather
+  # than returning a default when the message has no delta at all, so a change
+  # to the message format shows up as a named failure instead of a silent pass.
+  defp extract_delta_px(message) do
+    case Regex.run(~r/delta ([0-9.]+)px/, message) do
+      [_, captured] -> String.to_float(ensure_decimal(captured))
+      nil -> flunk("no \"delta <n>px\" found in assertion message:\n\n#{message}")
+    end
+  end
+
+  # String.to_float/1 rejects an integer-shaped string ("12"), which is exactly
+  # what the message carries when the delta lands on a whole pixel.
+  defp ensure_decimal(value) do
+    if String.contains?(value, "."), do: value, else: value <> ".0"
   end
 end

--- a/test/mydia_web/features/geometry_self_test.exs
+++ b/test/mydia_web/features/geometry_self_test.exs
@@ -132,6 +132,205 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
     end
   end
 
+  describe "assert_same_height/4" do
+    @tag :feature
+    test "passes for two elements with equal height", %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var a = document.createElement('div');
+        a.id = 'geo-height-eq-a';
+        a.style.cssText =
+          'position:fixed;top:10px;left:10px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(a);
+
+        var b = document.createElement('div');
+        b.id = 'geo-height-eq-b';
+        b.style.cssText =
+          'position:fixed;top:10px;left:200px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(b);
+      """)
+
+      assert_same_height(session, "#geo-height-eq-a", "#geo-height-eq-b")
+    end
+
+    @tag :feature
+    test "passes when the difference is within tolerance", %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var a = document.createElement('div');
+        a.id = 'geo-height-tol-a';
+        a.style.cssText =
+          'position:fixed;top:10px;left:10px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(a);
+
+        var b = document.createElement('div');
+        b.id = 'geo-height-tol-b';
+        b.style.cssText =
+          'position:fixed;top:10px;left:200px;width:50px;height:200.5px;z-index:9999';
+        document.body.appendChild(b);
+      """)
+
+      assert_same_height(session, "#geo-height-tol-a", "#geo-height-tol-b")
+    end
+
+    @tag :feature
+    test "fails and names both selectors, both heights, and the delta when they differ",
+         %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var a = document.createElement('div');
+        a.id = 'geo-height-diff-a';
+        a.style.cssText =
+          'position:fixed;top:10px;left:10px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(a);
+
+        var b = document.createElement('div');
+        b.id = 'geo-height-diff-b';
+        b.style.cssText =
+          'position:fixed;top:10px;left:200px;width:50px;height:212px;z-index:9999';
+        document.body.appendChild(b);
+      """)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_same_height(session, "#geo-height-diff-a", "#geo-height-diff-b")
+        end
+
+      assert error.message =~ "geo-height-diff-a"
+      assert error.message =~ "geo-height-diff-b"
+      assert error.message =~ "200px"
+      assert error.message =~ "212px"
+      assert error.message =~ "delta 12px"
+    end
+
+    @tag :feature
+    test "fails with a distinct sentinel when the first selector matches nothing",
+         %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var b = document.createElement('div');
+        b.id = 'geo-height-onlyb';
+        b.style.cssText =
+          'position:fixed;top:10px;left:200px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(b);
+      """)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_same_height(session, "#geo-height-missing-a", "#geo-height-onlyb")
+        end
+
+      assert error.message =~ "geo-height-missing-a"
+    end
+
+    @tag :feature
+    test "fails with a distinct sentinel when the second selector matches nothing",
+         %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var a = document.createElement('div');
+        a.id = 'geo-height-onlya';
+        a.style.cssText =
+          'position:fixed;top:10px;left:10px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(a);
+      """)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_same_height(session, "#geo-height-onlya", "#geo-height-missing-b")
+        end
+
+      assert error.message =~ "geo-height-missing-b"
+    end
+
+    @tag :feature
+    test "fails with a distinct sentinel when the first element has zero height",
+         %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var a = document.createElement('div');
+        a.id = 'geo-height-zero-a';
+        a.style.cssText =
+          'position:fixed;top:10px;left:10px;width:50px;height:0px;z-index:9999';
+        document.body.appendChild(a);
+
+        var b = document.createElement('div');
+        b.id = 'geo-height-zero-b';
+        b.style.cssText =
+          'position:fixed;top:10px;left:200px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(b);
+      """)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_same_height(session, "#geo-height-zero-a", "#geo-height-zero-b")
+        end
+
+      assert error.message =~ "geo-height-zero-a"
+    end
+
+    @tag :feature
+    test "fails with a distinct sentinel when the second element has zero height",
+         %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var a = document.createElement('div');
+        a.id = 'geo-height-zerob-a';
+        a.style.cssText =
+          'position:fixed;top:10px;left:10px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(a);
+
+        var b = document.createElement('div');
+        b.id = 'geo-height-zerob-b';
+        b.style.cssText =
+          'position:fixed;top:10px;left:200px;width:50px;height:0px;z-index:9999';
+        document.body.appendChild(b);
+      """)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_same_height(session, "#geo-height-zerob-a", "#geo-height-zerob-b")
+        end
+
+      assert error.message =~ "geo-height-zerob-b"
+    end
+  end
+
   defp inject(session, script) do
     Wallaby.Browser.execute_script(session, script, [])
     session

--- a/test/mydia_web/features/geometry_self_test.exs
+++ b/test/mydia_web/features/geometry_self_test.exs
@@ -218,6 +218,48 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       assert error.message =~ "delta 12px"
     end
 
+    # A delta a hair over the tolerance must not be displayed as though it sat
+    # exactly on it. Rounding the reported delta to 1 decimal place printed a
+    # failing 1.04px as "delta 1px, tolerance 1px", which reads like a message
+    # that should have passed and sends the reader hunting for a bug in the
+    # assertion rather than in their layout.
+    @tag :feature
+    test "reports a just-over-tolerance delta without rounding it onto the boundary",
+         %{session: session} do
+      login_as_admin(session)
+
+      session
+      |> visit("/")
+      |> wait_for_liveview()
+
+      inject(session, """
+        var a = document.createElement('div');
+        a.id = 'geo-height-edge-a';
+        a.style.cssText =
+          'position:fixed;top:10px;left:10px;width:50px;height:200px;z-index:9999';
+        document.body.appendChild(a);
+
+        var b = document.createElement('div');
+        b.id = 'geo-height-edge-b';
+        b.style.cssText =
+          'position:fixed;top:10px;left:200px;width:50px;height:201.04px;z-index:9999';
+        document.body.appendChild(b);
+      """)
+
+      error =
+        assert_raise ExUnit.AssertionError, fn ->
+          assert_same_height(session, "#geo-height-edge-a", "#geo-height-edge-b")
+        end
+
+      # Matched as a pattern rather than an exact string: the browser snaps the
+      # requested 201.04px to its own device-pixel grid (observed 201.03px), so
+      # pinning the literal would make this test about Chrome's rounding rather
+      # than about ours. What matters is that a sub-pixel delta survives into
+      # the message instead of collapsing onto the tolerance.
+      refute error.message =~ "delta 1px"
+      assert error.message =~ ~r/delta 1\.\d+px/
+    end
+
     @tag :feature
     test "fails with a distinct sentinel when the first selector matches nothing",
          %{session: session} do

--- a/test/mydia_web/live/dashboard_live/loading_skeleton_test.exs
+++ b/test/mydia_web/live/dashboard_live/loading_skeleton_test.exs
@@ -60,7 +60,7 @@ defmodule MydiaWeb.DashboardLive.LoadingSkeletonTest do
     refute has_element?(view, "#trending-tv-skeleton")
   end
 
-  test "each skeleton renders 10 placeholder cards, matching the Enum.take(10) real rails use",
+  test "each skeleton renders as many placeholder cards as the LiveView's trending rail limit",
        %{conn: conn} do
     {:ok, _view, html} = live(conn, ~p"/")
 
@@ -69,7 +69,12 @@ defmodule MydiaWeb.DashboardLive.LoadingSkeletonTest do
     movies_cards = doc |> LazyHTML.query("#trending-movies-skeleton div.card") |> Enum.count()
     tv_cards = doc |> LazyHTML.query("#trending-tv-skeleton div.card") |> Enum.count()
 
-    assert movies_cards == 10
-    assert tv_cards == 10
+    # Asserted against the LiveView's own limit, not a literal, so a change to
+    # @trending_rail_limit in index.ex cannot leave this test green while the
+    # skeleton and the settled row count drift apart.
+    limit = MydiaWeb.DashboardLive.Index.trending_rail_limit()
+
+    assert movies_cards == limit
+    assert tv_cards == limit
   end
 end

--- a/test/mydia_web/live/dashboard_live/loading_skeleton_test.exs
+++ b/test/mydia_web/live/dashboard_live/loading_skeleton_test.exs
@@ -59,4 +59,17 @@ defmodule MydiaWeb.DashboardLive.LoadingSkeletonTest do
     refute has_element?(view, "#trending-movies-skeleton")
     refute has_element?(view, "#trending-tv-skeleton")
   end
+
+  test "each skeleton renders 10 placeholder cards, matching the Enum.take(10) real rails use",
+       %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/")
+
+    doc = LazyHTML.from_document(html)
+
+    movies_cards = doc |> LazyHTML.query("#trending-movies-skeleton div.card") |> Enum.count()
+    tv_cards = doc |> LazyHTML.query("#trending-tv-skeleton div.card") |> Enum.count()
+
+    assert movies_cards == 10
+    assert tv_cards == 10
+  end
 end

--- a/test/mydia_web/live/dashboard_live/loading_skeleton_test.exs
+++ b/test/mydia_web/live/dashboard_live/loading_skeleton_test.exs
@@ -1,0 +1,62 @@
+defmodule MydiaWeb.DashboardLive.LoadingSkeletonTest do
+  @moduledoc """
+  The two rails are separate assigns fed by separate handle_info messages and
+  can resolve independently, so each is asserted on its own. A test that only
+  checked "both gone after load" would pass with one skeleton wired to the
+  other's assign.
+
+  Dashboard has no disconnected-render test: mount/3 sets both loading flags to
+  false when not connected, so only the first connected render shows them.
+  """
+
+  # async: false - the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
+  import MydiaWeb.AuthHelpers
+
+  setup %{conn: conn} do
+    # DashboardLive.Index unconditionally loads both trending rails on
+    # connected mount (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+
+    %{conn: log_in_user(conn, user_fixture())}
+  end
+
+  test "both trending rails render a skeleton on the first connected render", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/")
+
+    doc = LazyHTML.from_document(html)
+
+    refute doc |> LazyHTML.query("#trending-movies-skeleton") |> Enum.empty?()
+    refute doc |> LazyHTML.query("#trending-tv-skeleton") |> Enum.empty?()
+  end
+
+  test "each skeleton uses the rail's own five-column grid", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/")
+
+    doc = LazyHTML.from_document(html)
+
+    [movies_class] =
+      doc |> LazyHTML.query("#trending-movies-skeleton") |> LazyHTML.attribute("class")
+
+    [tv_class] = doc |> LazyHTML.query("#trending-tv-skeleton") |> LazyHTML.attribute("class")
+
+    for class <- [movies_class, tv_class] do
+      assert class =~ "grid-cols-2"
+      assert class =~ "lg:grid-cols-5"
+      assert class =~ "gap-3"
+    end
+  end
+
+  test "both skeletons are gone once the rails settle", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    refute has_element?(view, "#trending-movies-skeleton")
+    refute has_element?(view, "#trending-tv-skeleton")
+  end
+end

--- a/test/mydia_web/live/discover_live/loading_skeleton_test.exs
+++ b/test/mydia_web/live/discover_live/loading_skeleton_test.exs
@@ -1,0 +1,70 @@
+defmodule MydiaWeb.DiscoverLive.LoadingSkeletonTest do
+  @moduledoc """
+  Discover sets @loading true in mount/3 outside any connected?/1 check, so the
+  disconnected render always shows the loading branch. That is the one fully
+  deterministic place to assert the skeleton, and it is why the first test here
+  uses get/2 rather than live/2.
+
+  Asserting via has_element?/2 would not work: it re-renders, which drains the
+  LiveView mailbox and returns the post-load state.
+  """
+
+  # async: false - the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
+  import MydiaWeb.AuthHelpers
+
+  setup %{conn: conn} do
+    # DiscoverLive.Index unconditionally loads the movie genre list and its
+    # default (trending) category on connected mount (#530).
+    warm_genre_cache(:movie, [])
+    warm_trending_cache(:movie, [])
+
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  test "the disconnected render shows the skeleton, not a spinner", %{conn: conn} do
+    doc =
+      conn
+      |> get(~p"/discover")
+      |> html_response(200)
+      |> LazyHTML.from_document()
+
+    refute doc |> LazyHTML.query("#discover-grid-skeleton") |> Enum.empty?()
+    assert doc |> LazyHTML.query("#discover-grid") |> Enum.empty?()
+  end
+
+  test "the skeleton grid follows the stored density preference", %{conn: conn} do
+    doc =
+      conn
+      |> get(~p"/discover")
+      |> html_response(200)
+      |> LazyHTML.from_document()
+
+    [class] = doc |> LazyHTML.query("#discover-grid-skeleton") |> LazyHTML.attribute("class")
+
+    # The comfortable default, identical to the real results grid's own
+    # grid_columns_class(@grid_density) output.
+    assert class =~ "xl:grid-cols-6"
+  end
+
+  test "the first connected render still shows the skeleton", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/discover")
+
+    doc = LazyHTML.from_document(html)
+
+    refute doc |> LazyHTML.query("#discover-grid-skeleton") |> Enum.empty?()
+  end
+
+  test "the skeleton is gone once results land", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/discover")
+
+    # has_element?/2 re-renders, which processes the queued load message first,
+    # so this observes the settled state rather than the mount render.
+    refute has_element?(view, "#discover-grid-skeleton")
+  end
+end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -77,7 +77,8 @@ defmodule MydiaWeb.FeatureCase do
   - `js_click(session, selector)` - Escape hatch: click via JS. Prefer `click/2`.
 
   `MydiaWeb.FeatureCase.Geometry`'s `refute_covered/2`, `assert_in_viewport/2`,
-  and `refute_clipped/2` are also auto-imported, via the `using` block below.
+  `refute_clipped/2`, and `assert_same_height/4` are also auto-imported, via
+  the `using` block below.
 
   ## Wallaby DSL Reference
 

--- a/test/support/feature_case/geometry.ex
+++ b/test/support/feature_case/geometry.ex
@@ -73,6 +73,51 @@ defmodule MydiaWeb.FeatureCase.Geometry do
   end
 
   @doc """
+  Asserts `selector_a` and `selector_b` have the same rendered height, within
+  `tolerance_px`.
+
+  Built for skeleton/real card height parity: a placeholder that visually
+  promises to reserve a real element's height must actually do so, or the
+  page collapses and re-expands once real content replaces it. Compares the
+  first match of each selector.
+
+  `tolerance_px` defaults to 1, deliberately small. Sub-pixel layout
+  differences are normal and a 0-tolerance assertion would be flaky, but the
+  regression this helper exists to catch was 12px, so 1px cannot hide it.
+  """
+  def assert_same_height(session, selector_a, selector_b, tolerance_px \\ 1) do
+    case eval(session, same_height_script(), [selector_a, selector_b]) do
+      "__missing_a__" ->
+        flunk("assert_same_height/4: no element matched #{inspect(selector_a)}")
+
+      "__missing_b__" ->
+        flunk("assert_same_height/4: no element matched #{inspect(selector_b)}")
+
+      "__zero_size_a__" ->
+        flunk(
+          "assert_same_height/4: #{inspect(selector_a)} has zero height, so there is nothing to compare"
+        )
+
+      "__zero_size_b__" ->
+        flunk(
+          "assert_same_height/4: #{inspect(selector_b)} has zero height, so there is nothing to compare"
+        )
+
+      %{"a" => height_a, "b" => height_b} ->
+        delta = abs(height_a - height_b)
+
+        if delta <= tolerance_px do
+          session
+        else
+          flunk(
+            "#{selector_a} is #{format_px(height_a)}px but #{selector_b} is " <>
+              "#{format_px(height_b)}px (delta #{format_px(delta)}px, tolerance #{tolerance_px}px)"
+          )
+        end
+    end
+  end
+
+  @doc """
   Asserts the element is not clipped by its nearest scrollable ancestor.
   """
   def refute_clipped(session, selector) do
@@ -133,6 +178,41 @@ defmodule MydiaWeb.FeatureCase.Geometry do
     }
     return covering;
     """
+  end
+
+  defp same_height_script do
+    """
+    var selectorA = arguments[0];
+    var selectorB = arguments[1];
+
+    var elA = document.querySelector(selectorA);
+    if (!elA) { return '__missing_a__'; }
+
+    var elB = document.querySelector(selectorB);
+    if (!elB) { return '__missing_b__'; }
+
+    var heightA = elA.getBoundingClientRect().height;
+    if (heightA === 0) { return '__zero_size_a__'; }
+
+    var heightB = elB.getBoundingClientRect().height;
+    if (heightB === 0) { return '__zero_size_b__'; }
+
+    return {a: heightA, b: heightB};
+    """
+  end
+
+  # Renders a pixel measurement without a spurious ".0" (200, not 200.0) while
+  # keeping real sub-pixel deltas visible (341.5).
+  defp format_px(value) when is_integer(value), do: Integer.to_string(value)
+
+  defp format_px(value) when is_float(value) do
+    rounded = Float.round(value, 1)
+
+    if rounded == trunc(rounded) do
+      rounded |> trunc() |> Integer.to_string()
+    else
+      Float.to_string(rounded)
+    end
   end
 
   defp viewport_script do

--- a/test/support/feature_case/geometry.ex
+++ b/test/support/feature_case/geometry.ex
@@ -203,10 +203,17 @@ defmodule MydiaWeb.FeatureCase.Geometry do
 
   # Renders a pixel measurement without a spurious ".0" (200, not 200.0) while
   # keeping real sub-pixel deltas visible (341.5).
+  #
+  # Rounded to 2 places rather than 1 so a delta just past the tolerance cannot
+  # be displayed as though it sat exactly on it. At 1 place a failing 1.04px
+  # delta against the default 1px tolerance printed "delta 1px, tolerance 1px",
+  # which reads like a message that should have passed and sends the reader
+  # looking for a bug in the assertion rather than in their layout. Keep this
+  # finer than any tolerance a caller passes.
   defp format_px(value) when is_integer(value), do: Integer.to_string(value)
 
   defp format_px(value) when is_float(value) do
-    rounded = Float.round(value, 1)
+    rounded = Float.round(value, 2)
 
     if rounded == trunc(rounded) do
       rounded |> trunc() |> Integer.to_string()


### PR DESCRIPTION
Three poster grids fetch metadata asynchronously and showed a centered spinner while waiting, which collapses the layout and re-expands it when results land.

The worst case is not the initial load. `discover_live/index.ex` sets `@loading` on every filter, genre, year, rating, sort and media-type change, not only on mount. On a filter change the grid is already on screen at full height, and today it collapses to a spinner and re-expands. A placeholder that holds the shape removes that.

## What changed

`MydiaWeb.PosterCardComponents.poster_card_grid_skeleton/1` renders N placeholder cards shaped like a real poster card, into a caller-supplied column class. It sits directly below `poster_card_body/1`, the thing it imitates, so the two shapes stay visible to each other in review.

Wired into three loading branches:

| Site | Columns | Count |
| --- | --- | --- |
| Discover results grid | `grid_columns_class(@grid_density)`, all three densities | 20, an uncapped provider page |
| Dashboard Trending Movies | fixed 2/3/4/5 | `@trending_rail_limit` |
| Dashboard Trending TV | fixed 2/3/4/5 | `@trending_rail_limit` |

`columns` is a required attr with no default, because the two consumers genuinely differ and a default would let a call site silently lay out differently from its own results grid.

## Height parity is measured, not assumed

The premise is that a placeholder reserves the same height as a real card, so the bar heights were measured in headless Chromium rather than derived from reading CSS.

The first measurement found the placeholder 12px short in both themes. The cause decomposed exactly: Tailwind's `text-xs` line-height is `1rem`/16px and is not derived from its 0.75rem font-size (4px), and every real action element carries its own `mt-2` on top of `card-body`'s gap (8px). After correcting `h-3` to `h-4` and `gap-2` to `gap-4`, a placeholder and a real card both measure 341.5px, for two-line and one-line titles, in light and dark.

`test/mydia_web/features/discover_skeleton_height_parity_test.exs` makes that permanent. It uses a new `assert_same_height/4` in the existing `MydiaWeb.FeatureCase.Geometry`, and avoids racing the transient skeleton by fetching Discover's disconnected render (which always contains the skeleton, since `@loading` is set outside any `connected?/1` check) and splicing it beside the real grid, so both cards are measured in one document at one instant. The guard was verified to fail: perturbing the injected card by 12px produces `#injected-skeleton-grid .card is 331.5px but #discover-grid .card is 343.5px (delta 12px, tolerance 1px)`.

## Dashboard count coupling

The rails cap their data with `Enum.take/2`, so a skeleton at the component's default of 20 would have shown 4 rows collapsing to 2. Both the cap and the placeholder count now read one module attribute, `@trending_rail_limit`, and the regression test asserts against `DashboardLive.Index.trending_rail_limit()` rather than a literal, so the two cannot drift apart while staying green.

## Deliberately out of scope

- **Search.** Its loading state already shows per-indexer progress and streams results into a table, so grey rows would replace information with less information.
- **Discover's `loading_more`.** The grid above it is already populated and holding its shape.
- **Per-poster image placeholders**, and **the main library grid**, which loads synchronously and would need an async refactor first.
- **`assign_async`.** All 12 async sites in the tree hand-roll a boolean assign; introducing a second idiom for three of them was rejected.

## Accessibility

The replaced Discover spinner carried visible text ("Loading movies..."). The grid wrapper carries `role="status"` and `aria-label="Loading titles"` so that is not a regression for assistive tech. Reduced motion needs no handling: daisyUI gates the shimmer behind `prefers-reduced-motion: no-preference`.

## Verification

`mix precommit` green: 10102 tests, 0 failures, plus `credo --strict`. Feature tests pass under `./dev feature-test`.

One full run failed on `CandidatePromotionTest` with `database is locked`, the SQLite load-contention flake catalogued in `.github/ci-flakes.md`. It passes 10/10 in isolation and three of four full runs on this branch were green. Per that catalogue's own instruction, a second run on the identical tree was used to confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added responsive placeholder card grids for Dashboard trending movies and TV sections while content loads.
  - Added matching loading placeholders to Discover results, preserving the selected grid density and layout.
  - Loading placeholders now mirror the size and structure of finished poster cards.

- **Bug Fixes**
  - Improved loading-state consistency by aligning placeholder card counts and dimensions with the content that follows.
  - Replaced centered loading spinners with representative content skeletons for a smoother browsing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->