### PR TITLE
Poster click opens the detail dialog on the media detail page

### DIFF
--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -206,8 +206,8 @@ defmodule MydiaWeb.DiscoverComponents do
 
   attr :id, :string, default: "media-rail"
   attr :title, :string, default: "More like this"
-  # :any, not :string - see the note on trending_card/1. The media detail page
-  # passes nil here because it has no show_details handler.
+  # :any, not :string - see the note on trending_card/1. nil renders an inert
+  # poster, which is what a host with no show_details handler needs.
   attr :on_select, :any, default: "show_details"
   # Forwarded to trending_card/1. A host LiveView that does not handle
   # "add_to_library"/"request_media" must override these or the first click on

--- a/lib/mydia_web/components/discover_components.ex
+++ b/lib/mydia_web/components/discover_components.ex
@@ -101,6 +101,18 @@ defmodule MydiaWeb.DiscoverComponents do
         </div>
       <% end %>
       <%= cond do %>
+        <%!-- The card for the title whose page you are already on. It draws the
+              ring, renders no action, and must not open a dialog about itself:
+              the franchise strip gives it no `navigate` on purpose, so without
+              this branch a rail-level on_select would make it clickable. --%>
+        <% @current -> %>
+          <.card_poster
+            item={@item}
+            media_type={@media_type}
+            loading={@loading}
+            poster_size={@poster_size}
+            class="rounded-t-box"
+          />
         <% @navigate -> %>
           <.link navigate={@navigate} class="block">
             <.card_poster

--- a/lib/mydia_web/live/components/trending_detail_modal.ex
+++ b/lib/mydia_web/live/components/trending_detail_modal.ex
@@ -31,7 +31,10 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
   The component emits these events to the parent LiveView:
 
   - `close_details` - When user closes the modal
-  - `add_to_library` - When user clicks "Add to Library" (with tmdb_id and media_type params)
+  - `add_to_library` - When user clicks "Add to Library" (with tmdb_id and
+    media_type params). Overridable per host with `add_event`; `request_event`
+    does the same for the guest Request button. A host whose add handler is
+    named differently must pass them or the first click raises.
 
   ## `actions` slot
 
@@ -160,7 +163,7 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                     <%= if not in_library?(@item) do %>
                       <%= if @current_user && @current_user.role == "guest" do %>
                         <button
-                          phx-click="request_media"
+                          phx-click={@request_event}
                           phx-value-tmdb_id={@item.provider_id}
                           phx-value-media_type={media_type_string(@item)}
                           disabled={Map.get(@item, :request_status) != nil}
@@ -175,7 +178,7 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
                       <% else %>
                         <div class="join">
                           <button
-                            phx-click="add_to_library"
+                            phx-click={@add_event}
                             phx-value-tmdb_id={@item.provider_id}
                             phx-value-media_type={media_type_string(@item)}
                             class="btn btn-primary join-item"
@@ -304,7 +307,13 @@ defmodule MydiaWeb.Live.Components.TrendingDetailModal do
      # Optional slot: the dashboard renders this modal without one.
      |> assign_new(:rail, fn -> [] end)
      # Optional slot: Dashboard and Discovery render the default header actions.
-     |> assign_new(:actions, fn -> [] end)}
+     |> assign_new(:actions, fn -> [] end)
+     # The primary action is the dialog's event contract with its host, exactly
+     # as it is for trending_card/1: emitting an event the host does not handle
+     # raises FunctionClauseError and kills the LiveView on the first click.
+     # Discover, the Dashboard and the request pages all keep the defaults.
+     |> assign_new(:add_event, fn -> "add_to_library" end)
+     |> assign_new(:request_event, fn -> "request_media" end)}
   end
 
   # Helper functions for accessing data from either SearchResult (item) or MediaMetadata

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -15,6 +15,7 @@ defmodule MydiaWeb.DashboardLive.Index do
   alias Mydia.Accounts.Authorization
   alias MydiaWeb.DashboardLive.Components
   alias MydiaWeb.Live.Authorization, as: LiveAuthorization
+  alias MydiaWeb.Live.Helpers.DetailModal
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
 
@@ -42,9 +43,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:adding_item_ids, MapSet.new())
         |> assign(:requesting_item_id, nil)
         |> assign(:request_status_map, %{})
-        |> assign(:selected_item, nil)
-        |> assign(:selected_metadata, nil)
-        |> assign(:detail_loading, false)
+        |> DetailModal.init()
         |> assign(:movie_libraries, MediaAddHelpers.candidate_libraries(:movie))
         |> assign(:show_libraries, MediaAddHelpers.candidate_libraries(:tv_show))
         |> assign(:library_picker, nil)
@@ -68,9 +67,7 @@ defmodule MydiaWeb.DashboardLive.Index do
         |> assign(:requesting_item_id, nil)
         |> assign(:request_status_map, %{})
         |> assign(:pending_requests_count, 0)
-        |> assign(:selected_item, nil)
-        |> assign(:selected_metadata, nil)
-        |> assign(:detail_loading, false)
+        |> DetailModal.init()
         |> assign(:movie_libraries, [])
         |> assign(:show_libraries, [])
         |> assign(:library_picker, nil)
@@ -220,25 +217,17 @@ defmodule MydiaWeb.DashboardLive.Index do
   def handle_event("show_details", %{"id" => id, "type" => type}, socket) do
     with {:ok, media_type} <- parse_event_media_type(type),
          item when not is_nil(item) <- find_trending_item(socket, id, media_type) do
-      # Show modal with loading state and trigger metadata fetch
-      send(self(), {:fetch_detail_metadata, id, media_type})
-
-      {:noreply,
-       socket
-       |> assign(:selected_item, item)
-       |> assign(:selected_metadata, nil)
-       |> assign(:detail_loading, true)}
+      # recommendations: false because this page renders the dialog without a
+      # :rail slot. Fetching them would pay for a relay round trip whose result
+      # nothing draws.
+      {:noreply, DetailModal.select(socket, item, media_type, recommendations: false)}
     else
       _ -> {:noreply, socket}
     end
   end
 
   def handle_event("close_details", _, socket) do
-    {:noreply,
-     socket
-     |> assign(:selected_item, nil)
-     |> assign(:selected_metadata, nil)
-     |> assign(:detail_loading, false)}
+    {:noreply, DetailModal.close(socket)}
   end
 
   @impl true
@@ -293,17 +282,11 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   def handle_info({:fetch_detail_metadata, tmdb_id, media_type}, socket) do
-    case MediaAddHelpers.fetch_detail_metadata(tmdb_id, media_type) do
-      {:ok, metadata} ->
-        {:noreply,
-         socket
-         |> assign(:selected_metadata, metadata)
-         |> assign(:detail_loading, false)}
-
-      {:error, _reason} ->
-        # Even on error, stop loading and show what we have from SearchResult
-        {:noreply, assign(socket, :detail_loading, false)}
-    end
+    {:noreply,
+     DetailModal.put_metadata(
+       socket,
+       MediaAddHelpers.fetch_detail_metadata(tmdb_id, media_type)
+     )}
   end
 
   def handle_info({:add_media_to_library, provider_id, media_type, library_path_id}, socket) do
@@ -378,6 +361,7 @@ defmodule MydiaWeb.DashboardLive.Index do
          |> assign(:library_status_map, updated_map)
          |> assign(:trending_movies, trending_movies)
          |> assign(:trending_tv, trending_tv)
+         |> DetailModal.refresh_selected([trending_movies, trending_tv])
          |> put_flash(:info, "#{media_item.title} has been added to your library")}
 
       {:already_in_library, media_item, updated_map} ->
@@ -397,6 +381,7 @@ defmodule MydiaWeb.DashboardLive.Index do
          |> assign(:library_status_map, updated_map)
          |> assign(:trending_movies, trending_movies)
          |> assign(:trending_tv, trending_tv)
+         |> DetailModal.refresh_selected([trending_movies, trending_tv])
          |> put_flash(:info, "#{media_item.title} is already in your library")}
 
       {:error, {:changeset, changeset}} ->
@@ -453,23 +438,24 @@ defmodule MydiaWeb.DashboardLive.Index do
       {:ok, request, status_updates} ->
         request_status_map = Map.merge(socket.assigns.request_status_map, status_updates)
 
-        socket
-        |> assign(:requesting_item_id, nil)
-        |> assign(:request_status_map, request_status_map)
-        |> assign(
-          :trending_movies,
+        trending_movies =
           MediaRequestHelpers.enrich_with_request_status(
             socket.assigns.trending_movies,
             request_status_map
           )
-        )
-        |> assign(
-          :trending_tv,
+
+        trending_tv =
           MediaRequestHelpers.enrich_with_request_status(
             socket.assigns.trending_tv,
             request_status_map
           )
-        )
+
+        socket
+        |> assign(:requesting_item_id, nil)
+        |> assign(:request_status_map, request_status_map)
+        |> assign(:trending_movies, trending_movies)
+        |> assign(:trending_tv, trending_tv)
+        |> DetailModal.refresh_selected([trending_movies, trending_tv])
         |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")
 
       {:error, reason} ->

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -14,6 +14,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
   alias Mydia.Metadata
   alias Mydia.Settings
   alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.Live.Helpers.DetailModal
   alias MydiaWeb.Live.Helpers.GridDensity
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
@@ -67,11 +68,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
       |> assign(:adding_item_ids, MapSet.new())
       |> assign(:requesting_item_id, nil)
       |> assign(:request_status_map, %{})
-      |> assign(:selected_item, nil)
-      |> assign(:selected_metadata, nil)
-      |> assign(:selected_recommendations, [])
+      |> DetailModal.init()
       |> assign(:load_error, nil)
-      |> assign(:detail_loading, false)
       |> assign(:libraries, [])
       |> assign(:library_picker, nil)
       |> assign(:add_config, nil)
@@ -250,9 +248,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
         defaults = AddDefaults.resolve(socket.assigns.current_user, media_type_atom)
 
         item =
-          find_selectable_item(
-            socket.assigns.items,
-            socket.assigns.selected_recommendations,
+          DetailModal.find_selectable_item(
+            [socket.assigns.items, socket.assigns.selected_recommendations],
             provider_id
           )
 
@@ -360,31 +357,18 @@ defmodule MydiaWeb.DiscoverLive.Index do
   def handle_event("show_details", %{"id" => id, "type" => type}, socket) do
     with {:ok, media_type} <- parse_event_media_type(type),
          item when not is_nil(item) <-
-           find_selectable_item(
-             socket.assigns.items,
-             socket.assigns.selected_recommendations,
+           DetailModal.find_selectable_item(
+             [socket.assigns.items, socket.assigns.selected_recommendations],
              id
            ) do
-      send(self(), {:fetch_detail_metadata, id, media_type})
-      send(self(), {:fetch_recommendations, id, media_type})
-
-      {:noreply,
-       socket
-       |> assign(:selected_item, item)
-       |> assign(:selected_metadata, nil)
-       |> assign(:selected_recommendations, [])
-       |> assign(:detail_loading, true)}
+      {:noreply, DetailModal.select(socket, item, media_type)}
     else
       _ -> {:noreply, socket}
     end
   end
 
   def handle_event("close_details", _, socket) do
-    {:noreply,
-     socket
-     |> assign(:selected_item, nil)
-     |> assign(:selected_metadata, nil)
-     |> assign(:detail_loading, false)}
+    {:noreply, DetailModal.close(socket)}
   end
 
   def handle_event("set_grid_density", %{"density" => density}, socket) do
@@ -504,16 +488,11 @@ defmodule MydiaWeb.DiscoverLive.Index do
   end
 
   def handle_info({:fetch_detail_metadata, tmdb_id, media_type}, socket) do
-    case MediaAddHelpers.fetch_detail_metadata(tmdb_id, media_type) do
-      {:ok, metadata} ->
-        {:noreply,
-         socket
-         |> assign(:selected_metadata, metadata)
-         |> assign(:detail_loading, false)}
-
-      {:error, _reason} ->
-        {:noreply, assign(socket, :detail_loading, false)}
-    end
+    {:noreply,
+     DetailModal.put_metadata(
+       socket,
+       MediaAddHelpers.fetch_detail_metadata(tmdb_id, media_type)
+     )}
   end
 
   # Runs through start_async rather than inline: on a cache miss this makes a
@@ -550,9 +529,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
     # Also resolves against the recommendations rail. A rail title is not in
     # `items`, so searching only that list made a guest's Request click from
     # inside the modal silently do nothing.
-    case find_selectable_item(
-           socket.assigns.items,
-           socket.assigns.selected_recommendations,
+    case DetailModal.find_selectable_item(
+           [socket.assigns.items, socket.assigns.selected_recommendations],
            provider_id
          ) do
       nil ->
@@ -600,6 +578,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
          |> assign(:items, items)
          |> assign_visible_items()
          |> assign(:selected_recommendations, recommendations)
+         |> DetailModal.refresh_selected([items, recommendations])
          |> put_flash(:info, "#{media_item.title} has been added to your library")}
 
       {:already_in_library, media_item, updated_map} ->
@@ -608,12 +587,20 @@ defmodule MydiaWeb.DiscoverLive.Index do
           |> MediaAddHelpers.enrich_with_library_status(updated_map)
           |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
 
+        recommendations =
+          MediaAddHelpers.enrich_with_library_status(
+            socket.assigns.selected_recommendations,
+            updated_map
+          )
+
         {:noreply,
          socket
          |> clear_adding(provider_id)
          |> assign(:library_status_map, updated_map)
          |> assign(:items, items)
          |> assign_visible_items()
+         |> assign(:selected_recommendations, recommendations)
+         |> DetailModal.refresh_selected([items, recommendations])
          |> put_flash(:info, "#{media_item.title} is already in your library")}
 
       {:error, {:changeset, changeset}} ->
@@ -657,6 +644,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
         |> assign(:items, items)
         |> assign_visible_items()
         |> assign(:selected_recommendations, recommendations)
+        |> DetailModal.refresh_selected([items, recommendations])
         |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")
 
       {:error, reason} ->
@@ -668,16 +656,17 @@ defmodule MydiaWeb.DiscoverLive.Index do
 
   @impl true
   def handle_async(:load_recommendations, {:ok, {:ok, results}}, socket) do
-    {:noreply, assign(socket, :selected_recommendations, enrich_recommendations(socket, results))}
+    {:noreply,
+     DetailModal.put_recommendations(socket, results, &enrich_recommendations(socket, &1))}
   end
 
   def handle_async(:load_recommendations, {:ok, :none}, socket) do
-    {:noreply, assign(socket, :selected_recommendations, [])}
+    {:noreply, DetailModal.put_recommendations(socket, [], & &1)}
   end
 
   def handle_async(:load_recommendations, {:exit, reason}, socket) do
     Logger.warning("Discover recommendations lookup crashed: #{inspect(reason)}")
-    {:noreply, assign(socket, :selected_recommendations, [])}
+    {:noreply, DetailModal.put_recommendations(socket, [], & &1)}
   end
 
   # Request status matters as much as library status here: without it
@@ -702,21 +691,6 @@ defmodule MydiaWeb.DiscoverLive.Index do
     do: "Could not submit the request: #{MediaAddHelpers.format_changeset_errors(changeset)}"
 
   defp request_error_message(_), do: "Could not submit the request. Please try again."
-
-  @doc """
-  Resolves a clicked provider id against the current grid page, then the
-  recommendations rail.
-
-  A recommendation is not part of the grid page, so resolving against `items`
-  alone drops the click and the modal never swaps — a failure that looks like
-  nothing happening. Public so it can be exercised without a live process.
-  """
-  def find_selectable_item(items, recommendations, id) do
-    id = to_string(id)
-
-    Enum.find(items, &(to_string(&1.provider_id) == id)) ||
-      Enum.find(recommendations, &(to_string(&1.provider_id) == id))
-  end
 
   # Private helpers
 

--- a/lib/mydia_web/live/helpers/detail_modal.ex
+++ b/lib/mydia_web/live/helpers/detail_modal.ex
@@ -112,13 +112,27 @@ defmodule MydiaWeb.Live.Helpers.DetailModal do
 
   Ids are compared as strings on both sides: a `SearchResult`'s `provider_id`
   is a string while several hosts hold parsed integers.
+
+  `media_type` is optional and defaults to nil, which matches on id alone as
+  before. Click resolution leaves it out: every list a click resolves against
+  is homogeneous by media type already (Discover's grid and rail are both
+  movies or both TV shows for the active tab; the detail page's rails all
+  belong to the viewed title's type), so the id alone is unambiguous there.
+  `refresh_selected/2`, below, is the one caller that passes it, because TMDB
+  namespaces ids per media type and its lists are not homogeneous.
   """
-  def find_selectable_item(lists, id) do
+  def find_selectable_item(lists, id, media_type \\ nil) do
     id = to_string(id)
 
     Enum.find_value(lists, fn list ->
-      Enum.find(list, &(to_string(&1.provider_id) == id))
+      Enum.find(list, &matches_selectable?(&1, id, media_type))
     end)
+  end
+
+  defp matches_selectable?(item, id, nil), do: to_string(item.provider_id) == id
+
+  defp matches_selectable?(item, id, media_type) do
+    to_string(item.provider_id) == id and Map.get(item, :media_type) == media_type
   end
 
   @doc """
@@ -132,6 +146,14 @@ defmodule MydiaWeb.Live.Helpers.DetailModal do
   An id that is in none of the lists leaves the selection untouched rather than
   clearing it: the dialog is still open, and blanking it would close it out from
   under the user.
+
+  The stale item's `media_type` is passed to `find_selectable_item/3` alongside
+  its id. The Dashboard is the one caller whose lists mix media types
+  (`[trending_movies, trending_tv]`), and TMDB namespaces ids per type, so a
+  movie and a show can share one. Without the type check a refresh could swap
+  the dialog onto a same-id title of the other kind instead of just refreshing
+  the one already open. Every other caller's lists are homogeneous, so this is
+  a no-op there.
   """
   def refresh_selected(socket, lists) do
     case socket.assigns.selected_item do
@@ -139,7 +161,7 @@ defmodule MydiaWeb.Live.Helpers.DetailModal do
         socket
 
       item ->
-        case find_selectable_item(lists, item.provider_id) do
+        case find_selectable_item(lists, item.provider_id, Map.get(item, :media_type)) do
           nil -> socket
           fresh -> assign(socket, :selected_item, fresh)
         end

--- a/lib/mydia_web/live/helpers/detail_modal.ex
+++ b/lib/mydia_web/live/helpers/detail_modal.ex
@@ -1,0 +1,148 @@
+defmodule MydiaWeb.Live.Helpers.DetailModal do
+  @moduledoc """
+  Host-side state for `MydiaWeb.Live.Components.TrendingDetailModal`.
+
+  Discover, the Dashboard and the media detail page all open the same dialog
+  over the same four assigns. Before this module the first two each declared
+  those assigns, the select/close pair and the metadata fetch by hand, and the
+  detail page would have been a third copy of the same eighty lines.
+
+  Assigns owned here:
+
+    * `:selected_item` - the enriched `SearchResult` the dialog is open over,
+      or nil when it is closed
+    * `:selected_metadata` - the fuller `MediaMetadata`, once fetched
+    * `:detail_loading` - whether that fetch is in flight
+    * `:selected_recommendations` - the rail rendered inside the dialog
+
+  Both lookups are messages to `self()` rather than direct calls, so the dialog
+  paints its loading state before any relay round trip starts. The host owns the
+  `handle_info` clauses and hands their results back through `put_metadata/2`
+  and `put_recommendations/3`.
+  """
+
+  import Phoenix.Component, only: [assign: 3]
+
+  @doc """
+  Assigns every dialog assign to its empty value. Call from `mount/3`.
+  """
+  def init(socket) do
+    socket
+    |> assign(:selected_item, nil)
+    |> assign(:selected_metadata, nil)
+    |> assign(:detail_loading, false)
+    |> assign(:selected_recommendations, [])
+  end
+
+  @doc """
+  Opens the dialog over `item` and starts both lookups.
+
+  The rail is cleared rather than left in place: without that, the previous
+  title's recommendations stay on screen under the new header until the fetch
+  lands, which reads as the dialog having opened over the wrong item.
+
+  `recommendations: false` skips the rail lookup entirely, which is what a host
+  that renders no `:rail` slot wants. The fetch would otherwise pay for a relay
+  round trip whose result nothing renders.
+  """
+  def select(socket, item, media_type, opts \\ []) do
+    id = to_string(item.provider_id)
+
+    send(self(), {:fetch_detail_metadata, id, media_type})
+
+    if Keyword.get(opts, :recommendations, true) do
+      send(self(), {:fetch_recommendations, id, media_type})
+    end
+
+    socket
+    |> assign(:selected_item, item)
+    |> assign(:selected_metadata, nil)
+    |> assign(:selected_recommendations, [])
+    |> assign(:detail_loading, true)
+  end
+
+  @doc """
+  Closes the dialog.
+
+  `:selected_recommendations` is deliberately left alone. It is not rendered
+  with the dialog shut, and `select/4` clears it on the way back in.
+  """
+  def close(socket) do
+    socket
+    |> assign(:selected_item, nil)
+    |> assign(:selected_metadata, nil)
+    |> assign(:detail_loading, false)
+  end
+
+  @doc """
+  Stores the metadata lookup result and clears the loading flag.
+
+  A failed lookup still clears the flag: the dialog falls back to the
+  `SearchResult` it was opened with, which carries title, year, poster and
+  rating. No trailer and no synopsis, but no spinner forever either.
+  """
+  def put_metadata(socket, {:ok, metadata}) do
+    socket
+    |> assign(:selected_metadata, metadata)
+    |> assign(:detail_loading, false)
+  end
+
+  def put_metadata(socket, {:error, _reason}) do
+    assign(socket, :detail_loading, false)
+  end
+
+  @doc """
+  Stores the in-dialog rail, after the host's own enrichment.
+
+  The enrichment is a function rather than a fixed step because the hosts
+  disagree about where library and request status come from: Discover holds
+  cached status maps in its assigns, while the media detail page queries per
+  lookup.
+  """
+  def put_recommendations(socket, results, enrich) when is_function(enrich, 1) do
+    assign(socket, :selected_recommendations, enrich.(results))
+  end
+
+  @doc """
+  Resolves a provider id against several lists, first match wins.
+
+  A clicked title may live in the grid, in the page's own rail, or only in the
+  rail inside the dialog. Resolving against one list alone drops the click and
+  the dialog never swaps, a failure that looks like nothing happening.
+
+  Ids are compared as strings on both sides: a `SearchResult`'s `provider_id`
+  is a string while several hosts hold parsed integers.
+  """
+  def find_selectable_item(lists, id) do
+    id = to_string(id)
+
+    Enum.find_value(lists, fn list ->
+      Enum.find(list, &(to_string(&1.provider_id) == id))
+    end)
+  end
+
+  @doc """
+  Re-resolves `:selected_item` from `lists` after an add or a request.
+
+  The dialog reads a snapshot taken when it opened. Adding from inside it
+  updates the card underneath but not that snapshot, so without this the header
+  keeps offering "Add to Library" for a title that is now in the library, and a
+  second click fails on the tmdb_id index.
+
+  An id that is in none of the lists leaves the selection untouched rather than
+  clearing it: the dialog is still open, and blanking it would close it out from
+  under the user.
+  """
+  def refresh_selected(socket, lists) do
+    case socket.assigns.selected_item do
+      nil ->
+        socket
+
+      item ->
+        case find_selectable_item(lists, item.provider_id) do
+          nil -> socket
+          fresh -> assign(socket, :selected_item, fresh)
+        end
+    end
+  end
+end

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -20,6 +20,9 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.MediaLive.Show.RecommendationEvents
   alias MydiaWeb.MediaLive.Show.RecommendationComponents
   alias MydiaWeb.MediaLive.Show.LibraryPickerEvents
+  alias MydiaWeb.Live.Helpers.DetailModal
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
+  alias MydiaWeb.MediaLive.Show.DetailModalEvents
   alias MydiaWeb.Live.Helpers.RecommendationsExpanded
 
   # Import helper modules
@@ -181,6 +184,7 @@ defmodule MydiaWeb.MediaLive.Show do
      |> assign(:requesting_recommendation_id, nil)
      |> assign_new(:metadata_config, fn -> Mydia.Metadata.default_relay_config() end)
      |> assign_new(:library_picker, fn -> nil end)
+     |> DetailModal.init()
      |> assign(
        :can_create_media,
        Mydia.Accounts.Authorization.can_create_media?(socket.assigns.current_user)
@@ -571,6 +575,20 @@ defmodule MydiaWeb.MediaLive.Show do
   def handle_event("add_from_library_picker", params, socket),
     do: LibraryPickerEvents.add_from_library_picker(params, socket)
 
+  # Detail dialog events
+
+  def handle_event("show_details", params, socket),
+    do: DetailModalEvents.show_details(params, socket)
+
+  def handle_event("close_details", params, socket),
+    do: DetailModalEvents.close_details(params, socket)
+
+  def handle_event("add_selected_item", params, socket),
+    do: DetailModalEvents.add_selected_item(params, socket)
+
+  def handle_event("request_selected_item", params, socket),
+    do: DetailModalEvents.request_selected_item(params, socket)
+
   @impl true
   def handle_info({:download_created, download}, socket) do
     if download_for_media?(download, socket.assigns.media_item) do
@@ -812,6 +830,11 @@ defmodule MydiaWeb.MediaLive.Show do
     else
       {:noreply, socket}
     end
+  end
+
+  def handle_info({:fetch_detail_metadata, tmdb_id, media_type}, socket) do
+    {:noreply,
+     DetailModal.put_metadata(socket, MediaAddHelpers.fetch_detail_metadata(tmdb_id, media_type))}
   end
 
   def handle_info(_msg, socket), do: {:noreply, socket}

--- a/lib/mydia_web/live/media_live/show.ex
+++ b/lib/mydia_web/live/media_live/show.ex
@@ -24,6 +24,7 @@ defmodule MydiaWeb.MediaLive.Show do
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.MediaLive.Show.DetailModalEvents
   alias MydiaWeb.Live.Helpers.RecommendationsExpanded
+  alias MydiaWeb.DiscoverComponents
 
   # Import helper modules
   import MydiaWeb.MediaLive.Show.Formatters
@@ -837,6 +838,10 @@ defmodule MydiaWeb.MediaLive.Show do
      DetailModal.put_metadata(socket, MediaAddHelpers.fetch_detail_metadata(tmdb_id, media_type))}
   end
 
+  def handle_info({:fetch_recommendations, tmdb_id, media_type}, socket) do
+    {:noreply, DetailModalEvents.fetch_recommendations(socket, tmdb_id, media_type)}
+  end
+
   def handle_info(_msg, socket), do: {:noreply, socket}
 
   # handle_async dispatches to event modules
@@ -889,6 +894,12 @@ defmodule MydiaWeb.MediaLive.Show do
 
   def handle_async(:load_recommendations, result, socket),
     do: RecommendationEvents.handle_load_result(result, socket)
+
+  # The key is deliberately not :load_recommendations: that one is the page's
+  # own rail, and sharing a key would let the dialog's lookup overwrite it,
+  # since start_async/3 overwrites rather than cancels under an existing key.
+  def handle_async(:load_selected_recommendations, result, socket),
+    do: DetailModalEvents.handle_recommendations_result(result, socket)
 
   def handle_async(:load_season_order_info, result, socket),
     do: MediaItemEvents.handle_season_order_info_result(result, socket)

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -476,7 +476,23 @@
     config_open={false}
     add_event="add_selected_item"
     request_event="request_selected_item"
-  />
+  >
+    <:rail>
+      <DiscoverComponents.media_rail
+        :if={@selected_item}
+        id="media-detail-modal-rail"
+        items={@selected_recommendations}
+        media_type={@selected_item.media_type}
+        current_user={@current_user}
+        adding_ids={@adding_recommendation_tmdb_ids}
+        requesting_item_id={@requesting_recommendation_id}
+        libraries={@target_library_candidates}
+        can_add={@can_create_media}
+        add_event="add_selected_item"
+        request_event="request_selected_item"
+      />
+    </:rail>
+  </.live_component>
 
   <MydiaWeb.LibraryComponents.library_picker_dialog
     picker={@library_picker}

--- a/lib/mydia_web/live/media_live/show.html.heex
+++ b/lib/mydia_web/live/media_live/show.html.heex
@@ -457,6 +457,27 @@
     />
   <% end %>
 
+  <%!-- Same dialog Discover and the Dashboard use. picker_open guards Escape:
+        library_picker_dialog/1 is z-[1000] above this z-999, both bind
+        phx-window-keydown, and phx-window-keydown is not scoped by visual
+        stacking, so without it one Escape press would close both layers.
+        config_open is false because this page has no configure-before-adding
+        modal; the attr has no default on purpose. --%>
+  <.live_component
+    module={MydiaWeb.Live.Components.TrendingDetailModal}
+    id="media-detail-modal"
+    item={@selected_item}
+    metadata={@selected_metadata}
+    loading={@detail_loading}
+    current_user={@current_user}
+    open={@selected_item != nil}
+    libraries={@target_library_candidates}
+    picker_open={@library_picker != nil}
+    config_open={false}
+    add_event="add_selected_item"
+    request_event="request_selected_item"
+  />
+
   <MydiaWeb.LibraryComponents.library_picker_dialog
     picker={@library_picker}
     event="add_from_library_picker"

--- a/lib/mydia_web/live/media_live/show/detail_modal_events.ex
+++ b/lib/mydia_web/live/media_live/show/detail_modal_events.ex
@@ -19,23 +19,24 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalEvents do
   and quality profile, the right default for anything reached from this page.
   """
 
+  import Phoenix.LiveView, only: [start_async: 3]
+
+  alias Mydia.Media.Recommendations
   alias MydiaWeb.Live.Helpers.DetailModal
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
+  alias MydiaWeb.Live.Helpers.MediaRequestHelpers
   alias MydiaWeb.MediaLive.Show.FranchiseComponents
   alias MydiaWeb.MediaLive.Show.FranchiseEvents
   alias MydiaWeb.MediaLive.Show.LibraryPickerEvents
   alias MydiaWeb.MediaLive.Show.RecommendationEvents
+
+  require Logger
 
   @doc """
   Opens the dialog over the clicked title.
 
   An unresolvable id is dropped rather than raising: the rails re-render on
   every add, and a click that races a re-render must not take the page down.
-
-  This task ships the dialog without an in-dialog rail, which is a complete,
-  shippable state: it is exactly what the Dashboard renders permanently. So
-  `recommendations: false` is passed for the same reason the Dashboard passes
-  it: with no `:rail` slot on this page yet, the lookup would pay for a relay
-  round trip nothing draws.
   """
   def show_details(%{"id" => id, "type" => type}, socket) do
     case find_item(socket, id) do
@@ -43,7 +44,7 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalEvents do
         {:noreply, socket}
 
       item ->
-        {:noreply, DetailModal.select(socket, item, media_type(type), recommendations: false)}
+        {:noreply, DetailModal.select(socket, item, media_type(type))}
     end
   end
 
@@ -86,6 +87,50 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalEvents do
     ]
   end
 
+  @doc """
+  Starts the lookup behind the dialog's own rail.
+
+  Through `start_async/3` rather than inline: on a cache miss this is a relay
+  call with the config's timeout, and the dialog is already on screen by then,
+  so doing it in the handle_info would queue Close, Add and Request behind the
+  fetch and the dialog would look frozen.
+  """
+  def fetch_recommendations(socket, tmdb_id, media_type) do
+    config = socket.assigns.metadata_config
+
+    start_async(socket, :load_selected_recommendations, fn ->
+      Recommendations.for_tmdb_id(tmdb_id, media_type, config)
+    end)
+  end
+
+  @doc """
+  Stores the dialog's rail, or leaves it empty on anything but a clean result.
+
+  An empty rail renders nothing at all, which is the designed behaviour for a
+  title TMDB has no recommendations for. A crash must not take the page down for
+  a section that is meant to be silently absent.
+  """
+  def handle_recommendations_result({:ok, {:ok, results}}, socket) do
+    {:noreply, DetailModal.put_recommendations(socket, results, &decorate(socket, &1))}
+  end
+
+  def handle_recommendations_result({:ok, :none}, socket) do
+    {:noreply, DetailModal.put_recommendations(socket, [], & &1)}
+  end
+
+  def handle_recommendations_result({:exit, reason}, socket) do
+    Logger.warning("Detail dialog recommendations lookup crashed: #{inspect(reason)}")
+    {:noreply, DetailModal.put_recommendations(socket, [], & &1)}
+  end
+
+  def handle_recommendations_result(other, socket) do
+    Logger.warning(
+      "Detail dialog recommendations returned an unexpected result: #{inspect(other)}"
+    )
+
+    {:noreply, DetailModal.put_recommendations(socket, [], & &1)}
+  end
+
   defp find_item(socket, id), do: DetailModal.find_selectable_item(item_lists(socket), id)
 
   defp franchise_items(nil), do: []
@@ -93,4 +138,19 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalEvents do
 
   defp media_type("tv_show"), do: :tv_show
   defp media_type(_), do: :movie
+
+  # Mirrors RecommendationEvents.decorate/3 but without the navigate targets:
+  # the rail inside the dialog keeps every poster on the dialog, and a link out
+  # would close it from under the user mid-browse.
+  defp decorate(socket, results) do
+    media_item = socket.assigns.media_item
+    results = Enum.filter(results, &(RecommendationEvents.safe_provider_id(&1) != nil))
+    tmdb_ids = Enum.map(results, &RecommendationEvents.safe_provider_id/1)
+
+    status = Mydia.Media.library_status_for_tmdb_ids(tmdb_ids, media_item.type)
+
+    results
+    |> MediaAddHelpers.enrich_with_library_status(status)
+    |> MediaRequestHelpers.enrich_with_request_status(MediaRequestHelpers.request_status_map())
+  end
 end

--- a/lib/mydia_web/live/media_live/show/detail_modal_events.ex
+++ b/lib/mydia_web/live/media_live/show/detail_modal_events.ex
@@ -1,0 +1,96 @@
+defmodule MydiaWeb.MediaLive.Show.DetailModalEvents do
+  @moduledoc """
+  The detail page's host side of `TrendingDetailModal`.
+
+  An adapter, like `RecommendationComponents` and `FranchiseComponents`: the
+  state lives in `MydiaWeb.Live.Helpers.DetailModal`, and this module only maps
+  this page's three item lists and two add handlers onto it.
+
+  A clicked title can come from the recommendations rail, the franchise strip,
+  or the rail inside the dialog itself. All three are searched, in that order,
+  because a title reached by hopping through the dialog is in none of the page's
+  own lists and resolving against those alone would drop the click silently.
+
+  Adds and requests are dispatched by franchise membership, the same way
+  `LibraryPickerEvents` already routes the page's single library picker. An item
+  that is in neither of the page's lists falls to the recommendation branch,
+  which is correct: both paths add by TMDB id, and
+  `RecommendationEvents.perform_add/4` inherits the viewed item's monitored flag
+  and quality profile, the right default for anything reached from this page.
+  """
+
+  alias MydiaWeb.Live.Helpers.DetailModal
+  alias MydiaWeb.MediaLive.Show.FranchiseComponents
+  alias MydiaWeb.MediaLive.Show.FranchiseEvents
+  alias MydiaWeb.MediaLive.Show.LibraryPickerEvents
+  alias MydiaWeb.MediaLive.Show.RecommendationEvents
+
+  @doc """
+  Opens the dialog over the clicked title.
+
+  An unresolvable id is dropped rather than raising: the rails re-render on
+  every add, and a click that races a re-render must not take the page down.
+
+  This task ships the dialog without an in-dialog rail, which is a complete,
+  shippable state: it is exactly what the Dashboard renders permanently. So
+  `recommendations: false` is passed for the same reason the Dashboard passes
+  it: with no `:rail` slot on this page yet, the lookup would pay for a relay
+  round trip nothing draws.
+  """
+  def show_details(%{"id" => id, "type" => type}, socket) do
+    case find_item(socket, id) do
+      nil ->
+        {:noreply, socket}
+
+      item ->
+        {:noreply, DetailModal.select(socket, item, media_type(type), recommendations: false)}
+    end
+  end
+
+  @doc "Closes the dialog."
+  def close_details(_params, socket), do: {:noreply, DetailModal.close(socket)}
+
+  @doc """
+  Adds the title the dialog is open over, through the rail it belongs to.
+  """
+  def add_selected_item(%{"tmdb_id" => tmdb_id} = params, socket) do
+    if LibraryPickerEvents.franchise_entry?(socket.assigns[:franchise], tmdb_id) do
+      FranchiseEvents.add_franchise_movie(params, socket)
+    else
+      RecommendationEvents.add_recommendation(params, socket)
+    end
+  end
+
+  @doc """
+  Requests the title the dialog is open over, through the rail it belongs to.
+  """
+  def request_selected_item(%{"tmdb_id" => tmdb_id} = params, socket) do
+    if LibraryPickerEvents.franchise_entry?(socket.assigns[:franchise], tmdb_id) do
+      FranchiseEvents.request_franchise_movie(params, socket)
+    else
+      RecommendationEvents.request_recommendation(params, socket)
+    end
+  end
+
+  @doc """
+  The lists a poster click resolves against, in precedence order.
+
+  Public so the add and request paths can reuse it when refreshing the dialog's
+  own snapshot of the item. See `DetailModal.refresh_selected/2`.
+  """
+  def item_lists(socket) do
+    [
+      socket.assigns[:recommendations] || [],
+      franchise_items(socket.assigns[:franchise]),
+      socket.assigns[:selected_recommendations] || []
+    ]
+  end
+
+  defp find_item(socket, id), do: DetailModal.find_selectable_item(item_lists(socket), id)
+
+  defp franchise_items(nil), do: []
+  defp franchise_items(franchise), do: FranchiseComponents.rail_items(franchise)
+
+  defp media_type("tv_show"), do: :tv_show
+  defp media_type(_), do: :movie
+end

--- a/lib/mydia_web/live/media_live/show/franchise_components.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_components.ex
@@ -9,6 +9,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
   """
   use MydiaWeb, :html
 
+  alias Mydia.Metadata.Structs.SearchResult
   alias MydiaWeb.DiscoverComponents
 
   @doc """
@@ -25,7 +26,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
   attr :libraries, :list, default: []
 
   def franchise_section(assigns) do
-    assigns = assign(assigns, :items, items(assigns.franchise))
+    assigns = assign(assigns, :items, rail_items(assigns.franchise))
 
     ~H"""
     <DiscoverComponents.media_rail
@@ -56,21 +57,41 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
     """
   end
 
-  defp items(franchise) do
+  @doc """
+  Maps `FranchiseEntry` structs onto the shape `media_rail/1` and
+  `TrendingDetailModal` both read.
+
+  Public because `DetailModalEvents` resolves a poster click against the same
+  list, and rebuilding it there would be a second place to keep in step.
+  """
+  # A SearchResult rather than a plain map, because TrendingDetailModal reads
+  # media_type, overview and backdrop_path by direct field access and
+  # FranchiseEntry carries none of the three. A plain map raised KeyError and
+  # took the page down the moment a franchise poster opened the dialog.
+  #
+  # overview and backdrop_path stay nil until the dialog's own metadata fetch
+  # lands, so it opens without a synopsis or backdrop for one beat, exactly as
+  # Discover does for a thin search result.
+  #
+  # The Map.put decorations are the same shape the recommendations rail already
+  # carries; see RecommendationEvents.decorate/3.
+  def rail_items(franchise) do
     Enum.map(franchise.entries, fn entry ->
-      %{
-        provider_id: entry.tmdb_id,
+      %SearchResult{
+        provider_id: to_string(entry.tmdb_id),
+        provider: :metadata_relay,
+        media_type: :movie,
         title: entry.title,
         year: entry.year,
         poster_path: entry.poster_path,
         vote_average: entry.vote_average,
-        in_library: entry.in_library?,
-        monitored: entry.monitored,
-        id: entry.media_item_id,
-        navigate: navigate_to(entry),
-        current: entry.current?,
-        request_status: entry.request_status
+        id: entry.media_item_id
       }
+      |> Map.put(:in_library, entry.in_library?)
+      |> Map.put(:monitored, entry.monitored)
+      |> Map.put(:navigate, navigate_to(entry))
+      |> Map.put(:current, entry.current?)
+      |> Map.put(:request_status, entry.request_status)
     end)
   end
 

--- a/lib/mydia_web/live/media_live/show/franchise_components.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_components.ex
@@ -38,7 +38,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponents do
       can_add={@can_add}
       adding_ids={@adding_tmdb_ids}
       libraries={@libraries}
-      on_select={nil}
+      on_select="show_details"
       add_event="add_franchise_movie"
       request_event="request_franchise_movie"
     >

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -8,8 +8,10 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   alias Mydia.Media.FranchiseEntry
   alias Mydia.Media.Franchises
   alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.Live.Helpers.DetailModal
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
+  alias MydiaWeb.MediaLive.Show.DetailModalEvents
 
   require Logger
 
@@ -154,6 +156,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
      socket
      |> clear_in_flight(tmdb_id)
      |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
+     |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
      |> put_flash(:info, "Added #{added.title} to your library")}
   end
 
@@ -164,6 +167,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
      socket
      |> clear_in_flight(tmdb_id)
      |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
+     |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
      |> put_flash(:info, "#{added.title} is already in your library")}
   end
 
@@ -231,6 +235,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
            :franchise,
            mark_requested(socket.assigns.franchise, entry.tmdb_id, request.status)
          )
+         |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
          |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")}
 
       {:error, reason} ->

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -152,10 +152,17 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   end
 
   def handle_add_result(tmdb_id, {:ok, {:ok, added}}, socket) do
+    # Bound before building the item lists: item_lists/1 reads
+    # socket.assigns.franchise, and passing the pre-assign socket straight into
+    # the pipeline below would refresh the dialog from the stale franchise, so
+    # its header would keep the old ownership after an add made from inside it.
+    socket =
+      socket
+      |> clear_in_flight(tmdb_id)
+      |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
+
     {:noreply,
      socket
-     |> clear_in_flight(tmdb_id)
-     |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
      |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
      |> put_flash(:info, "Added #{added.title} to your library")}
   end
@@ -163,10 +170,15 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   # Not an error from here up: the movie the user clicked is already in the
   # library, just under an entry this panel had not linked up yet.
   def handle_add_result(tmdb_id, {:ok, {:already_in_library, added}}, socket) do
+    # See the comment in the {:ok, {:ok, added}} clause above: the socket must
+    # be bound before item_lists/1 reads :franchise off it.
+    socket =
+      socket
+      |> clear_in_flight(tmdb_id)
+      |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
+
     {:noreply,
      socket
-     |> clear_in_flight(tmdb_id)
-     |> assign(:franchise, mark_owned(socket.assigns.franchise, added))
      |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
      |> put_flash(:info, "#{added.title} is already in your library")}
   end
@@ -229,12 +241,18 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
 
     case MediaRequestHelpers.handle_request_media(item, :movie, socket.assigns.current_user.id) do
       {:ok, request, _status_updates} ->
+        # Bound before item_lists/1 reads :franchise off it, same reasoning as
+        # handle_add_result/3 above: an argument expression evaluates against
+        # this function's own `socket` parameter, not a later pipeline step.
+        socket =
+          assign(
+            socket,
+            :franchise,
+            mark_requested(socket.assigns.franchise, entry.tmdb_id, request.status)
+          )
+
         {:noreply,
          socket
-         |> assign(
-           :franchise,
-           mark_requested(socket.assigns.franchise, entry.tmdb_id, request.status)
-         )
          |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
          |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")}
 

--- a/lib/mydia_web/live/media_live/show/library_picker_events.ex
+++ b/lib/mydia_web/live/media_live/show/library_picker_events.ex
@@ -48,13 +48,25 @@ defmodule MydiaWeb.MediaLive.Show.LibraryPickerEvents do
     end
   end
 
-  defp franchise_entry?(nil, _tmdb_id), do: false
+  @doc """
+  Whether `tmdb_id` belongs to the franchise strip rather than the
+  recommendations rail.
 
-  defp franchise_entry?(%{entries: entries}, tmdb_id) do
+  Public because the detail dialog routes its own add and request the same way.
+  When the same movie sits in both rails (#460) the franchise strip wins and the
+  recommendations card stays stale; a later click there resolves to
+  `:already_in_library`, which both perform_add functions map to an
+  informational result rather than an error.
+  """
+  def franchise_entry?(franchise, tmdb_id)
+
+  def franchise_entry?(nil, _tmdb_id), do: false
+
+  def franchise_entry?(%{entries: entries}, tmdb_id) do
     Enum.any?(entries, fn %FranchiseEntry{} = entry ->
       to_string(entry.tmdb_id) == to_string(tmdb_id)
     end)
   end
 
-  defp franchise_entry?(_franchise, _tmdb_id), do: false
+  def franchise_entry?(_franchise, _tmdb_id), do: false
 end

--- a/lib/mydia_web/live/media_live/show/recommendation_components.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_components.ex
@@ -52,7 +52,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationComponents do
       requesting_item_id={@requesting_item_id}
       can_add={@can_add}
       libraries={@libraries}
-      on_select={nil}
+      on_select="show_details"
       add_event="add_recommendation"
       request_event="request_recommendation"
     />

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -11,9 +11,11 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   alias Mydia.Media.Add
   alias Mydia.Media.Recommendations
   alias MydiaWeb.Live.Authorization
+  alias MydiaWeb.Live.Helpers.DetailModal
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
   alias MydiaWeb.Live.Helpers.RecommendationsExpanded
+  alias MydiaWeb.MediaLive.Show.DetailModalEvents
 
   require Logger
 
@@ -156,16 +158,27 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
            socket.assigns.current_user.id
          ) do
       {:ok, request, status_updates} ->
+        socket =
+          socket
+          |> assign(:requesting_recommendation_id, nil)
+          |> assign(
+            :recommendations,
+            MediaRequestHelpers.enrich_with_request_status(
+              socket.assigns.recommendations,
+              status_updates
+            )
+          )
+          |> assign(
+            :selected_recommendations,
+            MediaRequestHelpers.enrich_with_request_status(
+              socket.assigns[:selected_recommendations] || [],
+              status_updates
+            )
+          )
+
         {:noreply,
          socket
-         |> assign(:requesting_recommendation_id, nil)
-         |> assign(
-           :recommendations,
-           MediaRequestHelpers.enrich_with_request_status(
-             socket.assigns.recommendations,
-             status_updates
-           )
-         )
+         |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
          |> put_flash(:info, "#{request.title} requested. An admin will review it soon.")}
 
       {:error, reason} ->
@@ -206,20 +219,36 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   end
 
   def handle_add_result(tmdb_id, {:ok, {:ok, added}}, socket) do
+    socket =
+      socket
+      |> clear_in_flight(tmdb_id)
+      |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
+      |> assign(
+        :selected_recommendations,
+        mark_owned(socket.assigns[:selected_recommendations] || [], added)
+      )
+
     {:noreply,
      socket
-     |> clear_in_flight(tmdb_id)
-     |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
+     |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
      |> put_flash(:info, "Added #{added.title} to your library")}
   end
 
   # Not an error from here up: the title the user clicked is already in the
   # library, just under a card this rail had not linked up yet.
   def handle_add_result(tmdb_id, {:ok, {:already_in_library, added}}, socket) do
+    socket =
+      socket
+      |> clear_in_flight(tmdb_id)
+      |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
+      |> assign(
+        :selected_recommendations,
+        mark_owned(socket.assigns[:selected_recommendations] || [], added)
+      )
+
     {:noreply,
      socket
-     |> clear_in_flight(tmdb_id)
-     |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
+     |> DetailModal.refresh_selected(DetailModalEvents.item_lists(socket))
      |> put_flash(:info, "#{added.title} is already in your library")}
   end
 
@@ -280,9 +309,14 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     end
   end
 
-  # Add.parse_provider_id/1 raises on a non-numeric binary. TMDB ids are always
-  # numeric, but one malformed entry must not take down the whole rail.
-  defp safe_provider_id(result) do
+  @doc """
+  Parses a provider id, or nil when it is not numeric.
+
+  `Add.parse_provider_id/1` raises on a non-numeric binary. TMDB ids are always
+  numeric, but one malformed entry must not take down a rail. Public because the
+  detail dialog's own rail needs the same guard.
+  """
+  def safe_provider_id(result) do
     Add.parse_provider_id(result.provider_id)
   rescue
     ArgumentError -> nil

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -225,7 +225,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
       |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
       |> assign(
         :selected_recommendations,
-        mark_owned(socket.assigns[:selected_recommendations] || [], added)
+        mark_owned(socket.assigns[:selected_recommendations] || [], added, navigate: false)
       )
 
     {:noreply,
@@ -243,7 +243,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
       |> assign(:recommendations, mark_owned(socket.assigns.recommendations, added))
       |> assign(
         :selected_recommendations,
-        mark_owned(socket.assigns[:selected_recommendations] || [], added)
+        mark_owned(socket.assigns[:selected_recommendations] || [], added, navigate: false)
       )
 
     {:noreply,
@@ -338,14 +338,30 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     )
   end
 
-  defp mark_owned(recommendations, added) do
+  # `navigate: true` (the default) is correct for the page's own :recommendations
+  # rail: an owned recommendation should link to its own media page. It must stay
+  # `navigate: false` for the dialog's :selected_recommendations rail, because
+  # `DiscoverComponents.trending_card/1` checks `@navigate` before `@on_select`,
+  # so a navigate target would turn the poster into a link that leaves the page
+  # and closes the dialog out from under the user mid-browse, instead of
+  # re-opening the dialog over that title. See the module doc on
+  # `DetailModalEvents.decorate/2` for the read-path half of the same rule.
+  defp mark_owned(recommendations, added, opts \\ []) do
+    navigate? = Keyword.get(opts, :navigate, true)
+
     Enum.map(recommendations, fn item ->
       if safe_provider_id(item) == added.tmdb_id do
-        item
-        |> Map.put(:in_library, true)
-        |> Map.put(:id, added.id)
-        |> Map.put(:monitored, added.monitored)
-        |> Map.put(:navigate, ~p"/media/#{added.id}")
+        item =
+          item
+          |> Map.put(:in_library, true)
+          |> Map.put(:id, added.id)
+          |> Map.put(:monitored, added.monitored)
+
+        if navigate? do
+          Map.put(item, :navigate, ~p"/media/#{added.id}")
+        else
+          item
+        end
       else
         item
       end

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -138,7 +138,14 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   """
   def request_recommendation(%{"tmdb_id" => tmdb_id}, socket) do
     with :ok <- Authorization.authorize_submit_request(socket) do
-      case Enum.find(socket.assigns.recommendations, &(to_string(&1.provider_id) == tmdb_id)) do
+      # Also resolves against the franchise strip and the dialog's own rail
+      # (:selected_recommendations). A title reached only by opening the dialog
+      # over a franchise entry, or by scrolling the rail inside the dialog
+      # itself, is in neither of this page's own lists, and searching just
+      # :recommendations dropped a guest's Request click there silently.
+      # Discover hit the same failure for its modal; see the explanatory
+      # comment on its `{:request_media, ...}` handle_info clause.
+      case DetailModal.find_selectable_item(DetailModalEvents.item_lists(socket), tmdb_id) do
         nil -> {:noreply, socket}
         item -> submit_request(item, tmdb_id, socket)
       end

--- a/test/mydia_web/live/components/detail_modal_events_attrs_test.exs
+++ b/test/mydia_web/live/components/detail_modal_events_attrs_test.exs
@@ -1,0 +1,71 @@
+defmodule MydiaWeb.Live.Components.DetailModalEventsAttrsTest do
+  @moduledoc """
+  The dialog's primary action is its event contract with the host. Emitting an
+  event the host does not handle raises FunctionClauseError and kills the
+  LiveView on the very first click, so a host with different handlers must be
+  able to say so. `trending_card/1` already carries the same pair for the same
+  reason.
+
+  Rendered through render_component/2 rather than a live page: this is about
+  which event name lands in the markup, and driving it through a host would add
+  a relay warm-up for nothing.
+  """
+
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Metadata.Structs.SearchResult
+  alias MydiaWeb.Live.Components.TrendingDetailModal
+
+  defp item do
+    %SearchResult{
+      provider_id: "4242",
+      provider: :metadata_relay,
+      media_type: :movie,
+      title: "Harrow Lane",
+      year: 2021
+    }
+    |> Map.put(:in_library, false)
+  end
+
+  defp render_modal(extra) do
+    render_component(
+      TrendingDetailModal,
+      Keyword.merge(
+        [
+          id: "detail-modal",
+          item: item(),
+          metadata: nil,
+          loading: false,
+          current_user: %{role: "admin"},
+          open: true,
+          libraries: [],
+          picker_open: false,
+          config_open: false
+        ],
+        extra
+      )
+    )
+  end
+
+  test "defaults to Discover's event names" do
+    html = render_modal([])
+
+    assert html =~ ~s(phx-click="add_to_library")
+  end
+
+  test "a host can override the add event" do
+    html = render_modal(add_event: "add_selected_item")
+
+    assert html =~ ~s(phx-click="add_selected_item")
+    refute html =~ ~s(phx-click="add_to_library")
+  end
+
+  test "a host can override the request event" do
+    html = render_modal(current_user: %{role: "guest"}, request_event: "request_selected_item")
+
+    assert html =~ ~s(phx-click="request_selected_item")
+    refute html =~ ~s(phx-click="request_media")
+  end
+end

--- a/test/mydia_web/live/discover_live/recommendations_lookup_test.exs
+++ b/test/mydia_web/live/discover_live/recommendations_lookup_test.exs
@@ -1,40 +1,43 @@
 defmodule MydiaWeb.DiscoverLive.RecommendationsLookupTest do
   @moduledoc """
-  Covers the widened `show_details` lookup.
+  Covers the widened `show_details` lookup for Discover's two lists.
 
   A recommendation is not part of the current grid page, so resolving the click
-  against `items` alone silently drops it and the modal never swaps. That failure
-  is invisible in the UI, which is why it gets a direct test.
+  against `items` alone silently drops it and the dialog never swaps. That
+  failure is invisible in the UI, which is why it gets a direct test.
+
+  The lookup itself moved to `MydiaWeb.Live.Helpers.DetailModal` when the
+  detail page became a third host; this file keeps Discover's two-list shape
+  under test.
 
   No rendering test here on purpose: see the header of library_picker_test.exs.
   """
 
   use ExUnit.Case, async: true
 
-  alias MydiaWeb.DiscoverLive.Index
+  alias MydiaWeb.Live.Helpers.DetailModal
 
   defp result(provider_id), do: %{provider_id: provider_id, title: "Title #{provider_id}"}
 
-  test "finds an item on the current grid page" do
-    items = [result("1"), result("2")]
+  defp lookup(items, recommendations, id),
+    do: DetailModal.find_selectable_item([items, recommendations], id)
 
-    assert %{provider_id: "2"} = Index.find_selectable_item(items, [], "2")
+  test "finds an item on the current grid page" do
+    assert %{provider_id: "2"} = lookup([result("1"), result("2")], [], "2")
   end
 
   test "finds an item that exists only in the recommendations rail" do
-    recommendations = [result("101")]
-
-    assert %{provider_id: "101"} = Index.find_selectable_item([], recommendations, "101")
+    assert %{provider_id: "101"} = lookup([], [result("101")], "101")
   end
 
   test "prefers the grid item when both lists carry the id" do
     grid = %{provider_id: "5", title: "From grid"}
     rail = %{provider_id: "5", title: "From rail"}
 
-    assert %{title: "From grid"} = Index.find_selectable_item([grid], [rail], "5")
+    assert %{title: "From grid"} = lookup([grid], [rail], "5")
   end
 
   test "returns nil for an unknown id" do
-    assert is_nil(Index.find_selectable_item([result("1")], [result("101")], "999"))
+    assert is_nil(lookup([result("1")], [result("101")], "999"))
   end
 end

--- a/test/mydia_web/live/helpers/detail_modal_test.exs
+++ b/test/mydia_web/live/helpers/detail_modal_test.exs
@@ -1,0 +1,80 @@
+defmodule MydiaWeb.Live.Helpers.DetailModalTest do
+  @moduledoc """
+  The two pure functions behind the detail dialog's host state.
+
+  `find_selectable_item/2` decides whether a poster click resolves to anything
+  at all, and `refresh_selected/2` decides whether the dialog's header still
+  offers "Add to Library" for a title the user just added. Both fail silently
+  in the UI, which is why they get direct tests rather than only being covered
+  through a LiveView.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias MydiaWeb.Live.Helpers.DetailModal
+
+  defp result(provider_id, title \\ nil) do
+    %{provider_id: provider_id, title: title || "Title #{provider_id}"}
+  end
+
+  describe "find_selectable_item/2" do
+    test "finds an item in the first list" do
+      assert %{provider_id: "2"} =
+               DetailModal.find_selectable_item([[result("1"), result("2")], []], "2")
+    end
+
+    test "finds an item that exists only in a later list" do
+      assert %{provider_id: "101"} =
+               DetailModal.find_selectable_item([[], [result("101")]], "101")
+    end
+
+    test "prefers the earlier list when both carry the id" do
+      assert %{title: "From grid"} =
+               DetailModal.find_selectable_item(
+                 [[result("5", "From grid")], [result("5", "From rail")]],
+                 "5"
+               )
+    end
+
+    test "compares ids as strings on both sides" do
+      assert %{provider_id: 7} = DetailModal.find_selectable_item([[result(7)]], "7")
+    end
+
+    test "returns nil for an unknown id" do
+      assert is_nil(DetailModal.find_selectable_item([[result("1")], [result("2")]], "999"))
+    end
+
+    test "returns nil for no lists at all" do
+      assert is_nil(DetailModal.find_selectable_item([], "1"))
+    end
+  end
+
+  describe "refresh_selected/2" do
+    defp socket(selected_item) do
+      %Phoenix.LiveView.Socket{assigns: %{selected_item: selected_item, __changed__: %{}}}
+    end
+
+    test "swaps in the refreshed copy of the selected item" do
+      stale = %{provider_id: "5", in_library: false}
+      fresh = %{provider_id: "5", in_library: true}
+
+      refreshed = DetailModal.refresh_selected(socket(stale), [[fresh]])
+
+      assert refreshed.assigns.selected_item.in_library
+    end
+
+    test "leaves the selection alone when the id is in none of the lists" do
+      stale = %{provider_id: "5", in_library: false}
+
+      refreshed = DetailModal.refresh_selected(socket(stale), [[%{provider_id: "9"}]])
+
+      assert refreshed.assigns.selected_item == stale
+    end
+
+    test "is a no-op with no dialog open" do
+      refreshed = DetailModal.refresh_selected(socket(nil), [[%{provider_id: "5"}]])
+
+      assert is_nil(refreshed.assigns.selected_item)
+    end
+  end
+end

--- a/test/mydia_web/live/helpers/detail_modal_test.exs
+++ b/test/mydia_web/live/helpers/detail_modal_test.exs
@@ -47,6 +47,16 @@ defmodule MydiaWeb.Live.Helpers.DetailModalTest do
     test "returns nil for no lists at all" do
       assert is_nil(DetailModal.find_selectable_item([], "1"))
     end
+
+    test "without a media type, matches on id alone even across differing media types" do
+      # Regression guard for click resolution: every list a click resolves
+      # against is homogeneous by media type already, so the 2-arity call
+      # must keep matching on id alone rather than start requiring a type.
+      movie = result("5", "A Fictional Heist")
+      show = %{provider_id: "5", title: "A Fictional Show"}
+
+      assert DetailModal.find_selectable_item([[show], [movie]], "5") == show
+    end
   end
 
   describe "refresh_selected/2" do
@@ -75,6 +85,28 @@ defmodule MydiaWeb.Live.Helpers.DetailModalTest do
       refreshed = DetailModal.refresh_selected(socket(nil), [[%{provider_id: "5"}]])
 
       assert is_nil(refreshed.assigns.selected_item)
+    end
+
+    test "does not swap the selection to a same-id item of a different media type" do
+      # Mirrors the Dashboard's `refresh_selected([trending_movies, trending_tv])`:
+      # TMDB namespaces ids per media type, so a movie and a show can share
+      # one. A refresh must not swap the dialog onto the wrong title just
+      # because the id matched.
+      stale = %{provider_id: "5", media_type: :movie, title: "A Fictional Heist"}
+      wrong_type = %{provider_id: "5", media_type: :tv_show, title: "A Fictional Show"}
+
+      refreshed = DetailModal.refresh_selected(socket(stale), [[wrong_type]])
+
+      assert refreshed.assigns.selected_item == stale
+    end
+
+    test "swaps in the refreshed item when the id and media type both match" do
+      stale = %{provider_id: "5", media_type: :movie, in_library: false}
+      fresh = %{provider_id: "5", media_type: :movie, in_library: true}
+
+      refreshed = DetailModal.refresh_selected(socket(stale), [[fresh]])
+
+      assert refreshed.assigns.selected_item == fresh
     end
   end
 end

--- a/test/mydia_web/live/media_live/show/detail_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/detail_modal_test.exs
@@ -239,4 +239,66 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalTest do
              ~s(#media-detail-modal button[phx-click="add_selected_item"][phx-value-tmdb_id="#{second_hop_tmdb_id}"])
            )
   end
+
+  test "adding a title from the dialog's own rail keeps its poster inside the dialog",
+       %{conn: conn} do
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
+    dialog_pick_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Harrow Lane",
+        year: 2021,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{"id" => recommended_tmdb_id, "title" => "Salt Verge", "release_date" => "2019-04-11"}
+    ])
+
+    warm_recommendations_cache(recommended_tmdb_id, :movie, [
+      %{"id" => dialog_pick_tmdb_id, "title" => "Ninth Tide", "release_date" => "2015-08-03"}
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    view
+    |> element(
+      ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{recommended_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    assert has_element?(
+             view,
+             ~s(#media-detail-modal-rail div[phx-click="show_details"][phx-value-id="#{dialog_pick_tmdb_id}"])
+           )
+
+    view
+    |> element(
+      ~s(#media-detail-modal-rail button[phx-click="add_selected_item"][phx-value-tmdb_id="#{dialog_pick_tmdb_id}"]),
+      "Add to Library"
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    # The regression this guards: RecommendationEvents.mark_owned/3 used to
+    # stamp :navigate on every rail it touched, including the one inside the
+    # dialog. DiscoverComponents.trending_card/1 checks @navigate before
+    # @on_select, so the poster would have become a plain link to the new
+    # title's own page. Clicking it would leave the page and close the dialog
+    # out from under the user, instead of re-opening the dialog over that
+    # title.
+    assert has_element?(
+             view,
+             ~s(#media-detail-modal-rail div[phx-click="show_details"][phx-value-id="#{dialog_pick_tmdb_id}"])
+           )
+
+    refute has_element?(view, ~s(#media-detail-modal-rail a[href^="/media/"]))
+  end
 end

--- a/test/mydia_web/live/media_live/show/detail_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/detail_modal_test.exs
@@ -1,0 +1,141 @@
+defmodule MydiaWeb.MediaLive.Show.DetailModalTest do
+  @moduledoc """
+  Clicking a poster in the detail page's rails opens the same dialog Discover
+  uses, so a recommended title's trailer is reachable without adding it first.
+
+  setup_metadata_stub swaps the provider registry so the dialog's own metadata
+  fetch resolves offline. warm_recommendations_cache is unaffected by that swap:
+  fetch_recommendations_cached calls the relay module directly rather than going
+  through the registry, so the two helpers compose.
+  """
+
+  # async: false: setup_metadata_stub swaps the global Provider.Registry, and
+  # connected LiveView mounts run outside the test process.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.AccountsFixtures
+  import MydiaWeb.AuthHelpers
+  import Mydia.MetadataCacheHelpers
+  import Mydia.MetadataStub
+
+  setup :setup_metadata_stub
+
+  setup %{conn: conn} do
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    %{conn: log_in_user(conn, admin_user_fixture())}
+  end
+
+  defp movie_with_recommendation(recommended_title) do
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Harrow Lane",
+        year: 2021,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{
+        "id" => recommended_tmdb_id,
+        "title" => recommended_title,
+        "release_date" => "2019-04-11",
+        "poster_path" => "/p.jpg"
+      }
+    ])
+
+    {movie, recommended_tmdb_id}
+  end
+
+  test "clicking a recommended poster opens the dialog", %{conn: conn} do
+    {movie, recommended_tmdb_id} = movie_with_recommendation("Salt Verge")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    refute has_element?(view, "#media-detail-modal[open]")
+
+    view
+    |> element(
+      ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{recommended_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    assert has_element?(view, "#media-detail-modal[open]")
+    assert render(view) =~ "Salt Verge"
+  end
+
+  test "closing the dialog leaves the page", %{conn: conn} do
+    {movie, recommended_tmdb_id} = movie_with_recommendation("Salt Verge")
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    view
+    |> element(
+      ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{recommended_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+    assert has_element?(view, "#media-detail-modal[open]")
+
+    # aria-label disambiguates: TrendingDetailModal always renders two
+    # phx-click="close_details" buttons when open (the header's icon-only X and
+    # the modal-backdrop button used for click-outside), matching the
+    # codebase's idiom for a modal with multiple same-selector buttons (see
+    # request_detail_popup_test.exs). Only the header button carries
+    # aria-label="Close"; the backdrop button's visible text is lowercase
+    # "close" and carries no aria-label.
+    view
+    |> element(~s(#media-detail-modal button[phx-click="close_details"][aria-label="Close"]))
+    |> render_click()
+
+    refute has_element?(view, "#media-detail-modal[open]")
+    assert has_element?(view, "#recommendations-rail")
+  end
+
+  test "an owned recommendation still links to its own page instead of opening the dialog",
+       %{conn: conn} do
+    source_tmdb_id = unique_provider_id()
+    owned_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Harrow Lane",
+        year: 2021,
+        tmdb_id: source_tmdb_id
+      })
+
+    owned =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Salt Verge",
+        year: 2019,
+        tmdb_id: owned_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{"id" => owned_tmdb_id, "title" => "Salt Verge", "release_date" => "2019-04-11"}
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    assert has_element?(view, ~s(#recommendations-rail a[href="/media/#{owned.id}"]))
+
+    refute has_element?(
+             view,
+             ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{owned_tmdb_id}"])
+           )
+  end
+end

--- a/test/mydia_web/live/media_live/show/detail_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/detail_modal_test.exs
@@ -301,4 +301,121 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalTest do
 
     refute has_element?(view, ~s(#media-detail-modal-rail a[href^="/media/"]))
   end
+
+  test "a guest requesting a title from inside the dialog's own rail creates the request",
+       %{conn: conn} do
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
+    dialog_only_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Harrow Lane",
+        year: 2021,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{"id" => recommended_tmdb_id, "title" => "Salt Verge", "release_date" => "2019-04-11"}
+    ])
+
+    warm_recommendations_cache(recommended_tmdb_id, :movie, [
+      %{"id" => dialog_only_tmdb_id, "title" => "Ninth Tide", "release_date" => "2015-08-03"}
+    ])
+
+    conn = log_in_user(conn, user_fixture(%{role: "guest"}))
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    view
+    |> element(
+      ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{recommended_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    # dialog_only_tmdb_id lives only in :selected_recommendations, never in
+    # this page's own :recommendations. Regression: request_recommendation/2
+    # used to search only :recommendations, so a guest's Request click on a
+    # card reached only through the dialog's own rail fell into the nil branch
+    # and silently did nothing. Mirrors the fix Discover already shipped for
+    # its own modal, see the comment on its `{:request_media, ...}` clause.
+    view
+    |> element(
+      ~s(#media-detail-modal-rail button[phx-click="request_selected_item"][phx-value-tmdb_id="#{dialog_only_tmdb_id}"]),
+      "Request"
+    )
+    |> render_click()
+
+    assert [request] = Mydia.MediaRequests.list_requests(status: "pending")
+    assert request.tmdb_id == dialog_only_tmdb_id
+    assert request.title == "Ninth Tide"
+  end
+
+  test "adding a missing franchise entry from inside the dialog refreshes its header",
+       %{conn: conn} do
+    source_tmdb_id = unique_provider_id()
+    collection_id = unique_provider_id()
+    missing_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Harrow Lane",
+        year: 2021,
+        tmdb_id: source_tmdb_id,
+        metadata: %{
+          "provider_id" => to_string(source_tmdb_id),
+          "provider" => "metadata_relay",
+          "media_type" => "movie",
+          "title" => "Harrow Lane",
+          "collection_id" => collection_id,
+          "collection_name" => "Vault Chronicles Collection"
+        }
+      })
+
+    warm_collection_cache(collection_id, [
+      %{"id" => source_tmdb_id, "title" => "Harrow Lane", "release_date" => "2021-03-01"},
+      %{"id" => missing_tmdb_id, "title" => "Salt Verge", "release_date" => "2019-04-11"}
+    ])
+
+    # The page's own recommendations rail (any movie/show with a tmdb_id starts
+    # this lookup on connect) and the dialog's own rail for whatever it opens
+    # over both need warming, same reasoning as movie_with_recommendation/1.
+    warm_recommendations_cache(source_tmdb_id, :movie, [])
+    warm_recommendations_cache(missing_tmdb_id, :movie, [])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    view
+    |> element(~s(#franchise-section-item-#{missing_tmdb_id} div[phx-click="show_details"]))
+    |> render_click()
+
+    render_async(view, 5000)
+
+    assert has_element?(
+             view,
+             ~s(#media-detail-modal button[phx-click="add_selected_item"][phx-value-tmdb_id="#{missing_tmdb_id}"])
+           )
+
+    view
+    |> element(
+      ~s(#media-detail-modal button[phx-click="add_selected_item"][phx-value-tmdb_id="#{missing_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    # Regression: DetailModalEvents.item_lists(socket) was an argument
+    # expression inside the pipeline that assigns :franchise, so it was
+    # evaluated against that function's own `socket` parameter, which still
+    # carried the pre-add franchise. The dialog's header kept offering "Add to
+    # Library" for a title that had just been added from inside it.
+    refute has_element?(view, ~s(#media-detail-modal button[phx-click="add_selected_item"]))
+    assert has_element?(view, "#trending-detail-modal-actions a", "Go to Movie")
+  end
 end

--- a/test/mydia_web/live/media_live/show/detail_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/detail_modal_test.exs
@@ -50,6 +50,13 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalTest do
       }
     ])
 
+    # The dialog now fetches its own rail for whatever it opens over (this
+    # task), so the recommended title's own recommendations need warming too,
+    # even though these tests only assert on the dialog opening, not on its
+    # rail. Left unwarmed, that lookup reaches the real relay and the run
+    # fails on the network-escape check in test_helper.exs.
+    warm_recommendations_cache(recommended_tmdb_id, :movie, [])
+
     {movie, recommended_tmdb_id}
   end
 
@@ -136,6 +143,100 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalTest do
     refute has_element?(
              view,
              ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{owned_tmdb_id}"])
+           )
+  end
+
+  test "the dialog carries its own recommendations rail", %{conn: conn} do
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
+    second_hop_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Harrow Lane",
+        year: 2021,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{"id" => recommended_tmdb_id, "title" => "Salt Verge", "release_date" => "2019-04-11"}
+    ])
+
+    warm_recommendations_cache(recommended_tmdb_id, :movie, [
+      %{"id" => second_hop_tmdb_id, "title" => "Ninth Tide", "release_date" => "2015-08-03"}
+    ])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    view
+    |> element(
+      ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{recommended_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    assert has_element?(view, "#media-detail-modal-rail")
+    assert render(view) =~ "Ninth Tide"
+  end
+
+  test "hopping to a title in the dialog's own rail swaps the dialog", %{conn: conn} do
+    source_tmdb_id = unique_provider_id()
+    recommended_tmdb_id = unique_provider_id()
+    second_hop_tmdb_id = unique_provider_id()
+
+    movie =
+      media_item_fixture(%{
+        type: "movie",
+        title: "Harrow Lane",
+        year: 2021,
+        tmdb_id: source_tmdb_id
+      })
+
+    warm_recommendations_cache(source_tmdb_id, :movie, [
+      %{"id" => recommended_tmdb_id, "title" => "Salt Verge", "release_date" => "2019-04-11"}
+    ])
+
+    warm_recommendations_cache(recommended_tmdb_id, :movie, [
+      %{"id" => second_hop_tmdb_id, "title" => "Ninth Tide", "release_date" => "2015-08-03"}
+    ])
+
+    warm_recommendations_cache(second_hop_tmdb_id, :movie, [])
+
+    {:ok, view, _html} = live(conn, ~p"/media/#{movie.id}")
+    render_async(view, 5000)
+
+    view
+    |> element(
+      ~s(#recommendations-rail div[phx-click="show_details"][phx-value-id="#{recommended_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    view
+    |> element(
+      ~s(#media-detail-modal-rail div[phx-click="show_details"][phx-value-id="#{second_hop_tmdb_id}"])
+    )
+    |> render_click()
+
+    render_async(view, 5000)
+
+    # Not a title assertion: MetadataStubProvider's fetch_by_id/3 returns the
+    # same canned "Stub Movie" for any provider_id, and TrendingDetailModal
+    # prefers loaded metadata's title over the SearchResult's own once that
+    # fetch lands (see title/2), so the header text is identical across every
+    # title this dialog ever opens over. The add button's phx-value-tmdb_id
+    # is read straight off @item rather than @metadata, so it is what proves
+    # the dialog actually swapped to the second-hop title rather than staying
+    # on the first.
+    assert has_element?(view, "#media-detail-modal[open]")
+
+    assert has_element?(
+             view,
+             ~s(#media-detail-modal button[phx-click="add_selected_item"][phx-value-tmdb_id="#{second_hop_tmdb_id}"])
            )
   end
 end

--- a/test/mydia_web/live/media_live/show/franchise_components_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_components_test.exs
@@ -197,6 +197,41 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseComponentsTest do
     assert missing =~ "7.4"
   end
 
+  test "rail items are SearchResult structs carrying what the detail dialog reads" do
+    entry = %Mydia.Media.FranchiseEntry{
+      tmdb_id: 4242,
+      title: "Harrow Lane",
+      year: 2021,
+      poster_path: "/p.jpg",
+      vote_average: 7.4,
+      media_item_id: nil,
+      in_library?: false,
+      monitored: false,
+      current?: false,
+      request_status: nil
+    }
+
+    franchise = %{name: "Harrow Collection", entries: [entry], owned_count: 0, total_count: 1}
+
+    [item] = FranchiseComponents.rail_items(franchise)
+
+    # TrendingDetailModal reads these three by direct field access. A plain map
+    # without them raises KeyError the moment a franchise poster opens it.
+    assert %Mydia.Metadata.Structs.SearchResult{media_type: :movie} = item
+    assert Map.has_key?(item, :overview)
+    assert Map.has_key?(item, :backdrop_path)
+
+    # provider_id is a string now. Every consumer already normalises with
+    # to_string/1, and the card's phx-value-id is unchanged either way.
+    assert item.provider_id == "4242"
+
+    # The rail decorations must survive the conversion.
+    assert item.in_library == false
+    assert item.monitored == false
+    assert item.current == false
+    assert item.navigate == nil
+  end
+
   # Slices one entry out of the section so an assertion cannot accidentally match
   # a sibling. `LazyHTML.filter/2` only matches root-level nodes and the entries
   # are nested inside #franchise-section, so this must be `query/2`.

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -31,7 +31,13 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       franchise: nil,
       adding_franchise_tmdb_ids: MapSet.new(),
       can_create_media: true,
-      current_user: user_fixture()
+      current_user: user_fixture(),
+      # DetailModal.refresh_selected/2 reads this directly (no default) since
+      # DetailModal.init/1 always sets it before any handler can fire in the
+      # real LiveView. A unit test socket has no mount to run that through, so
+      # it needs the same assign here or a success add/request crashes with a
+      # KeyError.
+      selected_item: nil
     }
 
     %Phoenix.LiveView.Socket{
@@ -104,7 +110,9 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
         __changed__: %{},
         franchise: franchise,
         current_user: user,
-        flash: %{}
+        flash: %{},
+        # Same reason as stub_socket/2's selected_item default above.
+        selected_item: nil
       }
     }
   end

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -24,7 +24,13 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       recommendations: [],
       adding_recommendation_tmdb_ids: MapSet.new(),
       requesting_recommendation_id: nil,
-      current_user: user_fixture()
+      current_user: user_fixture(),
+      # DetailModal.refresh_selected/2 reads this directly (no default) since
+      # DetailModal.init/1 always sets it before any handler can fire in the
+      # real LiveView. A unit test socket has no mount to run that through, so
+      # it needs the same assign here or a successful request crashes with a
+      # KeyError.
+      selected_item: nil
     }
 
     %Phoenix.LiveView.Socket{
@@ -159,6 +165,43 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       assert updated.assigns.recommendations == recommendations
       assert updated.assigns.requesting_recommendation_id == nil
       assert MediaRequests.list_requests(status: "pending") == []
+    end
+
+    # Regression: this handler searched only :recommendations, but a title
+    # reached by hopping into the dialog's own rail lives solely in
+    # :selected_recommendations. A guest clicking Request on such a card fell
+    # into the `nil` branch and the click silently did nothing. Matches the
+    # fix Discover already shipped for its own modal (see the comment on its
+    # `{:request_media, ...}` handle_info clause).
+    test "a guest requesting a title that lives only in the dialog's own rail creates the request" do
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Current",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      tmdb_id = System.unique_integer([:positive])
+
+      dialog_only_item =
+        result(%{provider_id: to_string(tmdb_id), title: "Dialog Only Title", year: 2018})
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          recommendations: [],
+          selected_recommendations: [dialog_only_item],
+          current_user: user_fixture(%{role: "guest"})
+        })
+
+      {:noreply, updated} =
+        RecommendationEvents.request_recommendation(%{"tmdb_id" => to_string(tmdb_id)}, socket)
+
+      assert [request] = MediaRequests.list_requests(status: "pending")
+      assert request.title == "Dialog Only Title"
+      assert request.tmdb_id == tmdb_id
+
+      refute updated.assigns.flash["error"]
     end
   end
 


### PR DESCRIPTION
Clicking a poster in the media detail page's "More like this" rail or its franchise strip now opens the same trailer and detail dialog Discover uses. Those were the last two surfaces pairing a poster with Add to Library that did nothing when clicked, so a recommended title's trailer, synopsis and cast previously required adding it to the library first.

Owned entries keep linking straight to their own page, since going to the real page beats a metadata popup for something you already have. The dialog carries its own recommendations rail, so you can hop from title to title without closing it.

Along the way:

- The dialog's host-side state moves into `MydiaWeb.Live.Helpers.DetailModal`. Discover and the Dashboard each hand-rolled the same four assigns and the same select/close/fetch trio; the detail page would have been a third copy. All three now share one helper.
- The dialog's header no longer goes stale after an add. It read a snapshot of the item taken when it opened, so it kept offering "Add to Library" for a title that was already in the library, and a second click failed on the tmdb_id index. Fixed on all three hosts.
- Franchise rail items become `SearchResult` structs. The dialog reads `media_type`, `overview` and `backdrop_path` by direct field access and `FranchiseEntry` carries none of the three, so a franchise poster would have raised `KeyError` and taken the page down.
- `trending_card/1` now renders the "you are here" card as an inert poster regardless of `on_select`, so the franchise strip's current entry cannot open a dialog about the movie you are already looking at.

## Notes for review

`TrendingDetailModal` gains `add_event` and `request_event` attrs, mirroring the pair `trending_card/1` already carried. Both default to the current values, so Discover, the Dashboard and the two request pages are behaviourally unchanged.

Escape layering is deliberate: the page-level library picker is `z-[1000]` and binds `phx-window-keydown` unconditionally, while the dialog is `z-999` and gates its own binding on `picker_open`. `phx-window-keydown` is not scoped by visual stacking, so without that guard one Escape press would close both layers at once.

The dialog's own rail refreshes without setting `:navigate`, unlike the page's rail. `trending_card/1` checks `navigate` before `on_select`, so a title added from inside the dialog would otherwise turn into a link that navigates away and closes the dialog mid-browse.

## Verification

`mix precommit` green: 10,526 tests, 0 failures, compile clean under `--warnings-as-errors`.

New coverage: `DetailModal` unit tests for the click-resolution and header-refresh transforms; LiveView tests on the detail page for opening the dialog from a recommendation, closing it, an owned poster still navigating, the dialog's own rail rendering, hopping two titles deep, and a title added from inside the dialog staying a dialog click target rather than becoming a navigate link.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added detail dialogs to media pages, recommendations, and franchise items.
  - Users can view metadata and recommendations, then add or request items directly from the dialog.
  - Added support for host-specific actions and refreshed dialog content after status changes.
  - Current items now display as non-interactive posters without opening details.
  - Add buttons now display “Add” with clear tooltip and accessibility text.

- **Bug Fixes**
  - Improved dialog loading, selection, and fallback handling.
  - Prevented nested library-picker dialogs from closing unexpectedly.
  - Ensured actions work for items shown only in the dialog’s recommendation rail.
  - Corrected provider handling for TVDB search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->