### PR TITLE
fix(migrations): drop the folded-away media_file_match_candidates dependent

### DIFF
--- a/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
+++ b/priv/repo/migrations/20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness.exs
@@ -35,13 +35,19 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness 
   # transcode_jobs is unique on (media_file_id, resolution) only WHERE
   # type = 'download'. Guarding on (resolution, type) is stricter than the
   # index, which at worst drops a non-download job that could have moved.
+  #
+  # media_file_match_candidates is NOT in this list. It used to hang off
+  # media_files, but 20260830143721_split_import_candidates_from_media_files
+  # drops the table outright, and that migration always runs first. Its
+  # replacement, import_candidates, is keyed on (library_path_id,
+  # relative_path) and carries no media_file_id at all, so a fold of duplicate
+  # media_files has nothing to repoint there.
   @dependents [
     {"subtitles", ["subtitle_hash"]},
     {"media_hashes", []},
     {"subtitle_track_settings", ["track_ref"]},
     {"transcode_jobs", ["resolution", "type"]},
-    {"media_segments", ["type"]},
-    {"media_file_match_candidates", ["rank"]}
+    {"media_segments", ["type"]}
   ]
 
   def up do

--- a/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
+++ b/test/mydia/repo/migrations/fold_duplicate_media_files_test.exs
@@ -366,13 +366,13 @@ defmodule Mydia.Repo.Migrations.FoldDuplicateMediaFilesTest do
     )
     """)
 
-    sql!("""
-    CREATE TABLE media_file_match_candidates (
-      id TEXT PRIMARY KEY,
-      media_file_id TEXT REFERENCES media_files(id) ON DELETE CASCADE,
-      rank INTEGER
-    )
-    """)
+    # media_file_match_candidates is deliberately absent.
+    # 20260830143721_split_import_candidates_from_media_files drops it, and that
+    # migration runs first, so by the time the fold runs no database has the
+    # table. Creating it here once hid #653's real failure: the fold only
+    # touches a dependent table when a duplicate group exists, so a fresh
+    # install migrated cleanly and CI stayed green while every populated
+    # install crashed on boot with "no such table".
   end
 
   defp seed_library_path(id, path) do


### PR DESCRIPTION
## What broke

`podman-mydia.service` on the production instance is in a crash loop. The release never binds a port, so the app is fully down.

```
== Running 20260901234336 Mydia.Repo.Migrations.FoldDuplicateMediaFilesAndEnforcePathUniqueness.up/0
Application mydia exited: Mydia.Application.start(:normal, []) returned an error:
  shutdown: failed to start child: Ecto.Migrator
    ** (Exqlite.Error) no such table: media_file_match_candidates
    SELECT count(*) FROM media_file_match_candidates WHERE media_file_id = '...'
```

`Ecto.Migrator` is a child in `Mydia.Application`'s supervision tree, so a raising migration is a boot failure rather than a degraded start.

## Root cause

`20260901234336_fold_duplicate_media_files_and_enforce_path_uniqueness` listed `media_file_match_candidates` in `@dependents`, the tables it repoints off a losing `media_files` row. `20260830143721_split_import_candidates_from_media_files` drops that table, and it always runs first.

Its replacement, `import_candidates`, is keyed on `(library_path_id, relative_path)` and carries no `media_file_id` at all, so a fold of duplicate `media_files` has nothing to repoint there. The entry is removed rather than renamed.

## Why CI was green

Two things hid it.

`fold_duplicate_media_files_test.exs` created `media_file_match_candidates` in its own fixture schema, fabricating a database no migration chain can produce. The table was never seeded or asserted on: it existed only to stop the migration raising.

The fold also consults a dependent table only when a duplicate group exists, so a fresh install migrates cleanly whether or not the entry is there. The failure needs real duplicate rows, which is why it reached production untouched by CI.

The fixture no longer creates the table. Without the fix, the existing duplicate-folding tests fail with production's exact stack frame (6 of 8); with it, they pass.

## Verification

- `mix test test/mydia/repo/migrations/fold_duplicate_media_files_test.exs test/mydia/repo/migrations/split_import_candidates_from_media_files_test.exs` — 10 tests, 0 failures.
- Confirmed red before the fix: same `no such table` error at `dependent_count/1`, matching the production trace frame for frame.
- The affected production database holds 153 duplicate groups over 306 `media_files` rows, and this is the only migration pending there.

Full `mix precommit` was cut short deliberately to get the fix moving while the instance is down; CI is the gate.

Fixes the boot failure introduced alongside #653.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected database migration handling for media file path uniqueness after earlier schema changes.
  - Updated migration verification to accurately reflect the current database structure, preventing previously masked failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->