### PR TITLE
feat(duplicates): trash one group at a time, with an undo

### DIFF
--- a/lib/mydia/events.ex
+++ b/lib/mydia/events.ex
@@ -633,6 +633,44 @@ defmodule Mydia.Events do
   end
 
   @doc """
+  Records a media_file.prune_undone event: copies that `files_pruned/4` trashed
+  were put back.
+
+  Recording the prune and staying silent about its reversal would leave the
+  activity trail describing a library that no longer exists, so this is the
+  counterpart to `files_pruned/4` rather than an optional extra.
+
+  There is no keeper to name. An undo restores copies, it does not choose among
+  them, so the group is identified from the media item and any one restored
+  file.
+
+  ## Examples
+
+      iex> prune_undone(media_item, [restored_file], "admin")
+      :ok
+  """
+  def prune_undone(media_item, [file | _] = restored_files, actor_id) do
+    {resource_type, resource_id} = upgrade_resource(file, media_item)
+
+    create_event_async(%{
+      category: "media",
+      type: "media_file.prune_undone",
+      actor_type: :user,
+      actor_id: actor_id,
+      resource_type: resource_type,
+      resource_id: resource_id,
+      severity: :info,
+      metadata: %{
+        "title" => media_item.title,
+        "media_type" => media_item.type,
+        "restored" => Enum.map(restored_files, & &1.relative_path),
+        "restored_ids" => Enum.map(restored_files, & &1.id),
+        "bytes_restored" => restored_files |> Enum.map(&(&1.size || 0)) |> Enum.sum()
+      }
+    })
+  end
+
+  @doc """
   Records a media_file.upgrade_rejected event — the counterpart to
   `file_upgraded/4` for when the candidate release did not actually deliver
   the quality it claimed. The originating release is blacklisted separately

--- a/lib/mydia/events/presentation.ex
+++ b/lib/mydia/events/presentation.ex
@@ -107,6 +107,12 @@ defmodule Mydia.Events.Presentation do
       color: "text-info",
       title: "Duplicate pruned"
     },
+    %{
+      type: "media_file.prune_undone",
+      icon: "hero-arrow-uturn-left",
+      color: "text-warning",
+      title: "Duplicate prune undone"
+    },
 
     # download.*
     %{
@@ -395,6 +401,21 @@ defmodule Mydia.Events.Presentation do
     case metadata["bytes_reclaimed"] do
       bytes when is_integer(bytes) and bytes > 0 ->
         "#{base}, #{humanize_bytes(bytes)} reclaimed"
+
+      _ ->
+        base
+    end
+  end
+
+  def detail(%Event{type: "media_file.prune_undone", metadata: metadata}) do
+    restored = metadata["restored"] || []
+    count = length(restored)
+    suffix = if count == 1, do: "file", else: "files"
+    base = "#{title_of(metadata)}, #{count} #{suffix} restored"
+
+    case metadata["bytes_restored"] do
+      bytes when is_integer(bytes) and bytes > 0 ->
+        "#{base}, #{humanize_bytes(bytes)} returned"
 
       _ ->
         base

--- a/lib/mydia/library/prune.ex
+++ b/lib/mydia/library/prune.ex
@@ -174,29 +174,33 @@ defmodule Mydia.Library.Prune do
     %{restored: restored, failed: failed}
   end
 
-  # One event per media item, mirroring the per-group shape of the
-  # `media_file.pruned` events `execute/3` writes.
+  # One event per subject (episode or movie), mirroring the per-group shape of
+  # the `media_file.pruned` events `execute/3` writes.
   #
-  # The grouping key is the media item's id, not the struct: two rows reached
-  # through different association paths (a movie's own `media_item`, an
-  # episode's parent) carry different preload states and would not compare
-  # equal as structs, splitting one item across two events.
+  # The grouping key is the file's own subject, not the media item: a show's
+  # `media_item` is shared by every one of its episodes, so grouping by media
+  # item would fold two different episodes' restored files into one event and
+  # silently drop the other.
   #
   # `restored` holds rows returned by `Repo.update/1`, which do not carry the
-  # preloads, so the media item is read from the matching row loaded before the
-  # restore.
+  # preloads, so both the subject key and the media item are read from the
+  # matching row loaded before the restore.
   defp announce_restored(restored, loaded, actor_id) do
     by_id = Map.new(loaded, &{&1.id, &1})
 
     restored
-    |> Enum.map(fn file -> {media_item_of(Map.fetch!(by_id, file.id)), file} end)
-    |> Enum.reject(fn {media_item, _file} -> is_nil(media_item) end)
-    |> Enum.group_by(fn {media_item, _file} -> media_item.id end)
-    |> Enum.each(fn {_id, pairs} ->
-      [{media_item, _} | _] = pairs
-      Events.prune_undone(media_item, Enum.map(pairs, &elem(&1, 1)), actor_id)
+    |> Enum.map(&Map.fetch!(by_id, &1.id))
+    |> Enum.group_by(&subject_key/1)
+    |> Enum.each(fn {_key, files} ->
+      case media_item_of(hd(files)) do
+        nil -> :ok
+        media_item -> Events.prune_undone(media_item, files, actor_id)
+      end
     end)
   end
+
+  defp subject_key(%MediaFile{episode_id: id}) when not is_nil(id), do: {:episode, id}
+  defp subject_key(%MediaFile{media_item_id: id}), do: {:media_item, id}
 
   # Preloaded by undo/2 as `[:media_item, episode: :media_item]`, so neither
   # clause queries.

--- a/lib/mydia/library/prune.ex
+++ b/lib/mydia/library/prune.ex
@@ -19,10 +19,14 @@ defmodule Mydia.Library.Prune do
   all. The UI is not the security boundary; this function is.
   """
 
+  import Ecto.Query, only: [where: 3]
+
   alias Mydia.Events
   alias Mydia.Library
   alias Mydia.Library.MediaFile
   alias Mydia.Library.Prune.{Decision, Eligibility, Group, Grouping, Ranker}
+  alias Mydia.Media.{Episode, MediaItem}
+  alias Mydia.Repo
 
   require Logger
 
@@ -120,6 +124,85 @@ defmodule Mydia.Library.Prune do
 
     %{trashed: trashed, failed: failed, aborted: refused_ids ++ aborted_keepers ++ unknown}
   end
+
+  @doc """
+  Restores files a previous `execute/3` trashed.
+
+  Only rows that are currently trashed are touched. A row can stop being
+  trashed between an undo being offered and the operator taking it:
+  `Mydia.Jobs.TrashCleanup` can purge it, a library scan can restore it, or
+  another admin session can act on it. Restoring a row that is not in the trash
+  is not a no-op further down, so the filter belongs here rather than in
+  `Mydia.Library.restore_media_file/1`.
+
+  An id matching no row is ignored for the same reason `execute/3` does not
+  trust its input: this function is reachable without going through the UI.
+
+  Partial failure is reported rather than rolled back, matching `execute/3`.
+  Bytes have already moved by the time a row update can fail, so a global
+  rollback would be a lie.
+  """
+  @spec undo([String.t()], String.t()) :: %{
+          restored: [MediaFile.t()],
+          failed: [{String.t(), term()}]
+        }
+  def undo(file_ids, actor_id) when is_list(file_ids) and is_binary(actor_id) do
+    files =
+      MediaFile
+      |> where([mf], mf.id in ^file_ids and not is_nil(mf.trashed_at))
+      |> Repo.all()
+      |> Repo.preload([:library_path, :media_item, episode: :media_item])
+
+    {restored, failed} =
+      Enum.reduce(files, {[], []}, fn file, {ok, bad} ->
+        case Library.restore_media_file(file) do
+          {:ok, file} ->
+            {ok ++ [file], bad}
+
+          {:error, reason} ->
+            Logger.error("Prune could not restore a trashed media file",
+              media_file_id: file.id,
+              reason: inspect(reason)
+            )
+
+            {ok, bad ++ [{file.id, reason}]}
+        end
+      end)
+
+    announce_restored(restored, files, actor_id)
+
+    %{restored: restored, failed: failed}
+  end
+
+  # One event per media item, mirroring the per-group shape of the
+  # `media_file.pruned` events `execute/3` writes.
+  #
+  # The grouping key is the media item's id, not the struct: two rows reached
+  # through different association paths (a movie's own `media_item`, an
+  # episode's parent) carry different preload states and would not compare
+  # equal as structs, splitting one item across two events.
+  #
+  # `restored` holds rows returned by `Repo.update/1`, which do not carry the
+  # preloads, so the media item is read from the matching row loaded before the
+  # restore.
+  defp announce_restored(restored, loaded, actor_id) do
+    by_id = Map.new(loaded, &{&1.id, &1})
+
+    restored
+    |> Enum.map(fn file -> {media_item_of(Map.fetch!(by_id, file.id)), file} end)
+    |> Enum.reject(fn {media_item, _file} -> is_nil(media_item) end)
+    |> Enum.group_by(fn {media_item, _file} -> media_item.id end)
+    |> Enum.each(fn {_id, pairs} ->
+      [{media_item, _} | _] = pairs
+      Events.prune_undone(media_item, Enum.map(pairs, &elem(&1, 1)), actor_id)
+    end)
+  end
+
+  # Preloaded by undo/2 as `[:media_item, episode: :media_item]`, so neither
+  # clause queries.
+  defp media_item_of(%MediaFile{episode: %Episode{media_item: %MediaItem{} = item}}), do: item
+  defp media_item_of(%MediaFile{media_item: %MediaItem{} = item}), do: item
+  defp media_item_of(%MediaFile{}), do: nil
 
   defp trash_all(files) do
     Enum.reduce(files, {[], []}, fn file, {ok, bad} ->

--- a/lib/mydia_web/live/admin_duplicates_live/components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/components.ex
@@ -355,6 +355,52 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
   end
 
   @doc """
+  The undo affordance for a completed trash run.
+
+  This cannot be a flash. `core_components.ex` puts
+  `phx-click="lv:clear-flash"` on the whole flash container, which would
+  swallow a nested Undo button, and flash values are strings, so the file ids
+  would need an assign regardless.
+
+  It sits bottom-end because the flash group sits top-end, and a partial run
+  shows both: an error flash for what could not move, and this for what did.
+
+  There is no auto-dismiss timer. Any interval is a guess, and an operator
+  reading filenames to check they trashed the right copy will lose that race.
+  """
+  attr :run, :map, required: true
+
+  def undo_toast(assigns) do
+    ~H"""
+    <div id="duplicates-undo-toast" class="toast toast-bottom toast-end z-50" role="status">
+      <div class="alert alert-success w-80 sm:w-96 max-w-80 sm:max-w-96 text-wrap">
+        <.icon name="hero-check-circle" class="size-5 shrink-0" />
+        <span class="text-sm">{@run.label}</span>
+        <div class="flex-1" />
+        <button
+          id="duplicates-undo"
+          type="button"
+          class="btn btn-sm btn-ghost"
+          phx-click="undo_trash"
+          phx-disable-with="Undoing..."
+        >
+          <.icon name="hero-arrow-uturn-left" class="w-4 h-4" /> Undo
+        </button>
+        <button
+          id="duplicates-undo-dismiss"
+          type="button"
+          class="group self-start cursor-pointer"
+          aria-label="Dismiss"
+          phx-click="dismiss_undo"
+        >
+          <.icon name="hero-x-mark" class="size-5 opacity-40 group-hover:opacity-70" />
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
   The operator-facing name of a group's subject. Public because the LiveView
   builds the undo toast's label from it, and a movie title or a
   "Show S01E02" string is a display concern that belongs here rather than
@@ -373,11 +419,16 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
     [file.resolution, file.codec] |> Enum.reject(&is_nil/1) |> Enum.join(" ")
   end
 
-  defp file_count(1), do: "1 file"
-  defp file_count(n), do: "#{n} files"
+  @doc """
+  Pluralized counts. Public for the same reason `humanize_bytes/1` is: the page
+  module builds the undo toast's label and must count files and items the same
+  way the rows above it do.
+  """
+  def file_count(1), do: "1 file"
+  def file_count(n), do: "#{n} files"
 
-  defp item_count(1), do: "1 item"
-  defp item_count(n), do: "#{n} items"
+  def item_count(1), do: "1 item"
+  def item_count(n), do: "#{n} items"
 
   defp refusal_label(:duplicate_registration), do: "Registered twice"
   defp refusal_label(:unanalyzed), do: "Not analyzed"

--- a/lib/mydia_web/live/admin_duplicates_live/components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/components.ex
@@ -9,6 +9,10 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
   left with an unlabelled red checkbox on the right, which left an operator
   with two controls, no labels, and no way to tell which one decided the
   file's fate.
+
+  Each group carries two buttons rather than one that swaps meaning: a marking
+  toggle, and a button that actually trashes. The marking half still swaps its
+  label so the row never goes dead once everything in it is kept.
   """
 
   use MydiaWeb, :html
@@ -64,9 +68,10 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
         Items holding more than one file, where every copy is proven to be the same content.
         Each file is set to either <span class="font-medium text-base-content">Keep</span>
         or <span class="font-medium text-error">Trash</span>; the best copy is listed first and
-        kept, the rest are already marked for trash, so one click on the Trash button clears them.
-        Every item always keeps at least one file. Trashed files are held for {@retention_days} days
-        before permanent deletion.
+        kept, the rest are already marked for trash. Trash one item with its own button, or
+        every item with the button above. Every item always keeps at least one file. Trashed
+        files are held for {@retention_days} days before permanent deletion, and a run can be
+        undone until you leave this page.
       </p>
 
       <%= if @decisions == [] do %>

--- a/lib/mydia_web/live/admin_duplicates_live/components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/components.ex
@@ -115,11 +115,13 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
   attr :selected, :any, required: true
 
   defp decision_row(assigns) do
-    selected_count = Enum.count(assigns.decision.losers, &MapSet.member?(assigns.selected, &1.id))
+    selected = assigns.selected
+    marked = Enum.filter(assigns.decision.losers, &MapSet.member?(selected, &1.id))
 
     assigns =
       assigns
-      |> assign(:selected_count, selected_count)
+      |> assign(:selected_count, length(marked))
+      |> assign(:selected_bytes, Enum.reduce(marked, 0, &(&2 + (&1.size || 0))))
       |> assign(:files, [assigns.decision.keeper | assigns.decision.losers])
 
     ~H"""
@@ -139,26 +141,31 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
         <span :if={@selected_count == 0} class="badge badge-sm badge-outline">Keeping all</span>
 
         <button
-          :if={@selected_count > 0}
-          id={"duplicates-group-keep-#{@decision.group.subject_id}"}
+          id={"duplicates-group-mark-#{@decision.group.subject_id}"}
           type="button"
           class="btn btn-sm btn-ghost ml-auto sm:ml-2"
-          aria-label={"Keep every file in #{subject_label(@decision.group)}"}
-          phx-click="keep_group"
+          aria-label={
+            if @selected_count > 0,
+              do: "Keep every file in #{subject_label(@decision.group)}",
+              else: "Mark every duplicate in #{subject_label(@decision.group)} for trash"
+          }
+          phx-click={if @selected_count > 0, do: "keep_group", else: "trash_group"}
           phx-value-subject={@decision.group.subject_id}
         >
-          Keep all
+          {if @selected_count > 0, do: "Keep all", else: "Mark all for trash"}
         </button>
         <button
-          :if={@selected_count == 0}
           id={"duplicates-group-trash-#{@decision.group.subject_id}"}
           type="button"
-          class="btn btn-sm btn-ghost ml-auto sm:ml-2"
-          aria-label={"Trash every duplicate in #{subject_label(@decision.group)}"}
-          phx-click="trash_group"
+          class="btn btn-sm btn-error"
+          disabled={@selected_count == 0}
+          aria-label={"Trash the marked duplicates in #{subject_label(@decision.group)}"}
+          phx-click="trash_group_now"
           phx-value-subject={@decision.group.subject_id}
+          phx-disable-with="Trashing..."
         >
-          Trash duplicates
+          <.icon name="hero-trash" class="w-4 h-4" />
+          Trash {file_count(@selected_count)} ({humanize_bytes(@selected_bytes)})
         </button>
       </div>
 
@@ -347,9 +354,15 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
     """
   end
 
-  defp subject_label(%{subject_type: :movie, subject: movie}), do: movie.title
+  @doc """
+  The operator-facing name of a group's subject. Public because the LiveView
+  builds the undo toast's label from it, and a movie title or a
+  "Show S01E02" string is a display concern that belongs here rather than
+  duplicated in the page module.
+  """
+  def subject_label(%{subject_type: :movie, subject: movie}), do: movie.title
 
-  defp subject_label(%{subject_type: :episode, subject: episode, media_item: show}) do
+  def subject_label(%{subject_type: :episode, subject: episode, media_item: show}) do
     "#{show.title} S#{pad(episode.season_number)}E#{pad(episode.episode_number)}"
   end
 

--- a/lib/mydia_web/live/admin_duplicates_live/index.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.ex
@@ -101,6 +101,27 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     end
   end
 
+  # Runs the trash for one group instead of the whole library. The ids are
+  # narrowed to that group's marked losers, and `keepers` still goes through:
+  # `execute/3` rebuilds the plan, and without the overrides it would re-rank
+  # the group with the default keeper and discard whatever the operator's Keep
+  # and Trash choices implied.
+  def handle_event("trash_group_now", %{"subject" => subject_id}, socket) do
+    with decision when not is_nil(decision) <- find_decision(socket, subject_id),
+         ids = group_selection(socket, decision),
+         false <- ids == [] do
+      actor_id = to_string(socket.assigns.current_scope.user.id)
+      result = Prune.execute(ids, actor_id, socket.assigns.keepers)
+
+      {:noreply,
+       socket
+       |> put_flash(:info, flash_for(result))
+       |> load_plan()}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
   def handle_event("trash_all_duplicates", _params, socket) do
     {:noreply, socket |> assign(:kept, MapSet.new()) |> assign_selection()}
   end
@@ -194,6 +215,12 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
 
   defp find_decision(socket, subject_id),
     do: Enum.find(socket.assigns.decisions, &(&1.group.subject_id == subject_id))
+
+  defp group_selection(socket, decision) do
+    for file <- decision.losers,
+        MapSet.member?(socket.assigns.selected, file.id),
+        do: file.id
+  end
 
   defp load_plan(socket) do
     plan = Prune.plan(socket.assigns.keepers)

--- a/lib/mydia_web/live/admin_duplicates_live/index.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.ex
@@ -37,6 +37,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
   use MydiaWeb, :live_view
 
   alias Mydia.Library.Prune
+  alias MydiaWeb.AdminDuplicatesLive.Components
 
   # Mirrors Mydia.Jobs.TrashCleanup's default, so this page never quotes a
   # retention period that disagrees with what actually purges trashed files.
@@ -53,6 +54,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
      |> assign(:kept, MapSet.new())
      |> assign(:keepers, %{})
      |> assign(:show_trash_modal, false)
+     |> assign(:last_run, nil)
      |> assign(:retention_days, retention_days)
      |> load_plan()}
   end
@@ -112,14 +114,50 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
          false <- ids == [] do
       actor_id = to_string(socket.assigns.current_scope.user.id)
       result = Prune.execute(ids, actor_id, socket.assigns.keepers)
+      label = "from #{Components.subject_label(decision.group)}"
 
       {:noreply,
        socket
-       |> put_flash(:info, flash_for(result))
+       |> report_run(result, label)
        |> load_plan()}
     else
       _ -> {:noreply, socket}
     end
+  end
+
+  def handle_event("undo_trash", _params, %{assigns: %{last_run: nil}} = socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("undo_trash", _params, socket) do
+    actor_id = to_string(socket.assigns.current_scope.user.id)
+    result = Prune.undo(socket.assigns.last_run.file_ids, actor_id)
+
+    # A restored file is a loser of an eligible group again, and every loser of
+    # an eligible group defaults to Trash. Without this the page would put the
+    # rescued copies straight back on Trash and offer to trash them again,
+    # which reads as the page ignoring the operator.
+    kept =
+      Enum.reduce(result.restored, socket.assigns.kept, &MapSet.put(&2, &1.id))
+
+    socket =
+      if result.failed == [] do
+        socket
+      else
+        put_flash(socket, :error, "#{length(result.failed)} file(s) could not be restored.")
+      end
+
+    # The toast clears either way. The run is over, and a second Undo on the
+    # same ids would find them untrashed and do nothing.
+    {:noreply,
+     socket
+     |> assign(:kept, kept)
+     |> assign(:last_run, nil)
+     |> load_plan()}
+  end
+
+  def handle_event("dismiss_undo", _params, socket) do
+    {:noreply, assign(socket, :last_run, nil)}
   end
 
   def handle_event("trash_all_duplicates", _params, socket) do
@@ -144,6 +182,10 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     result =
       Prune.execute(MapSet.to_list(socket.assigns.selected), actor_id, socket.assigns.keepers)
 
+    # `label` is computed before `load_plan/1` runs, because `load_plan/1`
+    # recomputes `:affected_items` against the post-run plan.
+    label = "across #{Components.item_count(socket.assigns.affected_items)}"
+
     # `:kept` survives the run. A group can still hold two files afterwards (a
     # keeper plus a copy the operator set to Keep), and it stays eligible, so
     # clearing the set would list that survivor as a loser and put it straight
@@ -152,7 +194,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     # the losers *not* in `:kept`, so the ids just trashed were never in it.
     {:noreply,
      socket
-     |> put_flash(:info, flash_for(result))
+     |> report_run(result, label)
      |> assign(:show_trash_modal, false)
      |> load_plan()}
   end
@@ -263,12 +305,40 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     |> assign(:affected_items, affected)
   end
 
-  defp flash_for(%{trashed: trashed, failed: failed, aborted: aborted}) do
-    base = "Trashed #{length(trashed)} file(s)."
-    base = if failed == [], do: base, else: base <> " #{length(failed)} could not be moved."
+  # A clean run says everything it needs to in the undo toast, so no info flash
+  # is raised: two success messages saying the same thing is noise. Failures
+  # and aborts still go through the flash, so a partial run shows the error at
+  # the top and the undo at the bottom, which is the truth: some files moved
+  # and can be put back, and some did not.
+  defp report_run(socket, result, scope_label) do
+    socket
+    |> maybe_flash_problems(result)
+    |> maybe_set_last_run(result, scope_label)
+  end
 
-    if aborted == [],
-      do: base,
-      else: base <> " #{length(aborted)} were skipped by re-verification."
+  defp maybe_flash_problems(socket, %{failed: [], aborted: []}), do: socket
+
+  defp maybe_flash_problems(socket, %{failed: failed, aborted: aborted}) do
+    parts =
+      [
+        failed != [] && "#{length(failed)} could not be moved",
+        aborted != [] && "#{length(aborted)} were skipped by re-verification"
+      ]
+      |> Enum.filter(& &1)
+
+    put_flash(socket, :error, Enum.join(parts, ". ") <> ".")
+  end
+
+  defp maybe_set_last_run(socket, %{trashed: []}, _scope_label), do: socket
+
+  defp maybe_set_last_run(socket, %{trashed: trashed}, scope_label) do
+    bytes = trashed |> Enum.map(&(&1.size || 0)) |> Enum.sum()
+
+    assign(socket, :last_run, %{
+      file_ids: Enum.map(trashed, & &1.id),
+      label:
+        "Trashed #{Components.file_count(length(trashed))} #{scope_label} " <>
+          "(#{Components.humanize_bytes(bytes)})"
+    })
   end
 end

--- a/lib/mydia_web/live/admin_duplicates_live/index.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.ex
@@ -19,6 +19,21 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
   stand in its place. That keeps the invariant every group needs: at least one
   file always survives, so the Trash button can never empty an item.
 
+  ## Two scopes, two confirmations
+
+  A group can be trashed on its own, and the whole library can be trashed at
+  once. Only the second gets a confirmation modal: two files in one item and
+  forty-seven across twenty-three are different blast radii, and the modal is
+  worth its click only for the second.
+
+  What the group run gets instead is `:last_run` and the undo toast. It holds
+  the ids the run trashed until another run replaces it, the operator dismisses
+  it, or they leave the page. `Mydia.Library.Prune.undo/2` puts those files
+  back, and the restored ids join `:kept` on the way through for the same
+  reason `:kept` survives a run at all: they are losers of an eligible group
+  again, and a loser defaults to Trash, so without that the page would offer to
+  trash the copies just rescued.
+
   ## Why the selection is stored as an exclusion set
 
   Every loser of every eligible group starts on Trash, so the ordinary path
@@ -189,7 +204,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     # `:kept` survives the run. A group can still hold two files afterwards (a
     # keeper plus a copy the operator set to Keep), and it stays eligible, so
     # clearing the set would list that survivor as a loser and put it straight
-    # back on Trash — offering to trash the very file the operator just spared.
+    # back on Trash, offering to trash the very file the operator just spared.
     # Nothing needs pruning out of the set either: `:selected` is built from
     # the losers *not* in `:kept`, so the ids just trashed were never in it.
     {:noreply,

--- a/lib/mydia_web/live/admin_duplicates_live/index.html.heex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.html.heex
@@ -17,5 +17,7 @@
         retention_days={@retention_days}
       />
     <% end %>
+
+    <MydiaWeb.AdminDuplicatesLive.Components.undo_toast :if={@last_run} run={@last_run} />
   </.admin_page>
 </Layouts.app>

--- a/test/mydia/events/presentation_test.exs
+++ b/test/mydia/events/presentation_test.exs
@@ -331,6 +331,35 @@ defmodule Mydia.Events.PresentationTest do
                )
              ) == "Unknown, 1 file trashed"
     end
+
+    test "prune_undone reports how many files came back and the bytes restored" do
+      assert Presentation.detail(
+               event(
+                 type: "media_file.prune_undone",
+                 metadata: %{
+                   "title" => "Harbor Lights",
+                   "restored" => ["Harbor Lights/Harbor.Lights.S02E03.360p.mp4"],
+                   "bytes_restored" => 2_147_483_648
+                 }
+               )
+             ) == "Harbor Lights, 1 file restored, 2.0 GB returned"
+    end
+
+    test "prune_undone pluralizes for more than one restored file" do
+      assert Presentation.detail(
+               event(
+                 type: "media_file.prune_undone",
+                 metadata: %{
+                   "title" => "Harbor Lights",
+                   "restored" => [
+                     "Harbor Lights/Harbor.Lights.S02E03.360p.mp4",
+                     "Harbor Lights/Harbor.Lights.S02E03.480p.mp4"
+                   ],
+                   "bytes_restored" => 500_000
+                 }
+               )
+             ) == "Harbor Lights, 2 files restored, 500000 B returned"
+    end
   end
 
   describe "detail/1 download.*" do

--- a/test/mydia/library/prune_test.exs
+++ b/test/mydia/library/prune_test.exs
@@ -11,7 +11,19 @@ defmodule Mydia.Library.PruneTest do
 
   defp episode_with(file_names, duration) do
     show = media_item_fixture(%{type: "tv_show", title: "Harbor Lights", year: 2013})
-    episode = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 3})
+    episode_with(show, 3, file_names, duration)
+  end
+
+  # Attaches a new episode to an existing show, so a test can put two
+  # episodes of the same show through undo/2 in one call.
+  defp episode_with(show, episode_number, file_names, duration) do
+    episode =
+      episode_fixture(%{
+        media_item_id: show.id,
+        season_number: 2,
+        episode_number: episode_number
+      })
+
     lp = library_path_fixture(%{type: "series"})
 
     files =
@@ -276,6 +288,65 @@ defmodule Mydia.Library.PruneTest do
       assert event.resource_id == episode.id
       assert event.metadata["restored"] == [loser.relative_path]
       assert event.metadata["bytes_restored"] == 1_000_000_000
+    end
+
+    test "emits one prune_undone event per episode, not per show, when undoing across episodes of the same show" do
+      show = media_item_fixture(%{type: "tv_show", title: "Harbor Lights", year: 2013})
+
+      {episode_a, files_a} =
+        episode_with(
+          show,
+          3,
+          [
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656, size: 3_000_000_000}},
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000, size: 1_000_000_000}}
+          ],
+          1320.0
+        )
+
+      {episode_b, files_b} =
+        episode_with(
+          show,
+          4,
+          [
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E04.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656, size: 3_000_000_000}},
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E04.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000, size: 1_000_000_000}}
+          ],
+          1320.0
+        )
+
+      loser_a = Enum.find(files_a, &(&1.relative_path =~ "360p"))
+      loser_b = Enum.find(files_b, &(&1.relative_path =~ "360p"))
+
+      %{trashed: [_]} = Prune.execute([loser_a.id], "admin")
+      %{trashed: [_]} = Prune.execute([loser_b.id], "admin")
+
+      result = Prune.undo([loser_a.id, loser_b.id], "admin")
+
+      assert length(result.restored) == 2
+      assert result.failed == []
+
+      events =
+        Mydia.Events.Event
+        |> Ecto.Query.where(type: "media_file.prune_undone")
+        |> Mydia.Repo.all()
+
+      assert length(events) == 2
+
+      by_resource_id = Map.new(events, &{&1.resource_id, &1})
+
+      assert event_a = Map.get(by_resource_id, episode_a.id)
+      assert event_b = Map.get(by_resource_id, episode_b.id)
+
+      assert event_a.resource_type == "episode"
+      assert event_b.resource_type == "episode"
+
+      assert event_a.metadata["restored"] == [loser_a.relative_path]
+      assert event_b.metadata["restored"] == [loser_b.relative_path]
     end
   end
 end

--- a/test/mydia/library/prune_test.exs
+++ b/test/mydia/library/prune_test.exs
@@ -7,7 +7,7 @@ defmodule Mydia.Library.PruneTest do
   alias Mydia.Library.Prune
 
   defp episode_with(file_names, duration) do
-    show = media_item_fixture(%{type: "tv_show", title: "Rick and Morty", year: 2013})
+    show = media_item_fixture(%{type: "tv_show", title: "Harbor Lights", year: 2013})
     episode = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 3})
     lp = library_path_fixture(%{type: "series"})
 
@@ -31,20 +31,20 @@ defmodule Mydia.Library.PruneTest do
       {_episode, _files} =
         episode_with(
           [
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
              %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
              %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
           ],
           1320.0
         )
 
-      movie = media_item_fixture(%{type: "movie", title: "Monsters University", year: 2013})
+      movie = media_item_fixture(%{type: "movie", title: "Tidepool Academy", year: 2013})
       lp = library_path_fixture(%{type: "movies"})
 
       for {name, duration} <- [
-            {"MU/Monsters University (2013).mkv", 6360.0},
-            {"MU/Campus Life.mkv", 280.0}
+            {"TA/Tidepool Academy (2013).mkv", 6360.0},
+            {"TA/Orientation Week.mkv", 280.0}
           ] do
         media_file_fixture(%{
           media_item_id: movie.id,
@@ -69,9 +69,9 @@ defmodule Mydia.Library.PruneTest do
       {_episode, files} =
         episode_with(
           [
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
              %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
              %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
           ],
           1320.0
@@ -91,13 +91,13 @@ defmodule Mydia.Library.PruneTest do
     end
 
     test "refuses to trash a file from a refused group even when handed its id" do
-      movie = media_item_fixture(%{type: "movie", title: "Monsters University", year: 2013})
+      movie = media_item_fixture(%{type: "movie", title: "Tidepool Academy", year: 2013})
       lp = library_path_fixture(%{type: "movies"})
 
       files =
         for {name, duration} <- [
-              {"MU/Monsters University (2013).mkv", 6360.0},
-              {"MU/Campus Life.mkv", 280.0}
+              {"TA/Tidepool Academy (2013).mkv", 6360.0},
+              {"TA/Orientation Week.mkv", 280.0}
             ] do
           media_file_fixture(%{
             media_item_id: movie.id,
@@ -107,7 +107,7 @@ defmodule Mydia.Library.PruneTest do
           })
         end
 
-      extra = Enum.find(files, &(&1.relative_path =~ "Campus Life"))
+      extra = Enum.find(files, &(&1.relative_path =~ "Orientation Week"))
 
       result = Prune.execute([extra.id], "admin")
 
@@ -121,9 +121,9 @@ defmodule Mydia.Library.PruneTest do
       {_episode, files} =
         episode_with(
           [
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
              %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
              %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
           ],
           1320.0
@@ -143,9 +143,9 @@ defmodule Mydia.Library.PruneTest do
       {episode, files} =
         episode_with(
           [
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
              %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
              %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
           ],
           1320.0
@@ -171,9 +171,9 @@ defmodule Mydia.Library.PruneTest do
       {episode, files} =
         episode_with(
           [
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
              %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
-            {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
              %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
           ],
           1320.0

--- a/test/mydia/library/prune_test.exs
+++ b/test/mydia/library/prune_test.exs
@@ -4,7 +4,10 @@ defmodule Mydia.Library.PruneTest do
   import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
 
+  alias Mydia.Library.MediaFile
   alias Mydia.Library.Prune
+
+  defp trashed_at(id), do: Mydia.Repo.get!(MediaFile, id).trashed_at
 
   defp episode_with(file_names, duration) do
     show = media_item_fixture(%{type: "tv_show", title: "Harbor Lights", year: 2013})
@@ -191,6 +194,88 @@ defmodule Mydia.Library.PruneTest do
 
       assert Mydia.Repo.get!(Mydia.Library.MediaFile, ranked_keeper.id).trashed_at
       refute Mydia.Repo.get!(Mydia.Library.MediaFile, overridden_keeper.id).trashed_at
+    end
+  end
+
+  describe "undo/2" do
+    setup do
+      {episode, files} =
+        episode_with(
+          [
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
+             %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656, size: 3_000_000_000}},
+            {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
+             %{resolution: "360p", codec: "h264", bitrate: 1_000_000, size: 1_000_000_000}}
+          ],
+          1320.0
+        )
+
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      %{episode: episode, keeper: keeper, loser: loser}
+    end
+
+    test "restores a trashed file and clears trashed_at", %{loser: loser} do
+      %{trashed: [trashed]} = Prune.execute([loser.id], "admin")
+      assert trashed_at(trashed.id)
+
+      result = Prune.undo([trashed.id], "admin")
+
+      assert [restored] = result.restored
+      assert restored.id == loser.id
+      assert result.failed == []
+      refute trashed_at(loser.id)
+    end
+
+    test "skips an id that is not trashed, without reporting it as a failure",
+         %{keeper: keeper} do
+      # The toast can outlive the state it describes: TrashCleanup can purge a
+      # row, a scan can restore it, or another admin session can act on it.
+      # Restoring something that is not in the trash is not a no-op below this
+      # layer, so it must be filtered out before the call.
+      refute trashed_at(keeper.id)
+
+      result = Prune.undo([keeper.id], "admin")
+
+      assert result.restored == []
+      assert result.failed == []
+    end
+
+    test "restores the trashed ids and ignores the untrashed ones in one call",
+         %{keeper: keeper, loser: loser} do
+      %{trashed: [_]} = Prune.execute([loser.id], "admin")
+
+      result = Prune.undo([loser.id, keeper.id], "admin")
+
+      assert [restored] = result.restored
+      assert restored.id == loser.id
+      refute trashed_at(loser.id)
+    end
+
+    test "ignores an id that matches no media file" do
+      result = Prune.undo([Ecto.UUID.generate()], "admin")
+
+      assert result.restored == []
+      assert result.failed == []
+    end
+
+    test "emits one prune_undone event for the group, not one per file",
+         %{loser: loser, episode: episode} do
+      %{trashed: [_]} = Prune.execute([loser.id], "admin")
+
+      Prune.undo([loser.id], "admin")
+
+      events =
+        Mydia.Events.Event
+        |> Ecto.Query.where(type: "media_file.prune_undone")
+        |> Mydia.Repo.all()
+
+      assert [event] = events
+      assert event.resource_type == "episode"
+      assert event.resource_id == episode.id
+      assert event.metadata["restored"] == [loser.relative_path]
+      assert event.metadata["bytes_restored"] == 1_000_000_000
     end
   end
 end

--- a/test/mydia_web/live/admin_duplicates_live_test.exs
+++ b/test/mydia_web/live/admin_duplicates_live_test.exs
@@ -493,5 +493,91 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
 
       assert Enum.count(files, &trashed?/1) == length(files) - 1
     end
+
+    test "a group run raises an undo toast naming the item", %{conn: conn} do
+      {_show, episode, _files} = duplicated_episode()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+      refute has_element?(view, "#duplicates-undo-toast")
+
+      view |> element("#duplicates-group-trash-#{episode.id}") |> render_click()
+
+      assert has_element?(view, "#duplicates-undo-toast")
+      assert render(view) =~ "Harbor Lights S02E03"
+    end
+
+    test "Undo restores the files and puts them back on Keep, not Trash", %{conn: conn} do
+      # A restored file is a loser of an eligible group again, and losers
+      # default to Trash. Without putting them on Keep the page would offer to
+      # trash the very copies the operator just rescued.
+      {_show, episode, files} = duplicated_episode()
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-group-trash-#{episode.id}") |> render_click()
+      assert trashed?(loser)
+
+      view |> element("#duplicates-undo") |> render_click()
+
+      refute trashed?(loser)
+      refute trashed?(keeper)
+      assert has_element?(view, "#duplicates-group-#{episode.id}")
+      assert has_element?(view, "#duplicates-keep-#{loser.id}[checked]")
+      refute has_element?(view, "#duplicates-trash-#{loser.id}[checked]")
+      refute has_element?(view, "#duplicates-undo-toast")
+    end
+
+    test "dismissing the toast leaves the files trashed", %{conn: conn} do
+      {_show, episode, files} = duplicated_episode()
+      loser = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-group-trash-#{episode.id}") |> render_click()
+      view |> element("#duplicates-undo-dismiss") |> render_click()
+
+      refute has_element?(view, "#duplicates-undo-toast")
+      assert trashed?(loser)
+    end
+
+    test "a second run replaces the first toast rather than stacking", %{conn: conn} do
+      # Both fixtures carry the same title, so the toast label cannot tell the
+      # groups apart. The counts can: group A trashes one file, group B two.
+      # The sharp assertion is what Undo reaches afterwards. If :last_run
+      # accumulated instead of being replaced, A's file would come back too.
+      {_show_a, episode_a, files_a} = duplicated_episode()
+      {_show_b, episode_b, files_b} = duplicated_episode(@three_files)
+      loser_a = Enum.find(files_a, &(&1.relative_path =~ "360p"))
+      keeper_b = Enum.find(files_b, &(&1.relative_path =~ "1080p"))
+      losers_b = Enum.reject(files_b, &(&1.id == keeper_b.id))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-group-trash-#{episode_a.id}") |> render_click()
+      view |> element("#duplicates-group-trash-#{episode_b.id}") |> render_click()
+
+      # The toast now describes the second run, not the first.
+      assert render(view) =~ "Trashed 2 files"
+
+      view |> element("#duplicates-undo") |> render_click()
+
+      for loser <- losers_b, do: refute(trashed?(loser))
+      assert trashed?(loser_a), "undo reached the first run's files, so :last_run accumulated"
+    end
+
+    test "the page-header run raises the across-items toast", %{conn: conn} do
+      duplicated_episode()
+      duplicated_episode()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-trash-selected") |> render_click()
+      view |> element("#duplicates-confirm") |> render_click()
+
+      assert has_element?(view, "#duplicates-undo-toast")
+      assert render(view) =~ "2 items"
+    end
   end
 end

--- a/test/mydia_web/live/admin_duplicates_live_test.exs
+++ b/test/mydia_web/live/admin_duplicates_live_test.exs
@@ -26,9 +26,9 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
   end
 
   @two_files [
-    {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.1080p.BluRay.x265.mp4",
+    {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
      %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
-    {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.360p.WEBRip.x264.mp4",
+    {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
      %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
   ]
 
@@ -37,12 +37,12 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
   # the selection and there is nothing left to assert about.
   @three_files @two_files ++
                  [
-                   {"Rick and Morty/Season 02/Rick.and.Morty.S02E03.480p.WEBRip.x264.mp4",
+                   {"Harbor Lights/Season 02/Harbor.Lights.S02E03.480p.WEBRip.x264.mp4",
                     %{resolution: "480p", codec: "h264", bitrate: 500_000}}
                  ]
 
   defp duplicated_episode(specs \\ @two_files) do
-    show = media_item_fixture(%{type: "tv_show", title: "Rick and Morty", year: 2013})
+    show = media_item_fixture(%{type: "tv_show", title: "Harbor Lights", year: 2013})
     episode = episode_fixture(%{media_item_id: show.id, season_number: 2, episode_number: 3})
     lp = library_path_fixture(%{type: "series"})
 
@@ -62,12 +62,12 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
   end
 
   defp refused_movie do
-    movie = media_item_fixture(%{type: "movie", title: "Monsters University", year: 2013})
+    movie = media_item_fixture(%{type: "movie", title: "Tidepool Academy", year: 2013})
     lp = library_path_fixture(%{type: "movies"})
 
     for {name, duration} <- [
-          {"MU/Monsters University (2013).mkv", 6360.0},
-          {"MU/Campus Life.mkv", 280.0}
+          {"TA/Tidepool Academy (2013).mkv", 6360.0},
+          {"TA/Orientation Week.mkv", 280.0}
         ] do
       media_file_fixture(%{
         media_item_id: movie.id,

--- a/test/mydia_web/live/admin_duplicates_live_test.exs
+++ b/test/mydia_web/live/admin_duplicates_live_test.exs
@@ -220,27 +220,104 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
       refute trashed?(keeper)
     end
 
-    test "Keep all spares the whole group, and Trash duplicates puts it back",
-         %{conn: conn} do
+    test "the marking toggle spares the whole group and puts it back", %{conn: conn} do
       {_show, episode, files} = duplicated_episode(@three_files)
       keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
       losers = Enum.reject(files, &(&1.id == keeper.id))
 
       {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
 
-      view |> element("#duplicates-group-keep-#{episode.id}") |> render_click()
+      view |> element("#duplicates-group-mark-#{episode.id}") |> render_click()
 
       for loser <- losers do
         assert has_element?(view, "#duplicates-keep-#{loser.id}[checked]")
       end
 
       assert has_element?(view, "#duplicates-trash-selected[disabled]")
+      # Nothing was trashed: this control only marks.
+      for file <- files, do: refute(trashed?(file))
 
-      view |> element("#duplicates-group-trash-#{episode.id}") |> render_click()
+      view |> element("#duplicates-group-mark-#{episode.id}") |> render_click()
 
       for loser <- losers do
         assert has_element?(view, "#duplicates-trash-#{loser.id}[checked]")
       end
+    end
+
+    test "the group trash button trashes only its own group", %{conn: conn} do
+      {_show_a, episode_a, files_a} = duplicated_episode(@three_files)
+      {_show_b, _episode_b, files_b} = duplicated_episode(@three_files)
+      keeper_a = Enum.find(files_a, &(&1.relative_path =~ "1080p"))
+      losers_a = Enum.reject(files_a, &(&1.id == keeper_a.id))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-group-trash-#{episode_a.id}") |> render_click()
+
+      for loser <- losers_a, do: assert(trashed?(loser))
+      refute trashed?(keeper_a)
+      for file <- files_b, do: refute(trashed?(file))
+    end
+
+    test "the group trash button spares a file set to Keep", %{conn: conn} do
+      {_show, episode, files} = duplicated_episode(@three_files)
+      keeper = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      spared = Enum.find(files, &(&1.relative_path =~ "480p"))
+      doomed = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-keep-#{spared.id}") |> render_click()
+      view |> element("#duplicates-group-trash-#{episode.id}") |> render_click()
+
+      assert trashed?(doomed)
+      refute trashed?(spared)
+      refute trashed?(keeper)
+    end
+
+    test "the group trash button honours a keeper override", %{conn: conn} do
+      # Trashing the best copy promotes the next one. The group button has to
+      # hand execute/3 that override, or the ranked keeper is re-derived as the
+      # 1080p file and the run is aborted as :would_leave_no_file.
+      {_show, episode, files} = duplicated_episode()
+      high = Enum.find(files, &(&1.relative_path =~ "1080p"))
+      low = Enum.find(files, &(&1.relative_path =~ "360p"))
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-trash-#{high.id}") |> render_click()
+      view |> element("#duplicates-group-trash-#{episode.id}") |> render_click()
+
+      assert trashed?(high)
+      refute trashed?(low)
+    end
+
+    test "a fully pruned group leaves the page entirely", %{conn: conn} do
+      # Grouping.multi_file_ids/1 selects with `having count > 1` over untrashed
+      # rows, so a group down to one file is no longer a group. It must not
+      # reappear under Needs Attention as a :nothing_to_prune refusal.
+      {_show, episode, _files} = duplicated_episode()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+      assert has_element?(view, "#duplicates-group-#{episode.id}")
+
+      view |> element("#duplicates-group-trash-#{episode.id}") |> render_click()
+
+      refute has_element?(view, "#duplicates-group-#{episode.id}")
+      refute has_element?(view, "#duplicates-refusal-#{episode.id}")
+    end
+
+    test "the group trash button is disabled when the group has nothing marked",
+         %{conn: conn} do
+      {_show, episode, _files} = duplicated_episode(@three_files)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      refute has_element?(view, "#duplicates-group-trash-#{episode.id}[disabled]")
+
+      view |> element("#duplicates-group-mark-#{episode.id}") |> render_click()
+
+      assert has_element?(view, "#duplicates-group-trash-#{episode.id}[disabled]")
     end
 
     test "the confirmation modal opens on Trash and closes on Cancel without trashing anything",


### PR DESCRIPTION
## What

On `/admin/config/duplicates`, each group of duplicate files can now be trashed on its own, in one click, with an Undo.

Before this, every per-group control only changed what was *marked*. The single button that actually moved files sat in the page header and ran across the whole library, so an operator who wanted to clear one item had to either mark every other group Keep first or trash everything at once.

## How it looks

Each group now carries two controls instead of one that swapped meaning:

- a marking toggle, labelled **Keep all** or **Mark all for trash** depending on the group's state
- a **Trash N (X GB)** button that trashes that group's marked files immediately, disabled when nothing is marked

The page-header button is unchanged and keeps its confirmation modal. The asymmetry is deliberate: two files in one item and forty-seven across twenty-three items are different blast radii, and only the second is worth a modal. The first gets an Undo instead.

## Undo

A successful run raises a toast holding that run's file ids. **Undo** restores them through `Library.restore_media_file/1`, which until now had no caller anywhere in the web layer. The toast stays until another run replaces it, the operator dismisses it, or they leave the page. There is no auto-dismiss timer, because any fixed interval is a guess and an operator reading filenames to check they trashed the right copy would lose that race.

Restored files come back marked **Keep**, not Trash. A restored file is once again a loser of an eligible group, and every loser defaults to Trash, so without that step the page would immediately offer to trash the very copies just rescued.

## Safety

- `Prune.execute/3` is unchanged and still re-verifies every id against a freshly built plan, so a stale page cannot trash the wrong file and no group can be emptied.
- The per-group run passes the same `keepers` overrides the on-screen plan was built from. Without them `execute/3` would silently re-rank each group with the default keeper and discard the operator's choices.
- A fully pruned group leaves the page entirely rather than reappearing under "Needs Attention", because `Grouping.multi_file_ids/1` selects with `having count > 1` and a one-file subject is no longer a group.
- Trashed files are still held for the retention window (30 days by default) before `TrashCleanup` purges them.

## Audit trail

Adds a `media_file.prune_undone` event as the counterpart to the existing `media_file.pruned`. Without it the activity trail would record a destructive action and stay silent about its reversal.

Events are emitted once per subject, not once per media item. That distinction matters: for a TV show every episode's group shares the same `media_item`, so grouping by media item merged two episodes' undos into a single event, dropping one and misattributing the other's file paths. There is a regression test covering two episodes of one show undone in a single call.

## Tests

19 tests added across the duplicates page, the prune context, and the event presentation registry, one of them replacing a test made obsolete by the split (it drove the old group button, which only marked). Coverage includes: a group run touching only its own group, sparing a file set to Keep, honouring a keeper override, a fully pruned group leaving the page, undo restoring files as Keep, a second run replacing the first toast rather than accumulating ids, and per-episode event attribution.

## Also

- Test fixtures no longer use real film or TV titles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to undo duplicate-file trash actions and restore eligible files.
  * Added per-item trash controls for duplicate groups.
  * Added an Undo/Dismiss notification after trash actions, including restored file counts and reclaimed storage.

* **Bug Fixes**
  * Partial restoration failures are now reported without preventing successful restorations.

* **Tests**
  * Added coverage for restoration, grouping, notifications, and restored storage totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->