### PR TITLE
fix(discover): route TVDB-sourced results to TVDB on add and preview

### DIFF
--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -503,8 +503,10 @@ defmodule MydiaWeb.DiscoverLive.Index do
     {:noreply, socket}
   end
 
-  def handle_info({:fetch_detail_metadata, tmdb_id, media_type}, socket) do
-    case MediaAddHelpers.fetch_detail_metadata(tmdb_id, media_type) do
+  def handle_info({:fetch_detail_metadata, provider_id, media_type}, socket) do
+    opts = put_source_provider([], provider_id, socket)
+
+    case MediaAddHelpers.fetch_detail_metadata(provider_id, media_type, nil, opts) do
       {:ok, metadata} ->
         {:noreply,
          socket
@@ -563,6 +565,35 @@ defmodule MydiaWeb.DiscoverLive.Index do
     end
   end
 
+  # Tells the add flow which provider the clicked id came from.
+  #
+  # `Relay.search/3` routes every TV search to TVDB, so a TV search result's
+  # `provider_id` is a TVDB series id even though the card ships it in a param
+  # named `tmdb_id`. `Mydia.Media.Add` defaults to TMDB, so without this the
+  # add fetches a TVDB id from `/tmdb/tv/shows/:id`: usually a 404 surfaced as
+  # "Failed to fetch metadata: ... Media not found", and worse when the id
+  # happens to name a real TMDB show, since the row is then built from the
+  # wrong title.
+  #
+  # Resolved from the item server-side rather than trusted from the click,
+  # mirroring `MediaRequestHelpers.build_request_attrs/3`, which has branched on
+  # `item.provider` for the Request button all along. An id that no longer
+  # resolves against the current page falls through to the TMDB default, which
+  # is what trending, discover and the recommendations rail all return.
+  defp put_source_provider(opts, provider_id, socket) do
+    item =
+      find_selectable_item(
+        socket.assigns.items,
+        socket.assigns.selected_recommendations,
+        provider_id
+      )
+
+    case item && Map.get(item, :provider) do
+      :tvdb -> Keyword.put(opts, :provider, :tvdb)
+      _ -> opts
+    end
+  end
+
   # The picker's blank placeholder ("") and an ordinary card click's nil both
   # mean "no explicit choice"; anything else is a client-supplied library id
   # override for the resolver.
@@ -576,7 +607,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
            media_type,
            socket.assigns.library_status_map,
            nil,
-           opts
+           put_source_provider(opts, provider_id, socket)
          ) do
       {:ok, media_item, updated_map} ->
         items =

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -232,29 +232,45 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   For movies, fetches TMDB metadata directly.
 
+  Pass `provider: :tvdb` when `provider_id` is already a TVDB series id, which
+  is what every Discover TV search result carries. The TMDB-first path above
+  only makes sense for a TMDB id, and the relay 404s a TVDB id on TMDB's route.
+
   An optional `config` can be injected for testing; defaults to
   `Metadata.default_relay_config()`.
   """
-  def fetch_detail_metadata(tmdb_id, media_type, config \\ nil) do
+  def fetch_detail_metadata(provider_id, media_type, config \\ nil, opts \\ []) do
     config = config || Metadata.default_relay_config()
 
-    if media_type == :tv_show do
-      case Metadata.fetch_by_id(config, tmdb_id, media_type: :tv_show, provider: :tmdb) do
-        {:ok, tmdb_metadata} ->
-          if Settings.derive_tv_metadata_source() == :tmdb do
-            {:ok, tmdb_metadata}
-          else
-            case Add.resolve_tvdb_metadata(tmdb_metadata, config) do
-              {:ok, tvdb_metadata, _tvdb_id} -> {:ok, tvdb_metadata}
-              {:error, _} -> {:ok, tmdb_metadata}
-            end
-          end
+    cond do
+      media_type != :tv_show ->
+        Metadata.fetch_by_id(config, provider_id, media_type: :movie)
 
-        error ->
-          error
-      end
-    else
-      Metadata.fetch_by_id(config, tmdb_id, media_type: :movie)
+      # The id is already a TVDB series id, so there is no TMDB lookup to start
+      # from: a Discover TV search result carries one, since `Relay.search/3`
+      # routes `:tv_show` to `/tvdb/search`. Asking TMDB for it 404s.
+      Keyword.get(opts, :provider) == :tvdb ->
+        Metadata.fetch_by_id(config, provider_id, media_type: :tv_show, provider: :tvdb)
+
+      true ->
+        fetch_tv_detail_from_tmdb(provider_id, config)
+    end
+  end
+
+  defp fetch_tv_detail_from_tmdb(provider_id, config) do
+    case Metadata.fetch_by_id(config, provider_id, media_type: :tv_show, provider: :tmdb) do
+      {:ok, tmdb_metadata} ->
+        if Settings.derive_tv_metadata_source() == :tmdb do
+          {:ok, tmdb_metadata}
+        else
+          case Add.resolve_tvdb_metadata(tmdb_metadata, config) do
+            {:ok, tvdb_metadata, _tvdb_id} -> {:ok, tvdb_metadata}
+            {:error, _} -> {:ok, tmdb_metadata}
+          end
+        end
+
+      error ->
+        error
     end
   end
 

--- a/test/mydia_web/live/discover_live/add_tvdb_result_test.exs
+++ b/test/mydia_web/live/discover_live/add_tvdb_result_test.exs
@@ -1,0 +1,84 @@
+defmodule MydiaWeb.DiscoverLive.AddTvdbResultTest do
+  @moduledoc """
+  Discover routes every TV search to TVDB (`Relay.search/3` sends `:tv_show` to
+  `/tvdb/search` unless an explicit `provider: :tmdb` overrides it), so a TV
+  search result carries a **TVDB series id** in `provider_id`. The card ships
+  that id in a param named `tmdb_id`, and the add flow took the name at face
+  value: `Mydia.Media.Add` defaults to `provider: :tmdb` and fetched the TVDB id
+  from `/tmdb/tv/shows/:id`, which the relay answers with 404:
+
+      Failed to fetch metadata: %Mydia.Metadata.Provider.Error{
+        type: :not_found, message: "Media not found: 280619"}
+
+  Reported from a production install adding a show from Discover search. The
+  404 was the lucky case: when a TVDB id happens to name a real TMDB show, the
+  add silently stores the wrong title's ids instead.
+
+  The request path already branched on `item.provider`
+  (`MediaRequestHelpers.build_request_attrs/3`, covered by
+  `guest_request_flow_test.exs`); the add path did not. This is that test's
+  twin for the Add button.
+  """
+
+  # async: false: setup_metadata_stub mutates the global Provider.Registry, and
+  # connected LiveView mounts run in a separate process from the test, which the
+  # non-shared Postgres sandbox hides rows from.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MetadataStub
+  import Mydia.MetadataCacheHelpers
+  import Mydia.SettingsFixtures
+
+  alias Mydia.MetadataStubProvider
+
+  setup :setup_metadata_stub
+
+  setup %{conn: conn} do
+    warm_genre_cache(:movie, [])
+    warm_genre_cache(:tv_show, [])
+
+    library_path_fixture(%{type: :series})
+
+    %{conn: log_in_user(conn, create_admin_user())}
+  end
+
+  test "adding a TVDB-sourced search result stores it under tvdb_id", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/discover?type=tv_show&q=stub")
+
+    assert render(view) =~ MetadataStubProvider.series_title()
+
+    view
+    |> element(
+      ~s(button[phx-click="add_to_library"][phx-value-tmdb_id="#{MetadataStubProvider.series_tvdb_id()}"])
+    )
+    |> render_click()
+
+    media_item = wait_until_media_item(MetadataStubProvider.series_tvdb_id())
+
+    assert media_item.type == "tv_show"
+    assert media_item.title == MetadataStubProvider.series_title()
+
+    assert is_nil(media_item.tmdb_id),
+           "a TVDB-sourced result must not be stored as a TMDB id, or the add fetches the wrong provider"
+  end
+
+  # The add lands in a handle_info the render_click round trip does not wait
+  # on, matching wait_until_media_item/1 in config_modal_test.exs.
+  defp wait_until_media_item(tvdb_id, retries \\ 200)
+
+  defp wait_until_media_item(tvdb_id, 0) do
+    flunk("media item for tvdb_id=#{tvdb_id} was not created in time")
+  end
+
+  defp wait_until_media_item(tvdb_id, retries) do
+    case Mydia.Media.get_media_item_by_tvdb(tvdb_id) do
+      nil ->
+        Process.sleep(10)
+        wait_until_media_item(tvdb_id, retries - 1)
+
+      media_item ->
+        media_item
+    end
+  end
+end

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -267,6 +267,34 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
 
       assert metadata.title == "Preview Show"
     end
+
+    # A Discover TV search result is TVDB-sourced: `Relay.search/3` routes
+    # `:tv_show` to `/tvdb/search`, so the id the preview is opened with is a
+    # TVDB series id. Asking TMDB for it is a 404, which left every TV search
+    # result's preview panel blank. Same root cause as the add failing with
+    # "Media not found: <tvdb id>".
+    test "fetches a TVDB-sourced id from TVDB rather than TMDB",
+         %{bypass: bypass, config: config} do
+      library_path_fixture(%{type: "series", tv_metadata_source: :tvdb})
+
+      id = System.unique_integer([:positive])
+      stub_tvdb_extended(bypass, id, "Harbour Lights")
+
+      # What the real relay does with a TVDB id on a TMDB route, and what the
+      # preview used to ask for.
+      Bypass.stub(bypass, "GET", "/tmdb/tv/shows/#{id}", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(404, Jason.encode!(%{"error" => "not found"}))
+      end)
+
+      assert {:ok, metadata} =
+               MediaAddHelpers.fetch_detail_metadata(to_string(id), :tv_show, config,
+                 provider: :tvdb
+               )
+
+      assert metadata.title == "Harbour Lights"
+    end
   end
 
   # Stub helpers (relay endpoints)

--- a/test/support/metadata_stub_provider.ex
+++ b/test/support/metadata_stub_provider.ex
@@ -168,6 +168,13 @@ defmodule Mydia.MetadataStubProvider do
       provider_id == to_string(@missing_id) ->
         {:error, Error.not_found("Media not found: #{@missing_id}")}
 
+      # The catalog's series id is a TVDB id, and the relay answers 404 for a
+      # TVDB id on TMDB's route. Answering it anyway is what let the Discover
+      # add ship sending TVDB search ids to TMDB: production failed with
+      # "Media not found: <tvdb id>" while the stub happily returned the show.
+      provider_id == to_string(@series_tvdb_id) and Keyword.get(opts, :provider) == :tmdb ->
+        {:error, Error.not_found("Media not found: #{provider_id}")}
+
       Keyword.get(opts, :provider) == :tvdb or Keyword.get(opts, :media_type) == :tv_show ->
         {:ok, series_metadata()}
 


### PR DESCRIPTION
Adding a show from Discover search failed on a production install:

```
Failed to fetch metadata: %Mydia.Metadata.Provider.Error{
  type: :not_found, message: "Media not found: 280619", details: nil}
```

`Relay.search/3` routes every TV search to `/tvdb/search`, so a Discover TV
search result carries a TVDB series id in `provider_id`. The card ships that id
in a param named `tmdb_id`, and the add flow fetched it from
`/tmdb/tv/shows/280619`, which the relay answers with 404. 280619 is The Expanse
on TVDB; the same show is 63639 on TMDB.

Verified against the live relay: `tvdb/series/280619` returns 200,
`tmdb/tv/shows/280619` returns 404.

The 404 is the lucky case. When a TVDB id happens to name a real TMDB show the
add succeeds against the wrong title, and either way the row was written with the
TVDB id stored in `tmdb_id`.

## What changed

`DiscoverLive` resolves the clicked id against the current page and passes
`provider: :tvdb` when the item came from TVDB, mirroring
`MediaRequestHelpers.build_request_attrs/3`, which has branched on
`item.provider` for the Request button all along. An id that no longer resolves
falls through to the TMDB default, which is what trending, discover and the
recommendations rail return.

The detail preview had the same defect from the same cause, which left every TV
search result's preview panel blank, so `fetch_detail_metadata` takes the
provider too.

`MetadataStubProvider` answered TMDB fetches for its TVDB catalog id, which is
why no test caught this. It now 404s that pairing the way the relay does, so the
new `DiscoverLive` test fails without the fix with the production symptom: no
media item is ever created.

## Testing

- New: `test/mydia_web/live/discover_live/add_tvdb_result_test.exs`
- Full suite: 13 doctests, 10446 tests, 0 failures, 44 skipped, 107 excluded
- Audited all 60 TV rows on the affected install; every stored `tmdb_id` resolves
  to the right show, so nothing was silently mis-added there

## Follow-up

A refactor making the provider travel with the id (`{:tvdb, 280619}` refs
through the whole metadata layer) is specced and planned. It closes two further
instances of the same class: import lists send TMDB ids to TVDB for TV lists, and
the Discover recommendations rail sends a TVDB id to TMDB and renders empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed adding TV show results from Discover so they resolve through the correct TVDB source.
  - Corrected TV show metadata loading for TVDB-sourced search results.
  - Ensured added TV shows retain their TVDB identity instead of being treated as TMDB entries.

- **Tests**
  - Added coverage for TVDB-based metadata retrieval and adding TVDB search results to the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->