### PR TITLE
fix: prevent lost concurrent preference updates

### DIFF
--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -392,6 +392,12 @@ defmodule Mydia.Accounts do
 
   ## User Preferences
 
+  @preference_update_retries 3
+  @preference_stale_opts [
+    stale_error_field: :lock_version,
+    stale_error_message: "is stale"
+  ]
+
   @doc """
   Gets a user's preferences, creating default preferences if they don't exist.
   """
@@ -438,10 +444,42 @@ defmodule Mydia.Accounts do
   def update_preference(%UserPreference{} = preference, attrs) do
     delta = Map.get(attrs, "preferences", attrs)
 
-    preference
-    |> UserPreference.update_preferences_changeset(delta)
-    |> validate_add_references(delta)
-    |> Repo.update()
+    update_preference_with_retry(preference, delta, @preference_update_retries)
+  end
+
+  defp update_preference_with_retry(preference, delta, retries_left) do
+    result =
+      preference
+      |> UserPreference.update_preferences_changeset(delta)
+      |> validate_add_references(delta)
+      |> Repo.update(@preference_stale_opts)
+
+    case result do
+      {:error, changeset} when retries_left > 0 ->
+        if stale_preference?(changeset) do
+          retry_preference_update(preference, delta, retries_left, changeset)
+        else
+          result
+        end
+
+      _ ->
+        result
+    end
+  end
+
+  defp retry_preference_update(preference, delta, retries_left, stale_changeset) do
+    case Repo.get(UserPreference, preference.id) do
+      nil -> {:error, stale_changeset}
+
+      fresh_preference ->
+        update_preference_with_retry(fresh_preference, delta, retries_left - 1)
+    end
+  end
+
+  defp stale_preference?(changeset) do
+    Enum.any?(Keyword.get_values(changeset.errors, :lock_version), fn {_message, metadata} ->
+      metadata[:stale] == true
+    end)
   end
 
   # The two ID-valued add preferences point at rows, which the schema module

--- a/lib/mydia/accounts/user_preference.ex
+++ b/lib/mydia/accounts/user_preference.ex
@@ -33,6 +33,7 @@ defmodule Mydia.Accounts.UserPreference do
   @type t :: %__MODULE__{
           id: binary(),
           preferences: map(),
+          lock_version: integer(),
           user: Mydia.Accounts.User.t() | Ecto.Association.NotLoaded.t(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
@@ -40,6 +41,7 @@ defmodule Mydia.Accounts.UserPreference do
 
   schema "user_preferences" do
     field :preferences, :map, default: %{}
+    field :lock_version, :integer, default: 1
 
     belongs_to :user, Mydia.Accounts.User
 
@@ -192,6 +194,7 @@ defmodule Mydia.Accounts.UserPreference do
     user_preference
     |> cast(%{preferences: merged_prefs}, [:preferences])
     |> validate_preferences()
+    |> optimistic_lock(:lock_version)
   end
 
   # Validate individual preference values

--- a/priv/repo/migrations/20260902070000_add_lock_version_to_user_preferences.exs
+++ b/priv/repo/migrations/20260902070000_add_lock_version_to_user_preferences.exs
@@ -1,0 +1,9 @@
+defmodule Mydia.Repo.Migrations.AddLockVersionToUserPreferences do
+  use Ecto.Migration
+
+  def change do
+    alter table(:user_preferences) do
+      add :lock_version, :integer, null: false, default: 1
+    end
+  end
+end

--- a/test/mydia/accounts/user_preference_test.exs
+++ b/test/mydia/accounts/user_preference_test.exs
@@ -63,6 +63,123 @@ defmodule Mydia.Accounts.UserPreferenceTest do
     end
   end
 
+  describe "update_preference/2 optimistic locking" do
+    test "retries a stale update against fresh preferences" do
+      user = user_fixture()
+      first_session = Accounts.get_user_preference!(user)
+      second_session = Accounts.get_user_preference!(user)
+
+      assert {:ok, first_update} =
+               Accounts.update_preference(first_session, %{"grid_density" => "dense"})
+
+      assert {:ok, retried_update} =
+               Accounts.update_preference(second_session, %{"recommendations_expanded" => true})
+
+      assert UserPreference.grid_density(retried_update) == "dense"
+      assert UserPreference.recommendations_expanded(retried_update)
+      assert retried_update.lock_version == first_update.lock_version + 1
+
+      assert {:ok, retained_update} =
+               Accounts.update_preference(retried_update, %{"theme" => "dark"})
+
+      assert UserPreference.grid_density(retained_update) == "dense"
+      assert UserPreference.recommendations_expanded(retained_update)
+      assert UserPreference.theme(retained_update) == "dark"
+      assert retained_update.lock_version == retried_update.lock_version + 1
+
+      persisted = Repo.get!(UserPreference, retained_update.id)
+      assert persisted.preferences == retained_update.preferences
+      assert persisted.lock_version == retained_update.lock_version
+    end
+
+    test "flat and nested deltas preserve unrelated preferences" do
+      user = user_fixture()
+      preference = Accounts.get_user_preference!(user)
+
+      assert {:ok, preference} =
+               Accounts.update_preference(preference, %{"theme" => "dark"})
+
+      assert {:ok, preference} =
+               Accounts.update_preference(preference, %{
+                 "preferences" => %{"grid_density" => "compact"}
+               })
+
+      assert UserPreference.theme(preference) == "dark"
+      assert UserPreference.grid_density(preference) == "compact"
+      assert UserPreference.metadata_language(preference) == "en"
+    end
+
+    test "invalid preference values are not treated as lock conflicts" do
+      user = user_fixture()
+      preference = Accounts.get_user_preference!(user)
+
+      assert {:error, changeset} =
+               Accounts.update_preference(preference, %{"grid_density" => "tiny"})
+
+      refute changeset.valid?
+      refute Keyword.has_key?(changeset.errors, :lock_version)
+      assert Repo.reload!(preference).lock_version == preference.lock_version
+    end
+
+    test "invalid reference ids are not treated as lock conflicts" do
+      user = user_fixture()
+      preference = Accounts.get_user_preference!(user)
+
+      assert {:error, changeset} =
+               Accounts.update_preference(preference, %{
+                 "add_quality_profile_id" => Ecto.UUID.generate()
+               })
+
+      refute changeset.valid?
+      refute Keyword.has_key?(changeset.errors, :lock_version)
+      assert Repo.reload!(preference).lock_version == preference.lock_version
+    end
+
+    test "returns a stale changeset after exhausting retries" do
+      user = user_fixture()
+      stale_preference = Accounts.get_user_preference!(user)
+
+      assert {:ok, _updated} =
+               Accounts.update_preference(stale_preference, %{"theme" => "dark"})
+
+      test_pid = self()
+      {:ok, conflict_count} = Agent.start_link(fn -> 0 end)
+      handler_id = {__MODULE__, :preference_retry_conflicts, test_pid}
+
+      :telemetry.attach(
+        handler_id,
+        [:mydia, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          query = String.trim_leading(metadata.query)
+
+          if Process.get(:force_preference_retry_conflicts, false) and
+               metadata.source == "user_preferences" and String.starts_with?(query, "SELECT") do
+            Repo.update_all(
+              from(p in UserPreference, where: p.id == ^stale_preference.id),
+              inc: [lock_version: 1]
+            )
+
+            Agent.update(conflict_count, &(&1 + 1))
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      task =
+        Task.async(fn ->
+          Ecto.Adapters.SQL.Sandbox.allow(Repo, test_pid, self())
+          Process.put(:force_preference_retry_conflicts, true)
+          Accounts.update_preference(stale_preference, %{"grid_density" => "dense"})
+        end)
+
+      assert {:error, changeset} = Task.await(task, 5_000)
+      assert Keyword.has_key?(changeset.errors, :lock_version)
+      assert Agent.get(conflict_count, & &1) > 1
+    end
+  end
+
   describe "update_preference/2 reference validation" do
     test "rejects a quality profile id that does not exist" do
       user = user_fixture()


### PR DESCRIPTION
`Mydia.Accounts.update_preference/2` currently merges a key delta into the caller's loaded `UserPreference.preferences` map and replaces the whole database value. Two sessions that loaded the same row can therefore write different keys in sequence while the later stale struct silently restores the earlier key's old value. The existing grid-density and recommendations-expanded helpers both use this shared path, and all current and future preference writers need the same protection. The issue is open, unassigned, has no claim or prior attempt, and the unrelated open PR #326 is only a weak title-keyword collision.

## Summary

Add a non-null integer lock-version column with a default suitable for existing rows on both SQLite and PostgreSQL, then expose that field on `UserPreference` and apply Ecto optimistic locking to preference-update changesets. Keep conflict handling centralized in `Mydia.Accounts.update_preference/2`: when an update is rejected as stale, reload the current row, merge the original delta into that fresh map, re-run the existing preference and reference validations, and retry a bounded number of times. Preserve the public `{:ok, preference} | {:error, changeset}` contract so `GridDensity`, `RecommendationsExpanded`, Profile LiveView, and the other callers inherit the fix without call-site changes; after the retry bound, return the stale changeset through the existing error path instead of raising or looping indefinitely.

## Verification

- Load the same preference row into two structs, update `grid_density` through one and `recommendations_expanded` through the stale second struct, then assert both different-key changes remain in the reloaded row.
- Assert the successful retry returns the fresh merged `UserPreference` and advances its lock version, so a long-lived caller can safely retain the returned struct for its next update.
- Verify a normal non-conflicting flat delta and a delta nested under `"preferences"` still preserve unrelated keys and return the existing success shape.
- Verify invalid preference values and invalid add-reference IDs still return their validation changesets without being mistaken for optimistic-lock conflicts or retried as stale writes.
- Force conflicts through the retry limit and assert `update_preference/2` returns an error changeset rather than raising or retrying forever.

Closes #558


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - User preference updates now handle simultaneous changes more reliably, automatically retrying when another update occurs first.
  - Unrelated preference values are preserved during concurrent flat or nested updates.
  - Invalid preference values and reference IDs continue to return appropriate validation errors.
  - Exhausted concurrent-update retries now provide a clear lock conflict error instead of silently overwriting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->