### PR TITLE
fix(ui): give unselected segmented-control buttons a visible body

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -34,8 +34,12 @@
 @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
 @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
 
-/* Use the data attribute for dark mode  */
-@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+/* Use the data attribute for dark mode.
+   The theme names are `mydia-dark` / `mydia-light` (see root.html.heex), not
+   the bare `dark` this variant originally targeted. Against `[data-theme=dark]`
+   the variant matched no element that exists, so every `dark:` utility silently
+   produced nothing. Guarded by test/mydia_web/components/dark_variant_test.exs. */
+@custom-variant dark (&:where([data-theme=mydia-dark], [data-theme=mydia-dark] *));
 
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session],

--- a/lib/mydia_web.ex
+++ b/lib/mydia_web.ex
@@ -95,6 +95,8 @@ defmodule MydiaWeb do
       import MydiaWeb.AdminComponents
       # Poster card body: shared title box and bottom-pinned metadata
       import MydiaWeb.PosterCardComponents
+      # One-of-N button groups (view mode, grid density, filters)
+      import MydiaWeb.SegmentedControl
 
       # Common modules used in templates
       alias Phoenix.LiveView.JS

--- a/lib/mydia_web/components/README.md
+++ b/lib/mydia_web/components/README.md
@@ -75,6 +75,75 @@ the unchecked state keeps daisyUI's default outline. Verified by building
 chromium in both themes. Live at
 `lib/mydia_web/live/admin_duplicates_live/components.ex`.
 
+## Inactive segments must not be btn-ghost
+
+daisyUI defines `btn-ghost` as `--btn-bg: #0000` and `--btn-border: #0000`, so
+a `btn-ghost` button computes to `alpha=0` and paints whatever is behind it.
+That is fine for an action strip, and wrong for one option of a segmented
+control, because the option ends up with no body at all.
+
+Measured on the `mydia-dark` theme, against the built stylesheet:
+
+| Surface | sRGB | vs page | vs inactive |
+| --- | --- | --- | --- |
+| page, `base-100` | `29,35,42` | | |
+| inactive segment as `btn-ghost` | `alpha=0` | 1.000 | |
+| inactive segment as plain `.btn` | `42,49,58` | 1.206 | |
+| active segment, `btn-primary` | `0,125,255` | 4.055 | 3.363 |
+
+`btn-active` is not a usable selection marker either. daisyUI sets it to
+`color-mix(in oklab, base-200, #000 5%)`, which measures `38,45,53`, a
+contrast of 1.059 against a plain button and darker than it. On a dark theme
+the selected option reads as recessed rather than chosen.
+
+Use `MydiaWeb.SegmentedControl` rather than hand-rolling either. It marks the
+selected option `btn-primary` and gives unselected options no colour class,
+which leaves them as plain opaque `.btn`.
+
+`test/mydia_web/components/no_ghost_segments_test.exs` fails the build if any
+`join` in `lib/mydia_web` pairs `btn-ghost` with `btn-primary`.
+
+## Every hover in Mydia gets darker, including on the dark theme
+
+daisyUI's `.btn:hover` sets `--btn-bg: color-mix(in oklab, base-200, #000 7%)`.
+It mixes toward black regardless of theme, so in dark mode a hovered button
+moves from `42,49,58` to `37,44,51`. That is a contrast of 1.075, and it is
+the wrong direction: the surface recedes instead of lifting.
+
+Segmented controls override it with `dark:hover:bg-base-300` (`65,74,84`, a
+1.459 step, lighter). Light mode keeps the daisyUI default, which is already
+1.226 there and stronger than `base-300` would be.
+
+The rest of the app still darkens on hover. Fixing that everywhere needs its
+own visual pass.
+
+## The dark: variant targets mydia-dark
+
+`app.css` declares Tailwind's `dark:` variant by hand. It originally read
+
+```css
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+```
+
+but `root.html.heex` only ever sets `mydia-dark` or `mydia-light`, so the
+variant matched no element that exists and every `dark:` utility silently
+produced nothing. Nothing errors when this regresses, which is why
+`test/mydia_web/components/dark_variant_test.exs` guards it.
+
+Tailwind utilities beat daisyUI's component rules, so `dark:hover:bg-base-300`
+overrides `background-color: var(--btn-bg)`. Tailwind emits utilities directly
+in `@layer utilities` while daisyUI's declaration sits in a nested `daisyui.l1`
+sublayer, and cascade layers beat specificity outright.
+
+One caution when checking any of this. Tailwind only generates classes it finds
+in the `@source` globs, so a class written into a scratch HTML file is never
+built and reads as "the rule does not work". Confirm the class is present in
+the built CSS before concluding anything:
+
+```
+./_build/tailwind-linux-x64-4.3.3 --input=assets/css/app.css --output=/tmp/app.css
+```
+
 ## No card-level dropdown can win on z-index
 
 Two traps, and the second is the fatal one.

--- a/lib/mydia_web/components/grid_density_components.ex
+++ b/lib/mydia_web/components/grid_density_components.ex
@@ -8,27 +8,9 @@ defmodule MydiaWeb.GridDensityComponents do
   `"grid-cols-\#{n}"` is never generated and the grid silently keeps whatever
   columns it had. Any new level must be added here as complete literals.
 
-  The buttons are icon-only. `aria-label` therefore carries each button's
-  accessible name and `aria-pressed` its state, since `btn-primary` alone
-  says nothing to a screen reader. `aria-pressed` is wrapped in `to_string/1`
-  on purpose: HEEx renders a `true` attribute value as a bare attribute and
-  omits it entirely for `false`, and ARIA needs the literal strings.
-
-  The tooltip lives on a wrapper `div`, never on the `<button>` itself.
-  daisyUI shows the tip on `.tooltip-open`, `:hover` and `.tooltip:has(:focus-visible)`,
-  and `:has()` carries an implicit descendant combinator: it matches when a
-  *descendant* is focused, not the element itself. A `.tooltip` button whose
-  only descendant is the non-focusable `<span>` from `icon/1` therefore never
-  shows its tip on keyboard focus, leaving a tabbing user with a bare icon.
-  Wrapping is the form every focusable tooltip in this app already uses.
-
-  `join-item` stays on the button and is deliberately kept off that wrapper.
-  daisyUI's `.join-item > *` resets `--join-ss`/`--join-se`/`--join-es`/`--join-ee`
-  to `initial`, so a button nested inside a `join-item` wrapper computes all
-  four corners to 0 and the filled active button spills square out of the
-  join's rounded end cap. With the wrapper left plain, the join's radius
-  variables inherit straight through to the button and the caps render as
-  they did before the tooltip moved.
+  The buttons are icon-only. `MydiaWeb.SegmentedControl` owns the accessible
+  naming, the tooltip wrapper and the `join-item` placement that icon-only
+  segments need; see its moduledoc for why each is shaped the way it is.
 
   Kept in step with `MydiaWeb.LibraryComponents.view_mode_toggle/1`, which is
   icon-only for the same reasons; the two sit side by side on the Libraries
@@ -41,7 +23,7 @@ defmodule MydiaWeb.GridDensityComponents do
 
   use Phoenix.Component
 
-  import MydiaWeb.CoreComponents, only: [icon: 1]
+  import MydiaWeb.SegmentedControl, only: [segmented_control: 1]
 
   @default "comfortable"
 
@@ -86,28 +68,21 @@ defmodule MydiaWeb.GridDensityComponents do
     assigns = assign(assigns, :levels, @levels)
 
     ~H"""
-    <div class="join" id={@id} role="group" aria-label="Grid density">
-      <div
+    <.segmented_control
+      id={@id}
+      value={@density}
+      event="set_grid_density"
+      param="density"
+      label="Grid density"
+      icon_only
+    >
+      <:option
         :for={{value, label, icon_name} <- @levels}
-        class="tooltip tooltip-bottom"
-        data-tip={label}
-      >
-        <button
-          type="button"
-          class={[
-            "btn btn-sm btn-square join-item",
-            @density == value && "btn-primary",
-            @density != value && "btn-ghost"
-          ]}
-          phx-click="set_grid_density"
-          phx-value-density={value}
-          aria-label={label}
-          aria-pressed={to_string(@density == value)}
-        >
-          <.icon name={icon_name} class="w-4 h-4" />
-        </button>
-      </div>
-    </div>
+        value={value}
+        label={label}
+        icon={icon_name}
+      />
+    </.segmented_control>
     """
   end
 end

--- a/lib/mydia_web/components/library_components.ex
+++ b/lib/mydia_web/components/library_components.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.LibraryComponents do
 
   # Import only what we need to avoid circular dependency
   import MydiaWeb.CoreComponents, only: [icon: 1, modal: 1]
+  import MydiaWeb.SegmentedControl, only: [segmented_control: 1]
 
   use Phoenix.VerifiedRoutes,
     endpoint: MydiaWeb.Endpoint,
@@ -251,22 +252,9 @@ defmodule MydiaWeb.LibraryComponents do
   @doc """
   Renders a view mode toggle (grid/list).
 
-  Icon-only, so `aria-label` carries each button's accessible name and
-  `aria-pressed` its state. `aria-pressed` is wrapped in `to_string/1` because
-  HEEx renders a `true` attribute value as a bare attribute and omits it for
-  `false`, and ARIA needs the literal strings.
-
-  Each tooltip sits on a wrapper `div` rather than on the button. daisyUI
-  reveals the tip via `.tooltip:has(:focus-visible)`, and `:has()` implies a
-  descendant combinator, so a `.tooltip` button whose only descendant is the
-  non-focusable icon `<span>` never shows its tip to a keyboard user.
-
-  `join-item` stays on the button and is deliberately kept off the wrapper:
-  `.join-item > *` resets `--join-ss`/`--join-se`/`--join-es`/`--join-ee` to
-  `initial`, so a button nested inside a `join-item` wrapper computes every
-  corner to 0 and the filled active button spills square out of the join's
-  rounded end cap. Left off the wrapper, the join's radius variables inherit
-  straight through to the button and the caps render as before.
+  The buttons are icon-only. `MydiaWeb.SegmentedControl` owns the accessible
+  naming, the tooltip wrapper and the `join-item` placement that icon-only
+  segments need; see its moduledoc for why each is shaped the way it is.
 
   Kept in step with `MydiaWeb.GridDensityComponents.grid_density_toggle/1`,
   which sits directly beside this on the Libraries toolbar.
@@ -279,40 +267,16 @@ defmodule MydiaWeb.LibraryComponents do
 
   def view_mode_toggle(assigns) do
     ~H"""
-    <div class="join" role="group" aria-label="View mode">
-      <div class="tooltip tooltip-bottom" data-tip="Grid">
-        <button
-          type="button"
-          class={[
-            "btn btn-sm btn-square join-item",
-            @view_mode == :grid && "btn-primary",
-            @view_mode != :grid && "btn-ghost"
-          ]}
-          phx-click="toggle_view"
-          phx-value-mode="grid"
-          aria-label="Grid"
-          aria-pressed={to_string(@view_mode == :grid)}
-        >
-          <.icon name="hero-squares-2x2" class="w-4 h-4" />
-        </button>
-      </div>
-      <div class="tooltip tooltip-bottom" data-tip="List">
-        <button
-          type="button"
-          class={[
-            "btn btn-sm btn-square join-item",
-            @view_mode == :list && "btn-primary",
-            @view_mode != :list && "btn-ghost"
-          ]}
-          phx-click="toggle_view"
-          phx-value-mode="list"
-          aria-label="List"
-          aria-pressed={to_string(@view_mode == :list)}
-        >
-          <.icon name="hero-list-bullet" class="w-4 h-4" />
-        </button>
-      </div>
-    </div>
+    <.segmented_control
+      value={@view_mode}
+      event="toggle_view"
+      param="mode"
+      label="View mode"
+      icon_only
+    >
+      <:option value="grid" label="Grid" icon="hero-squares-2x2" />
+      <:option value="list" label="List" icon="hero-list-bullet" />
+    </.segmented_control>
     """
   end
 

--- a/lib/mydia_web/components/segmented_control.ex
+++ b/lib/mydia_web/components/segmented_control.ex
@@ -1,0 +1,163 @@
+defmodule MydiaWeb.SegmentedControl do
+  @moduledoc """
+  A daisyUI `join` of buttons where exactly one option is selected.
+
+  This is the single owner of segment markup. Before it existed the app had
+  three conventions for the same control and two of them were invisible in
+  dark mode, measured against the built stylesheet:
+
+    * `btn-ghost` on the inactive segments sets `--btn-bg: #0000`. The segment
+      computes to `alpha=0` and paints the page background exactly, contrast
+      1.000. The button has no body at all.
+    * `btn-active` on the selected segment sets
+      `color-mix(in oklab, base-200, #000 5%)`, which is 1.059 against a plain
+      button and *darker* than it, so the chosen option reads as recessed.
+
+  So: the selected option gets `btn-primary` (4.055 against the page, 3.363
+  against its neighbours) and unselected options get no colour class at all,
+  falling through to plain `.btn` at opaque `base-200`.
+
+  Unselected options also carry `dark:hover:bg-base-300`. daisyUI's own
+  `.btn:hover` mixes toward black, which in dark mode moves `42,49,58` to
+  `37,44,51`, a contrast of 1.075 in the wrong direction. `base-300` is a
+  1.459 step and lightens. Light mode keeps daisyUI's default, which is
+  already a reasonable 1.226 there and stronger than `base-300` would be.
+
+  Full measurements and method in
+  `docs/superpowers/specs/2026-09-01-segmented-control-design.md`.
+
+  ## Icon-only controls
+
+  `icon_only` makes the buttons square and moves each label into `aria-label`
+  and a tooltip. Three daisyUI traps are handled here so no call site has to:
+
+    * `btn-square` keeps a label-less button from collapsing to its icon.
+    * The tooltip goes on a wrapper `div`, never on the button. daisyUI shows
+      the tip via `.tooltip:has(:focus-visible)`, and `:has()` carries an
+      implicit descendant combinator, so a `.tooltip` button whose only
+      descendant is the non-focusable `<span>` from `icon/1` never shows its
+      tip on keyboard focus.
+    * `join-item` stays on the button and off that wrapper. `.join-item > *`
+      resets `--join-ss`/`--join-se`/`--join-es`/`--join-ee` to `initial`, so
+      a button nested inside a `join-item` wrapper computes all four corners
+      to 0 and the filled active button spills square out of the join's
+      rounded end cap.
+
+  ## Values
+
+  `value` and each option's `value` both pass through `to_string/1` before
+  comparison, and `phx-value-*` is serialized the same way. Call sites hold
+  atoms (`:grid`, `:movie`) and strings (`"dense"`, `"today"`), and
+  `phx-value-*` reaches `handle_event` as a string either way, so one coercion
+  removes any per-call-site handling.
+  """
+
+  use Phoenix.Component
+
+  import MydiaWeb.CoreComponents, only: [icon: 1]
+
+  @doc """
+  Renders a segmented control.
+
+  ## Examples
+
+      <.segmented_control
+        id="library-density-toggle"
+        value={@grid_density}
+        event="set_grid_density"
+        param="density"
+        label="Grid density"
+        icon_only
+      >
+        <:option value="comfortable" label="Comfortable" icon="hero-stop" />
+        <:option value="compact" label="Compact" icon="hero-view-columns" />
+        <:option value="dense" label="Dense" icon="hero-table-cells" />
+      </.segmented_control>
+  """
+  attr :id, :string, default: nil, doc: "DOM id for the join container"
+  attr :value, :any, required: true, doc: "the currently selected value"
+  attr :event, :string, required: true, doc: "phx-click event name"
+  attr :param, :string, required: true, doc: "key for phx-value-<param>"
+  attr :label, :string, required: true, doc: "aria-label for the group"
+
+  attr :size, :string,
+    default: "sm",
+    values: ~w(sm md),
+    doc: "sm adds btn-sm; md leaves the button full size"
+
+  attr :icon_only, :boolean,
+    default: false,
+    doc: "square buttons whose label moves to aria-label and a tooltip"
+
+  slot :option, required: true do
+    attr :value, :any, required: true
+    attr :label, :string, required: true
+    attr :icon, :string
+  end
+
+  def segmented_control(assigns) do
+    ~H"""
+    <div class="join" id={@id} role="group" aria-label={@label}>
+      <%= for option <- @option do %>
+        <%= if @icon_only do %>
+          <div class="tooltip tooltip-bottom" data-tip={option.label}>
+            <.segment
+              option={option}
+              selected?={selected?(option, @value)}
+              event={@event}
+              param={@param}
+              size={@size}
+              icon_only={@icon_only}
+            />
+          </div>
+        <% else %>
+          <.segment
+            option={option}
+            selected?={selected?(option, @value)}
+            event={@event}
+            param={@param}
+            size={@size}
+            icon_only={@icon_only}
+          />
+        <% end %>
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :option, :map, required: true
+  attr :selected?, :boolean, required: true
+  attr :event, :string, required: true
+  attr :param, :string, required: true
+  attr :size, :string, required: true
+  attr :icon_only, :boolean, required: true
+
+  defp segment(assigns) do
+    assigns = assign(assigns, :icon_name, Map.get(assigns.option, :icon))
+
+    ~H"""
+    <button
+      type="button"
+      class={[
+        "btn join-item",
+        @size == "sm" && "btn-sm",
+        @icon_only && "btn-square",
+        !@icon_only && "gap-1.5",
+        @selected? && "btn-primary",
+        !@selected? && "dark:hover:bg-base-300"
+      ]}
+      phx-click={@event}
+      aria-label={@icon_only && @option.label}
+      aria-pressed={to_string(@selected?)}
+      {%{"phx-value-#{@param}" => to_string(@option.value)}}
+    >
+      <.icon :if={@icon_name} name={@icon_name} class="w-4 h-4" />
+      <%= unless @icon_only do %>
+        {@option.label}
+      <% end %>
+    </button>
+    """
+  end
+
+  defp selected?(option, value), do: to_string(option.value) == to_string(value)
+end

--- a/lib/mydia_web/live/activity_live/index.html.heex
+++ b/lib/mydia_web/live/activity_live/index.html.heex
@@ -49,58 +49,19 @@
                 Time Period
               </span>
             </div>
-            <div class="join">
-              <button
-                class={[
-                  "join-item btn btn-sm",
-                  if(@date_filter == "all", do: "btn-active", else: "")
-                ]}
-                phx-click="filter_date"
-                phx-value-date="all"
-              >
-                All
-              </button>
-              <button
-                class={[
-                  "join-item btn btn-sm",
-                  if(@date_filter == "today", do: "btn-active", else: "")
-                ]}
-                phx-click="filter_date"
-                phx-value-date="today"
-              >
-                Today
-              </button>
-              <button
-                class={[
-                  "join-item btn btn-sm",
-                  if(@date_filter == "yesterday", do: "btn-active", else: "")
-                ]}
-                phx-click="filter_date"
-                phx-value-date="yesterday"
-              >
-                Yesterday
-              </button>
-              <button
-                class={[
-                  "join-item btn btn-sm",
-                  if(@date_filter == "week", do: "btn-active", else: "")
-                ]}
-                phx-click="filter_date"
-                phx-value-date="week"
-              >
-                7 Days
-              </button>
-              <button
-                class={[
-                  "join-item btn btn-sm",
-                  if(@date_filter == "month", do: "btn-active", else: "")
-                ]}
-                phx-click="filter_date"
-                phx-value-date="month"
-              >
-                30 Days
-              </button>
-            </div>
+            <.segmented_control
+              id="activity-date-filter"
+              value={@date_filter}
+              event="filter_date"
+              param="date"
+              label="Time period"
+            >
+              <:option value="all" label="All" />
+              <:option value="today" label="Today" />
+              <:option value="yesterday" label="Yesterday" />
+              <:option value="week" label="7 Days" />
+              <:option value="month" label="30 Days" />
+            </.segmented_control>
           </div>
         </div>
       </div>

--- a/lib/mydia_web/live/discover_live/index.html.heex
+++ b/lib/mydia_web/live/discover_live/index.html.heex
@@ -14,22 +14,16 @@
         <%!-- Media type toggle + category tabs --%>
         <div class="flex flex-col sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-3">
           <div id="discover-view-controls" class="flex flex-wrap items-center gap-3">
-            <div class="join">
-              <button
-                phx-click="switch_media_type"
-                phx-value-type="movie"
-                class={["join-item btn btn-sm gap-1.5", @media_type == :movie && "btn-active"]}
-              >
-                <.icon name="hero-film" class="w-4 h-4" /> Movies
-              </button>
-              <button
-                phx-click="switch_media_type"
-                phx-value-type="tv_show"
-                class={["join-item btn btn-sm gap-1.5", @media_type == :tv_show && "btn-active"]}
-              >
-                <.icon name="hero-tv" class="w-4 h-4" /> TV Shows
-              </button>
-            </div>
+            <.segmented_control
+              id="discover-media-type"
+              value={@media_type}
+              event="switch_media_type"
+              param="type"
+              label="Media type"
+            >
+              <:option value="movie" label="Movies" icon="hero-film" />
+              <:option value="tv_show" label="TV Shows" icon="hero-tv" />
+            </.segmented_control>
 
             <.grid_density_toggle id="discover-density-toggle" density={@grid_density} />
           </div>

--- a/lib/mydia_web/live/profile_live/index.ex
+++ b/lib/mydia_web/live/profile_live/index.ex
@@ -5,9 +5,9 @@ defmodule MydiaWeb.ProfileLive.Index do
   alias Mydia.Accounts.UserPreference
 
   @themes [
-    {"System", "system"},
-    {"Light", "light"},
-    {"Dark", "dark"}
+    {"System", "system", "hero-computer-desktop"},
+    {"Light", "light", "hero-sun"},
+    {"Dark", "dark", "hero-moon"}
   ]
 
   @impl true

--- a/lib/mydia_web/live/profile_live/index.html.heex
+++ b/lib/mydia_web/live/profile_live/index.html.heex
@@ -116,29 +116,21 @@
               <p class="text-sm text-base-content/60 mb-3">
                 Choose how Mydia looks. System will match your device's theme.
               </p>
-              <div class="join">
-                <%= for {label, value} <- @themes do %>
-                  <button
-                    type="button"
-                    class={[
-                      "join-item btn",
-                      if(@theme == value, do: "btn-primary", else: "btn-ghost")
-                    ]}
-                    phx-click="update_theme"
-                    phx-value-theme={value}
-                  >
-                    <%= case value do %>
-                      <% "system" -> %>
-                        <.icon name="hero-computer-desktop" class="w-4 h-4 mr-1" />
-                      <% "light" -> %>
-                        <.icon name="hero-sun" class="w-4 h-4 mr-1" />
-                      <% "dark" -> %>
-                        <.icon name="hero-moon" class="w-4 h-4 mr-1" />
-                    <% end %>
-                    {label}
-                  </button>
-                <% end %>
-              </div>
+              <.segmented_control
+                id="theme-picker"
+                value={@theme}
+                event="update_theme"
+                param="theme"
+                label="Theme"
+                size="md"
+              >
+                <:option
+                  :for={{label, value, icon} <- @themes}
+                  value={value}
+                  label={label}
+                  icon={icon}
+                />
+              </.segmented_control>
             </div>
 
             <div class="divider my-2"></div>

--- a/test/mydia_web/components/dark_variant_test.exs
+++ b/test/mydia_web/components/dark_variant_test.exs
@@ -1,0 +1,47 @@
+defmodule MydiaWeb.Components.DarkVariantTest do
+  @moduledoc """
+  Tailwind's `dark:` variant is declared by hand in app.css. It was originally
+  written against `[data-theme=dark]`, but the application sets `mydia-dark`
+  (see `root.html.heex`), so the variant matched no element that exists and
+  every `dark:` utility silently produced nothing.
+
+  Nothing errors when this regresses. An unmatched variant compiles fine and
+  emits CSS that can never apply, so only this test catches it.
+  """
+
+  use ExUnit.Case, async: true
+
+  @app_css Path.expand("../../../assets/css/app.css", __DIR__)
+
+  test "the dark variant targets the theme name the application actually sets" do
+    css = File.read!(@app_css)
+
+    assert css =~ ~s(@custom-variant dark),
+           "app.css no longer declares a `dark:` custom variant"
+
+    variant_line =
+      css
+      |> String.split("\n")
+      |> Enum.find(&String.contains?(&1, "@custom-variant dark"))
+
+    assert variant_line =~ "data-theme=mydia-dark",
+           """
+           The `dark:` variant must target `mydia-dark`, the value
+           root.html.heex actually writes to data-theme. Got:
+
+             #{variant_line}
+           """
+
+    refute variant_line =~ "data-theme=dark]",
+           "The variant still matches the non-existent bare `dark` theme"
+  end
+
+  test "root.html.heex still sets the theme name the variant expects" do
+    root =
+      Path.expand("../../../lib/mydia_web/components/layouts/root.html.heex", __DIR__)
+      |> File.read!()
+
+    assert root =~ "'mydia-dark'",
+           "root.html.heex no longer sets mydia-dark; the dark variant needs updating too"
+  end
+end

--- a/test/mydia_web/components/no_ghost_segments_test.exs
+++ b/test/mydia_web/components/no_ghost_segments_test.exs
@@ -32,6 +32,19 @@ defmodule MydiaWeb.Components.NoGhostSegmentsTest do
            """
   end
 
+  test "the scanner does not let a > inside a class expression truncate the value" do
+    # This is the exact shape a reviewer found could defeat a naive
+    # `class=[\s\S]*?>` scan: `@count > 3` inside the class list has its own
+    # literal `>`, so a non-greedy match to "the next >" stops there instead
+    # of at the tag's closing bracket, and btn-primary/btn-ghost after it are
+    # never seen. Assert the real extractor keeps going past it.
+    fixture = ~S"""
+    <button class={["btn join-item", @count > 3 && "btn-primary", !@selected? && "btn-ghost"]}>
+    """
+
+    assert offends?(fixture)
+  end
+
   # A naive whole-file split on every `join` class occurrence (the join
   # container itself, or any `join-item` member) over-reaches: a file's last
   # join-related match is routinely an all-ghost admin action strip (edit /
@@ -42,24 +55,75 @@ defmodule MydiaWeb.Components.NoGhostSegmentsTest do
   # finished tree (admin_*_live/components.ex and friends), none of them
   # near each other, let alone in the same join.
   #
-  # Scan per opening tag instead: `class=` up to that tag's own closing `>`
-  # is one element's complete class expression, whether it is a plain string
-  # or a `class={[...]}` list. A file offends only when some tag combines
-  # `join-item` with `btn-ghost` and some tag combines `join-item` with
-  # `btn-primary`, which is what a ghost-vs-primary mismatch inside one join
-  # looks like at the markup level, regardless of whether the button markup
-  # is written inline or shared through a helper component (as in
-  # `MydiaWeb.SegmentedControl`'s own private `segment/1`, whose single
-  # class list applies `btn-primary` or `btn-ghost` conditionally on
-  # `@selected?`).
-  defp ghost_segment?(path) do
-    tags =
-      path
-      |> File.read!()
-      |> then(&Regex.scan(~r/class=[\s\S]*?>/, &1))
-      |> Enum.map(&hd/1)
+  # Scan per class attribute VALUE instead of per tag. `class="..."` and
+  # `class={...}` are extracted properly rather than by scanning to a `>`:
+  # a plain string runs to the next `"`, and a `{...}` expression is walked
+  # char by char counting brace depth, so a `>` or `->` inside the
+  # expression (a guard, a `cond`, an interpolation) cannot be mistaken for
+  # the end of the value. A file offends only when some class value combines
+  # `join-item` with `btn-ghost` and some class value combines `join-item`
+  # with `btn-primary`, which is what a ghost-vs-primary mismatch inside one
+  # join looks like at the markup level, regardless of whether the button
+  # markup is written inline or shared through a helper component (as in
+  # `MydiaWeb.SegmentedControl`'s own private `segment/1`, whose single class
+  # list applies `btn-primary` or `btn-ghost` conditionally on `@selected?`).
+  defp ghost_segment?(path), do: path |> File.read!() |> offends?()
 
-    Enum.any?(tags, &(&1 =~ "join-item" and &1 =~ "btn-ghost")) and
-      Enum.any?(tags, &(&1 =~ "join-item" and &1 =~ "btn-primary"))
+  defp offends?(content) do
+    values = class_attribute_values(content)
+
+    Enum.any?(values, &(&1 =~ "join-item" and &1 =~ "btn-ghost")) and
+      Enum.any?(values, &(&1 =~ "join-item" and &1 =~ "btn-primary"))
+  end
+
+  defp class_attribute_values(content) do
+    content
+    |> class_attr_starts()
+    |> Enum.map(&extract_class_value(content, &1))
+  end
+
+  # Byte offset right after each `class=` occurrence, i.e. where the value
+  # (a `"` or a `{`) begins.
+  defp class_attr_starts(content), do: class_attr_starts(content, 0, [])
+
+  defp class_attr_starts(content, offset, acc) when offset <= byte_size(content) do
+    case :binary.match(content, "class=", scope: {offset, byte_size(content) - offset}) do
+      {start, len} -> class_attr_starts(content, start + len, [start + len | acc])
+      :nomatch -> Enum.reverse(acc)
+    end
+  end
+
+  defp extract_class_value(content, pos) when pos < byte_size(content) do
+    case :binary.at(content, pos) do
+      ?" -> extract_quoted(content, pos + 1)
+      ?{ -> extract_braced(content, pos + 1, 1, pos + 1)
+      _ -> ""
+    end
+  end
+
+  defp extract_class_value(_content, _pos), do: ""
+
+  # class="..." runs to the next literal quote.
+  defp extract_quoted(content, start) do
+    case :binary.match(content, "\"", scope: {start, byte_size(content) - start}) do
+      {stop, _} -> binary_part(content, start, stop - start)
+      :nomatch -> binary_part(content, start, byte_size(content) - start)
+    end
+  end
+
+  # class={...} runs to the `}` that balances the opening `{`, counting
+  # nested braces along the way (a `cond`/`if`, a map, string interpolation)
+  # so any `>` inside never ends the scan early.
+  defp extract_braced(content, pos, depth, value_start) when pos < byte_size(content) do
+    case :binary.at(content, pos) do
+      ?{ -> extract_braced(content, pos + 1, depth + 1, value_start)
+      ?} when depth == 1 -> binary_part(content, value_start, pos - value_start)
+      ?} -> extract_braced(content, pos + 1, depth - 1, value_start)
+      _ -> extract_braced(content, pos + 1, depth, value_start)
+    end
+  end
+
+  defp extract_braced(content, pos, _depth, value_start) do
+    binary_part(content, value_start, pos - value_start)
   end
 end

--- a/test/mydia_web/components/no_ghost_segments_test.exs
+++ b/test/mydia_web/components/no_ghost_segments_test.exs
@@ -1,0 +1,65 @@
+defmodule MydiaWeb.Components.NoGhostSegmentsTest do
+  @moduledoc """
+  A segmented control must never mark its unselected options `btn-ghost`.
+
+  daisyUI sets `--btn-bg: #0000` for `btn-ghost`, so the segment computes to
+  `alpha=0` and paints the page background exactly. Beside a `btn-primary`
+  sibling in dark mode the group renders as one blue chip with loose glyphs
+  next to it, which is the bug `MydiaWeb.SegmentedControl` exists to prevent.
+
+  All-ghost action strips (an admin table row's edit/duplicate/delete buttons)
+  are fine and deliberately excluded: they have no selected sibling, so the
+  low-emphasis treatment is the point.
+  """
+
+  use ExUnit.Case, async: true
+
+  @web_root Path.expand("../../../lib/mydia_web", __DIR__)
+
+  test "no source file pairs btn-ghost with btn-primary on join-item siblings" do
+    offenders =
+      [Path.join(@web_root, "**/*.ex"), Path.join(@web_root, "**/*.heex")]
+      |> Enum.flat_map(&Path.wildcard/1)
+      |> Enum.filter(&ghost_segment?/1)
+
+    assert offenders == [],
+           """
+           These files put btn-ghost and btn-primary on join-item siblings, which
+           leaves the unselected segments with no visible body in dark mode.
+           Use <.segmented_control> instead:
+
+           #{Enum.map_join(offenders, "\n", &("  " <> Path.relative_to(&1, @web_root)))}
+           """
+  end
+
+  # A naive whole-file split on every `join` class occurrence (the join
+  # container itself, or any `join-item` member) over-reaches: a file's last
+  # join-related match is routinely an all-ghost admin action strip (edit /
+  # duplicate / delete), and the text after it runs unbounded to EOF, so it
+  # swallows any unrelated btn-primary elsewhere in the same file, such as a
+  # modal's Save button or a "New X" button that shares nothing with the
+  # join. That produced 13 false positives across lib/mydia_web on the
+  # finished tree (admin_*_live/components.ex and friends), none of them
+  # near each other, let alone in the same join.
+  #
+  # Scan per opening tag instead: `class=` up to that tag's own closing `>`
+  # is one element's complete class expression, whether it is a plain string
+  # or a `class={[...]}` list. A file offends only when some tag combines
+  # `join-item` with `btn-ghost` and some tag combines `join-item` with
+  # `btn-primary`, which is what a ghost-vs-primary mismatch inside one join
+  # looks like at the markup level, regardless of whether the button markup
+  # is written inline or shared through a helper component (as in
+  # `MydiaWeb.SegmentedControl`'s own private `segment/1`, whose single
+  # class list applies `btn-primary` or `btn-ghost` conditionally on
+  # `@selected?`).
+  defp ghost_segment?(path) do
+    tags =
+      path
+      |> File.read!()
+      |> then(&Regex.scan(~r/class=[\s\S]*?>/, &1))
+      |> Enum.map(&hd/1)
+
+    Enum.any?(tags, &(&1 =~ "join-item" and &1 =~ "btn-ghost")) and
+      Enum.any?(tags, &(&1 =~ "join-item" and &1 =~ "btn-primary"))
+  end
+end

--- a/test/mydia_web/components/segmented_control_test.exs
+++ b/test/mydia_web/components/segmented_control_test.exs
@@ -1,0 +1,189 @@
+defmodule MydiaWeb.Components.SegmentedControlTest do
+  @moduledoc """
+  The contract every segmented control in the app depends on.
+
+  These are markup assertions. They cannot see colour: the reason unselected
+  segments carry no colour class is that `btn-ghost` computes to `alpha=0`,
+  which measures 1.000 contrast against the page in dark mode. That number
+  came from a browser and any change to the treatment needs the same. See
+  docs/superpowers/specs/2026-09-01-segmented-control-design.md.
+  """
+
+  use ExUnit.Case, async: true
+  use Phoenix.Component
+
+  import Phoenix.LiveViewTest
+  import MydiaWeb.SegmentedControl
+
+  defp plain(value) do
+    assigns = %{value: value}
+
+    rendered_to_string(~H"""
+    <.segmented_control id="picker" value={@value} event="pick" param="choice" label="Pick one">
+      <:option value="a" label="Alpha" />
+      <:option value="b" label="Beta" />
+    </.segmented_control>
+    """)
+  end
+
+  defp sized(size) do
+    assigns = %{size: size}
+
+    rendered_to_string(~H"""
+    <.segmented_control value="b" event="pick" param="choice" label="Pick one" size={@size}>
+      <:option value="a" label="Alpha" />
+      <:option value="b" label="Beta" />
+    </.segmented_control>
+    """)
+  end
+
+  defp atom_valued(value) do
+    assigns = %{value: value}
+
+    rendered_to_string(~H"""
+    <.segmented_control value={@value} event="pick" param="choice" label="Pick one">
+      <:option value={:movie} label="Movies" />
+      <:option value={:tv_show} label="TV Shows" />
+    </.segmented_control>
+    """)
+  end
+
+  defp icon_only(value) do
+    assigns = %{value: value}
+
+    rendered_to_string(~H"""
+    <.segmented_control value={@value} event="pick" param="choice" label="Pick one" icon_only>
+      <:option value="a" label="Alpha" icon="hero-stop" />
+      <:option value="b" label="Beta" icon="hero-table-cells" />
+    </.segmented_control>
+    """)
+  end
+
+  defp labelled_with_icons(value) do
+    assigns = %{value: value}
+
+    rendered_to_string(~H"""
+    <.segmented_control value={@value} event="pick" param="choice" label="Pick one">
+      <:option value="a" label="Alpha" icon="hero-film" />
+      <:option value="b" label="Beta" icon="hero-tv" />
+    </.segmented_control>
+    """)
+  end
+
+  defp buttons(html), do: html |> LazyHTML.from_fragment() |> LazyHTML.query("button")
+  defp classes(html), do: html |> buttons() |> LazyHTML.attribute("class")
+  defp attrs(html, name), do: html |> buttons() |> LazyHTML.attribute(name)
+
+  test "the group is a labelled join carrying the given id" do
+    join = plain("b") |> LazyHTML.from_fragment() |> LazyHTML.filter("div.join")
+
+    assert LazyHTML.attribute(join, "id") == ["picker"]
+    assert LazyHTML.attribute(join, "role") == ["group"]
+    assert LazyHTML.attribute(join, "aria-label") == ["Pick one"]
+  end
+
+  test "options render in declaration order with the event and value binding" do
+    html = plain("b")
+
+    assert attrs(html, "phx-click") == ["pick", "pick"]
+    assert attrs(html, "phx-value-choice") == ["a", "b"]
+    assert html |> buttons() |> LazyHTML.text() =~ "Alpha"
+    assert html |> buttons() |> LazyHTML.text() =~ "Beta"
+  end
+
+  test "the selected option is the only one marked btn-primary" do
+    [first, second] = classes(plain("b"))
+
+    refute first =~ "btn-primary"
+    assert second =~ "btn-primary"
+  end
+
+  test "no option is ever btn-ghost" do
+    for class <- classes(plain("b")) do
+      refute class =~ "btn-ghost",
+             "btn-ghost computes to alpha=0, leaving the segment with no body"
+    end
+  end
+
+  test "unselected options carry the dark-mode hover override" do
+    # daisyUI's own .btn:hover mixes toward black, which on a dark theme is
+    # both imperceptible and the wrong direction.
+    [first, second] = classes(plain("b"))
+
+    assert first =~ "dark:hover:bg-base-300"
+    refute second =~ "dark:hover:bg-base-300"
+  end
+
+  test "aria-pressed is the literal string on every button" do
+    # HEEx renders aria-pressed={true} as a bare attribute and drops it
+    # entirely for false, so the component must wrap it in to_string/1.
+    assert attrs(plain("b"), "aria-pressed") == ["false", "true"]
+  end
+
+  test "an atom assign matches a string option value" do
+    assert attrs(plain(:a), "aria-pressed") == ["true", "false"]
+  end
+
+  test "an atom option value serializes to a bare string in phx-value" do
+    html = atom_valued(:movie)
+
+    assert attrs(html, "phx-value-choice") == ["movie", "tv_show"]
+    assert attrs(html, "aria-pressed") == ["true", "false"]
+  end
+
+  test "size defaults to btn-sm and md omits it" do
+    for class <- classes(plain("b")), do: assert(class =~ "btn-sm")
+    for class <- classes(sized("md")), do: refute(class =~ "btn-sm")
+  end
+
+  test "icon_only buttons are square, aria-named, and show no visible text" do
+    html = icon_only("b")
+
+    assert attrs(html, "aria-label") == ["Alpha", "Beta"]
+    for class <- classes(html), do: assert(class =~ "btn-square")
+
+    # Checked as text content, not as a raw substring: the labels still
+    # appear in aria-label and data-tip on correct output.
+    assert html |> buttons() |> LazyHTML.text() |> String.trim() == ""
+  end
+
+  test "each tooltip sits on a wrapper, and join-item stays on the button" do
+    html = icon_only("b")
+    wrappers = html |> LazyHTML.from_fragment() |> LazyHTML.query("div.tooltip")
+
+    assert LazyHTML.attribute(wrappers, "data-tip") == ["Alpha", "Beta"]
+
+    # daisyUI reveals the tip through `.tooltip:has(:focus-visible)`, and
+    # `:has()` implies a descendant combinator, so a tooltip on the button
+    # itself never fires for a keyboard user.
+    refute Enum.any?(classes(html), &(&1 =~ "tooltip"))
+
+    # `.join-item > *` resets the four --join-* radius variables to `initial`,
+    # so a button inside a join-item wrapper computes every corner to 0 and
+    # the filled active button spills square out of the join's rounded cap.
+    for class <- LazyHTML.attribute(wrappers, "class"), do: refute(class =~ "join-item")
+    for class <- classes(html), do: assert(class =~ "join-item")
+  end
+
+  test "labelled options render the icon beside visible text, with no tooltip" do
+    html = labelled_with_icons("b")
+
+    assert html |> buttons() |> LazyHTML.text() =~ "Alpha"
+
+    # The visible text is already the accessible name, so aria-label would be
+    # redundant and is deliberately absent.
+    refute html =~ ~s(aria-label="Alpha")
+
+    assert html |> LazyHTML.from_fragment() |> LazyHTML.query("span.hero-film") |> Enum.count() ==
+             1
+
+    assert html |> LazyHTML.from_fragment() |> LazyHTML.query("div.tooltip") |> Enum.empty?()
+  end
+
+  test "an option with no icon renders text only" do
+    html = plain("b")
+
+    assert html |> LazyHTML.from_fragment() |> LazyHTML.query("button > span") |> Enum.empty?()
+    assert html |> buttons() |> LazyHTML.text() =~ "Alpha"
+  end
+end

--- a/test/mydia_web/live/activity_live/index_test.exs
+++ b/test/mydia_web/live/activity_live/index_test.exs
@@ -416,6 +416,46 @@ defmodule MydiaWeb.ActivityLive.IndexTest do
       assert html =~ "no seasons"
     end
 
+    test "the date filter defaults to All with the other presets unselected", %{conn: conn} do
+      {:ok, view, html} = live(conn, ~p"/activity")
+
+      assert html =~ ~s(id="activity-date-filter")
+
+      assert has_element?(
+               view,
+               "#activity-date-filter button[phx-value-date='all'][aria-pressed='true']"
+             )
+
+      for preset <- ~w(today yesterday week month) do
+        assert has_element?(
+                 view,
+                 "#activity-date-filter button[phx-value-date='#{preset}'][aria-pressed='false']"
+               ),
+               "#{preset} should not be selected on mount"
+      end
+    end
+
+    test "choosing a date preset dispatches filter_date and moves the selection", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/activity")
+
+      view
+      |> element("#activity-date-filter button[phx-value-date='week']")
+      |> render_click()
+
+      # The selection is server-rendered from @date_filter, so a wrong param
+      # name or a handle_event clause that stopped matching would leave All
+      # selected instead of moving to 7 Days.
+      assert has_element?(
+               view,
+               "#activity-date-filter button[phx-value-date='week'][aria-pressed='true']"
+             )
+
+      assert has_element?(
+               view,
+               "#activity-date-filter button[phx-value-date='all'][aria-pressed='false']"
+             )
+    end
+
     test "renders a metadata_fields change whose field name is malformed", %{conn: conn} do
       # format_change_details/1 passes field_change["field"] straight to
       # Presentation.field_label/1. A hand-edited or legacy row can carry

--- a/test/mydia_web/live/discover_live/index_test.exs
+++ b/test/mydia_web/live/discover_live/index_test.exs
@@ -1,0 +1,78 @@
+defmodule MydiaWeb.DiscoverLive.IndexTest do
+  @moduledoc """
+  Covers the media-type segmented control (`#discover-media-type`, event
+  `switch_media_type`, param `type`).
+
+  This call site has no other rendering test: library_picker_test.exs and
+  friends in this directory only exercise handle_event/3 directly or unit
+  functions, and grid_density_test.exs (in the parent directory) covers the
+  density toggle, not the media-type one. A wrong param name or a
+  handle_event clause that stopped matching would be invisible to the rest
+  of the suite.
+  """
+
+  # async: false — the Postgres non-shared sandbox hides these rows from the
+  # LiveView mount process otherwise (mirrors grid_density_test.exs, which
+  # mounts the same LiveView).
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
+  import MydiaWeb.AuthHelpers
+
+  setup %{conn: conn} do
+    # DiscoverLive.Index unconditionally loads the movie genre list and its
+    # default (trending) category on connected mount (#530). Warming trending
+    # for both media types keeps the media-type click from falling through to
+    # the live relay once @media_type flips to :tv_show. The genre list must
+    # be non-empty: mount only skips a reload when `@genres != []`, so an
+    # empty warmed list still re-fetches (this time for :tv_show, unwarmed)
+    # the moment the media type switches.
+    warm_genre_cache(:movie, [%{"id" => 28, "name" => "Action"}])
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+
+    user = admin_user_fixture()
+    %{conn: log_in_user(conn, user)}
+  end
+
+  test "the media-type control defaults to Movies selected", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/discover")
+
+    assert html =~ ~s(id="discover-media-type")
+
+    assert has_element?(
+             view,
+             "#discover-media-type button[phx-value-type='movie'][aria-pressed='true']"
+           )
+
+    assert has_element?(
+             view,
+             "#discover-media-type button[phx-value-type='tv_show'][aria-pressed='false']"
+           )
+  end
+
+  test "choosing TV Shows dispatches switch_media_type and moves the selection", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/discover")
+
+    view
+    |> element("#discover-media-type button[phx-value-type='tv_show']")
+    |> render_click()
+
+    # switch_media_type push_patches to ?type=tv_show rather than assigning
+    # directly, so a moved selection also proves handle_params re-derived
+    # @media_type from the query string.
+    assert_patch(view, ~p"/discover?type=tv_show")
+
+    assert has_element?(
+             view,
+             "#discover-media-type button[phx-value-type='tv_show'][aria-pressed='true']"
+           )
+
+    assert has_element?(
+             view,
+             "#discover-media-type button[phx-value-type='movie'][aria-pressed='false']"
+           )
+  end
+end

--- a/test/mydia_web/live/profile_live_test.exs
+++ b/test/mydia_web/live/profile_live_test.exs
@@ -5,6 +5,9 @@ defmodule MydiaWeb.ProfileLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Mydia.Accounts
+  alias Mydia.Accounts.UserPreference
+
   setup %{conn: conn} do
     {conn, user} = register_and_log_in_user(conn)
     %{conn: conn, user: user}
@@ -21,5 +24,55 @@ defmodule MydiaWeb.ProfileLiveTest do
 
     # Integrations moved to /integrations; the profile page only points to it.
     assert has_element?(view, "#integrations-link[href='/integrations']")
+  end
+
+  test "the theme picker defaults to System with the other options unselected", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/profile")
+
+    assert html =~ ~s(id="theme-picker")
+
+    assert has_element?(
+             view,
+             "#theme-picker button[phx-value-theme='system'][aria-pressed='true']"
+           )
+
+    assert has_element?(
+             view,
+             "#theme-picker button[phx-value-theme='light'][aria-pressed='false']"
+           )
+
+    assert has_element?(
+             view,
+             "#theme-picker button[phx-value-theme='dark'][aria-pressed='false']"
+           )
+  end
+
+  test "choosing Dark moves the selection, persists the preference, and pushes the client event",
+       %{conn: conn, user: user} do
+    {:ok, view, _html} = live(conn, ~p"/profile")
+
+    view
+    |> element("#theme-picker button[phx-value-theme='dark']")
+    |> render_click()
+
+    # The selection itself is server-rendered from @theme, so a wrong param
+    # name or a handle_event clause that stopped matching would leave System
+    # selected instead of moving to Dark.
+    assert has_element?(
+             view,
+             "#theme-picker button[phx-value-theme='dark'][aria-pressed='true']"
+           )
+
+    assert has_element?(
+             view,
+             "#theme-picker button[phx-value-theme='system'][aria-pressed='false']"
+           )
+
+    # Applying the theme to the page happens client-side (a JS hook flips
+    # data-theme), which a server-rendered LiveView test cannot observe
+    # directly. What IS observable end to end: the stored preference changed,
+    # and the client got told to change it.
+    assert user |> Accounts.get_user_preference!() |> UserPreference.theme() == "dark"
+    assert_push_event(view, "theme_changed", %{theme: "dark"})
   end
 end


### PR DESCRIPTION
In dark mode the grouped toolbar buttons (Library view mode, grid density) showed no button body for the unselected options. The group rendered as one blue chip with loose glyphs floating beside it.

The cause is `btn-ghost`, which daisyUI defines as `--btn-bg: #0000`. The unselected segment computes to `alpha=0` and paints the page background exactly, so it measures 1.000 contrast against the page. It is not low contrast, it is absent.

On the Discover toolbar this was visible side by side: the Movies/TV Shows group rendered as a continuous pill while the density group next to it rendered as scattered glyphs, two segmented controls on one row reading as two different kinds of object.

## What changed

A shared `MydiaWeb.SegmentedControl` now owns this pattern. The selected option gets `btn-primary`, and unselected options get no colour class at all, falling through to plain `.btn` at opaque `base-200`.

`view_mode_toggle/1` and `grid_density_toggle/1` keep their names and call sites and delegate to it. Their existing tests are unchanged and still pass, which is what makes them the regression net for the refactor.

## Two things found along the way

Activity's date filter and Discover's media type marked the selection with `btn-active`, which daisyUI mixes toward black. In dark mode that is 1.059 against a plain button, and the selected segment is the darker one, so it read as recessed rather than chosen. Both now use `btn-primary`.

`assets/css/app.css` declared Tailwind's `dark:` variant against `[data-theme=dark]`, but the app only ever sets `mydia-dark` (see `root.html.heex`). The variant had never matched anything. It was used zero times, so nothing rendered differently, but the hover override needs it. A test guards it, since an unmatched variant compiles cleanly and produces CSS that can never apply.

## Measurements

Taken from the built stylesheet on the `mydia-dark` theme, computed in a browser and converted to sRGB.

| Surface | sRGB | vs page | vs unselected |
| --- | --- | --- | --- |
| page, `base-100` | `29,35,42` | | |
| unselected, `btn-ghost` (before) | `alpha=0` | 1.000 | |
| unselected, plain `.btn` (after) | `42,49,58` | 1.206 | |
| selected, `btn-primary` | `0,125,255` | 4.055 | 3.363 |

Unselected segments also take `dark:hover:bg-base-300`. daisyUI's own `.btn:hover` mixes toward black, moving `42,49,58` to `37,44,51` in dark mode, a contrast of 1.075 in the wrong direction. Light mode keeps the daisyUI default, which is already 1.226 there and stronger than `base-300` would be.

Verified in a real browser at the end: all four toolbars in both themes, and the dark-mode hover measured `42,49,58` at rest going to `65,74,84` hovered, so it lightens as intended. Worth knowing for anyone repeating this: headless Chromium reports `hover:none`, which silently defeats Tailwind's `@media (hover:hover)` gating for both the daisyUI default and this override, so a naive headless hover check reads as "no change".

## Deliberately unchanged

The 11 daisyUI `tabs` sites, the `filter` chip rows and the admin duplicates Keep/Trash radiogroup were all measured and are fine. Tabs use a container or underline affordance; the chips already render an opaque unselected state at 3.363, which is the treatment this PR standardizes on. The 11 all-ghost action strips have no selected option, so the low emphasis treatment is the point. `search_live`'s picker uses `btn-outline`, whose border measures 13.978 against the page in dark, so it stays visible.

## Follow-ups, not in this PR

`role="group"` plus `aria-pressed` models independent toggles, whereas "exactly one selected" is technically the ARIA radiogroup pattern. This PR preserves the existing semantics: both migrated toggles already used `aria-pressed` and their tests assert it. Moving to a radiogroup properly needs roving tabindex and arrow key handling, and doing it halfway would promise keyboard semantics it would not deliver.

`selection_controls/1` in `library_components.ex` still marks its active state with `btn-active`, so it has the same 1.059 legibility problem. It is a single binary toggle rather than a one of N group, so it sits outside this component's shape.

## Testing

`test/mydia_web/` is green at 1934 tests, 0 failures. New coverage: the component's own contract, a click driven test per migrated call site asserting the selection moves and the real event fires, a guard that fails the build if any `join` pairs `btn-ghost` with a `btn-primary` sibling, and a guard on the `dark:` variant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent segmented controls for date filters, media-type selection, view modes, grid density, and theme selection.
  - Improved segmented controls with accessible labels, selection states, icons, sizing, and tooltips.

- **Bug Fixes**
  - Fixed dark-mode styling so dark-theme utilities apply correctly.
  - Improved selected and unselected control contrast in dark mode.

- **Tests**
  - Added coverage for segmented controls, dark mode, filter interactions, media-type switching, and theme persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->