### PR TITLE
feat(collections): preset collections

### DIFF
--- a/lib/mydia/collections.ex
+++ b/lib/mydia/collections.ex
@@ -28,6 +28,7 @@ defmodule Mydia.Collections do
   import Mydia.QueryHelpers
   alias Mydia.Repo
   alias Mydia.Collections.{Collection, CollectionItem, SmartRules}
+  alias Mydia.Collections.Presets
   alias Mydia.Media.{MediaCategory, MediaItem}
   alias Mydia.Accounts.User
 
@@ -259,6 +260,46 @@ defmodule Mydia.Collections do
       %Collection{user_id: user.id}
       |> Collection.changeset(attrs)
       |> Repo.insert()
+    end
+  end
+
+  @doc """
+  Creates a collection from a catalog preset.
+
+  The preset's rules are stamped onto an ordinary private smart collection with
+  no back-reference to the preset, so the result is fully editable and deletable
+  like any hand-built collection. Adding the same preset twice is allowed and
+  produces two independent collections.
+
+  Delegates to `create_collection/2` rather than inserting directly, so changeset
+  validation and the admin-only shared-visibility rule both still apply.
+
+  Returns `{:error, :unknown_preset}` if the key is not in the catalog.
+
+  ## Examples
+
+      iex> add_preset(user, "decade_2000s")
+      {:ok, %Collection{name: "2000s", type: "smart"}}
+
+      iex> add_preset(user, "no_such_preset")
+      {:error, :unknown_preset}
+  """
+  @spec add_preset(User.t(), String.t()) ::
+          {:ok, Collection.t()} | {:error, Ecto.Changeset.t() | :unknown_preset}
+  def add_preset(%User{} = user, preset_key) do
+    case Presets.get(preset_key) do
+      nil ->
+        {:error, :unknown_preset}
+
+      preset ->
+        create_collection(user, %{
+          name: preset.name,
+          description: preset.description,
+          type: "smart",
+          visibility: "private",
+          sidebar_icon: preset.icon,
+          smart_rules: Jason.encode!(preset.rules)
+        })
     end
   end
 

--- a/lib/mydia/collections/preset.ex
+++ b/lib/mydia/collections/preset.ex
@@ -1,0 +1,27 @@
+defmodule Mydia.Collections.Preset do
+  @moduledoc """
+  One entry in the preset collection catalog.
+
+  A preset is a named bundle of smart rules. Adding one stamps `rules` onto an
+  ordinary smart collection, which then has no back-reference to the preset it
+  came from: it is fully editable and deletable like any hand-built collection.
+
+  `icon` is constrained to `Mydia.Collections.Collection.valid_sidebar_icons/0`.
+  That is not cosmetic. Preset icons are chosen at runtime from data in
+  `lib/mydia/`, which sits outside the `@source` globs in `app.css`, so Tailwind
+  never emits their CSS unless the name is safelisted. Reusing the sidebar
+  allowlist inherits both the safelist and its drift test.
+  """
+
+  @enforce_keys [:key, :name, :description, :icon, :group, :rules]
+  defstruct [:key, :name, :description, :icon, :group, :rules]
+
+  @type t :: %__MODULE__{
+          key: String.t(),
+          name: String.t(),
+          description: String.t(),
+          icon: String.t(),
+          group: String.t(),
+          rules: map()
+        }
+end

--- a/lib/mydia/collections/presets.ex
+++ b/lib/mydia/collections/presets.ex
@@ -1,0 +1,291 @@
+defmodule Mydia.Collections.Presets do
+  @moduledoc """
+  The preset collection catalog: common smart collections offered as one-click
+  additions.
+
+  Pure data. No database access and no configuration, so the catalog is
+  reviewable as a diff and testable without a repo. `test/mydia/collections/presets_test.exs`
+  walks every entry, validating and executing its rules, because a bad entry is
+  otherwise invisible until a user clicks it.
+
+  Adding a preset produces an independent collection. Editing this catalog later
+  does not change collections that were already created from it.
+  """
+
+  alias Mydia.Collections.Preset
+
+  @groups ["Decades", "Genres", "Highlights", "Series", "Language"]
+
+  @presets [
+    # Decades
+    %Preset{
+      key: "decade_1980s",
+      name: "1980s",
+      description: "Everything released between 1980 and 1989.",
+      icon: "hero-film",
+      group: "Decades",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "year", "operator" => "between", "value" => [1980, 1989]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "decade_1990s",
+      name: "1990s",
+      description: "Everything released between 1990 and 1999.",
+      icon: "hero-film",
+      group: "Decades",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "year", "operator" => "between", "value" => [1990, 1999]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "decade_2000s",
+      name: "2000s",
+      description: "Everything released between 2000 and 2009.",
+      icon: "hero-film",
+      group: "Decades",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "year", "operator" => "between", "value" => [2000, 2009]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "decade_2010s",
+      name: "2010s",
+      description: "Everything released between 2010 and 2019.",
+      icon: "hero-film",
+      group: "Decades",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "year", "operator" => "between", "value" => [2010, 2019]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "decade_2020s",
+      name: "2020s",
+      description: "Everything released from 2020 onward.",
+      icon: "hero-film",
+      group: "Decades",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "year", "operator" => "between", "value" => [2020, 2029]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+
+    # Genres
+    %Preset{
+      key: "genre_action",
+      name: "Action",
+      description: "Action titles from across your library.",
+      icon: "hero-bolt",
+      group: "Genres",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{
+            "field" => "metadata.genres",
+            "operator" => "contains_any",
+            "value" => ["Action", "Action & Adventure"]
+          }
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "genre_comedy",
+      name: "Comedy",
+      description: "Comedies from across your library.",
+      icon: "hero-face-smile",
+      group: "Genres",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "metadata.genres", "operator" => "contains_any", "value" => ["Comedy"]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "genre_horror",
+      name: "Horror",
+      description: "Horror titles from across your library.",
+      icon: "hero-fire",
+      group: "Genres",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "metadata.genres", "operator" => "contains_any", "value" => ["Horror"]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "genre_science_fiction",
+      name: "Science Fiction",
+      description: "Science fiction and fantasy from across your library.",
+      icon: "hero-rocket-launch",
+      group: "Genres",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{
+            "field" => "metadata.genres",
+            "operator" => "contains_any",
+            # TMDB names this genre differently for movies and for series.
+            "value" => ["Science Fiction", "Sci-Fi & Fantasy"]
+          }
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "genre_documentary",
+      name: "Documentary",
+      description: "Documentaries from across your library.",
+      icon: "hero-book-open",
+      group: "Genres",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{
+            "field" => "metadata.genres",
+            "operator" => "contains_any",
+            "value" => ["Documentary"]
+          }
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "genre_animation",
+      name: "Animation",
+      description: "Animated titles from across your library.",
+      icon: "hero-sparkles",
+      group: "Genres",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "metadata.genres", "operator" => "contains_any", "value" => ["Animation"]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    },
+
+    # Highlights
+    %Preset{
+      key: "highly_rated",
+      name: "Highly Rated",
+      description: "Rated 8.0 or better.",
+      icon: "hero-star",
+      group: "Highlights",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "metadata.vote_average", "operator" => "gte", "value" => 8.0}
+        ],
+        "sort" => %{"field" => "rating", "direction" => "desc"}
+      }
+    },
+    %Preset{
+      key: "recently_added",
+      name: "Recently Added",
+      description: "Added to your library in the last 30 days.",
+      icon: "hero-sparkles",
+      group: "Highlights",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "inserted_at", "operator" => "within_last", "value" => 30}
+        ],
+        "sort" => %{"field" => "added_date", "direction" => "desc"}
+      }
+    },
+
+    # Series
+    %Preset{
+      key: "ongoing_series",
+      name: "Ongoing Series",
+      description: "Series that are still releasing new episodes.",
+      icon: "hero-tv",
+      group: "Series",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "type", "operator" => "eq", "value" => "tv_show"},
+          %{"field" => "metadata.status", "operator" => "eq", "value" => "Returning Series"}
+        ],
+        "sort" => %{"field" => "title", "direction" => "asc"}
+      }
+    },
+    %Preset{
+      key: "completed_series",
+      name: "Completed Series",
+      description: "Series that have finished their run.",
+      icon: "hero-tv",
+      group: "Series",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "type", "operator" => "eq", "value" => "tv_show"},
+          %{"field" => "metadata.status", "operator" => "eq", "value" => "Ended"}
+        ],
+        "sort" => %{"field" => "title", "direction" => "asc"}
+      }
+    },
+
+    # Language
+    %Preset{
+      key: "foreign_language",
+      name: "Foreign Language",
+      description: "Titles whose original language is not English.",
+      icon: "hero-globe-alt",
+      group: "Language",
+      rules: %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "metadata.original_language", "operator" => "not_in", "value" => ["en"]}
+        ],
+        "sort" => %{"field" => "year", "direction" => "desc"}
+      }
+    }
+  ]
+
+  @doc """
+  Returns every preset in display order.
+  """
+  @spec list() :: [Preset.t()]
+  def list, do: @presets
+
+  @doc """
+  Returns the preset with the given key, or nil.
+  """
+  @spec get(String.t()) :: Preset.t() | nil
+  def get(key) when is_binary(key) do
+    Enum.find(@presets, &(&1.key == key))
+  end
+
+  def get(_), do: nil
+
+  @doc """
+  Returns the group names in the order the gallery should render them.
+  """
+  @spec groups() :: [String.t()]
+  def groups, do: @groups
+end

--- a/lib/mydia/collections/presets.ex
+++ b/lib/mydia/collections/presets.ex
@@ -77,7 +77,7 @@ defmodule Mydia.Collections.Presets do
     %Preset{
       key: "decade_2020s",
       name: "2020s",
-      description: "Everything released from 2020 onward.",
+      description: "Everything released between 2020 and 2029.",
       icon: "hero-film",
       group: "Decades",
       rules: %{

--- a/lib/mydia/collections/smart_rules.ex
+++ b/lib/mydia/collections/smart_rules.ex
@@ -586,6 +586,21 @@ defmodule Mydia.Collections.SmartRules do
     end)
   end
 
+  defp build_dynamic("metadata.original_language", "not_in", values) when is_list(values) do
+    json_val = json_extract_dynamic(:metadata, "$.original_language")
+
+    matches_any =
+      Enum.reduce(values, dynamic([m], false), fn value, acc ->
+        dynamic([m], ^acc or ^json_val == ^value)
+      end)
+
+    # A row with no recorded original_language does not match any of the
+    # excluded values either, so it belongs in the result. Without the
+    # explicit is_nil check, a bare SQL NOT IN against NULL is NULL, not
+    # true, and the row is silently dropped instead of included.
+    dynamic([m], is_nil(^json_val) or not (^matches_any))
+  end
+
   defp build_dynamic("metadata.status", "eq", value) do
     dynamic([m], ^DB.json_equals(:metadata, "$.status", value))
   end
@@ -596,6 +611,19 @@ defmodule Mydia.Collections.SmartRules do
     Enum.reduce(values, dynamic([m], false), fn value, acc ->
       dynamic([m], ^acc or ^json_val == ^value)
     end)
+  end
+
+  defp build_dynamic("metadata.status", "not_in", values) when is_list(values) do
+    json_val = json_extract_dynamic(:metadata, "$.status")
+
+    matches_any =
+      Enum.reduce(values, dynamic([m], false), fn value, acc ->
+        dynamic([m], ^acc or ^json_val == ^value)
+      end)
+
+    # Same NULL handling as metadata.original_language above: a row with no
+    # recorded status is not one of the excluded statuses, so it stays in.
+    dynamic([m], is_nil(^json_val) or not (^matches_any))
   end
 
   defp build_dynamic("inserted_at", "gte", value) do

--- a/lib/mydia/collections/smart_rules.ex
+++ b/lib/mydia/collections/smart_rules.ex
@@ -42,6 +42,7 @@ defmodule Mydia.Collections.SmartRules do
   - `contains` - String/array contains value
   - `contains_any` - Array contains any of the values
   - `between` - Value is between two numbers [min, max]
+  - `within_last` - Date field is within the last N days (positive integer)
   """
 
   import Ecto.Query, warn: false
@@ -56,7 +57,7 @@ defmodule Mydia.Collections.SmartRules do
     inserted_at
   )
 
-  @valid_operators ~w(eq gt gte lt lte in not_in contains contains_any between)
+  @valid_operators ~w(eq gt gte lt lte in not_in contains contains_any between within_last)
 
   @valid_sort_fields ~w(title year rating added_date position)
   @valid_sort_directions ~w(asc desc)
@@ -69,6 +70,9 @@ defmodule Mydia.Collections.SmartRules do
 
   # Fields that require boolean values
   @boolean_fields ~w(monitored)
+
+  # Fields that hold timestamps and accept relative-date operators
+  @date_fields ~w(inserted_at)
 
   # Valid type values
   @valid_type_values ~w(movie tv_show)
@@ -334,6 +338,23 @@ defmodule Mydia.Collections.SmartRules do
   defp validate_field_value_type(field, value, _operator, _prefix, errors)
        when is_nil(field) or is_nil(value) do
     errors
+  end
+
+  defp validate_field_value_type(field, _value, "within_last", prefix, errors)
+       when not is_nil(field) and field not in @date_fields do
+    ["#{prefix}: within_last is only valid on date fields" | errors]
+  end
+
+  defp validate_field_value_type(field, value, "within_last", prefix, errors)
+       when field in @date_fields do
+    if is_integer(value) and value > 0 do
+      errors
+    else
+      [
+        "#{prefix}: #{field} within_last requires a positive whole number of days, got: #{inspect(value)}"
+        | errors
+      ]
+    end
   end
 
   defp validate_field_value_type("type", value, operator, prefix, errors)
@@ -603,6 +624,12 @@ defmodule Mydia.Collections.SmartRules do
       {:ok, datetime} -> dynamic([m], m.inserted_at < ^datetime)
       _ -> dynamic([m], true)
     end
+  end
+
+  defp build_dynamic("inserted_at", "within_last", days)
+       when is_integer(days) and days > 0 do
+    cutoff = DateTime.add(DateTime.utc_now(), -days, :day)
+    dynamic([m], m.inserted_at >= ^cutoff)
   end
 
   # Fallback for unknown conditions

--- a/lib/mydia/collections/smart_rules.ex
+++ b/lib/mydia/collections/smart_rules.ex
@@ -341,7 +341,7 @@ defmodule Mydia.Collections.SmartRules do
   end
 
   defp validate_field_value_type(field, _value, "within_last", prefix, errors)
-       when not is_nil(field) and field not in @date_fields do
+       when field not in @date_fields do
     ["#{prefix}: within_last is only valid on date fields" | errors]
   end
 

--- a/lib/mydia/collections/smart_rules_fields.ex
+++ b/lib/mydia/collections/smart_rules_fields.ex
@@ -86,7 +86,7 @@ defmodule Mydia.Collections.SmartRulesFields do
         label: "Date Added",
         group: "Dates",
         type: :date,
-        operators: [:gt, :gte, :lt, :lte],
+        operators: [:gt, :gte, :lt, :lte, :within_last],
         values: nil
       }
     }
@@ -161,7 +161,8 @@ defmodule Mydia.Collections.SmartRulesFields do
       not_in: "is not one of",
       contains: "contains",
       contains_any: "contains any of",
-      between: "between"
+      between: "between",
+      within_last: "in the last (days)"
     }
   end
 

--- a/lib/mydia_web/live/collection_live/index.ex
+++ b/lib/mydia_web/live/collection_live/index.ex
@@ -10,11 +10,17 @@ defmodule MydiaWeb.CollectionLive.Index do
   """
   use MydiaWeb, :live_view
 
+  require Logger
+
   alias Mydia.Collections
   alias Mydia.Collections.Collection
+  alias Mydia.Collections.Presets
+  alias Mydia.Collections.SmartRules
 
   import MydiaWeb.CollectionLive.Components,
     only: [smart_rules_editor: 1, load_value_options: 1, value_list: 1, value_string: 1]
+
+  import MydiaWeb.CollectionLive.PresetComponents, only: [preset_gallery: 1]
 
   @default_condition %{"field" => "", "operator" => "eq", "value" => ""}
 
@@ -30,6 +36,10 @@ defmodule MydiaWeb.CollectionLive.Index do
      |> assign(:new_collection_type, "manual")
      |> assign(:new_form, to_form(%{}, as: :collection))
      |> assign(:collections_empty?, true)
+     |> assign(:show_preset_gallery, false)
+     |> assign(:preset_counts, %{})
+     |> assign(:added_presets, MapSet.new())
+     |> assign(:existing_collection_names, MapSet.new())
      |> assign_default_rules()
      |> stream(:collections, [])}
   end
@@ -64,6 +74,14 @@ defmodule MydiaWeb.CollectionLive.Index do
           </div>
           <div class="flex items-center gap-2">
             <.view_mode_toggle view_mode={@view_mode} />
+            <button
+              id="browse-presets-button"
+              type="button"
+              class="btn btn-outline gap-2"
+              phx-click="open_preset_gallery"
+            >
+              <.icon name="hero-squares-2x2" class="w-4 h-4" /> Browse presets
+            </button>
             <button
               type="button"
               class="btn btn-primary gap-2"
@@ -124,6 +142,14 @@ defmodule MydiaWeb.CollectionLive.Index do
                 phx-click="open_new_modal"
               >
                 <.icon name="hero-plus" class="w-5 h-5" /> Create your first collection
+              </button>
+              <button
+                id="browse-presets-button-empty"
+                type="button"
+                class="btn btn-outline gap-2"
+                phx-click="open_preset_gallery"
+              >
+                <.icon name="hero-squares-2x2" class="w-4 h-4" /> Browse presets
               </button>
             </:actions>
           </.collection_empty_state>
@@ -240,6 +266,47 @@ defmodule MydiaWeb.CollectionLive.Index do
             </button>
           </:actions>
         </.modal>
+
+        <%!-- Preset Gallery Modal --%>
+        <.modal
+          :if={@show_preset_gallery}
+          id="preset-gallery-modal"
+          show={@show_preset_gallery}
+          on_cancel={JS.push("close_preset_gallery")}
+        >
+          <:title>
+            <div class="flex items-center gap-3">
+              <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/20">
+                <.icon name="hero-squares-2x2" class="w-5 h-5 text-primary" />
+              </div>
+              <div>
+                <div class="font-bold text-lg">Browse presets</div>
+                <div class="text-xs text-base-content/60 font-normal">
+                  Common collections, ready to add
+                </div>
+              </div>
+            </div>
+          </:title>
+
+          <.preset_gallery
+            presets={Presets.list()}
+            groups={Presets.groups()}
+            counts={@preset_counts}
+            added={@added_presets}
+            existing_names={@existing_collection_names}
+          />
+
+          <:actions>
+            <button
+              id="close-preset-gallery"
+              type="button"
+              class="btn btn-ghost"
+              phx-click="close_preset_gallery"
+            >
+              Done
+            </button>
+          </:actions>
+        </.modal>
       </div>
     </Layouts.app>
     """
@@ -291,6 +358,35 @@ defmodule MydiaWeb.CollectionLive.Index do
 
   def handle_event("close_new_modal", _params, socket) do
     {:noreply, assign(socket, :show_new_modal, false)}
+  end
+
+  def handle_event("open_preset_gallery", _params, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_preset_gallery, true)
+     |> assign(:preset_counts, %{})
+     |> start_async(:preset_counts, fn -> preset_counts() end)}
+  end
+
+  def handle_event("close_preset_gallery", _params, socket) do
+    {:noreply, assign(socket, :show_preset_gallery, false)}
+  end
+
+  def handle_event("add_preset", %{"key" => key}, socket) do
+    case Collections.add_preset(socket.assigns.current_user, key) do
+      {:ok, collection} ->
+        {:noreply,
+         socket
+         |> assign(:added_presets, MapSet.put(socket.assigns.added_presets, key))
+         |> put_flash(:info, "Added \"#{collection.name}\"")
+         |> load_collections()}
+
+      {:error, :unknown_preset} ->
+        {:noreply, put_flash(socket, :error, "That preset is no longer available.")}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, put_flash(socket, :error, extract_changeset_error(changeset))}
+    end
   end
 
   alias MydiaWeb.MediaLive.Show.Helpers, as: PlayerHelpers
@@ -389,6 +485,25 @@ defmodule MydiaWeb.CollectionLive.Index do
          |> put_flash(:error, error_msg)
          |> assign(:new_form, to_form(changeset, as: :collection))}
     end
+  end
+
+  @impl true
+  def handle_async(:preset_counts, {:ok, counts}, socket) do
+    {:noreply, assign(socket, :preset_counts, counts)}
+  end
+
+  def handle_async(:preset_counts, {:exit, reason}, socket) do
+    Logger.warning("preset count query failed: #{inspect(reason)}")
+    # Badges stay blank. A failed count must not take down the gallery.
+    {:noreply, socket}
+  end
+
+  # SmartRules.execute_count/1 accepts the rules map directly and already
+  # rescues query errors to 0, so a single bad preset cannot break the batch.
+  defp preset_counts do
+    Map.new(Presets.list(), fn preset ->
+      {preset.key, SmartRules.execute_count(preset.rules)}
+    end)
   end
 
   defp update_rules_from_params(socket, params) do
@@ -556,6 +671,19 @@ defmodule MydiaWeb.CollectionLive.Index do
     socket
     |> assign(:collections_empty?, collections == [])
     |> stream(:collections, collections, reset: true)
+    |> assign_existing_collection_names()
+  end
+
+  # Names of every collection the user has, for the preset gallery's duplicate
+  # hint. Queried separately because :collections is a stream, which cannot be
+  # read back, and because the hint ignores the active search and filters.
+  defp assign_existing_collection_names(socket) do
+    names =
+      socket.assigns.current_user
+      |> Collections.list_collections()
+      |> MapSet.new(&String.downcase(&1.name))
+
+    assign(socket, :existing_collection_names, names)
   end
 
   defp maybe_add_filter(opts, _key, nil), do: opts

--- a/lib/mydia_web/live/collection_live/index.ex
+++ b/lib/mydia_web/live/collection_live/index.ex
@@ -361,10 +361,16 @@ defmodule MydiaWeb.CollectionLive.Index do
   end
 
   def handle_event("open_preset_gallery", _params, socket) do
+    # `added_presets` is a per-visit confirmation that the click landed, not a
+    # record of what exists. Clearing it on open keeps duplicates addable, as
+    # `add_preset/2` allows, and stops the badge outliving the collection it
+    # describes when one is removed elsewhere. The soft name-match hint, which is
+    # recomputed from the live list, is what warns about an existing collection.
     {:noreply,
      socket
      |> assign(:show_preset_gallery, true)
      |> assign(:preset_counts, %{})
+     |> assign(:added_presets, MapSet.new())
      |> start_async(:preset_counts, fn -> preset_counts() end)}
   end
 

--- a/lib/mydia_web/live/collection_live/preset_components.ex
+++ b/lib/mydia_web/live/collection_live/preset_components.ex
@@ -1,0 +1,112 @@
+defmodule MydiaWeb.CollectionLive.PresetComponents do
+  @moduledoc """
+  Function components for the preset collection gallery on the collections page.
+
+  Kept out of `MydiaWeb.CollectionComponents` (already over the size guideline)
+  and out of the sibling `components.ex` (which holds the smart rules editor), so
+  the gallery stays reviewable on its own.
+  """
+  use MydiaWeb, :html
+
+  alias Mydia.Collections.Preset
+
+  @doc """
+  The grouped grid of preset cards.
+
+  `counts` maps preset key to item count. A key missing from the map means the
+  count has not loaded yet and the card shows a spinner instead of a number.
+  `added` is the set of keys added during this gallery session. `existing_names`
+  is the set of downcased collection names the user already has, used only for a
+  soft hint.
+  """
+  attr :presets, :list, required: true
+  attr :groups, :list, required: true
+  attr :counts, :map, required: true
+  attr :added, :any, required: true
+  attr :existing_names, :any, required: true
+
+  def preset_gallery(assigns) do
+    ~H"""
+    <div class="space-y-6">
+      <%= for group <- @groups do %>
+        <% group_presets = Enum.filter(@presets, &(&1.group == group)) %>
+        <div :if={group_presets != []}>
+          <h3 class="text-sm font-semibold text-base-content/70 mb-3">{group}</h3>
+          <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <.preset_card
+              :for={preset <- group_presets}
+              preset={preset}
+              count={Map.get(@counts, preset.key)}
+              added={MapSet.member?(@added, preset.key)}
+              duplicate={MapSet.member?(@existing_names, String.downcase(preset.name))}
+            />
+          </div>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  @doc """
+  A single preset card.
+  """
+  attr :preset, Preset, required: true
+  attr :count, :any, default: nil
+  attr :added, :boolean, default: false
+  attr :duplicate, :boolean, default: false
+
+  def preset_card(assigns) do
+    ~H"""
+    <div
+      id={"preset-card-#{@preset.key}"}
+      class={[
+        "card card-compact bg-base-200 border border-base-300 transition-all duration-200",
+        @added && "opacity-60",
+        !@added && "hover:border-primary/40 hover:shadow-md"
+      ]}
+    >
+      <div class="card-body">
+        <div class="flex items-start gap-3">
+          <div class="flex items-center justify-center w-9 h-9 shrink-0 rounded-lg bg-primary/15">
+            <.icon name={@preset.icon} class="w-5 h-5 text-primary" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="font-semibold text-sm truncate">{@preset.name}</div>
+            <div class="text-xs text-base-content/60 line-clamp-2">{@preset.description}</div>
+          </div>
+        </div>
+
+        <div class="flex items-center justify-between gap-2 mt-2">
+          <span class="badge badge-ghost badge-sm">
+            <%= if is_nil(@count) do %>
+              <span class="loading loading-spinner loading-xs" />
+            <% else %>
+              {@count} {if @count == 1, do: "item", else: "items"}
+            <% end %>
+          </span>
+
+          <%= if @added do %>
+            <span id={"preset-added-#{@preset.key}"} class="text-xs text-success font-medium">
+              <.icon name="hero-check" class="w-4 h-4 align-text-bottom" /> Added
+            </span>
+          <% else %>
+            <button
+              id={"preset-add-#{@preset.key}"}
+              type="button"
+              class="btn btn-primary btn-xs"
+              phx-click="add_preset"
+              phx-value-key={@preset.key}
+            >
+              Add
+            </button>
+          <% end %>
+        </div>
+
+        <div :if={@duplicate and not @added} class="text-[11px] text-base-content/50">
+          You already have a collection with this name.
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/test/mydia/collections/presets_test.exs
+++ b/test/mydia/collections/presets_test.exs
@@ -11,7 +11,7 @@ defmodule Mydia.Collections.PresetsTest do
   alias Mydia.Collections.SmartRules
 
   test "the catalog is not empty" do
-    assert length(Presets.list()) > 0
+    assert Presets.list() != []
   end
 
   test "every preset validates" do

--- a/test/mydia/collections/presets_test.exs
+++ b/test/mydia/collections/presets_test.exs
@@ -10,8 +10,8 @@ defmodule Mydia.Collections.PresetsTest do
   alias Mydia.Collections.Presets
   alias Mydia.Collections.SmartRules
 
-  test "the catalog is not empty" do
-    assert Presets.list() != []
+  test "the catalog holds every preset" do
+    assert length(Presets.list()) == 16
   end
 
   test "every preset validates" do

--- a/test/mydia/collections/presets_test.exs
+++ b/test/mydia/collections/presets_test.exs
@@ -1,0 +1,76 @@
+defmodule Mydia.Collections.PresetsTest do
+  # Guards the preset catalog against three failures that are invisible until a
+  # user clicks the preset: rules that do not validate, rules that validate but
+  # have no matching build_dynamic/3 clause and raise at query time, and icons
+  # outside the Tailwind safelist that render as blank boxes.
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Collections.Collection
+  alias Mydia.Collections.Preset
+  alias Mydia.Collections.Presets
+  alias Mydia.Collections.SmartRules
+
+  test "the catalog is not empty" do
+    assert length(Presets.list()) > 0
+  end
+
+  test "every preset validates" do
+    for %Preset{} = preset <- Presets.list() do
+      assert {:ok, _} = SmartRules.validate(preset.rules),
+             "preset #{preset.key} has rules that do not validate"
+    end
+  end
+
+  test "every preset executes without raising" do
+    # validate/1 checks the field and operator names against allowlists, but
+    # build_dynamic/3 is a set of specific clauses. A field and operator pair
+    # that validates without a matching clause raises FunctionClauseError only
+    # when the query is built, which is when a user clicks the preset.
+    for %Preset{} = preset <- Presets.list() do
+      assert is_integer(SmartRules.execute_count(preset.rules)),
+             "preset #{preset.key} raised when its query was built"
+    end
+  end
+
+  test "keys are unique" do
+    keys = Enum.map(Presets.list(), & &1.key)
+    assert keys == Enum.uniq(keys)
+  end
+
+  test "every preset's group is listed in groups/0" do
+    groups = Presets.groups()
+
+    for %Preset{} = preset <- Presets.list() do
+      assert preset.group in groups,
+             "preset #{preset.key} has group #{inspect(preset.group)}, which groups/0 omits"
+    end
+  end
+
+  test "every group in groups/0 has at least one preset" do
+    used = Presets.list() |> Enum.map(& &1.group) |> Enum.uniq()
+
+    for group <- Presets.groups() do
+      assert group in used, "groups/0 lists #{inspect(group)} but no preset uses it"
+    end
+  end
+
+  test "every preset icon is a valid sidebar icon" do
+    # Preset icons live in lib/mydia/, outside the @source globs in app.css, so
+    # Tailwind never sees the class name. Reusing the sidebar allowlist means
+    # the existing safelist and its drift test already cover them.
+    valid = Collection.valid_sidebar_icons()
+
+    for %Preset{} = preset <- Presets.list() do
+      assert preset.icon in valid,
+             "preset #{preset.key} uses icon #{preset.icon}, which is not in Collection.valid_sidebar_icons/0"
+    end
+  end
+
+  test "get/1 finds a preset by key and returns nil for an unknown key" do
+    known = Presets.list() |> List.first()
+
+    assert %Preset{} = found = Presets.get(known.key)
+    assert found.key == known.key
+    assert Presets.get("no_such_preset") == nil
+  end
+end

--- a/test/mydia/collections/smart_rules_fields_test.exs
+++ b/test/mydia/collections/smart_rules_fields_test.exs
@@ -82,4 +82,14 @@ defmodule Mydia.Collections.SmartRulesFieldsTest do
       refute Map.has_key?(options, "inserted_at")
     end
   end
+
+  describe "within_last exposure" do
+    test "inserted_at offers the within_last operator" do
+      assert :within_last in SmartRulesFields.get_operators("inserted_at")
+    end
+
+    test "within_last has a display label" do
+      assert SmartRulesFields.operator_label(:within_last) == "in the last (days)"
+    end
+  end
 end

--- a/test/mydia/collections/smart_rules_operator_coverage_test.exs
+++ b/test/mydia/collections/smart_rules_operator_coverage_test.exs
@@ -1,0 +1,106 @@
+defmodule Mydia.Collections.SmartRulesOperatorCoverageTest do
+  # Guards a cross-file invariant, in the spirit of
+  # test/mydia/collections/sidebar_icon_safelist_test.exs: the rules editor
+  # (SmartRulesFields) advertises which operators are valid for each field,
+  # but the query builder (SmartRules.build_dynamic/3) is a fixed set of
+  # function clauses. SmartRules.validate/1 checks field and operator names
+  # against allowlists that are not field-specific, so an operator the editor
+  # offers for a field can validate cleanly and still have no matching
+  # build_dynamic clause. When that happens, build_dynamic falls through to
+  # its own module-level catch-all,
+  # `defp build_dynamic(_field, _operator, _value), do: dynamic([m], true)`,
+  # which does not raise: it silently matches every row instead of filtering,
+  # or of failing loudly. This is exactly the class of bug that shipped the
+  # foreign_language preset broken (see task-2-report.md).
+  #
+  # Detection method, verified empirically before writing this test: probed
+  # both a catch-all pair and a real-clause pair through
+  # `Ecto.Adapters.SQL.to_sql/3` on this project's (SQLite) test adapter.
+  # A condition that falls through to the catch-all produces NO "WHERE"
+  # clause at all in the rendered SQL (Ecto prunes a literal `where: true`
+  # dynamic entirely, rather than emitting something like `WHERE (1)` or
+  # `WHERE TRUE`), while every real build_dynamic clause produces a
+  # `WHERE (...)` clause, because the base query
+  # (`from(m in MediaItem)` in build_query/1) carries no filter of its own.
+  # That is the signal this test asserts on, rather than looking for a
+  # literal TRUE token the adapter never actually emits.
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Collections.SmartRules
+  alias Mydia.Collections.SmartRulesFields
+
+  test "every field/operator pair the rules editor advertises has a real build_dynamic clause" do
+    for {field, %{operators: operators}} <- SmartRulesFields.field_definitions(),
+        operator <- operators do
+      value = plausible_value(field, operator)
+
+      rules = %{
+        "conditions" => [
+          %{"field" => field, "operator" => to_string(operator), "value" => value}
+        ]
+      }
+
+      case SmartRules.query(rules) do
+        {:ok, query} ->
+          {sql, _params} = Ecto.Adapters.SQL.to_sql(:all, Mydia.Repo, query)
+
+          assert sql =~ "WHERE",
+                 "#{field} + #{operator} validates but produces no WHERE clause: " <>
+                   "build_dynamic/3 has no clause for this pair and it silently falls " <>
+                   "through to the catch-all, which matches every row instead of " <>
+                   "filtering or raising"
+
+        {:error, reason} ->
+          flunk(
+            "#{field} + #{operator} (probe value #{inspect(value)}) failed to validate: " <>
+              "#{reason}. Fix plausible_value/2 in this test; SmartRulesFields advertises " <>
+              "this pair, but the probe value chosen for it does not pass SmartRules.validate/1."
+          )
+      end
+    end
+  end
+
+  # One plausible value per field, valid for every operator that field
+  # advertises. Hand-picked per field rather than derived generically from
+  # the field's declared :type, because some fields (type, category)
+  # restrict values to a fixed allowlist that a generic placeholder value
+  # would fail validation against.
+  defp plausible_value("type", operator) when operator in [:in, :not_in], do: ["movie"]
+  defp plausible_value("type", _operator), do: "movie"
+
+  defp plausible_value("category", operator) when operator in [:in, :not_in], do: ["movie"]
+  defp plausible_value("category", _operator), do: "movie"
+
+  defp plausible_value("year", :between), do: [2010, 2020]
+  defp plausible_value("year", _operator), do: 2015
+
+  defp plausible_value("title", _operator), do: "Test"
+
+  defp plausible_value("monitored", _operator), do: true
+
+  defp plausible_value("metadata.vote_average", :between), do: [5.0, 8.0]
+  defp plausible_value("metadata.vote_average", _operator), do: 7.0
+
+  defp plausible_value("metadata.genres", :contains), do: "Action"
+  defp plausible_value("metadata.genres", :contains_any), do: ["Action"]
+
+  defp plausible_value("metadata.original_language", operator) when operator in [:in, :not_in],
+    do: ["en"]
+
+  defp plausible_value("metadata.original_language", _operator), do: "en"
+
+  defp plausible_value("metadata.status", operator) when operator in [:in, :not_in],
+    do: ["Ended"]
+
+  defp plausible_value("metadata.status", _operator), do: "Ended"
+
+  defp plausible_value("inserted_at", :within_last), do: 30
+  defp plausible_value("inserted_at", _operator), do: "2020-01-01T00:00:00Z"
+
+  defp plausible_value(field, operator) do
+    flunk(
+      "no plausible_value/2 clause for #{field} + #{operator}. SmartRulesFields advertises " <>
+        "this pair; add a matching clause here so the coverage test actually exercises it."
+    )
+  end
+end

--- a/test/mydia/collections/smart_rules_test.exs
+++ b/test/mydia/collections/smart_rules_test.exs
@@ -3,6 +3,7 @@ defmodule Mydia.Collections.SmartRulesTest do
 
   alias Mydia.Collections.SmartRules
 
+  import Ecto.Query
   import Mydia.MediaFixtures
 
   describe "validate/1" do
@@ -445,6 +446,70 @@ defmodule Mydia.Collections.SmartRulesTest do
       }
 
       assert {:ok, %Ecto.Query{}} = SmartRules.query(rules)
+    end
+  end
+
+  describe "within_last operator" do
+    test "matches an item inserted inside the window" do
+      item = media_item_fixture(%{title: "Harbor Lights"})
+
+      rules = %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "inserted_at", "operator" => "within_last", "value" => 30}
+        ]
+      }
+
+      ids = SmartRules.execute_query!(rules) |> Enum.map(& &1.id)
+      assert item.id in ids
+    end
+
+    test "excludes an item inserted before the window" do
+      item = media_item_fixture(%{title: "Quiet Harvest"})
+
+      old = DateTime.add(DateTime.utc_now(), -90, :day) |> DateTime.truncate(:second)
+
+      {1, _} =
+        Mydia.Repo.update_all(
+          from(m in Mydia.Media.MediaItem, where: m.id == ^item.id),
+          set: [inserted_at: old]
+        )
+
+      rules = %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "inserted_at", "operator" => "within_last", "value" => 30}
+        ]
+      }
+
+      ids = SmartRules.execute_query!(rules) |> Enum.map(& &1.id)
+      refute item.id in ids
+    end
+
+    test "validation rejects zero, negative, and non-integer values" do
+      for bad <- [0, -5, 1.5, "30", nil] do
+        rules = %{
+          "match_type" => "all",
+          "conditions" => [
+            %{"field" => "inserted_at", "operator" => "within_last", "value" => bad}
+          ]
+        }
+
+        assert {:error, _errors} = SmartRules.validate(rules),
+               "expected within_last to reject #{inspect(bad)}"
+      end
+    end
+
+    test "validation rejects within_last on a non-date field" do
+      rules = %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "year", "operator" => "within_last", "value" => 30}
+        ]
+      }
+
+      assert {:error, errors} = SmartRules.validate(rules)
+      assert Enum.any?(errors, &String.contains?(&1, "within_last"))
     end
   end
 end

--- a/test/mydia/collections/smart_rules_test.exs
+++ b/test/mydia/collections/smart_rules_test.exs
@@ -465,13 +465,14 @@ defmodule Mydia.Collections.SmartRulesTest do
     end
 
     test "excludes an item inserted before the window" do
-      item = media_item_fixture(%{title: "Quiet Harvest"})
+      old_item = media_item_fixture(%{title: "Quiet Harvest"})
+      recent_item = media_item_fixture(%{title: "Copper Ridge"})
 
       old = DateTime.add(DateTime.utc_now(), -90, :day) |> DateTime.truncate(:second)
 
       {1, _} =
         Mydia.Repo.update_all(
-          from(m in Mydia.Media.MediaItem, where: m.id == ^item.id),
+          from(m in Mydia.Media.MediaItem, where: m.id == ^old_item.id),
           set: [inserted_at: old]
         )
 
@@ -483,7 +484,8 @@ defmodule Mydia.Collections.SmartRulesTest do
       }
 
       ids = SmartRules.execute_query!(rules) |> Enum.map(& &1.id)
-      refute item.id in ids
+      refute old_item.id in ids
+      assert recent_item.id in ids
     end
 
     test "validation rejects zero, negative, and non-integer values" do
@@ -498,6 +500,15 @@ defmodule Mydia.Collections.SmartRulesTest do
         assert {:error, _errors} = SmartRules.validate(rules),
                "expected within_last to reject #{inspect(bad)}"
       end
+
+      valid_rules = %{
+        "match_type" => "all",
+        "conditions" => [
+          %{"field" => "inserted_at", "operator" => "within_last", "value" => 30}
+        ]
+      }
+
+      assert {:ok, _} = SmartRules.validate(valid_rules)
     end
 
     test "validation rejects within_last on a non-date field" do

--- a/test/mydia/collections/smart_rules_test.exs
+++ b/test/mydia/collections/smart_rules_test.exs
@@ -400,6 +400,44 @@ defmodule Mydia.Collections.SmartRulesTest do
       assert length(items) == 1
       assert hd(items).id == japanese.id
     end
+
+    test "filters by metadata.original_language not_in, including items missing the field" do
+      japanese = media_item_fixture(%{type: "movie", metadata: %{"original_language" => "ja"}})
+      english = media_item_fixture(%{type: "movie", metadata: %{"original_language" => "en"}})
+      no_language = media_item_fixture(%{type: "movie", metadata: %{}})
+
+      rules = %{
+        "conditions" => [
+          %{"field" => "metadata.original_language", "operator" => "not_in", "value" => ["en"]}
+        ]
+      }
+
+      item_ids = SmartRules.execute_query!(rules) |> Enum.map(& &1.id)
+
+      assert japanese.id in item_ids
+      assert no_language.id in item_ids
+      refute english.id in item_ids
+    end
+
+    test "filters by metadata.status not_in, including items missing the field" do
+      returning =
+        media_item_fixture(%{type: "tv_show", metadata: %{"status" => "Returning Series"}})
+
+      ended = media_item_fixture(%{type: "tv_show", metadata: %{"status" => "Ended"}})
+      no_status = media_item_fixture(%{type: "tv_show", metadata: %{}})
+
+      rules = %{
+        "conditions" => [
+          %{"field" => "metadata.status", "operator" => "not_in", "value" => ["Ended"]}
+        ]
+      }
+
+      item_ids = SmartRules.execute_query!(rules) |> Enum.map(& &1.id)
+
+      assert returning.id in item_ids
+      assert no_status.id in item_ids
+      refute ended.id in item_ids
+    end
   end
 
   describe "helper functions" do

--- a/test/mydia/collections_test.exs
+++ b/test/mydia/collections_test.exs
@@ -408,4 +408,55 @@ defmodule Mydia.CollectionsTest do
       assert Collections.item_count(collection) == 3
     end
   end
+
+  describe "add_preset/2" do
+    setup do
+      %{user: user_fixture()}
+    end
+
+    test "creates a private smart collection carrying the preset's rules", %{user: user} do
+      preset = Mydia.Collections.Presets.get("decade_2000s")
+
+      assert {:ok, collection} = Collections.add_preset(user, "decade_2000s")
+
+      assert collection.type == "smart"
+      assert collection.visibility == "private"
+      assert collection.name == preset.name
+      assert collection.description == preset.description
+      assert collection.sidebar_icon == preset.icon
+      assert collection.user_id == user.id
+      refute collection.is_system
+
+      assert Jason.decode!(collection.smart_rules) ==
+               Jason.decode!(Jason.encode!(preset.rules))
+    end
+
+    test "the created collection is a normal, editable collection", %{user: user} do
+      {:ok, collection} = Collections.add_preset(user, "decade_2000s")
+
+      assert {:ok, renamed} =
+               Collections.update_collection(user, collection, %{name: "My Own Name"})
+
+      assert renamed.name == "My Own Name"
+      assert {:ok, _} = Collections.delete_collection(user, renamed)
+    end
+
+    test "returns an error for an unknown key", %{user: user} do
+      assert {:error, :unknown_preset} = Collections.add_preset(user, "no_such_preset")
+      assert {:error, :unknown_preset} = Collections.add_preset(user, nil)
+    end
+
+    test "adding the same preset twice is allowed and makes two collections", %{user: user} do
+      assert {:ok, first} = Collections.add_preset(user, "decade_2000s")
+      assert {:ok, second} = Collections.add_preset(user, "decade_2000s")
+      refute first.id == second.id
+    end
+
+    test "every preset in the catalog can be added", %{user: user} do
+      for preset <- Mydia.Collections.Presets.list() do
+        assert {:ok, _collection} = Collections.add_preset(user, preset.key),
+               "preset #{preset.key} could not be added"
+      end
+    end
+  end
 end

--- a/test/mydia_web/live/collection_live/index_test.exs
+++ b/test/mydia_web/live/collection_live/index_test.exs
@@ -64,6 +64,29 @@ defmodule MydiaWeb.CollectionLive.IndexTest do
       assert "2010s" in names
     end
 
+    test "reopening the gallery makes an added preset addable again", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+      view |> element("#preset-add-decade_2000s") |> render_click()
+
+      refute has_element?(view, "#preset-add-decade_2000s")
+
+      view |> element("#close-preset-gallery") |> render_click()
+      view |> element("#browse-presets-button") |> render_click()
+
+      # The added state is scoped to one visit, so it can never outlive the
+      # collection it describes. Duplicates are permitted by design; the
+      # name-match hint warns without blocking.
+      assert has_element?(view, "#preset-add-decade_2000s")
+      refute has_element?(view, "#preset-added-decade_2000s")
+      assert render(view) =~ "You already have a collection with this name."
+
+      view |> element("#preset-add-decade_2000s") |> render_click()
+
+      assert Collections.list_collections(user)
+             |> Enum.count(&(&1.name == "2000s")) == 2
+    end
+
     test "an unknown preset key flashes instead of crashing", %{conn: conn} do
       {:ok, view, _html} = live(conn, ~p"/collections")
       view |> element("#browse-presets-button") |> render_click()

--- a/test/mydia_web/live/collection_live/index_test.exs
+++ b/test/mydia_web/live/collection_live/index_test.exs
@@ -5,6 +5,7 @@ defmodule MydiaWeb.CollectionLive.IndexTest do
 
   import Phoenix.LiveViewTest
   import Mydia.AccountsFixtures
+  import Mydia.MediaFixtures
 
   alias Mydia.Collections
 
@@ -80,6 +81,59 @@ defmodule MydiaWeb.CollectionLive.IndexTest do
 
       view |> element("#close-preset-gallery") |> render_click()
       refute has_element?(view, "#preset-gallery-modal")
+    end
+  end
+
+  describe "preset counts" do
+    # Guards against the three count states being conflated. Design intent is
+    # explicit that a loaded zero must render as "0 items" and stay addable,
+    # never fall back to the not-yet-loaded spinner (a regression a naive
+    # `if @count do ... else spinner end` would introduce silently).
+    test "a preset with zero matches still shows \"0 items\" and stays addable",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+
+      # No media exists yet, so every preset's count is a genuine, loaded
+      # zero rather than "not loaded yet".
+      render_async(view, 2000)
+
+      assert has_element?(view, "#preset-card-decade_2000s", "0 items")
+      assert has_element?(view, "#preset-add-decade_2000s")
+      refute has_element?(view, "#preset-added-decade_2000s")
+
+      add_button_html = view |> element("#preset-add-decade_2000s") |> render()
+      refute add_button_html =~ "disabled"
+    end
+
+    test "a preset with matches shows the real count", %{conn: conn} do
+      media_item_fixture(%{type: "movie", title: "Static Horizon", year: 2005})
+      media_item_fixture(%{type: "movie", title: "Nebula Drift", year: 2005})
+      # Outside the 2000s range: proves the count is a real query result and
+      # not just "however many media items exist".
+      media_item_fixture(%{type: "movie", title: "Copper Skyline", year: 1975})
+
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+
+      render_async(view, 2000)
+
+      assert has_element?(view, "#preset-card-decade_2000s", "2 items")
+    end
+
+    # render_click's return value is a snapshot taken synchronously while the
+    # LiveView handles the click and replies over the test channel, strictly
+    # before it can process the start_async task's completion message (a
+    # GenServer only picks up its next mailbox message once the current one
+    # is fully handled). So this does not race the async count query,
+    # regardless of how fast that query runs.
+    test "counts start as spinners before the async query resolves", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+
+      html = view |> element("#browse-presets-button") |> render_click()
+
+      assert html =~ "loading loading-spinner loading-xs"
+      refute html =~ "0 items"
     end
   end
 end

--- a/test/mydia_web/live/collection_live/index_test.exs
+++ b/test/mydia_web/live/collection_live/index_test.exs
@@ -1,0 +1,85 @@
+defmodule MydiaWeb.CollectionLive.IndexTest do
+  # async: false - a connected LiveView cannot share the PostgreSQL sandbox
+  # connection with an async test process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Collections
+
+  setup %{conn: conn} do
+    user = user_fixture()
+    %{conn: log_in_user(conn, user), user: user}
+  end
+
+  describe "preset gallery" do
+    test "the browse presets button opens the gallery", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+
+      refute has_element?(view, "#preset-gallery-modal")
+
+      view |> element("#browse-presets-button") |> render_click()
+
+      assert has_element?(view, "#preset-gallery-modal")
+      assert has_element?(view, "#preset-card-decade_2000s")
+      assert has_element?(view, "#preset-card-highly_rated")
+    end
+
+    test "the gallery renders a card for every preset", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+
+      for preset <- Collections.Presets.list() do
+        assert has_element?(view, "#preset-card-#{preset.key}"),
+               "no card rendered for preset #{preset.key}"
+      end
+    end
+
+    test "adding a preset creates a collection and flips the card", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+
+      view |> element("#preset-add-decade_2000s") |> render_click()
+
+      collections = Collections.list_collections(user)
+      assert Enum.any?(collections, &(&1.name == "2000s" and &1.type == "smart"))
+
+      # The gallery stays open so several presets can be added in a row.
+      assert has_element?(view, "#preset-gallery-modal")
+      assert has_element?(view, "#preset-added-decade_2000s")
+      refute has_element?(view, "#preset-add-decade_2000s")
+    end
+
+    test "several presets can be added without reopening the gallery", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+
+      view |> element("#preset-add-decade_2000s") |> render_click()
+      view |> element("#preset-add-decade_2010s") |> render_click()
+
+      names = Collections.list_collections(user) |> Enum.map(& &1.name)
+      assert "2000s" in names
+      assert "2010s" in names
+    end
+
+    test "an unknown preset key flashes instead of crashing", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+
+      html = render_click(view, "add_preset", %{"key" => "no_such_preset"})
+
+      assert html =~ "no longer available"
+      assert has_element?(view, "#preset-gallery-modal")
+    end
+
+    test "the gallery closes", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/collections")
+      view |> element("#browse-presets-button") |> render_click()
+      assert has_element?(view, "#preset-gallery-modal")
+
+      view |> element("#close-preset-gallery") |> render_click()
+      refute has_element?(view, "#preset-gallery-modal")
+    end
+  end
+end


### PR DESCRIPTION
## What this adds

Preset collections: a browsable gallery of common smart collections that a user can add in one click, instead of hand-building the same rules every time.

Open **Browse presets** on `/collections` and you get sixteen presets grouped into Decades, Genres, Highlights, Series and Language, each showing a live count of how many items in your library match. Clicking Add creates an ordinary smart collection and leaves you in the gallery, so adding four decades takes four clicks rather than four trips through the modal.

The gallery doubles as a discovery surface. Smart rules could already express most of this; almost nobody knew, because the only way in was an empty condition builder.

## Design decisions

**Presets run against your own library.** A preset is a bundle of smart rules, not a curated external list. "2000s" means `year between [2000, 2009]` over what you already have. No external fetching, no new relay endpoints.

**Nothing is auto-seeded.** Presets appear only when you open the gallery and click Add. A fresh install does not get a page of empty shelves it never asked for.

**Adding produces an independent copy.** The rules are stamped onto a normal smart collection with no back-reference to the preset. No new column and no migration. The accepted cost: the gallery cannot know for certain which presets you already added, so it shows a soft name-match hint that never blocks the button, and duplicates are allowed.

**One new operator.** `within_last` for relative dates, so "Recently Added" stays a rolling 30-day window instead of freezing to the date it was created. It is exposed in the rules editor too, not just used by the preset. Watch state stayed out of scope: it lives outside `media_items` and is per-user, so exposing it as a rule field needs a join the engine does not do yet.

## A pre-existing bug this uncovered

Building the catalog surfaced a real bug in the rules engine, unrelated to presets but hit by one of them.

`build_dynamic/3` ends in a catch-all returning `dynamic([m], true)`. The rules editor advertises `not_in` for four fields, but only `category` and `type` had clauses for it. `metadata.original_language` and `metadata.status` fell through to that catch-all, so the condition silently matched every row instead of filtering.

The user-visible effect, present before this branch: building "Language is not one of [English]" in the rules editor produced a smart collection containing your entire library, with nothing to indicate anything had gone wrong. The `foreign_language` preset here would have shipped that same behavior.

This PR adds the two missing clauses, with explicit NULL handling so a title with no recorded language still counts as not-English (a bare SQL `NOT IN` against NULL yields NULL, not TRUE, which would silently drop exactly the rows you would expect to see). Both adapters are covered; the clauses reuse the existing `json_extract_dynamic/2` helper rather than introducing adapter-specific SQL.

It also adds `test/mydia/collections/smart_rules_operator_coverage_test.exs`, which asserts that every operator the rules editor advertises has a real `build_dynamic/3` clause rather than falling through. That guard is in the spirit of `sidebar_icon_safelist_test.exs`: a cross-file invariant that fails loudly in CI instead of silently in production.

## Known follow-ups, deliberately not in this PR

**The catch-all itself is unchanged.** `dynamic([m], true)` means any future unimplemented pair silently widens results rather than failing. Changing it to fail safe is the right fix, but it alters shared engine behavior for any existing collection currently hitting the bug, which is a bigger decision than this feature should make on its own.

**The coverage test spans UI-reachable pairs only.** `SmartRules.validate/1` has no general per-field operator whitelist, so a hand-crafted event payload such as `category` + `gt` still passes validation and reaches the catch-all. Not reachable by clicking, since the operator dropdown is populated from the advertised list. It belongs with the catch-all decision above.

**`index.ex` is now 716 lines**, over the ~500 guideline. It was already 588 before this branch; the gallery's markup went into its own 112-line `preset_components.ex` specifically to avoid making it worse. Extracting the rest is its own change.

## Testing

- `test/mydia/collections/presets_test.exs` walks the catalog and **executes** every preset's rules, not just validates them. `validate/1` only checks names against allowlists, while `build_dynamic/3` is a set of specific clauses, so a preset can validate and still raise `FunctionClauseError` when the query is built. Without this, a bad catalog entry ships green and breaks only when a user clicks it.
- Every preset icon is asserted to be in `Collection.valid_sidebar_icons/0`. Preset icons are chosen at runtime from `lib/mydia/`, outside the `@source` globs in `app.css`, so an unsafelisted icon would render as an invisible blank box with no error anywhere.
- Behavioral tests for `not_in` on both fields, including rows missing the field entirely.
- Gallery tests cover the three count states separately: not-yet-loaded renders a spinner, zero renders "0 items" with the Add button still enabled, and a seeded non-zero count renders that number. The async assertions use `render_async/2` and the synchronous per-event reply rather than sleeps or polling.

Full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse and add 16 ready-to-use smart collection presets from a grouped gallery with icons, descriptions, item counts, duplicate-name hints, and added states.
  * Added an “in the last (days)” filter for recently added items.
  * Added support for excluding metadata values while retaining items without that metadata.

* **Bug Fixes**
  * Improved exclusion filtering so items missing metadata are not unintentionally omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->