### PR TITLE
fix(discover): stop the Add to Library button wrapping in poster cards

### DIFF
--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -314,17 +314,27 @@ defmodule MydiaWeb.DiscoverComponents do
         </button>
       <% not @item.in_library and @can_add -> %>
         <div class="join w-full mt-2">
+          <%!-- The visible label is "Add", not "Add to Library". daisyUI's
+                .btn has a fixed height (32px at btn-sm) and flex-wrap: nowrap,
+                which stops the icon and label splitting but not the label's own
+                text node from wrapping. "Add to Library" needs ~124px of button
+                width; a w-36 rail card gives the add half of the join 91px, so
+                it wrapped to two lines and spilled out of the pill. The full
+                wording stays as the accessible name and the tooltip. See
+                docs/superpowers/specs/2026-09-02-add-to-library-button-wrap-design.md --%>
           <button
             phx-click={@add_event}
             phx-value-tmdb_id={@item.provider_id}
             phx-value-media_type={@media_type}
             disabled={@adding}
+            title="Add to Library"
+            aria-label="Add to Library"
             class="btn btn-primary btn-sm join-item flex-1"
           >
             <%= if @adding do %>
               <span class="loading loading-spinner loading-xs"></span> Adding...
             <% else %>
-              <.icon name="hero-plus" class="w-4 h-4" /> Add to Library
+              <.icon name="hero-plus" class="w-4 h-4" /> Add
             <% end %>
           </button>
           <LibraryComponents.library_picker_button

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -106,7 +106,7 @@ defmodule MydiaWeb.DiscoverComponentsTest do
       refute html =~ "Requesting..."
     end
 
-    test "keeps Add to Library for non-guest users" do
+    test "offers the add action instead of a request for non-guest users" do
       html = card(%{current_user: %{role: "admin", id: "admin-1"}})
 
       assert html =~ "Add to Library"
@@ -205,9 +205,10 @@ defmodule MydiaWeb.DiscoverComponentsTest do
         |> LazyHTML.from_fragment()
         |> LazyHTML.query(~s(button[phx-click="add_to_library"]))
 
-      # Guard the cardinality first: LazyHTML.attribute/2 on a zero-node match
-      # returns [], so a missing button would otherwise sail past the
-      # attribute assertion below.
+      # Guard the cardinality first: LazyHTML.attribute/2 silently drops any
+      # matched node that lacks the attribute, so a spurious second button
+      # missing aria-label would still produce a single-element list below
+      # and pass the assertion undetected.
       assert Enum.count(button) == 1
       assert LazyHTML.attribute(button, "aria-label") == ["Add to Library"]
       assert LazyHTML.attribute(button, "title") == ["Add to Library"]

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -218,5 +218,25 @@ defmodule MydiaWeb.DiscoverComponentsTest do
       # the aria-label.
       assert button |> LazyHTML.text() |> String.trim() == "Add"
     end
+
+    # Regression: the existing media_rail tests above only assert
+    # `html =~ "Add to Library"`, which now passes via the aria-label/title
+    # attributes rather than the visible label, so nothing actually verified
+    # what a rail card renders on screen. The rail's w-36 (144px) card is the
+    # worst-affected case for the wrap, so it gets the same rendered-text
+    # assertion as the grid card above.
+    test "a rail card shows the short label while keeping the full accessible name" do
+      html = rail(%{})
+
+      button =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query(~s(button[phx-click="add_to_library"]))
+
+      assert Enum.count(button) == 1
+      assert LazyHTML.attribute(button, "aria-label") == ["Add to Library"]
+      assert LazyHTML.attribute(button, "title") == ["Add to Library"]
+      assert button |> LazyHTML.text() |> String.trim() == "Add"
+    end
   end
 end

--- a/test/mydia_web/components/discover_components_test.exs
+++ b/test/mydia_web/components/discover_components_test.exs
@@ -195,4 +195,27 @@ defmodule MydiaWeb.DiscoverComponentsTest do
       refute html =~ "library-picker-caret"
     end
   end
+
+  describe "card add button" do
+    test "shows the short label while keeping the full accessible name" do
+      html = card(%{current_user: %{role: "admin", id: "admin-1"}})
+
+      button =
+        html
+        |> LazyHTML.from_fragment()
+        |> LazyHTML.query(~s(button[phx-click="add_to_library"]))
+
+      # Guard the cardinality first: LazyHTML.attribute/2 on a zero-node match
+      # returns [], so a missing button would otherwise sail past the
+      # attribute assertion below.
+      assert Enum.count(button) == 1
+      assert LazyHTML.attribute(button, "aria-label") == ["Add to Library"]
+      assert LazyHTML.attribute(button, "title") == ["Add to Library"]
+
+      # The visible label is what wraps at 144px, so assert on rendered text
+      # rather than on the raw HTML, which still contains the long string in
+      # the aria-label.
+      assert button |> LazyHTML.text() |> String.trim() == "Add"
+    end
+  end
 end

--- a/test/mydia_web/live/discover_live/authorization_test.exs
+++ b/test/mydia_web/live/discover_live/authorization_test.exs
@@ -75,7 +75,7 @@ defmodule MydiaWeb.DiscoverLive.AuthorizationTest do
       {:ok, view, _html} = live(conn, ~p"/discover?type=movie&q=quiet+harbour")
 
       assert has_element?(view, "button", "Request")
-      refute has_element?(view, "button", "Add to Library")
+      refute has_element?(view, ~s(button[phx-click="add_to_library"]))
     end
   end
 end


### PR DESCRIPTION
## The bug

The "Add to Library" button in a poster card wrapped to two lines, and the second line spilled outside the pill.

daisyUI 5's `.btn` sets a fixed `height` (32px at `btn-sm`) together with `flex-wrap: nowrap`. The nowrap keeps the icon and label on one flex line, but it does not stop the label's own text node wrapping internally. Two lines measure 33px inside a pill locked at 32px, so the text bled out of the fill and the join row sat lopsided next to the 32px caret.

## Measurement

Measured in headless Chromium against the real built CSS, using the real card markup and the real page shell (`drawer lg:drawer-open`, `w-64` sidebar, `main.lg:p-8`).

The icon plus "Add to Library" needs about **124px of button width**. Measured either side: 123.2px wraps, 124.5px does not.

Card widths as actually rendered, and whether the label fits:

| Viewport | Discover comfortable | Discover dense | Dashboard | Rail (`w-36`) |
| --- | --- | --- | --- | --- |
| 375 | 160 wraps | 72 wraps | 162 wraps | 144 wraps |
| 1024 | 122 wraps | 51 wraps | 125 wraps | 144 wraps |
| 1440 | 168 wraps | 74 wraps | 208 ok | 144 wraps |
| 1920 | 250 ok | 115 wraps | 307 ok | 144 wraps |

Rail cards are a fixed `w-36`, so they wrap at every viewport on every page hosting a rail. Discover's comfortable density only clears from about 1500px up, and dense wraps even at 2560. The 1024 row is the worst case everywhere, because the `lg` breakpoint adds the 256px sidebar and an extra column at the same time.

"Add to Library" is also the only label in that card slot with the problem. `Request`, `Requesting...`, `Requested`, `Adding...`, `Go to Movie` and `Go to Show` all measured one line at 144px, because they are full-width and get 120px where the add half of the join gets 91px.

## The change

All four poster-card render sites funnel through `trending_card_action/1`, so this is one button. The visible label becomes `Add`; the full wording moves to `aria-label` and `title`, which keeps the accessible name intact (WCAG 2.5.3 Label in Name is satisfied, since the accessible name contains the visible label) and adds a hover tooltip.

Three sites keep the full wording, because all three measured comfortably on one line: the trending detail modal, the configure-before-adding modal, and admin requests' "Approve & Add to Library".

No grid, density, card width, padding or `btn-*` size class changes.

## Tests

One existing assertion went vacuous and is retargeted. `has_element?/3`'s third argument filters on rendered **text**, not attributes, so `refute has_element?(view, "button", "Add to Library")` in the guest authorization test would have passed whether or not the button existed once the label became "Add". It now matches on `button[phx-click="add_to_library"]`.

The other five assertions that mention "Add to Library" use `=~` against the raw HTML and keep working unchanged, since the wording is still present in the `aria-label`.

Worth knowing for future selectors here: the add button's `phx-click` is parameterised through `@add_event` and takes three production values (`add_to_library`, `add_recommendation`, `add_franchise_movie`), so a selector hard-coding the first silently misses the recommendation and franchise rails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the library action button to display the shorter label “Add” on grid and rail cards.
  * Preserved “Add to Library” as the button’s title and accessible label.
  * Guests no longer see the library add action, while authorized users retain it.
  * The loading-state behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->