### PR TITLE
fix(import-lists): close the audit findings and enable by default

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -452,9 +452,12 @@ config :mydia, :features,
   # Can be overridden via ENABLE_CARDIGANN environment variable
   cardigann_enabled: true,
   # Enable/disable Import Lists feature
-  # When enabled, shows the Import Lists UI for syncing external lists (TMDB watchlists, etc.)
+  # When enabled, runs the Import Lists UI and scheduled sync for external
+  # lists (TMDB watchlists, etc.); when disabled, the admin route redirects
+  # away and the scheduler job is a no-op
+  # On by default: syncing an external list is a normal admin action
   # Can be overridden via ENABLE_IMPORT_LISTS environment variable
-  import_lists_enabled: false,
+  import_lists_enabled: true,
   # Enable/disable Remote Access feature (iroh-based peer-to-peer connectivity)
   # When enabled, starts the p2p server for remote device pairing and media streaming
   # On by default: connecting a player is a normal user action, and requiring an

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -250,9 +250,21 @@ if config_env() == :prod do
 
   import_lists_enabled =
     case System.get_env("ENABLE_IMPORT_LISTS") do
-      "true" -> true
-      "false" -> false
-      _ -> Application.get_env(:mydia, :features)[:import_lists_enabled] || false
+      "true" ->
+        true
+
+      "false" ->
+        false
+
+      _ ->
+        # An explicit `false` configured elsewhere must still win: only a
+        # genuinely missing key falls back to the compile-time default
+        # (true), so `Keyword.get/3` (which can't tell "missing" from
+        # "explicitly false") would be wrong here.
+        case Keyword.fetch(Application.get_env(:mydia, :features, []), :import_lists_enabled) do
+          {:ok, value} -> value
+          :error -> true
+        end
     end
 
   remote_access_enabled =
@@ -411,9 +423,21 @@ if config_env() in [:dev, :test] do
 
   import_lists_enabled =
     case System.get_env("ENABLE_IMPORT_LISTS") do
-      "true" -> true
-      "false" -> false
-      _ -> Application.get_env(:mydia, :features)[:import_lists_enabled] || false
+      "true" ->
+        true
+
+      "false" ->
+        false
+
+      _ ->
+        # An explicit `false` configured elsewhere must still win: only a
+        # genuinely missing key falls back to the compile-time default
+        # (true), so `Keyword.get/3` (which can't tell "missing" from
+        # "explicitly false") would be wrong here.
+        case Keyword.fetch(Application.get_env(:mydia, :features, []), :import_lists_enabled) do
+          {:ok, value} -> value
+          :error -> true
+        end
     end
 
   remote_access_enabled =
@@ -429,6 +453,14 @@ if config_env() in [:dev, :test] do
     import_lists_enabled: import_lists_enabled,
     remote_access_enabled: remote_access_enabled
 end
+
+# A custom-URL import list is fetched by the server, so an admin-supplied URL is
+# a way to reach anything the server can reach. Private, loopback and link-local
+# destinations are refused by default. Operators who legitimately serve a list
+# from their own LAN or container network can opt back in here.
+config :mydia,
+       :import_lists_allow_private_destinations,
+       System.get_env("IMPORT_LISTS_ALLOW_PRIVATE_DESTINATIONS") == "true"
 
 # P2P bind port configuration (all environments)
 # Required for hole punching when running in Docker

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ A modern, self-hosted media management platform for tracking, organizing, and mo
 - **Multi-User System** - Built-in admin/guest roles with request approval workflow
 - **SSO Support** - Local authentication plus OIDC/OpenID Connect integration
 - **Release Calendar** - Track upcoming releases and monitor episodes
-- **Import Lists** - Sync external lists from TMDB (watchlists, popular, trending) to auto-add content (experimental)
+- **Import Lists** - Sync external lists from TMDB (watchlists, popular, trending) to auto-add content
 - **Remote Access** - P2P connectivity for the Flutter player via iroh (experimental)
 - **Media Playback** - HLS streaming with on-the-fly transcoding (experimental)
 - **Trakt.tv Integration** - Scrobbling and library sync

--- a/docs/using/reference/environment-variables.md
+++ b/docs/using/reference/environment-variables.md
@@ -98,8 +98,24 @@ Configure additional libraries using numbered variables (`<N>` = 1, 2, 3, etc.):
 |----------|-------------|---------|
 | `ENABLE_PLAYBACK` | Enable media playback controls and HLS streaming | `true` |
 | `ENABLE_CARDIGANN` | Enable native Cardigann indexer support | `true` |
-| `ENABLE_IMPORT_LISTS` | Enable import lists for syncing external lists (TMDB watchlists, popular, etc.) | `false` |
+| `ENABLE_IMPORT_LISTS` | Enable import lists for syncing external lists (TMDB watchlists, popular, etc.) | `true` |
 | `ENABLE_REMOTE_ACCESS` | Enable P2P remote access for the Flutter player | `false` |
+
+## Import Lists
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `IMPORT_LISTS_ALLOW_PRIVATE_DESTINATIONS` | Allow a Custom URL import list to fetch from private, loopback or link-local addresses | `false` |
+
+!!! warning "Only enable this for a list you host yourself"
+    A Custom URL list is fetched by the Mydia server, not by your browser, so the
+    URL can reach anything the server can reach: other containers, your router,
+    a cloud metadata endpoint. Mydia refuses those destinations by default and
+    revalidates every redirect hop.
+
+    Set this to `true` only if you serve the list from your own LAN or container
+    network, for example a JSON file on a NAS. It never relaxes the scheme
+    allowlist, which is always limited to `http` and `https`.
 
 ## Download Clients
 

--- a/lib/mydia/import_lists.ex
+++ b/lib/mydia/import_lists.ex
@@ -742,13 +742,20 @@ defmodule Mydia.ImportLists do
   defp check_duplicate_by_title_year(type, title, year) do
     normalized_title = title |> String.trim() |> String.downcase()
 
+    # Nothing stops the library holding two rows with the same type, year and
+    # title and no tmdb_id: uniqueness is enforced on tmdb_id and tvdb_id, and
+    # NULLs do not collide, so two scanned copies of one title land here.
+    # Without the limit Repo.one/1 would raise Ecto.MultipleResultsError and
+    # take down the sync job rather than linking either row.
     query =
       from(m in MediaItem,
         where:
           m.type == ^type and
             is_nil(m.tmdb_id) and
             m.year == ^year and
-            fragment("lower(trim(?))", m.title) == ^normalized_title
+            fragment("lower(trim(?))", m.title) == ^normalized_title,
+        order_by: [asc: m.id],
+        limit: 1
       )
 
     case Repo.one(query) do

--- a/lib/mydia/import_lists.ex
+++ b/lib/mydia/import_lists.ex
@@ -12,6 +12,7 @@ defmodule Mydia.ImportLists do
   alias Mydia.Repo
 
   alias Mydia.ImportLists.{ImportList, ImportListItem}
+  alias Mydia.Media.MediaItem
 
   ## Preset Definitions
 
@@ -244,35 +245,57 @@ defmodule Mydia.ImportLists do
   end
 
   @doc """
-  Creates an import list item, or updates it if it already exists.
+  Creates an import list item, or atomically updates it if it already exists.
 
-  Uses the unique constraint on (import_list_id, tmdb_id) to detect conflicts.
-  Returns {:ok, item} where item is either newly created or the updated existing item.
+  Uses a real `INSERT ... ON CONFLICT` on the `(import_list_id, tmdb_id)` unique
+  index rather than a select-then-write, so two syncs racing the same item can
+  never have the loser silently drop it (the old select-then-insert/update
+  raced the unique constraint and swallowed the resulting changeset error).
+
+  Only the cached display fields (`title`, `year`, `poster_path`) are
+  overwritten when an existing row is matched; `discovered_at`, `status`,
+  `skip_reason` and `media_item_id` are left exactly as they were.
+
+  Because the same changeset both inserts and (via conflict) updates, every
+  call must supply the full set of required fields (`tmdb_id`, `title`,
+  `discovered_at`, `import_list_id`), not just the fields that would change.
+
+  Returns `{:ok, item, :created}` when a new row was inserted, `{:ok, item,
+  :updated}` when an existing row was matched, or `{:error, changeset}`.
   """
   def upsert_import_list_item(attrs) do
-    import_list_id = attrs[:import_list_id] || attrs["import_list_id"]
-    tmdb_id = attrs[:tmdb_id] || attrs["tmdb_id"]
+    title = attrs[:title] || attrs["title"]
+    year = attrs[:year] || attrs["year"]
+    poster_path = attrs[:poster_path] || attrs["poster_path"]
 
-    # Try to find existing item first
-    existing =
-      ImportListItem
-      |> where([i], i.import_list_id == ^import_list_id and i.tmdb_id == ^tmdb_id)
-      |> Repo.one()
+    # Pre-generate the id so created-vs-updated can be told apart afterwards
+    # without a race: on conflict, Postgres and SQLite both leave the
+    # existing row's id untouched, so the returned id only matches this one
+    # when the insert actually happened.
+    candidate_id = Ecto.UUID.generate()
 
-    case existing do
-      nil ->
-        # Create new item
-        create_import_list_item(attrs)
+    changeset =
+      %ImportListItem{}
+      |> ImportListItem.changeset(%{
+        import_list_id: attrs[:import_list_id] || attrs["import_list_id"],
+        tmdb_id: attrs[:tmdb_id] || attrs["tmdb_id"],
+        title: title,
+        year: year,
+        poster_path: poster_path,
+        discovered_at: attrs[:discovered_at] || attrs["discovered_at"]
+      })
+      |> Ecto.Changeset.put_change(:id, candidate_id)
 
-      item ->
-        # Update existing item (only update cached display fields)
-        item
-        |> ImportListItem.changeset(%{
-          title: attrs[:title] || attrs["title"],
-          year: attrs[:year] || attrs["year"],
-          poster_path: attrs[:poster_path] || attrs["poster_path"]
-        })
-        |> Repo.update()
+    changeset
+    |> Repo.insert(
+      on_conflict: [set: [title: title, year: year, poster_path: poster_path]],
+      conflict_target: [:import_list_id, :tmdb_id],
+      returning: true
+    )
+    |> case do
+      {:ok, %ImportListItem{id: ^candidate_id} = item} -> {:ok, item, :created}
+      {:ok, item} -> {:ok, item, :updated}
+      {:error, _} = error -> error
     end
   end
 
@@ -399,18 +422,42 @@ defmodule Mydia.ImportLists do
 
   ## Sync Operations
 
+  # Backoff state (consecutive failure count and the time of the last
+  # failure) lives in the existing `config` map rather than as dedicated
+  # columns. `config` is already a schema field with no migration needed, and
+  # every write below merges into it rather than replacing it wholesale, so
+  # it never clobbers the `list_url` some list types also keep there.
+  @max_backoff_seconds 24 * 60 * 60
+
+  # 2 ** 32 minutes already dwarfs @max_backoff_seconds, so clamping here costs
+  # nothing and keeps :math.pow/2 well clear of the float range it raises on.
+  @max_backoff_exponent 32
+
   @doc """
-  Updates the last synced timestamp for an import list.
+  Marks an import list sync as successful.
+
+  Updates `last_synced_at`, clears `sync_error`, and resets the consecutive
+  failure count so the next sync is scheduled at the normal interval again
+  instead of continuing any backoff from prior failures.
   """
   def mark_sync_success(%ImportList{} = import_list) do
     update_import_list(import_list, %{
       last_synced_at: DateTime.utc_now(),
-      sync_error: nil
+      sync_error: nil,
+      config: clear_backoff_state(import_list.config)
     })
   end
 
   @doc """
-  Records a sync error for an import list.
+  Records a sync error for an import list and applies exponential backoff.
+
+  A failed list used to stay permanently "due": `sync_due?/1` only looked at
+  `last_synced_at`, which this function never touched, so a cron tick every
+  15 minutes re-enqueued the same failing list forever regardless of its
+  configured interval. This now records the failure time and increments a
+  consecutive-failure count (both in `config`), and `sync_due?/1` uses them to
+  delay the next attempt by `sync_interval * 2^(failures - 1)`, capped at 24
+  hours, instead of retrying at the full interval (or immediately) every time.
   """
   def mark_sync_error(%ImportList{} = import_list, error) do
     error_message =
@@ -420,17 +467,89 @@ defmodule Mydia.ImportLists do
         _ -> inspect(error)
       end
 
-    update_import_list(import_list, %{sync_error: error_message})
+    failures = consecutive_failures(import_list) + 1
+
+    updated_config =
+      (import_list.config || %{})
+      |> Map.put("consecutive_failures", failures)
+      |> Map.put("last_failed_at", DateTime.to_iso8601(DateTime.utc_now()))
+
+    update_import_list(import_list, %{sync_error: error_message, config: updated_config})
+  end
+
+  defp clear_backoff_state(config) do
+    (config || %{})
+    |> Map.delete("consecutive_failures")
+    |> Map.delete("last_failed_at")
+  end
+
+  defp consecutive_failures(%ImportList{config: %{"consecutive_failures" => n}})
+       when is_integer(n) and n > 0,
+       do: n
+
+  defp consecutive_failures(%ImportList{}), do: 0
+
+  defp last_failed_at(%ImportList{config: %{"last_failed_at" => value}}) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, dt, _offset} -> dt
+      {:error, _} -> nil
+    end
+  end
+
+  defp last_failed_at(%ImportList{}), do: nil
+
+  # interval * 2^(n-1), capped at 24h. The first failure (n = 1) delays by
+  # exactly one interval, which alone fixes "hammered every 15 minutes
+  # forever" since sync_due?/1 previously ignored failures entirely; each
+  # additional consecutive failure doubles the delay from there.
+  defp backoff_delay_seconds(interval_minutes, failures) do
+    # Clamp the exponent before it reaches :math.pow/2. The delay is capped at
+    # 24 hours anyway, so any exponent past this point is already saturated, and
+    # 2 ** 1024 overflows a float and raises ArithmeticError. A list that fails
+    # forever accrues roughly one failure per day once the cap is reached, and
+    # list_sync_due_lists/0 filters every list through sync_due?/1, so an
+    # unclamped raise would eventually stop syncing for all lists, not just the
+    # broken one.
+    exponent = min(failures - 1, @max_backoff_exponent)
+    delay = trunc(interval_minutes * 60 * :math.pow(2, exponent))
+    min(delay, @max_backoff_seconds)
+  end
+
+  defp backoff_elapsed?(%ImportList{sync_interval: interval} = import_list) do
+    case last_failed_at(import_list) do
+      # A failure count with no recorded failure time (shouldn't happen in
+      # practice, but config is a free-form map) can't compute a delay, so
+      # default to due rather than stuck.
+      nil ->
+        true
+
+      failed_at ->
+        delay_seconds = backoff_delay_seconds(interval, consecutive_failures(import_list))
+        due_at = DateTime.add(failed_at, delay_seconds, :second)
+        DateTime.compare(DateTime.utc_now(), due_at) in [:gt, :eq]
+    end
   end
 
   @doc """
   Checks if an import list is due for sync based on its interval.
+
+  A list with consecutive failures uses the exponential backoff delay from
+  its last failure instead of the plain interval from `last_synced_at`; see
+  `mark_sync_error/2`.
   """
   def sync_due?(%ImportList{enabled: false}), do: false
 
-  def sync_due?(%ImportList{last_synced_at: nil}), do: true
+  def sync_due?(%ImportList{} = import_list) do
+    if consecutive_failures(import_list) > 0 do
+      backoff_elapsed?(import_list)
+    else
+      due_by_interval?(import_list)
+    end
+  end
 
-  def sync_due?(%ImportList{last_synced_at: last_synced, sync_interval: interval}) do
+  defp due_by_interval?(%ImportList{last_synced_at: nil}), do: true
+
+  defp due_by_interval?(%ImportList{last_synced_at: last_synced, sync_interval: interval}) do
     now = DateTime.utc_now()
     due_at = DateTime.add(last_synced, interval * 60, :second)
     DateTime.compare(now, due_at) in [:gt, :eq]
@@ -453,7 +572,7 @@ defmodule Mydia.ImportLists do
   Returns `{:ok, media_item}` on success, or `{:error, reason}` on failure.
   """
   def add_item_to_library(%ImportListItem{} = item, %ImportList{} = import_list) do
-    case check_duplicate(item.tmdb_id, import_list.media_type) do
+    case check_duplicate(item.tmdb_id, import_list.media_type, item.title, item.year) do
       {:duplicate, media_item} ->
         handle_duplicate_item(item, media_item)
 
@@ -462,8 +581,13 @@ defmodule Mydia.ImportLists do
     end
   end
 
+  # Links the item to the media already in the library. A single write: an
+  # earlier version wrote mark_item_skipped/2 first and mark_item_added/2
+  # right after, which immediately overwrote the skip (mark_item_added/2
+  # clears skip_reason), so the row always ended up "added" anyway. That made
+  # the write pointless and, worse, made the job's own stats (which reported
+  # it as skipped) disagree with what the database actually stored.
   defp handle_duplicate_item(item, media_item) do
-    mark_item_skipped(item, "Already in library")
     {:ok, _} = mark_item_added(item, media_item.id)
     {:ok, media_item}
   end
@@ -578,29 +702,58 @@ defmodule Mydia.ImportLists do
   ## Duplicate Detection
 
   @doc """
-  Checks if media with the given TMDB ID exists in the library.
+  Checks if media matching an import list item already exists in the library.
+
+  Looks up by TMDB ID first. Media that entered the library from a filesystem
+  scan often has no TMDB ID at all, so a miss falls back to a conservative
+  title+year match: normalised (trimmed, case-insensitive) title, an exact
+  year match, and only against rows where `tmdb_id` is still `NULL` (a row
+  that already carries a *different* TMDB ID is a genuinely different title,
+  not a fuzzy match). The fallback only runs when both `title` and `year` are
+  given; a `nil` year is treated as too little information to match on safely.
 
   Returns `{:duplicate, media_item}` if found, `:not_found` otherwise.
   """
-  def check_duplicate(tmdb_id, media_type) when is_integer(tmdb_id) do
-    alias Mydia.Media.MediaItem
+  def check_duplicate(tmdb_id, media_type, title \\ nil, year \\ nil)
+      when is_integer(tmdb_id) do
+    type = normalize_media_check_type(media_type)
 
-    type =
-      case media_type do
-        "movie" -> "movie"
-        "tv_show" -> "tv_show"
-        :movie -> "movie"
-        :tv_show -> "tv_show"
-        _ -> media_type
-      end
-
-    # Check by tmdb_id first
     case Repo.get_by(MediaItem, tmdb_id: tmdb_id, type: type) do
-      nil ->
-        :not_found
+      nil -> check_duplicate_by_title_year(type, title, year)
+      media_item -> {:duplicate, media_item}
+    end
+  end
 
-      media_item ->
-        {:duplicate, media_item}
+  defp normalize_media_check_type(media_type) do
+    case media_type do
+      "movie" -> "movie"
+      "tv_show" -> "tv_show"
+      :movie -> "movie"
+      :tv_show -> "tv_show"
+      _ -> media_type
+    end
+  end
+
+  defp check_duplicate_by_title_year(_type, title, year)
+       when is_nil(title) or title == "" or is_nil(year) do
+    :not_found
+  end
+
+  defp check_duplicate_by_title_year(type, title, year) do
+    normalized_title = title |> String.trim() |> String.downcase()
+
+    query =
+      from(m in MediaItem,
+        where:
+          m.type == ^type and
+            is_nil(m.tmdb_id) and
+            m.year == ^year and
+            fragment("lower(trim(?))", m.title) == ^normalized_title
+      )
+
+    case Repo.one(query) do
+      nil -> :not_found
+      media_item -> {:duplicate, media_item}
     end
   end
 
@@ -615,7 +768,7 @@ defmodule Mydia.ImportLists do
 
     updated_count =
       Enum.reduce(pending_items, 0, fn item, count ->
-        case check_duplicate(item.tmdb_id, import_list.media_type) do
+        case check_duplicate(item.tmdb_id, import_list.media_type, item.title, item.year) do
           {:duplicate, media_item} ->
             {:ok, _} = mark_item_skipped(item, "Already in library")
             # Also link to the existing media item

--- a/lib/mydia/import_lists/feature_flags.ex
+++ b/lib/mydia/import_lists/feature_flags.ex
@@ -1,9 +1,10 @@
 defmodule Mydia.ImportLists.FeatureFlags do
   @moduledoc """
-  Helper module for checking Import Lists feature flag.
+  Helper module for checking the Import Lists feature flag.
 
   This module handles the ENABLE_IMPORT_LISTS feature flag which controls
-  whether Import Lists functionality is visible in the UI.
+  whether Import Lists functionality runs at all, not just whether its UI
+  is visible.
 
   When enabled, users can configure external lists (like TMDB watchlists)
   to automatically import media into their libraries.
@@ -11,16 +12,21 @@ defmodule Mydia.ImportLists.FeatureFlags do
   ## Features Controlled
 
   - Navigation link to Import Lists in admin menu
-  - Import Lists management UI
+  - Mounting the Import Lists admin LiveView (`/admin/import-lists`); a
+    disabled flag redirects instead of rendering the page, so the route
+    itself cannot be used to bypass the flag
+  - The `Mydia.Jobs.ImportListScheduler` cron job; when disabled it exits
+    immediately without enqueueing any sync or auto-add work
 
   ## Configuration
 
   The feature flag reads from `:mydia, :features, :import_lists_enabled`
-  configuration and defaults to `false` (disabled).
+  configuration and defaults to `true` (enabled).
 
   Set via environment variable:
-  - `ENABLE_IMPORT_LISTS=true` - Enable Import Lists UI
-  - `ENABLE_IMPORT_LISTS=false` - Disable Import Lists UI (default)
+  - `ENABLE_IMPORT_LISTS=true` - Enable Import Lists (default)
+  - `ENABLE_IMPORT_LISTS=false` - Disable Import Lists entirely, including
+    the scheduled sync job
   """
 
   @doc """
@@ -31,15 +37,15 @@ defmodule Mydia.ImportLists.FeatureFlags do
   ## Examples
 
       iex> Mydia.ImportLists.FeatureFlags.enabled?()
-      false
-
-      # After setting ENABLE_IMPORT_LISTS=true environment variable
-      iex> Mydia.ImportLists.FeatureFlags.enabled?()
       true
+
+      # After setting ENABLE_IMPORT_LISTS=false environment variable
+      iex> Mydia.ImportLists.FeatureFlags.enabled?()
+      false
 
   """
   def enabled? do
     Application.get_env(:mydia, :features, [])
-    |> Keyword.get(:import_lists_enabled, false)
+    |> Keyword.get(:import_lists_enabled, true)
   end
 end

--- a/lib/mydia/import_lists/import_list.ex
+++ b/lib/mydia/import_lists/import_list.ex
@@ -25,6 +25,15 @@ defmodule Mydia.ImportLists.ImportList do
 
   @media_type_values ~w(movie tv_show)
 
+  # Types restricted to a single media type. TMDB has no "upcoming TV shows"
+  # or "now playing TV shows" endpoint, and no "movies on the air" or
+  # "movies airing today" endpoint, so pairing these types with the wrong
+  # media_type has no real target and must be rejected up front rather than
+  # silently fetching the wrong content (see
+  # Mydia.ImportLists.Provider.TMDB.build_endpoint/2).
+  @movie_only_types ~w(tmdb_upcoming tmdb_now_playing)
+  @tv_only_types ~w(tmdb_on_the_air tmdb_airing_today)
+
   @sync_interval_values [60, 360, 720, 1440]
 
   @type t :: %__MODULE__{
@@ -96,6 +105,7 @@ defmodule Mydia.ImportLists.ImportList do
     |> validate_inclusion(:type, @type_values)
     |> validate_inclusion(:media_type, @media_type_values)
     |> validate_inclusion(:sync_interval, @sync_interval_values)
+    |> validate_media_type_compatibility()
     |> validate_list_url()
     |> store_list_url_in_config()
     |> maybe_add_unique_constraint()
@@ -103,6 +113,35 @@ defmodule Mydia.ImportLists.ImportList do
     |> foreign_key_constraint(:library_path_id)
     |> foreign_key_constraint(:target_collection_id)
   end
+
+  # Rejects a type/media_type pair with no real target, e.g. tmdb_upcoming
+  # (movie-only) paired with media_type "tv_show". Runs after
+  # validate_inclusion/3 on both fields so it only has to reason about
+  # already-valid values; an unrecognized type or media_type is reported by
+  # those validations instead.
+  defp validate_media_type_compatibility(changeset) do
+    type = get_field(changeset, :type)
+    media_type = get_field(changeset, :media_type)
+
+    if is_nil(type) or is_nil(media_type) or supports_media_type?(type, media_type) do
+      changeset
+    else
+      add_error(
+        changeset,
+        :media_type,
+        "is not supported by this list type (#{type_label(type)} only supports #{compatible_media_types_label(type)})"
+      )
+    end
+  end
+
+  defp compatible_media_types_label(type) do
+    type
+    |> compatible_media_types()
+    |> Enum.map_join(" or ", &media_type_label/1)
+  end
+
+  defp media_type_label("movie"), do: "movies"
+  defp media_type_label("tv_show"), do: "TV shows"
 
   # Validates that list_url is provided when the type requires config
   defp validate_list_url(changeset) do
@@ -216,6 +255,39 @@ defmodule Mydia.ImportLists.ImportList do
   def source_category("tmdb_" <> _), do: :tmdb
   def source_category("custom_url"), do: :custom
   def source_category(_), do: :unknown
+
+  @doc """
+  Returns the media types a given list type can be configured with.
+
+  Most types accept either `"movie"` or `"tv_show"`. A handful of TMDB
+  preset types have no counterpart endpoint for the other media type
+  (`tmdb_upcoming`/`tmdb_now_playing` are movie-only, `tmdb_on_the_air`/
+  `tmdb_airing_today` are TV-only) and so only accept one. A LiveView form
+  can use this to filter the Media Type select's options for the chosen
+  type.
+
+  ## Examples
+
+      iex> Mydia.ImportLists.ImportList.compatible_media_types("tmdb_upcoming")
+      ["movie"]
+
+      iex> Mydia.ImportLists.ImportList.compatible_media_types("tmdb_trending")
+      ["movie", "tv_show"]
+  """
+  @spec compatible_media_types(String.t()) :: [String.t()]
+  def compatible_media_types(type) when type in @movie_only_types, do: ["movie"]
+  def compatible_media_types(type) when type in @tv_only_types, do: ["tv_show"]
+  def compatible_media_types(_type), do: @media_type_values
+
+  @doc """
+  Returns true if `media_type` is a valid pairing for list `type`.
+
+  See `compatible_media_types/1` for the compatibility rule.
+  """
+  @spec supports_media_type?(String.t(), String.t()) :: boolean()
+  def supports_media_type?(type, media_type) do
+    media_type in compatible_media_types(type)
+  end
 
   @doc """
   Returns true if this list type requires a URL or ID config.

--- a/lib/mydia/import_lists/provider/custom_url.ex
+++ b/lib/mydia/import_lists/provider/custom_url.ex
@@ -27,11 +27,57 @@ defmodule Mydia.ImportLists.Provider.CustomURL do
 
   Required fields: tmdb_id (or tmdbId)
   Optional fields: title, year, poster_path
+
+  ## Server-Side Request Forgery (SSRF) protection
+
+  `list_url` is an admin-configured value that this module fetches directly, so it
+  is validated before every request:
+
+    * only `http` and `https` schemes are allowed. This is always enforced and is
+      not affected by the config switch below.
+    * the *resolved* IP address (via DNS, not just the literal host text) must not
+      be loopback, an RFC1918 private range, carrier-grade NAT (`100.64.0.0/10`),
+      link-local (including the `169.254.169.254` cloud metadata address),
+      multicast or reserved (`224.0.0.0/4`, `240.0.0.0/4`), unique-local IPv6
+      (`fc00::/7`), unspecified, or broadcast. IPv4-mapped IPv6 forms of these
+      (e.g. `::ffff:127.0.0.1`) are unwrapped and checked too. A hostname that
+      fails to resolve is rejected.
+    * Req's automatic redirect following is disabled and redirects are followed
+      manually, so every hop is revalidated against the same rules, up to 5 hops.
+
+  Self-hosted operators legitimately point `list_url` at something on their own
+  LAN or container network (a JSON file served by a NAS, say). To allow that, set:
+
+      config :mydia, :import_lists_allow_private_destinations, true
+
+  This defaults to `false`, meaning private/internal destinations are blocked. It
+  only relaxes the destination check; the scheme allowlist above is always
+  enforced. It is read via `Application.get_env/3` at call time, not a module
+  attribute, so it can be changed at runtime and overridden in tests. Operators
+  running the container set it with `IMPORT_LISTS_ALLOW_PRIVATE_DESTINATIONS=true`.
+
+  ### Residual risk
+
+  Validation resolves the hostname and then Req resolves it again when it
+  connects, so a hostile DNS server that answers differently between those two
+  lookups (DNS rebinding) can still get a request sent to a blocked address.
+  Closing that means connecting to the validated IP directly and carrying the
+  original hostname in the `Host` header plus TLS SNI, which Req does not make
+  easy. The guard is defence in depth on an admin-only field, so the simpler
+  check is the deliberate trade-off here rather than an oversight.
   """
 
   @behaviour Mydia.ImportLists.Provider
 
+  import Bitwise
+
   require Logger
+
+  @allowed_schemes ~w(http https)
+  @max_redirects 5
+  # Req 0.7.1 has no `max_response_size` request option (see check_response_size/1
+  # for the residual risk of the content-length fallback used instead).
+  @max_response_bytes 20 * 1024 * 1024
 
   @impl true
   def supports?("custom_url"), do: true
@@ -52,11 +98,68 @@ defmodule Mydia.ImportLists.Provider.CustomURL do
 
   def fetch_items(_), do: {:error, "Invalid import list type for CustomURL provider"}
 
+  @doc false
+  # Exposed (but undocumented in public docs) so tests can exercise the SSRF
+  # guard directly against literal addresses and hostnames without needing a
+  # live server for every case.
+  @spec validate_url(String.t()) :: :ok | {:error, String.t()}
+  def validate_url(url) do
+    with :ok <- validate_scheme(url) do
+      validate_destination(url)
+    end
+  end
+
   ## Private Functions
 
   defp fetch_from_url(url, media_type) do
     Logger.info("[CustomURL] Fetching from URL", url: url)
 
+    with {:ok, response} <- fetch_with_redirects(url, @max_redirects) do
+      handle_response(response, media_type)
+    end
+  end
+
+  defp fetch_with_redirects(url, redirects_remaining) do
+    with :ok <- validate_url(url),
+         {:ok, response} <- do_get(url) do
+      maybe_follow_redirect(response, url, redirects_remaining)
+    end
+  end
+
+  defp maybe_follow_redirect(%{status: status}, _url, 0)
+       when status in [301, 302, 303, 307, 308] do
+    {:error, "Too many redirects (max #{@max_redirects}) while fetching import list URL"}
+  end
+
+  defp maybe_follow_redirect(%{status: status} = response, url, redirects_remaining)
+       when status in [301, 302, 303, 307, 308] do
+    with {:ok, location} <- get_redirect_location(response),
+         {:ok, next_url} <- resolve_redirect_url(url, location) do
+      Logger.debug("[CustomURL] Following redirect", from: url, to: next_url)
+      fetch_with_redirects(next_url, redirects_remaining - 1)
+    end
+  end
+
+  defp maybe_follow_redirect(response, _url, _redirects_remaining), do: {:ok, response}
+
+  defp get_redirect_location(response) do
+    case Req.Response.get_header(response, "location") do
+      [location | _] -> {:ok, location}
+      [] -> {:error, "Redirect response is missing a Location header"}
+    end
+  end
+
+  defp resolve_redirect_url(base_url, location) do
+    next_url =
+      base_url
+      |> URI.parse()
+      |> URI.merge(location)
+      |> URI.to_string()
+
+    {:ok, next_url}
+  end
+
+  defp do_get(url) do
     req =
       Req.new(
         url: url,
@@ -64,33 +167,164 @@ defmodule Mydia.ImportLists.Provider.CustomURL do
           {"accept", "application/json"},
           {"user-agent", "Mydia/1.0"}
         ],
-        receive_timeout: 30_000
+        receive_timeout: 30_000,
+        # Redirects are followed manually in `fetch_with_redirects/2` so each hop
+        # can be revalidated; Req would otherwise follow them itself before we
+        # get a chance to check the destination.
+        redirect: false
       )
 
     case Req.get(req) do
-      {:ok, %{status: 200, body: body}} when is_list(body) ->
-        parse_items(body, media_type)
-
-      {:ok, %{status: 200, body: %{"items" => items}}} when is_list(items) ->
-        parse_items(items, media_type)
-
-      {:ok, %{status: 200, body: %{"results" => results}}} when is_list(results) ->
-        parse_items(results, media_type)
-
-      {:ok, %{status: 200, body: body}} ->
-        Logger.warning("[CustomURL] Unexpected response format", body: inspect(body))
-        {:error, "Unexpected JSON format - expected array or object with items/results key"}
-
-      {:ok, %{status: status, body: body}} ->
-        {:error, "HTTP #{status}: #{inspect(body)}"}
-
-      {:error, %{reason: reason}} ->
-        {:error, "Request failed: #{inspect(reason)}"}
-
-      {:error, error} ->
-        {:error, "Request failed: #{inspect(error)}"}
+      {:ok, response} -> check_response_size(response)
+      {:error, %{reason: reason}} -> {:error, "Request failed: #{inspect(reason)}"}
+      {:error, error} -> {:error, "Request failed: #{inspect(error)}"}
     end
   end
+
+  # Req 0.7.1 does not expose a `max_response_size` request option, and by the
+  # time a response reaches here Req has already buffered the whole body, so
+  # this only stops a badly-behaved-but-honest server that declares an
+  # oversized body up front via `content-length`. A server that omits or lies
+  # about `content-length`, or streams via chunked transfer-encoding, can still
+  # force a large allocation before this check runs. Fully closing that gap
+  # would need streaming consumption with a running byte cap (Req's `into: fun`
+  # option), which is a bigger change than this guard warrants today.
+  defp check_response_size(response) do
+    case declared_content_length(response) do
+      size when is_integer(size) and size > @max_response_bytes ->
+        {:error, "Response body too large (#{size} bytes declared, max #{@max_response_bytes})"}
+
+      _ ->
+        {:ok, response}
+    end
+  end
+
+  defp declared_content_length(response) do
+    case Req.Response.get_header(response, "content-length") do
+      [value | _] -> parse_int(value)
+      [] -> nil
+    end
+  end
+
+  defp handle_response(%{status: 200, body: body}, media_type) when is_list(body) do
+    parse_items(body, media_type)
+  end
+
+  defp handle_response(%{status: 200, body: %{"items" => items}}, media_type)
+       when is_list(items) do
+    parse_items(items, media_type)
+  end
+
+  defp handle_response(%{status: 200, body: %{"results" => results}}, media_type)
+       when is_list(results) do
+    parse_items(results, media_type)
+  end
+
+  defp handle_response(%{status: 200, body: body}, _media_type) do
+    Logger.warning("[CustomURL] Unexpected response format", body: inspect(body))
+    {:error, "Unexpected JSON format - expected array or object with items/results key"}
+  end
+
+  defp handle_response(%{status: status, body: body}, _media_type) do
+    {:error, "HTTP #{status}: #{inspect(body)}"}
+  end
+
+  ## Destination validation (SSRF guard)
+
+  defp validate_scheme(url) do
+    case URI.parse(url).scheme do
+      scheme when scheme in @allowed_schemes ->
+        :ok
+
+      scheme ->
+        {:error, "Unsupported URL scheme #{inspect(scheme)}; only http and https are allowed"}
+    end
+  end
+
+  defp validate_destination(url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) and host != "" ->
+        with {:ok, addrs} <- resolve_host(host) do
+          reject_blocked_addresses(addrs, host)
+        end
+
+      _ ->
+        {:error, "URL is missing a host"}
+    end
+  end
+
+  defp resolve_host(host) do
+    charlist = String.to_charlist(host)
+    addrs = getaddrs(charlist, :inet) ++ getaddrs(charlist, :inet6)
+
+    case addrs do
+      [] -> {:error, "Could not resolve host #{host}"}
+      addrs -> {:ok, addrs}
+    end
+  end
+
+  defp getaddrs(charlist, family) do
+    case :inet.getaddrs(charlist, family) do
+      {:ok, addrs} -> addrs
+      {:error, _reason} -> []
+    end
+  end
+
+  defp reject_blocked_addresses(addrs, host) do
+    if allow_private_destinations?() do
+      :ok
+    else
+      case Enum.find(addrs, &(not public_address?(&1))) do
+        nil ->
+          :ok
+
+        blocked ->
+          {:error,
+           "Refusing to fetch #{host}: resolves to a private/internal address (#{format_ip(blocked)})"}
+      end
+    end
+  end
+
+  defp allow_private_destinations? do
+    Application.get_env(:mydia, :import_lists_allow_private_destinations, false)
+  end
+
+  defp format_ip(ip), do: ip |> :inet.ntoa() |> to_string()
+
+  defp public_address?(ip) when tuple_size(ip) == 4, do: public_ipv4?(ip)
+  defp public_address?(ip) when tuple_size(ip) == 8, do: public_ipv6?(ip)
+
+  defp public_ipv4?({0, 0, 0, 0}), do: false
+  defp public_ipv4?({255, 255, 255, 255}), do: false
+  defp public_ipv4?({127, _, _, _}), do: false
+  defp public_ipv4?({10, _, _, _}), do: false
+  defp public_ipv4?({172, b, _, _}) when b in 16..31, do: false
+  defp public_ipv4?({192, 168, _, _}), do: false
+  defp public_ipv4?({169, 254, _, _}), do: false
+  # 100.64.0.0/10 - carrier-grade NAT. Plenty of home ISPs hand these out, so
+  # for a self-hosted install this is neighbouring equipment, not the internet.
+  defp public_ipv4?({100, b, _, _}) when b in 64..127, do: false
+  # 224.0.0.0/4 multicast and 240.0.0.0/4 reserved. Never a valid list host.
+  defp public_ipv4?({a, _, _, _}) when a in 224..255, do: false
+  defp public_ipv4?(_), do: true
+
+  defp public_ipv6?({0, 0, 0, 0, 0, 0, 0, 0}), do: false
+  defp public_ipv6?({0, 0, 0, 0, 0, 0, 0, 1}), do: false
+
+  # IPv4-mapped IPv6 (::ffff:a.b.c.d): unwrap and validate the embedded IPv4
+  # address so a blocked address cannot be smuggled past the IPv6-only checks
+  # below (e.g. ::ffff:127.0.0.1).
+  defp public_ipv6?({0, 0, 0, 0, 0, 0xFFFF, hi, lo}), do: public_ipv4?(embedded_ipv4(hi, lo))
+
+  # fc00::/7 - unique local addresses.
+  defp public_ipv6?({h1, _, _, _, _, _, _, _}) when (h1 &&& 0xFE00) == 0xFC00, do: false
+  # fe80::/10 - link-local addresses.
+  defp public_ipv6?({h1, _, _, _, _, _, _, _}) when (h1 &&& 0xFFC0) == 0xFE80, do: false
+  defp public_ipv6?(_), do: true
+
+  defp embedded_ipv4(hi, lo), do: {hi >>> 8, hi &&& 0xFF, lo >>> 8, lo &&& 0xFF}
+
+  ## JSON item parsing
 
   defp parse_items(items, media_type) do
     parsed =

--- a/lib/mydia/import_lists/provider/custom_url.ex
+++ b/lib/mydia/import_lists/provider/custom_url.ex
@@ -304,6 +304,8 @@ defmodule Mydia.ImportLists.Provider.CustomURL do
   # 100.64.0.0/10 - carrier-grade NAT. Plenty of home ISPs hand these out, so
   # for a self-hosted install this is neighbouring equipment, not the internet.
   defp public_ipv4?({100, b, _, _}) when b in 64..127, do: false
+  # 198.18.0.0/15 - benchmarking range, routed internally on some networks.
+  defp public_ipv4?({198, b, _, _}) when b in 18..19, do: false
   # 224.0.0.0/4 multicast and 240.0.0.0/4 reserved. Never a valid list host.
   defp public_ipv4?({a, _, _, _}) when a in 224..255, do: false
   defp public_ipv4?(_), do: true
@@ -320,6 +322,10 @@ defmodule Mydia.ImportLists.Provider.CustomURL do
   defp public_ipv6?({h1, _, _, _, _, _, _, _}) when (h1 &&& 0xFE00) == 0xFC00, do: false
   # fe80::/10 - link-local addresses.
   defp public_ipv6?({h1, _, _, _, _, _, _, _}) when (h1 &&& 0xFFC0) == 0xFE80, do: false
+  # fec0::/10 - deprecated site-local, still routed on some internal networks.
+  defp public_ipv6?({h1, _, _, _, _, _, _, _}) when (h1 &&& 0xFFC0) == 0xFEC0, do: false
+  # ff00::/8 - multicast. Never a valid list host.
+  defp public_ipv6?({h1, _, _, _, _, _, _, _}) when (h1 &&& 0xFF00) == 0xFF00, do: false
   defp public_ipv6?(_), do: true
 
   defp embedded_ipv4(hi, lo), do: {hi >>> 8, hi &&& 0xFF, lo >>> 8, lo &&& 0xFF}

--- a/lib/mydia/import_lists/provider/tmdb.ex
+++ b/lib/mydia/import_lists/provider/tmdb.ex
@@ -28,6 +28,27 @@ defmodule Mydia.ImportLists.Provider.TMDB do
     tmdb_list
   )
 
+  # Maximum number of pages to fetch from a single TMDB relay endpoint. TMDB
+  # curated endpoints return roughly 20 items per page, so 5 pages caps a
+  # single sync at ~100 items instead of the 20 a single-page fetch used to
+  # cap it at.
+  @max_pages 5
+
+  defmodule Source do
+    @moduledoc false
+    # The parts of a paginated fetch that stay put across the recursion, so
+    # only the page cursor and accumulator get threaded through it.
+    defstruct [:req, :endpoint, :results_key, :status_error_fn, :require_metadata?]
+
+    @type t :: %__MODULE__{
+            req: Req.Request.t(),
+            endpoint: String.t(),
+            results_key: String.t(),
+            status_error_fn: (integer(), term() -> String.t()),
+            require_metadata?: boolean()
+          }
+  end
+
   @impl true
   def supports?(type), do: type in @supported_types
 
@@ -98,13 +119,22 @@ defmodule Mydia.ImportLists.Provider.TMDB do
 
   defp fetch_user_list(config, list_id, media_type) do
     endpoint = "/tmdb/list/#{list_id}"
-    params = [language: "en-US"]
-
     req = HTTP.new_request(config)
 
-    case HTTP.get(req, endpoint, params: params) do
-      {:ok, %{status: 200, body: %{"items" => items}}} when is_list(items) ->
-        # Filter items by media type and parse them
+    status_error_fn = fn
+      404, _body -> "TMDB list not found (ID: #{list_id})"
+      status, body -> "API returned status #{status}: #{inspect(body)}"
+    end
+
+    # The user-list endpoint may or may not paginate like the curated
+    # endpoints do. `require_pagination_metadata?: true` means we only
+    # follow to a second page when the first page's response actually
+    # reports `total_pages`; otherwise we treat it as a single, unpaginated
+    # response, matching the previous single-request behavior.
+    case fetch_paginated(req, endpoint, "items", status_error_fn,
+           require_pagination_metadata?: true
+         ) do
+      {:ok, items} ->
         filtered_items =
           items
           |> Enum.filter(&matches_media_type?(&1, media_type))
@@ -112,18 +142,8 @@ defmodule Mydia.ImportLists.Provider.TMDB do
 
         {:ok, filtered_items}
 
-      {:ok, %{status: 200, body: body}} ->
-        Logger.warning("Unexpected TMDB list response format", body: inspect(body))
-        {:ok, []}
-
-      {:ok, %{status: 404, body: _}} ->
-        {:error, "TMDB list not found (ID: #{list_id})"}
-
-      {:ok, %{status: status, body: body}} ->
-        {:error, "API returned status #{status}: #{inspect(body)}"}
-
-      {:error, error} ->
-        {:error, error}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -136,43 +156,116 @@ defmodule Mydia.ImportLists.Provider.TMDB do
   defp matches_media_type?(_, _), do: false
 
   defp fetch_from_endpoint(config, type, media_type) do
-    endpoint = build_endpoint(type, media_type)
-    params = [language: "en-US", page: 1]
+    with {:ok, endpoint} <- build_endpoint(type, media_type) do
+      req = HTTP.new_request(config)
+      status_error_fn = fn status, body -> "API returned status #{status}: #{inspect(body)}" end
 
-    req = HTTP.new_request(config)
-
-    case HTTP.get(req, endpoint, params: params) do
-      {:ok, %{status: 200, body: %{"results" => results}}} when is_list(results) ->
-        {:ok, results}
-
-      {:ok, %{status: 200, body: body}} ->
-        # Some endpoints might return results directly
-        if is_list(body), do: {:ok, body}, else: {:ok, []}
-
-      {:ok, %{status: status, body: body}} ->
-        {:error, "API returned status #{status}: #{inspect(body)}"}
-
-      {:error, error} ->
-        {:error, error}
+      fetch_paginated(req, endpoint, "results", status_error_fn,
+        require_pagination_metadata?: false
+      )
     end
   end
 
-  defp build_endpoint("tmdb_trending", "movie"), do: "/tmdb/movies/trending"
-  defp build_endpoint("tmdb_trending", "tv_show"), do: "/tmdb/tv/trending"
-  defp build_endpoint("tmdb_popular", "movie"), do: "/tmdb/movies/popular"
-  defp build_endpoint("tmdb_popular", "tv_show"), do: "/tmdb/tv/popular"
-  defp build_endpoint("tmdb_upcoming", "movie"), do: "/tmdb/movies/upcoming"
-  defp build_endpoint("tmdb_now_playing", "movie"), do: "/tmdb/movies/now_playing"
-  defp build_endpoint("tmdb_on_the_air", "tv_show"), do: "/tmdb/tv/on_the_air"
-  defp build_endpoint("tmdb_airing_today", "tv_show"), do: "/tmdb/tv/airing_today"
-  # Fallback for invalid combinations
-  defp build_endpoint(type, media_type) do
-    Logger.warning("Invalid TMDB list type/media_type combination",
-      type: type,
-      media_type: media_type
+  # Fetches up to @max_pages pages from `endpoint`, concatenating the list
+  # found under `results_key` in each page's body. Stops early when a page
+  # comes back empty, when a page has fewer items than the previous page
+  # (the previous page was the last full one), or when the response's own
+  # `total_pages` says the last page has been reached.
+  #
+  # When `require_pagination_metadata?: true`, a first page with no
+  # `total_pages` in its body is treated as the only page: the endpoint is
+  # assumed not to paginate, and no further pages are requested.
+  #
+  # If the first page fails, the whole fetch fails. If a later page fails,
+  # the items already gathered are returned and a warning is logged, so a
+  # transient failure partway through does not fail the entire sync.
+  defp fetch_paginated(req, endpoint, results_key, status_error_fn, opts) do
+    source = %Source{
+      req: req,
+      endpoint: endpoint,
+      results_key: results_key,
+      status_error_fn: status_error_fn,
+      require_metadata?: Keyword.fetch!(opts, :require_pagination_metadata?)
+    }
+
+    do_fetch_paginated(source, 1, [], nil)
+  end
+
+  defp do_fetch_paginated(%Source{}, page, acc, _prev_count) when page > @max_pages do
+    {:ok, acc}
+  end
+
+  defp do_fetch_paginated(%Source{} = source, page, acc, prev_count) do
+    %Source{req: req, endpoint: endpoint, results_key: results_key} = source
+    params = [language: "en-US", page: page]
+
+    case HTTP.get(req, endpoint, params: params) do
+      {:ok, %{status: 200, body: %{^results_key => items} = body}} when is_list(items) ->
+        continue_pagination(source, page, acc, prev_count, items, body["total_pages"])
+
+      {:ok, %{status: 200, body: body}} ->
+        Logger.warning("Unexpected TMDB response format", endpoint: endpoint, body: inspect(body))
+        {:ok, acc}
+
+      {:ok, %{status: status, body: body}} ->
+        handle_page_error(page, acc, source.status_error_fn.(status, body))
+
+      {:error, error} ->
+        handle_page_error(page, acc, error)
+    end
+  end
+
+  defp continue_pagination(%Source{} = source, page, acc, prev_count, items, total_pages) do
+    new_acc = acc ++ items
+
+    cond do
+      items == [] ->
+        {:ok, acc}
+
+      is_integer(prev_count) and length(items) < prev_count ->
+        {:ok, new_acc}
+
+      is_integer(total_pages) and page >= total_pages ->
+        {:ok, new_acc}
+
+      is_nil(total_pages) and source.require_metadata? ->
+        {:ok, new_acc}
+
+      page >= @max_pages ->
+        {:ok, new_acc}
+
+      true ->
+        do_fetch_paginated(source, page + 1, new_acc, length(items))
+    end
+  end
+
+  defp handle_page_error(1, _acc, reason), do: {:error, reason}
+
+  defp handle_page_error(page, acc, reason) do
+    Logger.warning("TMDB pagination request failed; returning items gathered so far",
+      page: page,
+      error: inspect(reason)
     )
 
-    "/tmdb/movies/trending"
+    {:ok, acc}
+  end
+
+  defp build_endpoint("tmdb_trending", "movie"), do: {:ok, "/tmdb/movies/trending"}
+  defp build_endpoint("tmdb_trending", "tv_show"), do: {:ok, "/tmdb/tv/trending"}
+  defp build_endpoint("tmdb_popular", "movie"), do: {:ok, "/tmdb/movies/popular"}
+  defp build_endpoint("tmdb_popular", "tv_show"), do: {:ok, "/tmdb/tv/popular"}
+  defp build_endpoint("tmdb_upcoming", "movie"), do: {:ok, "/tmdb/movies/upcoming"}
+  defp build_endpoint("tmdb_now_playing", "movie"), do: {:ok, "/tmdb/movies/now_playing"}
+  defp build_endpoint("tmdb_on_the_air", "tv_show"), do: {:ok, "/tmdb/tv/on_the_air"}
+  defp build_endpoint("tmdb_airing_today", "tv_show"), do: {:ok, "/tmdb/tv/airing_today"}
+
+  # Invalid combination (e.g. a movie-only type with media_type "tv_show").
+  # Fail loudly instead of silently falling back to trending movies: a caller
+  # storing this reason should recognize it as configuration error, not a
+  # transient failure.
+  defp build_endpoint(type, media_type) do
+    {:error,
+     "Invalid TMDB list type/media_type combination: #{inspect(type)} does not support media_type #{inspect(media_type)}"}
   end
 
   defp parse_result(result, media_type) do

--- a/lib/mydia/jobs/import_list_auto_add.ex
+++ b/lib/mydia/jobs/import_list_auto_add.ex
@@ -97,25 +97,33 @@ defmodule Mydia.Jobs.ImportListAutoAdd do
     end
   end
 
+  # Note: an item found already in the library links to the existing media
+  # item and counts as :added, same as a freshly created one; see
+  # process_item/2. Nothing currently returns :skipped, but the bucket stays
+  # in the accumulator so the shape (and the Logger.info call below that
+  # reads stats.skipped) doesn't have to change if a future path adds one.
   defp process_pending_items(import_list, pending_items) do
     Enum.reduce(pending_items, %{added: 0, skipped: 0, failed: 0}, fn item, acc ->
       case process_item(import_list, item) do
         :added -> %{acc | added: acc.added + 1}
-        :skipped -> %{acc | skipped: acc.skipped + 1}
         :failed -> %{acc | failed: acc.failed + 1}
       end
     end)
   end
 
   defp process_item(import_list, item) do
-    # First check if already in library
-    case ImportLists.check_duplicate(item.tmdb_id, import_list.media_type) do
+    # First check if already in library (by tmdb_id, falling back to
+    # title+year for library items that predate any external id)
+    case ImportLists.check_duplicate(item.tmdb_id, import_list.media_type, item.title, item.year) do
       {:duplicate, media_item} ->
-        # Already exists, mark as skipped
-        ImportLists.mark_item_skipped(item, "Already in library")
-        # Link to existing media item
+        # Already exists: link to it. A single write, marking the item
+        # "added" (mark_item_added/2 also clears any skip_reason). An earlier
+        # version wrote mark_item_skipped/2 first and mark_item_added/2 right
+        # after, which immediately overwrote the skip, so the row always
+        # ended up "added" in the database while this function still
+        # reported :skipped to the caller, which disagreed with reality.
         ImportLists.mark_item_added(item, media_item.id)
-        :skipped
+        :added
 
       :not_found ->
         # Try to add to library

--- a/lib/mydia/jobs/import_list_scheduler.ex
+++ b/lib/mydia/jobs/import_list_scheduler.ex
@@ -22,34 +22,40 @@ defmodule Mydia.Jobs.ImportListScheduler do
   require Logger
 
   alias Mydia.ImportLists
+  alias Mydia.ImportLists.FeatureFlags
   alias Mydia.Jobs.ImportListSync
 
   @spec perform(Oban.Job.t()) :: :ok | {:ok, term()} | {:error, term()} | {:snooze, pos_integer()}
   @impl Oban.Worker
   def perform(%Oban.Job{}) do
-    Logger.info("[ImportListScheduler] Checking for import lists due for sync")
+    if FeatureFlags.enabled?() do
+      Logger.info("[ImportListScheduler] Checking for import lists due for sync")
 
-    due_lists = ImportLists.list_sync_due_lists()
+      due_lists = ImportLists.list_sync_due_lists()
 
-    Logger.info("[ImportListScheduler] Found #{length(due_lists)} lists due for sync")
+      Logger.info("[ImportListScheduler] Found #{length(due_lists)} lists due for sync")
 
-    Enum.each(due_lists, fn import_list ->
-      case ImportListSync.enqueue(import_list.id) do
-        {:ok, _job} ->
-          Logger.debug("[ImportListScheduler] Enqueued sync for list",
-            import_list_id: import_list.id,
-            name: import_list.name
-          )
+      Enum.each(due_lists, fn import_list ->
+        case ImportListSync.enqueue(import_list.id) do
+          {:ok, _job} ->
+            Logger.debug("[ImportListScheduler] Enqueued sync for list",
+              import_list_id: import_list.id,
+              name: import_list.name
+            )
 
-        {:error, reason} ->
-          Logger.warning("[ImportListScheduler] Failed to enqueue sync",
-            import_list_id: import_list.id,
-            error: inspect(reason)
-          )
-      end
-    end)
+          {:error, reason} ->
+            Logger.warning("[ImportListScheduler] Failed to enqueue sync",
+              import_list_id: import_list.id,
+              error: inspect(reason)
+            )
+        end
+      end)
 
-    :ok
+      :ok
+    else
+      Logger.debug("[ImportListScheduler] Skipping - Import Lists feature disabled")
+      :ok
+    end
   end
 
   @doc """

--- a/lib/mydia/jobs/import_list_sync.ex
+++ b/lib/mydia/jobs/import_list_sync.ex
@@ -179,12 +179,10 @@ defmodule Mydia.Jobs.ImportListSync do
         }
 
         case ImportLists.upsert_import_list_item(attrs) do
-          {:ok, %{id: id}} when is_binary(id) ->
-            # Check if this was a new insert or update by looking at discovered_at
-            # If discovered_at matches now, it's likely new
+          {:ok, _item, :created} ->
             %{acc | total: acc.total + 1, new: acc.new + 1}
 
-          {:ok, _} ->
+          {:ok, _item, :updated} ->
             %{acc | total: acc.total + 1, updated: acc.updated + 1}
 
           {:error, _} ->

--- a/lib/mydia_web/live/admin_import_lists_live/index.ex
+++ b/lib/mydia_web/live/admin_import_lists_live/index.ex
@@ -17,24 +17,31 @@ defmodule MydiaWeb.AdminImportListsLive.Index do
 
   @impl true
   def mount(_params, _session, socket) do
-    if connected?(socket) do
-      Phoenix.PubSub.subscribe(Mydia.PubSub, "import_lists")
-    end
+    if Mydia.ImportLists.FeatureFlags.enabled?() do
+      if connected?(socket) do
+        Phoenix.PubSub.subscribe(Mydia.PubSub, "import_lists")
+      end
 
-    {:ok,
-     socket
-     |> assign(:page_title, "Import Lists")
-     |> assign(:show_list_modal, false)
-     |> assign(:show_items_modal, false)
-     |> assign(:show_preset_confirm_modal, false)
-     |> assign(:pending_preset_id, nil)
-     |> assign(:list_mode, nil)
-     |> assign(:selected_list, nil)
-     |> assign(:form, nil)
-     |> assign(:items, [])
-     |> assign(:items_filter, "all")
-     |> assign(:syncing_list_id, nil)
-     |> load_data()}
+      {:ok,
+       socket
+       |> assign(:page_title, "Import Lists")
+       |> assign(:show_list_modal, false)
+       |> assign(:show_items_modal, false)
+       |> assign(:show_preset_confirm_modal, false)
+       |> assign(:pending_preset_id, nil)
+       |> assign(:list_mode, nil)
+       |> assign(:selected_list, nil)
+       |> assign(:form, nil)
+       |> assign(:items, [])
+       |> assign(:items_filter, "all")
+       |> assign(:syncing_list_id, nil)
+       |> load_data()}
+    else
+      {:ok,
+       socket
+       |> put_flash(:error, "Import Lists is currently disabled")
+       |> redirect(to: ~p"/admin/dashboard")}
+    end
   end
 
   @impl true
@@ -219,7 +226,7 @@ defmodule MydiaWeb.AdminImportListsLive.Index do
 
     changeset =
       import_list
-      |> ImportLists.change_import_list(params)
+      |> ImportLists.change_import_list(coerce_media_type(params))
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, :form, to_form(changeset))}
@@ -549,6 +556,41 @@ defmodule MydiaWeb.AdminImportListsLive.Index do
       preset_id
     end
   end
+
+  # Keeps the media type in step with the chosen list source. Several TMDB
+  # sources only ever publish one media type, so once the operator picks one
+  # of those the incompatible option is no longer offered by the select. Without
+  # this the form would keep submitting a value the operator can no longer see.
+  defp coerce_media_type(%{"type" => type, "media_type" => media_type} = params)
+       when is_binary(type) and is_binary(media_type) do
+    case ImportList.compatible_media_types(type) do
+      [only] when only != media_type -> Map.put(params, "media_type", only)
+      _ -> params
+    end
+  end
+
+  defp coerce_media_type(params), do: params
+
+  @doc """
+  Returns the media type select options a list source actually supports.
+
+  Movie-only and TV-only TMDB sources offer a single option so an operator
+  cannot build a list whose source and media type disagree.
+  """
+  def media_type_options(type) when is_binary(type) and type != "" do
+    type
+    |> ImportList.compatible_media_types()
+    |> Enum.map(&{media_type_label(&1), &1})
+  end
+
+  # No source picked yet, so nothing narrows the choice.
+  def media_type_options(_type) do
+    Enum.map(ImportList.valid_media_types(), &{media_type_label(&1), &1})
+  end
+
+  defp media_type_label("movie"), do: "Movies"
+  defp media_type_label("tv_show"), do: "TV Shows"
+  defp media_type_label(other), do: other
 
   def media_type_icon("movie"), do: "hero-film"
   def media_type_icon("tv_show"), do: "hero-tv"

--- a/lib/mydia_web/live/admin_import_lists_live/index.html.heex
+++ b/lib/mydia_web/live/admin_import_lists_live/index.html.heex
@@ -250,7 +250,7 @@
                 field={@form[:media_type]}
                 type="select"
                 label="Media Type"
-                options={[{"Movies", "movie"}, {"TV Shows", "tv_show"}]}
+                options={media_type_options(selected_type)}
                 required
               />
             <% else %>
@@ -343,6 +343,10 @@
                   <span class="font-medium">Auto-add to library</span>
                   <p class="text-xs text-base-content/60">
                     Automatically add new items without manual approval
+                  </p>
+                  <p class="text-xs text-warning">
+                    Added items appear in your library immediately. When the list is also
+                    monitored, they are searched for on indexers and downloaded automatically.
                   </p>
                 </div>
               </label>

--- a/test/mydia/import_lists/provider/custom_url_test.exs
+++ b/test/mydia/import_lists/provider/custom_url_test.exs
@@ -1,0 +1,200 @@
+defmodule Mydia.ImportLists.Provider.CustomURLTest do
+  # Mutates the global :mydia, :import_lists_allow_private_destinations app env,
+  # so this suite runs sequentially.
+  use ExUnit.Case, async: false
+
+  alias Mydia.ImportLists.Provider.CustomURL
+
+  @config_key :import_lists_allow_private_destinations
+
+  defp import_list(url) do
+    %{type: "custom_url", config: %{"list_url" => url}, media_type: "movie"}
+  end
+
+  # Bypass only ever binds to loopback, which the guard blocks by default, so
+  # every Bypass-backed test needs the escape hatch just to reach the server at
+  # all. Restored via on_exit so later tests see the secure default again.
+  defp allow_private_destinations! do
+    previous = Application.get_env(:mydia, @config_key)
+    Application.put_env(:mydia, @config_key, true)
+
+    on_exit(fn ->
+      if is_nil(previous) do
+        Application.delete_env(:mydia, @config_key)
+      else
+        Application.put_env(:mydia, @config_key, previous)
+      end
+    end)
+  end
+
+  describe "fetch_items/1 JSON shapes (guard relaxed via Bypass)" do
+    setup do
+      allow_private_destinations!()
+      bypass = Bypass.open()
+      %{bypass: bypass}
+    end
+
+    test "parses a bare array of items", %{bypass: bypass} do
+      body =
+        Jason.encode!([
+          %{"tmdb_id" => 111, "title" => "The Wandering Reactor", "year" => 2024},
+          %{"tmdb_id" => 222, "title" => "Silent Orchard"}
+        ])
+
+      Bypass.expect_once(bypass, "GET", "/list.json", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      list = import_list("http://localhost:#{bypass.port}/list.json")
+
+      assert {:ok, items} = CustomURL.fetch_items(list)
+      assert length(items) == 2
+      assert Enum.any?(items, &(&1.tmdb_id == 111 and &1.title == "The Wandering Reactor"))
+      assert Enum.any?(items, &(&1.tmdb_id == 222))
+    end
+
+    test "parses an object with an items key", %{bypass: bypass} do
+      body = Jason.encode!(%{"items" => [%{"tmdb_id" => 333, "title" => "Glass Meridian"}]})
+
+      Bypass.expect_once(bypass, "GET", "/list.json", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      list = import_list("http://localhost:#{bypass.port}/list.json")
+
+      assert {:ok, [item]} = CustomURL.fetch_items(list)
+      assert item.tmdb_id == 333
+      assert item.title == "Glass Meridian"
+    end
+
+    test "parses an object with a results key", %{bypass: bypass} do
+      body = Jason.encode!(%{"results" => [%{"tmdb_id" => 444, "title" => "Copper Latitude"}]})
+
+      Bypass.expect_once(bypass, "GET", "/list.json", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      list = import_list("http://localhost:#{bypass.port}/list.json")
+
+      assert {:ok, [item]} = CustomURL.fetch_items(list)
+      assert item.tmdb_id == 444
+    end
+
+    test "parses Radarr/Sonarr-style tmdbId and skips items without any tmdb id", %{
+      bypass: bypass
+    } do
+      body =
+        Jason.encode!([
+          %{"tmdbId" => 555, "title" => "Basalt Overture"},
+          %{"title" => "No Identifier Here"}
+        ])
+
+      Bypass.expect_once(bypass, "GET", "/list.json", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      list = import_list("http://localhost:#{bypass.port}/list.json")
+
+      assert {:ok, items} = CustomURL.fetch_items(list)
+      assert [%{tmdb_id: 555, title: "Basalt Overture"}] = items
+    end
+  end
+
+  describe "fetch_items/1 redirect revalidation (guard relaxed via Bypass)" do
+    setup do
+      allow_private_destinations!()
+      bypass = Bypass.open()
+      %{bypass: bypass}
+    end
+
+    test "rejects a redirect into a blocked destination instead of following it", %{
+      bypass: bypass
+    } do
+      # The origin (Bypass, on loopback) is only reachable because the guard is
+      # relaxed for this test. The scheme allowlist is *not* affected by that
+      # switch, so redirecting to a disallowed scheme proves each hop is
+      # independently revalidated rather than the guard only checking the
+      # original URL once.
+      Bypass.expect_once(bypass, "GET", "/list.json", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "ftp://blocked.invalid/data")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      list = import_list("http://localhost:#{bypass.port}/list.json")
+
+      assert {:error, reason} = CustomURL.fetch_items(list)
+      assert reason =~ "scheme"
+    end
+  end
+
+  describe "validate_url/1 SSRF guard (direct calls, default secure config)" do
+    test "rejects non-http(s) schemes" do
+      assert {:error, reason} = CustomURL.validate_url("file:///etc/passwd")
+      assert reason =~ "scheme"
+
+      assert {:error, _reason} = CustomURL.validate_url("ftp://example.com/list.json")
+    end
+
+    test "rejects a literal loopback address" do
+      assert {:error, reason} = CustomURL.validate_url("http://127.0.0.1/list.json")
+      assert reason =~ "127.0.0.1"
+
+      assert {:error, _reason} = CustomURL.validate_url("http://[::1]/list.json")
+    end
+
+    test "rejects literal RFC1918 private addresses" do
+      assert {:error, _reason} = CustomURL.validate_url("http://10.0.0.5/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://172.16.0.5/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://192.168.1.5/list.json")
+    end
+
+    test "rejects link-local addresses, including the cloud metadata IP" do
+      assert {:error, reason} = CustomURL.validate_url("http://169.254.169.254/latest/meta-data/")
+      assert reason =~ "169.254.169.254"
+
+      assert {:error, _reason} = CustomURL.validate_url("http://[fe80::1]/list.json")
+    end
+
+    test "rejects unique-local IPv6, unspecified, and broadcast addresses" do
+      assert {:error, _reason} = CustomURL.validate_url("http://[fc00::1]/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://0.0.0.0/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://255.255.255.255/list.json")
+    end
+
+    test "rejects an IPv4-mapped IPv6 loopback address" do
+      assert {:error, reason} = CustomURL.validate_url("http://[::ffff:127.0.0.1]/list.json")
+      assert reason =~ "127.0.0.1"
+    end
+
+    test "rejects a hostname that resolves to a blocked address" do
+      assert {:error, reason} = CustomURL.validate_url("http://localhost/list.json")
+      assert reason =~ "localhost"
+    end
+  end
+
+  describe "validate_url/1 with the config switch enabled" do
+    setup do
+      allow_private_destinations!()
+      :ok
+    end
+
+    test "allows private destinations once explicitly enabled" do
+      assert :ok = CustomURL.validate_url("http://127.0.0.1/list.json")
+      assert :ok = CustomURL.validate_url("http://169.254.169.254/latest/meta-data/")
+    end
+
+    test "still enforces the scheme allowlist" do
+      assert {:error, reason} = CustomURL.validate_url("file:///etc/passwd")
+      assert reason =~ "scheme"
+    end
+  end
+end

--- a/test/mydia/import_lists/provider/custom_url_test.exs
+++ b/test/mydia/import_lists/provider/custom_url_test.exs
@@ -170,6 +170,17 @@ defmodule Mydia.ImportLists.Provider.CustomURLTest do
       assert {:error, _reason} = CustomURL.validate_url("http://255.255.255.255/list.json")
     end
 
+    test "rejects benchmarking, site-local and multicast ranges" do
+      # 198.18.0.0/15 is the benchmarking range and is routed internally on
+      # some networks; fec0::/10 is deprecated site-local; ff00::/8 is IPv6
+      # multicast. None is ever a legitimate list host.
+      assert {:error, _reason} = CustomURL.validate_url("http://198.18.0.1/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://198.19.255.254/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://[fec0::1]/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://[ff02::1]/list.json")
+      assert {:error, _reason} = CustomURL.validate_url("http://224.0.0.1/list.json")
+    end
+
     test "rejects an IPv4-mapped IPv6 loopback address" do
       assert {:error, reason} = CustomURL.validate_url("http://[::ffff:127.0.0.1]/list.json")
       assert reason =~ "127.0.0.1"

--- a/test/mydia/import_lists/provider/tmdb_test.exs
+++ b/test/mydia/import_lists/provider/tmdb_test.exs
@@ -1,0 +1,372 @@
+defmodule Mydia.ImportLists.Provider.TMDBTest do
+  @moduledoc """
+  Bypass-backed tests for the TMDB import list provider.
+
+  These tests mutate the global `:mydia, :metadata_relay_url` application env
+  to point at a Bypass server, so the module runs `async: false` (see
+  `test/README.md`, "To test any path reaching `default_config/1`...").
+  """
+  use ExUnit.Case, async: false
+
+  alias Mydia.ImportLists.ImportList
+  alias Mydia.ImportLists.Provider.TMDB
+
+  setup do
+    bypass = Bypass.open()
+    previous_metadata_relay_url = Application.get_env(:mydia, :metadata_relay_url)
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      case previous_metadata_relay_url do
+        nil -> Application.delete_env(:mydia, :metadata_relay_url)
+        value -> Application.put_env(:mydia, :metadata_relay_url, value)
+      end
+    end)
+
+    %{bypass: bypass}
+  end
+
+  ## Helpers
+
+  defp import_list(type, media_type, config \\ %{}) do
+    %ImportList{
+      id: Ecto.UUID.generate(),
+      name: "Test #{type}/#{media_type}",
+      type: type,
+      media_type: media_type,
+      config: config
+    }
+  end
+
+  # A single raw TMDB result. Carries both "title"/"release_date" and
+  # "name"/"first_air_date" so the same fixture works for movie and TV
+  # endpoints alike; parse_result/2 only reads whichever pair applies.
+  defp raw_item(id) do
+    %{
+      "id" => id,
+      "title" => "Fictional Title #{id}",
+      "name" => "Fictional Title #{id}",
+      "release_date" => "2024-05-01",
+      "first_air_date" => "2024-05-01",
+      "poster_path" => "/poster#{id}.jpg"
+    }
+  end
+
+  defp page_body(results, opts \\ []) do
+    body = %{"page" => Keyword.get(opts, :page, 1), "results" => results}
+
+    case Keyword.fetch(opts, :total_pages) do
+      {:ok, total_pages} -> Map.put(body, "total_pages", total_pages)
+      :error -> body
+    end
+  end
+
+  defp list_body(items, opts \\ []) do
+    body = %{"items" => items}
+
+    case Keyword.fetch(opts, :total_pages) do
+      {:ok, total_pages} -> Map.put(body, "total_pages", total_pages)
+      :error -> body
+    end
+  end
+
+  defp json_response(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(status, Jason.encode!(body))
+  end
+
+  defp page_param(conn) do
+    conn = Plug.Conn.fetch_query_params(conn)
+    conn.query_params["page"]
+  end
+
+  defp errors_on(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+
+  ## Endpoint mapping (bug 1)
+
+  describe "fetch_items/1 - valid type/media_type endpoint mapping" do
+    @valid_pairs [
+      {"tmdb_trending", "movie", "/tmdb/movies/trending"},
+      {"tmdb_trending", "tv_show", "/tmdb/tv/trending"},
+      {"tmdb_popular", "movie", "/tmdb/movies/popular"},
+      {"tmdb_popular", "tv_show", "/tmdb/tv/popular"},
+      {"tmdb_upcoming", "movie", "/tmdb/movies/upcoming"},
+      {"tmdb_now_playing", "movie", "/tmdb/movies/now_playing"},
+      {"tmdb_on_the_air", "tv_show", "/tmdb/tv/on_the_air"},
+      {"tmdb_airing_today", "tv_show", "/tmdb/tv/airing_today"}
+    ]
+
+    test "each valid pair hits its documented endpoint", %{bypass: bypass} do
+      for {type, media_type, endpoint} <- @valid_pairs do
+        Bypass.expect_once(bypass, "GET", endpoint, fn conn ->
+          json_response(conn, 200, page_body([raw_item(1)], total_pages: 1))
+        end)
+
+        assert {:ok, [item]} = TMDB.fetch_items(import_list(type, media_type))
+        assert item.tmdb_id == 1
+        assert item.media_type == media_type
+      end
+    end
+  end
+
+  describe "fetch_items/1 - invalid type/media_type combination" do
+    @invalid_pairs [
+      {"tmdb_upcoming", "tv_show"},
+      {"tmdb_now_playing", "tv_show"},
+      {"tmdb_on_the_air", "movie"},
+      {"tmdb_airing_today", "movie"}
+    ]
+
+    test "returns a descriptive error and performs no HTTP request" do
+      # No Bypass stub is registered for this describe block. Bypass fails
+      # the owning test if any request reaches it with no matching
+      # expectation, so a passing test here also proves no HTTP call was
+      # made.
+      for {type, media_type} <- @invalid_pairs do
+        assert {:error, reason} = TMDB.fetch_items(import_list(type, media_type))
+        assert reason =~ "Invalid TMDB list type/media_type combination"
+        assert reason =~ type
+        assert reason =~ media_type
+      end
+    end
+  end
+
+  ## Pagination (bug 2) - preset endpoint path
+
+  describe "fetch_items/1 - preset endpoint pagination" do
+    test "concatenates pages and stops once a page is shorter than the previous one", %{
+      bypass: bypass
+    } do
+      Bypass.expect(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+        case page_param(conn) do
+          "1" -> json_response(conn, 200, page_body([raw_item(1), raw_item(2), raw_item(3)]))
+          "2" -> json_response(conn, 200, page_body([raw_item(4)]))
+          other -> flunk("unexpected page requested: #{inspect(other)}")
+        end
+      end)
+
+      assert {:ok, items} = TMDB.fetch_items(import_list("tmdb_trending", "movie"))
+      assert Enum.map(items, & &1.tmdb_id) == [1, 2, 3, 4]
+    end
+
+    test "stops once the response's total_pages is reached", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+        assert page_param(conn) == "1"
+        json_response(conn, 200, page_body([raw_item(1), raw_item(2)], total_pages: 1))
+      end)
+
+      assert {:ok, items} = TMDB.fetch_items(import_list("tmdb_trending", "movie"))
+      assert length(items) == 2
+    end
+
+    test "stops after an empty page", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+        case page_param(conn) do
+          "1" -> json_response(conn, 200, page_body([raw_item(1), raw_item(2)], total_pages: 5))
+          "2" -> json_response(conn, 200, page_body([], total_pages: 5))
+          other -> flunk("unexpected page requested: #{inspect(other)}")
+        end
+      end)
+
+      assert {:ok, items} = TMDB.fetch_items(import_list("tmdb_trending", "movie"))
+      assert Enum.map(items, & &1.tmdb_id) == [1, 2]
+    end
+
+    test "never requests more than the page cap", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+        case page_param(conn) do
+          page when page in ["1", "2", "3", "4", "5"] ->
+            id = String.to_integer(page)
+            json_response(conn, 200, page_body([raw_item(id), raw_item(id + 100)]))
+
+          other ->
+            flunk("unexpected page requested: #{inspect(other)}")
+        end
+      end)
+
+      assert {:ok, items} = TMDB.fetch_items(import_list("tmdb_trending", "movie"))
+      assert length(items) == 10
+    end
+
+    test "returns items gathered so far when a later page fails", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+        case page_param(conn) do
+          "1" ->
+            json_response(
+              conn,
+              200,
+              page_body([raw_item(1), raw_item(2), raw_item(3)], total_pages: 5)
+            )
+
+          "2" ->
+            Plug.Conn.resp(conn, 500, "boom")
+
+          other ->
+            flunk("unexpected page requested: #{inspect(other)}")
+        end
+      end)
+
+      assert {:ok, items} = TMDB.fetch_items(import_list("tmdb_trending", "movie"))
+      assert Enum.map(items, & &1.tmdb_id) == [1, 2, 3]
+    end
+
+    test "returns an error when the first page fails", %{bypass: bypass} do
+      # HTTP.new_request/1 configures retry: :transient, so a 500 is retried
+      # a few times by Req before this stub's caller sees the failure; use
+      # expect/4 (any number of calls) rather than expect_once/4.
+      Bypass.expect(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+        Plug.Conn.resp(conn, 500, "boom")
+      end)
+
+      assert {:error, _reason} = TMDB.fetch_items(import_list("tmdb_trending", "movie"))
+    end
+  end
+
+  ## Pagination (bug 2) - tmdb_list user-list path
+
+  describe "fetch_items/1 - tmdb_list user list" do
+    test "fetches, filters by media_type, and parses items", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/tmdb/list/4242", fn conn ->
+        items = [
+          Map.put(raw_item(1), "media_type", "movie"),
+          Map.put(raw_item(2), "media_type", "tv")
+        ]
+
+        json_response(conn, 200, list_body(items))
+      end)
+
+      list = import_list("tmdb_list", "movie", %{"list_url" => "4242"})
+
+      assert {:ok, [item]} = TMDB.fetch_items(list)
+      assert item.tmdb_id == 1
+      assert item.media_type == "movie"
+    end
+
+    test "does not request a second page when the response has no pagination metadata", %{
+      bypass: bypass
+    } do
+      Bypass.expect_once(bypass, "GET", "/tmdb/list/4242", fn conn ->
+        json_response(conn, 200, list_body([raw_item(1), raw_item(2)]))
+      end)
+
+      list = import_list("tmdb_list", "movie", %{"list_url" => "4242"})
+
+      assert {:ok, items} = TMDB.fetch_items(list)
+      assert length(items) == 2
+    end
+
+    test "paginates when the response reports total_pages", %{bypass: bypass} do
+      Bypass.expect(bypass, "GET", "/tmdb/list/4242", fn conn ->
+        case page_param(conn) do
+          "1" -> json_response(conn, 200, list_body([raw_item(1), raw_item(2)], total_pages: 2))
+          "2" -> json_response(conn, 200, list_body([raw_item(3)], total_pages: 2))
+          other -> flunk("unexpected page requested: #{inspect(other)}")
+        end
+      end)
+
+      list = import_list("tmdb_list", "movie", %{"list_url" => "4242"})
+
+      assert {:ok, items} = TMDB.fetch_items(list)
+      assert Enum.map(items, & &1.tmdb_id) == [1, 2, 3]
+    end
+
+    test "returns a not-found error for an unknown list id", %{bypass: bypass} do
+      Bypass.expect_once(bypass, "GET", "/tmdb/list/9999", fn conn ->
+        Plug.Conn.resp(conn, 404, "")
+      end)
+
+      list = import_list("tmdb_list", "movie", %{"list_url" => "9999"})
+
+      assert {:error, reason} = TMDB.fetch_items(list)
+      assert reason =~ "not found"
+    end
+
+    test "returns an error when no list ID is configured" do
+      list = import_list("tmdb_list", "movie", %{})
+
+      assert {:error, "No list ID configured"} = TMDB.fetch_items(list)
+    end
+  end
+
+  ## Changeset validation (bug 1, storage layer)
+
+  describe "changeset/2 - media_type/type compatibility" do
+    @movie_only ~w(tmdb_upcoming tmdb_now_playing)
+    @tv_only ~w(tmdb_on_the_air tmdb_airing_today)
+    @both_types ~w(tmdb_trending tmdb_popular)
+
+    test "rejects a movie-only type paired with tv_show" do
+      for type <- @movie_only do
+        changeset =
+          ImportList.changeset(%ImportList{}, %{name: "Test", type: type, media_type: "tv_show"})
+
+        refute changeset.valid?
+        assert Enum.any?(errors_on(changeset).media_type, &(&1 =~ "is not supported"))
+      end
+    end
+
+    test "rejects a tv-only type paired with movie" do
+      for type <- @tv_only do
+        changeset =
+          ImportList.changeset(%ImportList{}, %{name: "Test", type: type, media_type: "movie"})
+
+        refute changeset.valid?
+        assert Enum.any?(errors_on(changeset).media_type, &(&1 =~ "is not supported"))
+      end
+    end
+
+    test "accepts a movie-only type paired with movie" do
+      for type <- @movie_only do
+        changeset =
+          ImportList.changeset(%ImportList{}, %{name: "Test", type: type, media_type: "movie"})
+
+        assert changeset.valid?
+      end
+    end
+
+    test "accepts a tv-only type paired with tv_show" do
+      for type <- @tv_only do
+        changeset =
+          ImportList.changeset(%ImportList{}, %{name: "Test", type: type, media_type: "tv_show"})
+
+        assert changeset.valid?
+      end
+    end
+
+    test "accepts types compatible with both media types, for both media types" do
+      for type <- @both_types, media_type <- ~w(movie tv_show) do
+        changeset =
+          ImportList.changeset(%ImportList{}, %{name: "Test", type: type, media_type: media_type})
+
+        assert changeset.valid?
+      end
+    end
+
+    test "compatible_media_types/1 and supports_media_type?/2 agree with the changeset rule" do
+      for type <- @movie_only do
+        assert ImportList.compatible_media_types(type) == ["movie"]
+        assert ImportList.supports_media_type?(type, "movie")
+        refute ImportList.supports_media_type?(type, "tv_show")
+      end
+
+      for type <- @tv_only do
+        assert ImportList.compatible_media_types(type) == ["tv_show"]
+        assert ImportList.supports_media_type?(type, "tv_show")
+        refute ImportList.supports_media_type?(type, "movie")
+      end
+
+      for type <- @both_types do
+        assert ImportList.compatible_media_types(type) == ["movie", "tv_show"]
+        assert ImportList.supports_media_type?(type, "movie")
+        assert ImportList.supports_media_type?(type, "tv_show")
+      end
+    end
+  end
+end

--- a/test/mydia/import_lists_test.exs
+++ b/test/mydia/import_lists_test.exs
@@ -272,16 +272,89 @@ defmodule Mydia.ImportListsTest do
       assert item.status == "pending"
     end
 
-    test "upsert_import_list_item/1 updates existing item", %{import_list: import_list} do
+    test "upsert_import_list_item/1 reports :created for a brand new item", %{
+      import_list: import_list
+    } do
+      attrs = Map.put(@valid_item_attrs, :import_list_id, import_list.id)
+
+      assert {:ok, %ImportListItem{} = item, :created} =
+               ImportLists.upsert_import_list_item(attrs)
+
+      assert item.tmdb_id == 123
+      assert item.title == "Test Movie"
+    end
+
+    test "upsert_import_list_item/1 updates existing item and reports :updated", %{
+      import_list: import_list
+    } do
       attrs = Map.put(@valid_item_attrs, :import_list_id, import_list.id)
       {:ok, original} = ImportLists.create_import_list_item(attrs)
 
       updated_attrs = Map.merge(attrs, %{title: "Updated Title", year: 2025})
-      {:ok, updated} = ImportLists.upsert_import_list_item(updated_attrs)
+
+      assert {:ok, updated, :updated} = ImportLists.upsert_import_list_item(updated_attrs)
 
       assert updated.id == original.id
       assert updated.title == "Updated Title"
       assert updated.year == 2025
+    end
+
+    test "upsert_import_list_item/1 only refreshes cached display fields on conflict, not status, skip_reason, media_item_id or discovered_at",
+         %{import_list: import_list} do
+      {:ok, media_item} =
+        Mydia.Media.create_media_item(%{type: "movie", title: "Already Added Movie", year: 2024})
+
+      original_discovered_at = ~U[2024-01-01 00:00:00Z]
+
+      attrs =
+        Map.merge(@valid_item_attrs, %{
+          import_list_id: import_list.id,
+          discovered_at: original_discovered_at
+        })
+
+      {:ok, item} = ImportLists.create_import_list_item(attrs)
+      {:ok, item} = ImportLists.mark_item_added(item, media_item.id)
+
+      # A later sync re-discovering the same item must not clobber the
+      # status, the link, or the original discovery time, only the cached
+      # display fields.
+      resync_attrs =
+        Map.merge(attrs, %{
+          title: "Refreshed Title",
+          year: 2030,
+          poster_path: "/refreshed.jpg",
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:ok, updated, :updated} = ImportLists.upsert_import_list_item(resync_attrs)
+
+      assert updated.id == item.id
+      assert updated.title == "Refreshed Title"
+      assert updated.year == 2030
+      assert updated.poster_path == "/refreshed.jpg"
+      assert updated.status == "added"
+      assert updated.skip_reason == nil
+      assert updated.media_item_id == media_item.id
+      assert updated.discovered_at == original_discovered_at
+    end
+
+    test "upsert_import_list_item/1 never returns a unique-constraint error for the same key twice",
+         %{import_list: import_list} do
+      # The old implementation did a plain Repo.one lookup followed by a
+      # separate insert or update; two callers racing the same
+      # (import_list_id, tmdb_id) pair with no existing row yet could both
+      # see `nil` and both attempt to insert, and the loser got back
+      # {:error, changeset} from the unique constraint, which
+      # process_items/2 silently dropped. The atomic on_conflict upsert has
+      # no such window: every call for the same key succeeds and only one
+      # row ever exists, insert or not.
+      attrs = Map.put(@valid_item_attrs, :import_list_id, import_list.id)
+
+      assert {:ok, _item, :created} = ImportLists.upsert_import_list_item(attrs)
+      assert {:ok, _item, :updated} = ImportLists.upsert_import_list_item(attrs)
+      assert {:ok, _item, :updated} = ImportLists.upsert_import_list_item(attrs)
+
+      assert ImportLists.count_import_list_items(import_list) == 1
     end
 
     test "mark_item_added/2 updates status to added", %{import_list: import_list} do
@@ -530,6 +603,195 @@ defmodule Mydia.ImportListsTest do
       assert updated.sync_error == "Connection failed"
     end
 
+    test "mark_sync_error/2 records the failure time and increments the consecutive failure count" do
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie"
+        })
+
+      {:ok, once} = ImportLists.mark_sync_error(list, "Connection failed")
+      assert once.config["consecutive_failures"] == 1
+      assert is_binary(once.config["last_failed_at"])
+
+      {:ok, twice} = ImportLists.mark_sync_error(once, "Connection failed again")
+      assert twice.config["consecutive_failures"] == 2
+    end
+
+    test "mark_sync_success/1 resets the consecutive failure count" do
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie"
+        })
+
+      {:ok, failed} = ImportLists.mark_sync_error(list, "Connection failed")
+      assert failed.config["consecutive_failures"] == 1
+
+      {:ok, recovered} = ImportLists.mark_sync_success(failed)
+
+      refute Map.has_key?(recovered.config, "consecutive_failures")
+      refute Map.has_key?(recovered.config, "last_failed_at")
+    end
+
+    test "mark_sync_error/2 preserves other config keys such as list_url" do
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "custom_url",
+          media_type: "movie",
+          list_url: "https://example.com/feed.json"
+        })
+
+      assert list.config["list_url"] == "https://example.com/feed.json"
+
+      {:ok, failed} = ImportLists.mark_sync_error(list, "Connection failed")
+
+      assert failed.config["list_url"] == "https://example.com/feed.json"
+      assert failed.config["consecutive_failures"] == 1
+    end
+
+    test "sync_due?/1 is not immediately due again right after a failure, even for a list that has never synced" do
+      # This is the exact scenario from the bug report: a misconfigured
+      # list's very first sync fails. last_synced_at is only ever set by
+      # mark_sync_success/1, so it stays nil forever, and before this fix
+      # sync_due?/1's `last_synced_at: nil -> true` clause fired
+      # unconditionally, ignoring the failure and every future one. A cron
+      # tick every 15 minutes would re-enqueue this list forever.
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie",
+          enabled: true,
+          sync_interval: 60
+        })
+
+      {:ok, failed} = ImportLists.mark_sync_error(list, "boom")
+
+      refute failed.last_synced_at
+      refute ImportLists.sync_due?(failed)
+    end
+
+    test "sync_due?/1 is due again once the backoff delay from the first failure elapses" do
+      old_failure = DateTime.add(DateTime.utc_now(), -70, :minute)
+
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie",
+          enabled: true,
+          sync_interval: 60,
+          config: %{
+            "consecutive_failures" => 1,
+            "last_failed_at" => DateTime.to_iso8601(old_failure)
+          }
+        })
+
+      # One failure delays by exactly one interval (60 min); 70 min have passed.
+      assert ImportLists.sync_due?(list)
+    end
+
+    test "sync_due?/1 is not yet due before the backoff delay from the first failure elapses" do
+      recent_failure = DateTime.add(DateTime.utc_now(), -10, :minute)
+
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie",
+          enabled: true,
+          sync_interval: 60,
+          config: %{
+            "consecutive_failures" => 1,
+            "last_failed_at" => DateTime.to_iso8601(recent_failure)
+          }
+        })
+
+      refute ImportLists.sync_due?(list)
+    end
+
+    test "sync_due?/1 doubles the delay for each additional consecutive failure" do
+      # Two failures => 2x the interval (120 min). 90 minutes ago is past the
+      # plain interval but still within the doubled delay.
+      ninety_minutes_ago = DateTime.add(DateTime.utc_now(), -90, :minute)
+
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie",
+          enabled: true,
+          sync_interval: 60,
+          config: %{
+            "consecutive_failures" => 2,
+            "last_failed_at" => DateTime.to_iso8601(ninety_minutes_ago)
+          }
+        })
+
+      refute ImportLists.sync_due?(list)
+    end
+
+    test "sync_due?/1 caps the backoff delay at 24 hours no matter how many failures" do
+      within_cap = DateTime.add(DateTime.utc_now(), -23, :hour)
+      beyond_cap = DateTime.add(DateTime.utc_now(), -25, :hour)
+
+      {:ok, still_backing_off} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie",
+          enabled: true,
+          sync_interval: 60,
+          config: %{
+            "consecutive_failures" => 10,
+            "last_failed_at" => DateTime.to_iso8601(within_cap)
+          }
+        })
+
+      refute ImportLists.sync_due?(still_backing_off)
+
+      {:ok, past_cap} =
+        ImportLists.create_import_list(%{
+          name: "Test 2",
+          type: "tmdb_popular",
+          media_type: "movie",
+          enabled: true,
+          sync_interval: 60,
+          config: %{
+            "consecutive_failures" => 10,
+            "last_failed_at" => DateTime.to_iso8601(beyond_cap)
+          }
+        })
+
+      assert ImportLists.sync_due?(past_cap)
+    end
+
+    test "sync_due?/1 survives a failure count large enough to overflow the backoff exponent" do
+      # 2 ** 1024 overflows a float and raises ArithmeticError. A list that
+      # keeps failing accrues about one failure a day once the 24h cap is
+      # reached, and list_sync_due_lists/0 runs every list through sync_due?/1,
+      # so an unclamped exponent would eventually stop syncing for every list.
+      {:ok, absurdly_failed} =
+        ImportLists.create_import_list(%{
+          name: "Test",
+          type: "tmdb_trending",
+          media_type: "movie",
+          enabled: true,
+          sync_interval: 360,
+          config: %{
+            "consecutive_failures" => 5000,
+            "last_failed_at" => DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), -25, :hour))
+          }
+        })
+
+      assert ImportLists.sync_due?(absurdly_failed)
+      assert ImportLists.list_sync_due_lists() != []
+    end
+
     test "list_sync_due_lists/0 returns only enabled lists due for sync" do
       # Create enabled list that needs sync (never synced)
       {:ok, due_list} =
@@ -562,6 +824,392 @@ defmodule Mydia.ImportListsTest do
       due_lists = ImportLists.list_sync_due_lists()
       assert length(due_lists) == 1
       assert hd(due_lists).id == due_list.id
+    end
+  end
+
+  describe "check_duplicate/2" do
+    test "matches an existing media item by tmdb_id" do
+      {:ok, media_item} =
+        Mydia.Media.create_media_item(%{
+          type: "movie",
+          title: "Nebula Drift",
+          year: 2022,
+          tmdb_id: 555
+        })
+
+      assert {:duplicate, ^media_item} = ImportLists.check_duplicate(555, "movie")
+    end
+
+    test "returns :not_found when nothing matches and no title/year fallback is given" do
+      assert :not_found = ImportLists.check_duplicate(9999, "movie")
+    end
+
+    test "falls back to a normalised title+year match when the tmdb_id lookup misses" do
+      {:ok, media_item} =
+        Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      assert {:duplicate, ^media_item} =
+               ImportLists.check_duplicate(12_345, "movie", "  SILVERBACK STATION  ", 2019)
+    end
+
+    test "does not fall back when year is nil, even with a matching title" do
+      Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      assert :not_found = ImportLists.check_duplicate(12_345, "movie", "Silverback Station", nil)
+    end
+
+    test "does not fall back when title is nil, even with a matching year" do
+      Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      assert :not_found = ImportLists.check_duplicate(12_345, "movie", nil, 2019)
+    end
+
+    test "the title+year fallback ignores a row that already has a different tmdb_id" do
+      # A row with its own tmdb_id is a genuinely different item, not a
+      # scan-time match waiting to be linked, even if the title and year
+      # happen to coincide.
+      Mydia.Media.create_media_item(%{
+        type: "movie",
+        title: "Silverback Station",
+        year: 2019,
+        tmdb_id: 111
+      })
+
+      assert :not_found =
+               ImportLists.check_duplicate(12_345, "movie", "Silverback Station", 2019)
+    end
+
+    test "the title+year fallback requires an exact year match" do
+      Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      assert :not_found =
+               ImportLists.check_duplicate(12_345, "movie", "Silverback Station", 2020)
+    end
+
+    test "the title+year fallback respects media type" do
+      # skip_episode_refresh: true avoids Mydia.Media's post-insert TVDB
+      # lookup for a tv_show with no provider id, which would otherwise
+      # reach the network in this test.
+      Mydia.Media.create_media_item(
+        %{type: "tv_show", title: "Silverback Station", year: 2019},
+        skip_episode_refresh: true
+      )
+
+      assert :not_found =
+               ImportLists.check_duplicate(12_345, "movie", "Silverback Station", 2019)
+    end
+  end
+
+  describe "add_item_to_library/2" do
+    setup do
+      {:ok, import_list} =
+        ImportLists.create_import_list(%{
+          name: "Test List",
+          type: "tmdb_trending",
+          media_type: "movie"
+        })
+
+      %{import_list: import_list}
+    end
+
+    test "links a duplicate to the existing media item in a single write", %{
+      import_list: import_list
+    } do
+      {:ok, media_item} =
+        Mydia.Media.create_media_item(%{
+          type: "movie",
+          title: "Nebula Drift",
+          year: 2022,
+          tmdb_id: 777
+        })
+
+      {:ok, item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 777,
+          title: "Nebula Drift",
+          year: 2022,
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:ok, ^media_item} = ImportLists.add_item_to_library(item, import_list)
+
+      reloaded = ImportLists.get_import_list_item!(item.id)
+      assert reloaded.status == "added"
+      assert reloaded.media_item_id == media_item.id
+      # The wasted intermediate skip write (and its stale reason) must not
+      # survive: the final row is honestly "added", not "skipped".
+      assert reloaded.skip_reason == nil
+    end
+
+    test "links a duplicate found only via the title+year fallback", %{import_list: import_list} do
+      {:ok, media_item} =
+        Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      {:ok, item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 9001,
+          title: "Silverback Station",
+          year: 2019,
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:ok, ^media_item} = ImportLists.add_item_to_library(item, import_list)
+    end
+
+    test "creates a new media item from relay metadata when nothing matches", %{
+      import_list: import_list
+    } do
+      bypass = Bypass.open()
+      previous_url = Application.get_env(:mydia, :metadata_relay_url)
+      Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+      on_exit(fn ->
+        case previous_url do
+          nil -> Application.delete_env(:mydia, :metadata_relay_url)
+          value -> Application.put_env(:mydia, :metadata_relay_url, value)
+        end
+      end)
+
+      tmdb_id = 424_242
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        body = %{
+          "id" => tmdb_id,
+          "title" => "Halcyon Fields",
+          "release_date" => "2024-03-15",
+          "credits" => %{"cast" => [], "crew" => []},
+          "external_ids" => %{"imdb_id" => "tt9999999"}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      {:ok, item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: tmdb_id,
+          title: "Halcyon Fields",
+          year: 2024,
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:ok, media_item} = ImportLists.add_item_to_library(item, import_list)
+      assert media_item.title == "Halcyon Fields"
+
+      reloaded = ImportLists.get_import_list_item!(item.id)
+      assert reloaded.status == "added"
+      assert reloaded.media_item_id == media_item.id
+    end
+
+    test "marks the item failed when the metadata fetch fails", %{import_list: import_list} do
+      bypass = Bypass.open()
+      previous_url = Application.get_env(:mydia, :metadata_relay_url)
+      Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+      on_exit(fn ->
+        case previous_url do
+          nil -> Application.delete_env(:mydia, :metadata_relay_url)
+          value -> Application.put_env(:mydia, :metadata_relay_url, value)
+        end
+      end)
+
+      tmdb_id = 424_243
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        Plug.Conn.resp(conn, 404, Jason.encode!(%{"error" => "not found"}))
+      end)
+
+      {:ok, item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: tmdb_id,
+          title: "Missing Movie",
+          year: 2024,
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:error, _reason} = ImportLists.add_item_to_library(item, import_list)
+
+      reloaded = ImportLists.get_import_list_item!(item.id)
+      assert reloaded.status == "failed"
+    end
+  end
+
+  describe "add_all_pending_to_library/1" do
+    test "reports duplicates as added and totals stats across pending items" do
+      {:ok, import_list} =
+        ImportLists.create_import_list(%{
+          name: "Test List",
+          type: "tmdb_trending",
+          media_type: "movie"
+        })
+
+      {:ok, _media_item} =
+        Mydia.Media.create_media_item(%{
+          type: "movie",
+          title: "Nebula Drift",
+          year: 2022,
+          tmdb_id: 777
+        })
+
+      {:ok, _duplicate_item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 777,
+          title: "Nebula Drift",
+          year: 2022,
+          discovered_at: DateTime.utc_now()
+        })
+
+      bypass = Bypass.open()
+      previous_url = Application.get_env(:mydia, :metadata_relay_url)
+      Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+      on_exit(fn ->
+        case previous_url do
+          nil -> Application.delete_env(:mydia, :metadata_relay_url)
+          value -> Application.put_env(:mydia, :metadata_relay_url, value)
+        end
+      end)
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/424244", fn conn ->
+        body = %{
+          "id" => 424_244,
+          "title" => "Halcyon Fields",
+          "release_date" => "2024-03-15",
+          "credits" => %{"cast" => [], "crew" => []}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      {:ok, _new_item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 424_244,
+          title: "Halcyon Fields",
+          year: 2024,
+          discovered_at: DateTime.utc_now()
+        })
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/424245", fn conn ->
+        Plug.Conn.resp(conn, 404, Jason.encode!(%{"error" => "not found"}))
+      end)
+
+      {:ok, _failed_item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 424_245,
+          title: "Missing Movie",
+          year: 2024,
+          discovered_at: DateTime.utc_now()
+        })
+
+      stats = ImportLists.add_all_pending_to_library(import_list)
+
+      assert stats.added == 2
+      assert stats.skipped == 0
+      assert stats.failed == 1
+    end
+  end
+
+  describe "mark_existing_items_in_library/1" do
+    test "marks pending items already in the library as skipped and links them" do
+      {:ok, import_list} =
+        ImportLists.create_import_list(%{
+          name: "Test List",
+          type: "tmdb_trending",
+          media_type: "movie"
+        })
+
+      {:ok, media_item} =
+        Mydia.Media.create_media_item(%{
+          type: "movie",
+          title: "Nebula Drift",
+          year: 2022,
+          tmdb_id: 777
+        })
+
+      {:ok, matching_item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 777,
+          title: "Nebula Drift",
+          year: 2022,
+          discovered_at: DateTime.utc_now()
+        })
+
+      {:ok, unmatched_item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 778,
+          title: "Something Else",
+          year: 2023,
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:ok, 1} = ImportLists.mark_existing_items_in_library(import_list)
+
+      reloaded_matching = ImportLists.get_import_list_item!(matching_item.id)
+      assert reloaded_matching.status == "skipped"
+      assert reloaded_matching.skip_reason == "Already in library"
+      assert reloaded_matching.media_item_id == media_item.id
+
+      reloaded_unmatched = ImportLists.get_import_list_item!(unmatched_item.id)
+      assert reloaded_unmatched.status == "pending"
+    end
+
+    test "matches via the title+year fallback for library items with no tmdb_id" do
+      {:ok, import_list} =
+        ImportLists.create_import_list(%{
+          name: "Test List",
+          type: "tmdb_trending",
+          media_type: "movie"
+        })
+
+      {:ok, media_item} =
+        Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      {:ok, item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 9001,
+          title: "Silverback Station",
+          year: 2019,
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:ok, 1} = ImportLists.mark_existing_items_in_library(import_list)
+
+      reloaded = ImportLists.get_import_list_item!(item.id)
+      assert reloaded.status == "skipped"
+      assert reloaded.media_item_id == media_item.id
+    end
+
+    test "returns 0 when no pending items match the library" do
+      {:ok, import_list} =
+        ImportLists.create_import_list(%{
+          name: "Test List",
+          type: "tmdb_trending",
+          media_type: "movie"
+        })
+
+      {:ok, _item} =
+        ImportLists.create_import_list_item(%{
+          import_list_id: import_list.id,
+          tmdb_id: 42,
+          title: "Nothing Matches",
+          year: 2025,
+          discovered_at: DateTime.utc_now()
+        })
+
+      assert {:ok, 0} = ImportLists.mark_existing_items_in_library(import_list)
     end
   end
 end

--- a/test/mydia/import_lists_test.exs
+++ b/test/mydia/import_lists_test.exs
@@ -1,5 +1,9 @@
 defmodule Mydia.ImportListsTest do
-  use Mydia.DataCase, async: true
+  # async: false because the metadata-relay tests below point
+  # :mydia, :metadata_relay_url at a Bypass port, which is global application
+  # env. DataCase forces async: false on SQLite anyway, so running async here
+  # only ever leaked on PostgreSQL. See test/README.md.
+  use Mydia.DataCase, async: false
 
   alias Mydia.ImportLists
   alias Mydia.ImportLists.{ImportList, ImportListItem}
@@ -850,6 +854,27 @@ defmodule Mydia.ImportListsTest do
 
       assert {:duplicate, ^media_item} =
                ImportLists.check_duplicate(12_345, "movie", "  SILVERBACK STATION  ", 2019)
+    end
+
+    test "the title+year fallback picks one row when the library holds duplicates" do
+      # Uniqueness is enforced on tmdb_id and tvdb_id, and NULLs do not
+      # collide, so two scanned copies of one title can both sit here. This
+      # used to raise Ecto.MultipleResultsError and take the sync job down.
+      {:ok, first} =
+        Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      {:ok, second} =
+        Mydia.Media.create_media_item(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      assert {:duplicate, matched} =
+               ImportLists.check_duplicate(12_345, "movie", "Silverback Station", 2019)
+
+      assert matched.id in [first.id, second.id]
+
+      # The id is a UUID, so ordering by it is not insertion order, but it is
+      # stable: the same call must keep returning the same row.
+      assert {:duplicate, ^matched} =
+               ImportLists.check_duplicate(12_345, "movie", "Silverback Station", 2019)
     end
 
     test "does not fall back when year is nil, even with a matching title" do

--- a/test/mydia/jobs/import_list_auto_add_test.exs
+++ b/test/mydia/jobs/import_list_auto_add_test.exs
@@ -1,0 +1,207 @@
+defmodule Mydia.Jobs.ImportListAutoAddTest do
+  @moduledoc """
+  Covers `Mydia.Jobs.ImportListAutoAdd`, previously untested.
+
+  Oban is not started in the test environment, so `perform/1` is called
+  directly with a hand-built `%Oban.Job{}`, matching the pattern in
+  `import_list_sync_test.exs` and `test/mydia/jobs/import_run_job_test.exs`.
+
+  Network isolation follows `test/mydia/jobs/metadata_refresh_test.exs`:
+  `Application.put_env(:mydia, :metadata_relay_url, ...)` points the relay
+  client at a local Bypass server, so this is `async: false` for the same
+  reason that module is (mutating global config). Tests that only exercise
+  the already-in-library branch never reach the network at all, since
+  `check_duplicate/4`'s tmdb_id/title/year matching short-circuits before
+  any metadata fetch.
+  """
+
+  use Mydia.DataCase, async: false
+
+  alias Mydia.ImportLists
+  alias Mydia.Jobs.ImportListAutoAdd
+
+  import Mydia.MediaFixtures
+
+  defp job(args) do
+    %Oban.Job{args: args, attempt: 1, max_attempts: 3}
+  end
+
+  defp movie_list(attrs \\ %{}) do
+    {:ok, list} =
+      %{name: "Test List", type: "tmdb_trending", media_type: "movie", enabled: true}
+      |> Map.merge(attrs)
+      |> ImportLists.create_import_list()
+
+    list
+  end
+
+  defp pending_item(list, attrs) do
+    {:ok, item} =
+      %{import_list_id: list.id, discovered_at: DateTime.utc_now()}
+      |> Map.merge(attrs)
+      |> ImportLists.create_import_list_item()
+
+    item
+  end
+
+  defp point_relay_at(bypass) do
+    previous_url = Application.get_env(:mydia, :metadata_relay_url)
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      case previous_url do
+        nil -> Application.delete_env(:mydia, :metadata_relay_url)
+        value -> Application.put_env(:mydia, :metadata_relay_url, value)
+      end
+    end)
+  end
+
+  describe "perform/1" do
+    test "returns :ok without error when the import list no longer exists" do
+      assert :ok = ImportListAutoAdd.perform(job(%{"import_list_id" => Ecto.UUID.generate()}))
+    end
+
+    test "returns :ok and does nothing when there are no pending items" do
+      list = movie_list()
+
+      assert :ok = ImportListAutoAdd.perform(job(%{"import_list_id" => list.id}))
+    end
+
+    test "an item already in the library (matched by tmdb_id) is linked in a single write, never hits the network" do
+      list = movie_list()
+
+      media_item =
+        media_item_fixture(%{type: "movie", title: "Nebula Drift", year: 2022, tmdb_id: 777})
+
+      item = pending_item(list, %{tmdb_id: 777, title: "Nebula Drift", year: 2022})
+
+      # No Bypass/relay override configured at all: if this reached the
+      # network it would either fail to connect or hit RelayGuard's escape
+      # tracker (see test/test_helper.exs), not silently succeed.
+      assert :ok = ImportListAutoAdd.perform(job(%{"import_list_id" => list.id}))
+
+      reloaded = ImportLists.get_import_list_item!(item.id)
+      assert reloaded.status == "added"
+      assert reloaded.media_item_id == media_item.id
+      # The wasted intermediate skip write must be gone: mark_item_skipped/2
+      # followed immediately by mark_item_added/2 always ended up "added"
+      # anyway, so the row is honestly added, not "skipped" with the write
+      # thrown away.
+      assert reloaded.skip_reason == nil
+    end
+
+    test "an item already in the library matched only via the title+year fallback is linked" do
+      list = movie_list()
+
+      media_item =
+        media_item_fixture(%{type: "movie", title: "Silverback Station", year: 2019})
+
+      # No tmdb_id on the library row (e.g. it came from a filesystem scan),
+      # so only the title+year fallback in check_duplicate/4 can find it.
+      item = pending_item(list, %{tmdb_id: 9001, title: "Silverback Station", year: 2019})
+
+      assert :ok = ImportListAutoAdd.perform(job(%{"import_list_id" => list.id}))
+
+      reloaded = ImportLists.get_import_list_item!(item.id)
+      assert reloaded.status == "added"
+      assert reloaded.media_item_id == media_item.id
+    end
+
+    test "creates a new media item from relay metadata when nothing matches" do
+      bypass = Bypass.open()
+      point_relay_at(bypass)
+
+      list = movie_list()
+      tmdb_id = 424_242
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/#{tmdb_id}", fn conn ->
+        body = %{
+          "id" => tmdb_id,
+          "title" => "Halcyon Fields",
+          "release_date" => "2024-03-15",
+          "credits" => %{"cast" => [], "crew" => []},
+          "external_ids" => %{"imdb_id" => "tt9999999"}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      item = pending_item(list, %{tmdb_id: tmdb_id, title: "Halcyon Fields", year: 2024})
+
+      assert :ok = ImportListAutoAdd.perform(job(%{"import_list_id" => list.id}))
+
+      reloaded = ImportLists.get_import_list_item!(item.id)
+      assert reloaded.status == "added"
+      refute is_nil(reloaded.media_item_id)
+
+      media_item = Mydia.Media.get_media_item!(reloaded.media_item_id)
+      assert media_item.title == "Halcyon Fields"
+    end
+
+    test "marks the item failed when the metadata fetch fails, and keeps processing the rest" do
+      bypass = Bypass.open()
+      point_relay_at(bypass)
+
+      list = movie_list()
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/424243", fn conn ->
+        Plug.Conn.resp(conn, 404, Jason.encode!(%{"error" => "not found"}))
+      end)
+
+      Bypass.stub(bypass, "GET", "/tmdb/movies/424244", fn conn ->
+        body = %{
+          "id" => 424_244,
+          "title" => "Working Item",
+          "release_date" => "2024-01-01",
+          "credits" => %{"cast" => [], "crew" => []}
+        }
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(body))
+      end)
+
+      failing = pending_item(list, %{tmdb_id: 424_243, title: "Missing Movie", year: 2024})
+      working = pending_item(list, %{tmdb_id: 424_244, title: "Working Item", year: 2024})
+
+      assert :ok = ImportListAutoAdd.perform(job(%{"import_list_id" => list.id}))
+
+      reloaded_failing = ImportLists.get_import_list_item!(failing.id)
+      assert reloaded_failing.status == "failed"
+
+      reloaded_working = ImportLists.get_import_list_item!(working.id)
+      assert reloaded_working.status == "added"
+    end
+
+    test "only processes pending items, leaving already-added or skipped items alone" do
+      list = movie_list()
+
+      already_added_media = media_item_fixture(%{type: "movie", title: "Old News", year: 2020})
+
+      already_added =
+        pending_item(list, %{
+          tmdb_id: 1,
+          title: "Old News",
+          year: 2020,
+          status: "added",
+          media_item_id: already_added_media.id
+        })
+
+      already_skipped =
+        pending_item(list, %{
+          tmdb_id: 2,
+          title: "Ignored",
+          year: 2021,
+          status: "skipped",
+          skip_reason: "manual"
+        })
+
+      assert :ok = ImportListAutoAdd.perform(job(%{"import_list_id" => list.id}))
+
+      assert ImportLists.get_import_list_item!(already_added.id).status == "added"
+      assert ImportLists.get_import_list_item!(already_skipped.id).status == "skipped"
+    end
+  end
+end

--- a/test/mydia/jobs/import_list_sync_test.exs
+++ b/test/mydia/jobs/import_list_sync_test.exs
@@ -1,0 +1,243 @@
+defmodule Mydia.Jobs.ImportListSyncTest do
+  @moduledoc """
+  Covers `Mydia.Jobs.ImportListSync`, previously untested.
+
+  Oban is not started in the test environment (`config :mydia, Oban,
+  testing: :manual, engine: false, queues: false, plugins: false`), so
+  `perform/1` is called directly with a hand-built `%Oban.Job{}` rather than
+  through `Oban.Testing`'s `perform_job/2` helper (this project's other job
+  tests follow the same pattern, see e.g.
+  `test/mydia/jobs/import_run_job_test.exs`).
+
+  `auto_add` is left `false` on every fixture list here deliberately: when
+  true, `perform/1` calls `Mydia.Jobs.ImportListAutoAdd.enqueue/1`, which
+  calls `Oban.insert/1` directly. With no Oban supervisor running in test,
+  that raises `RuntimeError` (see `Oban.Registry.config/1`), so exercising
+  that branch would crash the test rather than exercise anything meaningful.
+  The auto-add worker itself is covered independently in
+  `import_list_auto_add_test.exs`.
+
+  A `tmdb_trending` list (the TMDB provider) is used throughout rather than
+  `custom_url`: `Mydia.ImportLists.Provider.CustomURL` fetches from a
+  caller-supplied URL and rejects loopback/private addresses by default (an
+  SSRF guard, see `import_lists_allow_private_destinations` in
+  `test/mydia/import_lists/provider/custom_url_test.exs`), which is exactly
+  what Bypass binds to. The TMDB provider instead goes through the
+  metadata-relay client, which has no such guard and is the same seam
+  `test/mydia/jobs/metadata_refresh_test.exs` already points at Bypass via
+  `Application.put_env(:mydia, :metadata_relay_url, ...)`.
+
+  `async: false` for the same reason as that module: overriding
+  `:metadata_relay_url` mutates global application config.
+  """
+
+  use Mydia.DataCase, async: false
+
+  alias Mydia.ImportLists
+  alias Mydia.Jobs.ImportListSync
+
+  defp job(args) do
+    %Oban.Job{args: args, attempt: 1, max_attempts: 3}
+  end
+
+  defp tmdb_trending_list(bypass, attrs \\ %{}) do
+    previous_url = Application.get_env(:mydia, :metadata_relay_url)
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+
+    on_exit(fn ->
+      case previous_url do
+        nil -> Application.delete_env(:mydia, :metadata_relay_url)
+        value -> Application.put_env(:mydia, :metadata_relay_url, value)
+      end
+    end)
+
+    {:ok, list} =
+      %{
+        name: "Trending Movies",
+        type: "tmdb_trending",
+        media_type: "movie",
+        enabled: true
+      }
+      |> Map.merge(attrs)
+      |> ImportLists.create_import_list()
+
+    list
+  end
+
+  defp stub_trending(bypass, results) do
+    Bypass.stub(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+      body = %{
+        "page" => 1,
+        "total_pages" => 1,
+        "total_results" => length(results),
+        "results" => results
+      }
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  defp stub_trending_error(bypass, status) do
+    Bypass.stub(bypass, "GET", "/tmdb/movies/trending", fn conn ->
+      Plug.Conn.resp(conn, status, Jason.encode!(%{"error" => "boom"}))
+    end)
+  end
+
+  describe "perform/1" do
+    test "returns :ok without error when the import list no longer exists" do
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => Ecto.UUID.generate()}))
+    end
+
+    test "returns :ok and touches nothing for a disabled list" do
+      {:ok, list} =
+        ImportLists.create_import_list(%{
+          name: "Disabled List",
+          type: "tmdb_trending",
+          media_type: "movie",
+          enabled: false
+        })
+
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      reloaded = ImportLists.get_import_list!(list.id)
+      assert reloaded.last_synced_at == nil
+      assert reloaded.sync_error == nil
+      assert ImportLists.list_import_list_items(reloaded) == []
+    end
+
+    test "fetches items, creates them as pending, and marks the sync successful" do
+      bypass = Bypass.open()
+      list = tmdb_trending_list(bypass)
+
+      stub_trending(bypass, [
+        %{"id" => 111, "title" => "Aurora Rising", "release_date" => "2023-05-01"},
+        %{"id" => 222, "title" => "Glass Horizon", "release_date" => "2021-11-20"}
+      ])
+
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      reloaded = ImportLists.get_import_list!(list.id)
+      assert reloaded.last_synced_at != nil
+      assert reloaded.sync_error == nil
+
+      items = ImportLists.list_import_list_items(reloaded)
+      assert length(items) == 2
+      assert Enum.all?(items, &(&1.status == "pending"))
+    end
+
+    test "broadcasts new-item stats on the first sync and updated-item stats on a re-sync" do
+      bypass = Bypass.open()
+      list = tmdb_trending_list(bypass)
+
+      stub_trending(bypass, [
+        %{"id" => 111, "title" => "Aurora Rising", "release_date" => "2023-05-01"},
+        %{"id" => 222, "title" => "Glass Horizon", "release_date" => "2021-11-20"}
+      ])
+
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "import_lists")
+
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      assert_receive {:import_list_sync_complete, list_id, {:ok, first_stats}}
+      assert list_id == list.id
+      assert first_stats.new == 2
+      assert first_stats.updated == 0
+      assert first_stats.total == 2
+
+      # Same feed, same tmdb_ids: every item now matches an existing row
+      # (Bug 2: the old code checked `is_binary(id)`, which is true for
+      # both an insert and an update, so it reported every item as new
+      # every time).
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      assert_receive {:import_list_sync_complete, ^list_id, {:ok, second_stats}}
+      assert second_stats.new == 0
+      assert second_stats.updated == 2
+      assert second_stats.total == 2
+
+      # Still only two rows: the second sync updated in place, it didn't
+      # duplicate (Bug 4: a select-then-write upsert could otherwise race
+      # or double-insert under concurrent syncs).
+      assert length(ImportLists.list_import_list_items(list)) == 2
+    end
+
+    test "a changed title on re-sync updates the cached display field" do
+      bypass = Bypass.open()
+      list = tmdb_trending_list(bypass)
+
+      stub_trending(bypass, [
+        %{"id" => 111, "title" => "Working Title", "release_date" => "2023-05-01"}
+      ])
+
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      stub_trending(bypass, [
+        %{"id" => 111, "title" => "Final Title", "release_date" => "2023-05-01"}
+      ])
+
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      [item] = ImportLists.list_import_list_items(list)
+      assert item.title == "Final Title"
+    end
+
+    test "records a sync error and applies backoff instead of retrying at the next tick" do
+      bypass = Bypass.open()
+      list = tmdb_trending_list(bypass)
+      stub_trending_error(bypass, 400)
+
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "import_lists")
+
+      assert {:error, _reason} = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      assert_receive {:import_list_sync_complete, list_id, {:error, _reason}}
+      assert list_id == list.id
+
+      reloaded = ImportLists.get_import_list!(list.id)
+      assert reloaded.last_synced_at == nil
+      assert reloaded.sync_error != nil
+      assert reloaded.config["consecutive_failures"] == 1
+
+      # The core bug: before the fix, sync_due?/1 stayed true immediately
+      # after a failure, so the cron's 15-minute tick would re-enqueue this
+      # list every single time forever, ignoring sync_interval entirely.
+      refute ImportLists.sync_due?(reloaded)
+    end
+
+    test "repeated failures grow the consecutive failure count" do
+      bypass = Bypass.open()
+      list = tmdb_trending_list(bypass)
+      stub_trending_error(bypass, 400)
+
+      assert {:error, _} = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+      once = ImportLists.get_import_list!(list.id)
+      assert once.config["consecutive_failures"] == 1
+
+      assert {:error, _} = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+      twice = ImportLists.get_import_list!(list.id)
+      assert twice.config["consecutive_failures"] == 2
+    end
+
+    test "a successful sync after prior failures clears the error and resets backoff" do
+      bypass = Bypass.open()
+      list = tmdb_trending_list(bypass)
+      stub_trending_error(bypass, 400)
+
+      assert {:error, _reason} = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+      failed = ImportLists.get_import_list!(list.id)
+      assert failed.config["consecutive_failures"] == 1
+
+      stub_trending(bypass, [
+        %{"id" => 111, "title" => "Aurora Rising", "release_date" => "2023-05-01"}
+      ])
+
+      assert :ok = ImportListSync.perform(job(%{"import_list_id" => list.id}))
+
+      recovered = ImportLists.get_import_list!(list.id)
+      assert recovered.sync_error == nil
+      refute Map.has_key?(recovered.config, "consecutive_failures")
+    end
+  end
+end

--- a/test/mydia_web/live/admin_import_lists_live_test.exs
+++ b/test/mydia_web/live/admin_import_lists_live_test.exs
@@ -1,0 +1,95 @@
+defmodule MydiaWeb.AdminImportListsLiveTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Jobs.ImportListScheduler
+
+  # Tests mutate the global :mydia, :features application env to flip the
+  # ENABLE_IMPORT_LISTS flag on and off. Always save/restore it via on_exit
+  # (see test/README.md, "Tests must not mutate global env") and keep this
+  # module async: false so no concurrent test observes the mutated value.
+  defp put_import_lists_enabled(value) do
+    original = Application.get_env(:mydia, :features, [])
+
+    Application.put_env(
+      :mydia,
+      :features,
+      Keyword.put(original, :import_lists_enabled, value)
+    )
+
+    on_exit(fn -> Application.put_env(:mydia, :features, original) end)
+  end
+
+  defp login_admin(conn) do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  describe "with Import Lists enabled" do
+    setup %{conn: conn} do
+      put_import_lists_enabled(true)
+      login_admin(conn)
+    end
+
+    test "an admin can load /admin/import-lists", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/import-lists")
+
+      assert has_element?(view, "h1", "Import Lists")
+    end
+
+    test "the nav link is present", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/dashboard")
+
+      assert has_element?(view, "a[href='/admin/import-lists']")
+    end
+
+    test "the auto-add warning explains what turning it on does", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/import-lists")
+
+      view
+      |> element("button[phx-click='new_list']")
+      |> render_click()
+
+      assert has_element?(view, "#import-list-form")
+
+      assert has_element?(
+               view,
+               "#import-list-form p.text-warning",
+               "downloaded automatically"
+             )
+    end
+  end
+
+  describe "with Import Lists disabled" do
+    setup %{conn: conn} do
+      put_import_lists_enabled(false)
+      login_admin(conn)
+    end
+
+    test "mounting redirects instead of rendering the page", %{conn: conn} do
+      assert {:error, {:redirect, redirect}} = live(conn, ~p"/admin/import-lists")
+
+      assert redirect.to == ~p"/admin/dashboard"
+      assert redirect.flash["error"] =~ "disabled"
+    end
+
+    test "the nav link is absent", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/admin/dashboard")
+
+      refute has_element?(view, "a[href='/admin/import-lists']")
+    end
+  end
+
+  describe "Mydia.Jobs.ImportListScheduler.perform/1" do
+    test "returns :ok without enqueueing when the flag is off" do
+      put_import_lists_enabled(false)
+
+      # Oban is not started in test (see test/README.md, "Oban is disabled in
+      # test"), so this calls perform/1 directly with a hand-built job rather
+      # than going through Oban.insert/enqueue.
+      assert ImportListScheduler.perform(%Oban.Job{args: %{}}) == :ok
+    end
+  end
+end


### PR DESCRIPTION
An audit of the import lists feature found that `ENABLE_IMPORT_LISTS` gated nothing but a nav link, and turned up eight bugs behind it. This fixes all of them, makes the flag real, and turns the feature on by default.

## The flag gated a nav link

`FeatureFlags.enabled?/0` had exactly one call site in the app, the sidebar link in `layouts.ex`. The route, the every-15-minutes scheduler cron, and the sync and auto-add jobs all ran regardless, so an operator who set `ENABLE_IMPORT_LISTS=false` still had the feature running on a schedule and reachable by URL.

The scheduler now returns early when disabled, following the `CardigannHealthCheck` precedent already in the repo, and the LiveView redirects on mount. With the flag actually gating the feature, the default flips to on: syncing an external list is a normal admin action and should not require setting an environment variable first. An explicitly configured `false` still wins; only a genuinely missing key falls back to the new default.

## Bugs fixed

| # | Bug | Effect |
|---|---|---|
| 1 | `mark_sync_error/2` never touched `last_synced_at` | A failing list stayed permanently due, so the cron re-enqueued it every 15 minutes forever, roughly 96 relay hits a day per broken list |
| 2 | `build_endpoint/2` fell through to trending movies | An Upcoming + TV Shows list silently filled with movies stored as TV shows; auto-add then resolved movie TMDB IDs as series |
| 3 | `page: 1` hardcoded | Every list capped at about 20 items |
| 4 | Both upsert branches returned the same shape | The `updated` counter was unreachable, so every sync reported every item as new |
| 5 | Upsert was select-then-insert | Concurrent syncs raced the unique constraint and the loser was silently dropped |
| 6 | Duplicates marked skipped, then immediately added | The skip was erased, so stats and database disagreed and the Skipped filter never showed them |
| 7 | `check_duplicate` matched only `tmdb_id` | Library items from a filesystem scan with no external id were added a second time |
| 8 | Custom URL fetched with no scheme or destination check | An admin-supplied URL could reach loopback, the LAN, container neighbours, or a cloud metadata endpoint |

Notes on the two with the most design in them:

**Backoff (1).** Failures now record a timestamp and a consecutive-failure count and back off exponentially, capped at 24 hours, reset on success. State lives in the existing `config` map, so no migration. The exponent is clamped: `2 ** 1024` overflows a float and raises, and since `list_sync_due_lists/0` runs every list through `sync_due?/1`, one raise would have stopped syncing for all lists, not just the broken one.

**SSRF (8).** Requests are limited to `http`/`https` against public addresses, checked on the *resolved* IP rather than the host text, with IPv4-mapped IPv6 unwrapped and every redirect hop revalidated. Operators legitimately serving a list from their own NAS or container network can opt back in with `IMPORT_LISTS_ALLOW_PRIVATE_DESTINATIONS=true`. DNS rebinding remains out of scope and is documented as a deliberate trade-off in the moduledoc.

## UI

The auto-add checkbox now says what it does. Auto-added items are monitored by default, which hands them to the hourly `MovieSearch` and half-hourly `TVShowSearch` in `all_monitored` mode, so ticking it on a popular-movies list starts real downloads. Nothing in the UI said so. The Media Type select now only offers types the chosen source actually supports, and the form keeps the shown value and the submitted value in sync.

## Tests

The feature had 40 tests covering only context CRUD and changesets. Both providers, all three workers, the LiveView, and the entire add-to-library path had none, so the tested surface was the half that could not fail in a way that mattered.

Adds 81 tests, including the first LiveView test for the page: 121 across the feature, all green. Full suite green at 10,227.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import Lists is enabled by default and presented as a stable feature.
  * TMDB imports now support multi-page lists.
  * Media type options adjust automatically based on the selected source.
  * Custom URL imports support configurable private-destination access.

* **Improvements**
  * Improved duplicate matching and linking of existing library items.
  * Added sync failure tracking with automatic retry backoff.
  * Added validation for incompatible list sources and media types.
  * Auto-add forms now warn about automatic downloads for monitored items.

* **Security**
  * Custom URL imports validate protocols, destinations, redirects, and response sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->