### PR TITLE
fix(indexers): stop a magnet redirect crashing the grab

### DIFF
--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -26,6 +26,18 @@ defmodule Mydia.Application do
 
     children = children()
 
+    # Attached before the supervisor starts, unlike its sibling
+    # Mydia.Jobs.Broadcaster below: Oban is one of the children
+    # Supervisor.start_link/2 is about to start, and it can begin executing
+    # (and failing) jobs immediately. Attaching after start_link/2 leaves a
+    # window where a job can fail before anything is listening, and the
+    # failure goes unlogged, exactly what this handler exists to prevent. This
+    # is safe to do this early because the handler only calls Logger.error and
+    # touches no Repo. Broadcaster cannot move here: its handler calls
+    # Mydia.Jobs.list_executing_jobs(), which needs the Repo child already
+    # running.
+    Mydia.Jobs.ErrorLogger.attach()
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Mydia.Supervisor]
@@ -38,10 +50,6 @@ defmodule Mydia.Application do
       reset_stale_jobs()
       # Attach Oban job broadcaster for real-time job status updates
       Mydia.Jobs.Broadcaster.attach()
-      # Log Oban job failures. Without this a raising worker is silent: the
-      # crash lands only in oban_jobs.errors and a discarded job looks like a
-      # job that simply had nothing to do.
-      Mydia.Jobs.ErrorLogger.attach()
       # Register download client adapters after supervisor has started
       Mydia.Downloads.register_clients()
       # Register indexer adapters after supervisor has started

--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -38,6 +38,10 @@ defmodule Mydia.Application do
       reset_stale_jobs()
       # Attach Oban job broadcaster for real-time job status updates
       Mydia.Jobs.Broadcaster.attach()
+      # Log Oban job failures. Without this a raising worker is silent: the
+      # crash lands only in oban_jobs.errors and a discarded job looks like a
+      # job that simply had nothing to do.
+      Mydia.Jobs.ErrorLogger.attach()
       # Register download client adapters after supervisor has started
       Mydia.Downloads.register_clients()
       # Register indexer adapters after supervisor has started

--- a/lib/mydia/indexers/cardigann_download.ex
+++ b/lib/mydia/indexers/cardigann_download.ex
@@ -144,9 +144,17 @@ defmodule Mydia.Indexers.CardigannDownload do
          variables,
          user_config
        ) do
-    with {:ok, response} <-
-           infohash_source(definition, infohash, download_url, before_response, user_config),
-         {:ok, hash} <- match_selector(response, Map.get(infohash, :hash), variables, "hash"),
+    with {:ok, source} <-
+           infohash_source(definition, infohash, download_url, before_response, user_config) do
+      case source do
+        {:magnet, magnet} -> {:ok, {:magnet, magnet}}
+        {:response, response} -> build_magnet_from_response(response, infohash, variables)
+      end
+    end
+  end
+
+  defp build_magnet_from_response(response, infohash, variables) do
+    with {:ok, hash} <- match_selector(response, Map.get(infohash, :hash), variables, "hash"),
          {:ok, title} <- match_title(response, Map.get(infohash, :title), variables) do
       case TorrentHash.build_magnet(hash, title) do
         nil ->
@@ -162,7 +170,7 @@ defmodule Mydia.Indexers.CardigannDownload do
   # instead of spending a second round trip on the landing page.
   defp infohash_source(_definition, %{usebeforeresponse: true}, _url, before_response, _config)
        when is_map(before_response) do
-    {:ok, before_response}
+    {:ok, {:response, before_response}}
   end
 
   defp infohash_source(definition, _infohash, download_url, _before_response, user_config) do
@@ -184,32 +192,49 @@ defmodule Mydia.Indexers.CardigannDownload do
   # -- selectors --------------------------------------------------------------
 
   defp resolve_selectors(definition, selectors, download_url, before_response, variables, config) do
-    with {:ok, response} <- selector_source(definition, download_url, before_response, config) do
-      selectors
-      |> Enum.find_value(fn selector ->
-        case match_selector(response, selector, variables, "download link") do
-          {:ok, link} when is_binary(link) and link != "" -> link
-          _ -> nil
-        end
-      end)
-      |> case do
-        nil ->
-          {:error, {:cardigann_download, "no download selector matched the response"}}
+    with {:ok, source} <- selector_source(definition, download_url, before_response, config) do
+      case source do
+        {:magnet, magnet} ->
+          {:ok, {:magnet, magnet}}
 
-        link ->
-          # Many definitions point their download selector straight at a magnet.
-          # Handing that back as a link would send the grab path off to fetch a
-          # `magnet:` URL over HTTP, which it cannot do.
-          case absolute_link(definition, download_url, link, config) do
-            "magnet:" <> _ = magnet -> {:ok, {:magnet, magnet}}
-            resolved -> {:ok, {:link, resolved}}
-          end
+        {:response, response} ->
+          match_download_selectors(
+            definition,
+            selectors,
+            download_url,
+            response,
+            variables,
+            config
+          )
       end
     end
   end
 
+  defp match_download_selectors(definition, selectors, download_url, response, variables, config) do
+    selectors
+    |> Enum.find_value(fn selector ->
+      case match_selector(response, selector, variables, "download link") do
+        {:ok, link} when is_binary(link) and link != "" -> link
+        _ -> nil
+      end
+    end)
+    |> case do
+      nil ->
+        {:error, {:cardigann_download, "no download selector matched the response"}}
+
+      link ->
+        # Many definitions point their download selector straight at a magnet.
+        # Handing that back as a link would send the grab path off to fetch a
+        # `magnet:` URL over HTTP, which it cannot do.
+        case absolute_link(definition, download_url, link, config) do
+          "magnet:" <> _ = magnet -> {:ok, {:magnet, magnet}}
+          resolved -> {:ok, {:link, resolved}}
+        end
+    end
+  end
+
   defp selector_source(_definition, _url, before_response, _config) when is_map(before_response),
-    do: {:ok, before_response}
+    do: {:ok, {:response, before_response}}
 
   defp selector_source(definition, download_url, _before_response, user_config),
     do: fetch(definition, download_url, user_config)
@@ -275,7 +300,7 @@ defmodule Mydia.Indexers.CardigannDownload do
   defp fetch(definition, url, user_config) do
     params = %{query_params: %{}, headers: [], method: :get, decode_body: false}
 
-    CardigannSearchEngine.execute_http_request(
+    CardigannSearchEngine.execute_download_request(
       definition,
       url,
       params,

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -635,7 +635,11 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   of being carried across one blindly.
 
   A `magnet:` Location resolves without issuing a second request at all, so no
-  credential is transmitted to the host that named it.
+  credential is transmitted to the host that named it, regardless of
+  `definition.follow_redirect`. An http(s) Location instead honours
+  `follow_redirect`: when it is `false` the hop is not taken and this returns
+  an error naming the status and Location, the same wording
+  `validate_response/1` uses for an unfollowed redirect in the search path.
   """
   @spec execute_download_request(
           Parsed.t(),
@@ -669,6 +673,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
         follow_download_redirect(
           definition,
           url,
+          status,
           headers,
           request_params,
           user_config,
@@ -693,6 +698,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   defp follow_download_redirect(
          definition,
          url,
+         status,
          headers,
          request_params,
          user_config,
@@ -704,10 +710,14 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
         {:error, Error.search_failed("Redirect with no Location header for #{url}")}
 
       "magnet:" <> _ = magnet ->
+        # A magnet Location is the payload itself, handed over via a header
+        # rather than a second request. Reading it issues no request and
+        # leaks no credential, so this resolves regardless of
+        # `follow_redirect: false`.
         Logger.info("Cardigann download URL redirected to a magnet")
         {:ok, {:magnet, magnet}}
 
-      location ->
+      location when definition.follow_redirect ->
         next =
           url
           |> URI.parse()
@@ -715,6 +725,12 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
           |> URI.to_string()
 
         execute_download_request(definition, next, request_params, user_config, config, hops - 1)
+
+      location ->
+        {:error,
+         Error.search_failed(
+           "Redirected (HTTP #{status}) to #{location} and the redirect was not followed"
+         )}
     end
   end
 

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -593,14 +593,7 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
     Logger.debug("Request params: #{inspect(request_params.query_params)}")
 
     # Execute request based on method
-    result =
-      case request_params.method do
-        :get ->
-          Req.get(url, req_opts)
-
-        :post ->
-          Req.post(url, req_opts)
-      end
+    result = safe_request(request_params.method, url, req_opts)
 
     case result do
       {:ok, %Req.Response{status: status, body: body, headers: headers}} ->

--- a/lib/mydia/indexers/cardigann_search_engine.ex
+++ b/lib/mydia/indexers/cardigann_search_engine.ex
@@ -624,6 +624,119 @@ defmodule Mydia.Indexers.CardigannSearchEngine do
   end
 
   @doc """
+  Runs a download-block HTTP request, resolving redirects by hand.
+
+  The download path cannot reuse `execute_http_request/5`'s redirect handling.
+  A tracker answering a download URL with `302 Location: magnet:?xt=...` is
+  handing over the payload, but Req follows that redirect into
+  `Finch.Request.parse_url/1`, which raises `ArgumentError` on any scheme that
+  is not http(s). That exception escaped the whole Indexers boundary and
+  discarded the calling Oban job, so a monitored show searched, ranked, picked
+  a release, and then never grabbed it, with nothing in the log.
+
+  Redirects are therefore followed one hop at a time with `redirect: false`.
+  Each hop rebuilds its options through `build_request_options/5`, so
+  `attach_cookies/4` re-runs `cookie_disposition/2` against the new URL. That
+  is the per-hop origin check left out of the branch that first enabled
+  redirect following: a session cookie is re-authorised for every hop instead
+  of being carried across one blindly.
+
+  A `magnet:` Location resolves without issuing a second request at all, so no
+  credential is transmitted to the host that named it.
+  """
+  @spec execute_download_request(
+          Parsed.t(),
+          String.t(),
+          map(),
+          map(),
+          map(),
+          non_neg_integer()
+        ) ::
+          {:ok, {:magnet, String.t()}}
+          | {:ok, {:response, http_response()}}
+          | {:error, Error.t()}
+  def execute_download_request(definition, url, request_params, user_config, config, hops \\ 5)
+
+  def execute_download_request(_definition, url, _request_params, _user_config, _config, 0) do
+    {:error, Error.search_failed("Too many redirects resolving download URL #{url}")}
+  end
+
+  def execute_download_request(definition, url, request_params, user_config, config, hops) do
+    apply_rate_limit(definition)
+
+    req_opts =
+      definition
+      |> build_request_options(url, request_params, user_config, config)
+      |> Keyword.put(:redirect, false)
+
+    Logger.debug("Cardigann download request: #{request_params.method} #{url}")
+
+    case safe_request(request_params.method, url, req_opts) do
+      {:ok, %Req.Response{status: status, headers: headers}} when status in 300..399 ->
+        follow_download_redirect(
+          definition,
+          url,
+          headers,
+          request_params,
+          user_config,
+          config,
+          hops
+        )
+
+      {:ok, %Req.Response{status: status, body: body, headers: headers}} ->
+        {:ok, {:response, %{status: status, body: body, headers: headers}}}
+
+      {:error, %Req.TransportError{reason: :timeout}} ->
+        {:error, Error.connection_failed("Request timeout")}
+
+      {:error, %Req.TransportError{reason: reason}} ->
+        {:error, Error.connection_failed("Connection failed: #{inspect(reason)}")}
+
+      {:error, reason} ->
+        {:error, Error.search_failed("Request failed: #{inspect(reason)}")}
+    end
+  end
+
+  defp follow_download_redirect(
+         definition,
+         url,
+         headers,
+         request_params,
+         user_config,
+         config,
+         hops
+       ) do
+    case location_header(headers) do
+      nil ->
+        {:error, Error.search_failed("Redirect with no Location header for #{url}")}
+
+      "magnet:" <> _ = magnet ->
+        Logger.info("Cardigann download URL redirected to a magnet")
+        {:ok, {:magnet, magnet}}
+
+      location ->
+        next =
+          url
+          |> URI.parse()
+          |> URI.merge(location)
+          |> URI.to_string()
+
+        execute_download_request(definition, next, request_params, user_config, config, hops - 1)
+    end
+  end
+
+  defp safe_request(:get, url, req_opts), do: run_req(&Req.get/2, url, req_opts)
+  defp safe_request(:post, url, req_opts), do: run_req(&Req.post/2, url, req_opts)
+
+  defp run_req(fun, url, req_opts) do
+    fun.(url, req_opts)
+  rescue
+    exception ->
+      Logger.error("Cardigann HTTP request raised for #{url}: #{Exception.message(exception)}")
+      {:error, exception}
+  end
+
+  @doc """
   Validates the HTTP response before passing to the result parser.
 
   Checks for common error conditions:

--- a/lib/mydia/jobs/error_logger.ex
+++ b/lib/mydia/jobs/error_logger.ex
@@ -1,0 +1,55 @@
+defmodule Mydia.Jobs.ErrorLogger do
+  @moduledoc """
+  Logs Oban job failures.
+
+  Oban emits `[:oban, :job, :exception]` for every failed attempt, but nothing
+  in this application listened for it and `Oban.Telemetry.attach_default_logger/1`
+  was never called. A worker that raised produced no output at all: the crash
+  was recorded only in the `errors` column of `oban_jobs`, and a job that
+  exhausted `max_attempts` was discarded in silence.
+
+  That is how a TV search which crashed on every one of its three attempts
+  looked, from the logs, exactly like a search that found nothing worth
+  grabbing. Sibling of `Mydia.Jobs.Broadcaster`; both are attached from
+  `Mydia.Application.start/2`.
+  """
+
+  require Logger
+
+  @handler_id "mydia-oban-error-logger"
+  @event [:oban, :job, :exception]
+
+  @spec attach() :: :ok | {:error, :already_exists}
+  def attach do
+    :telemetry.attach(@handler_id, @event, &__MODULE__.handle_event/4, nil)
+  end
+
+  @spec detach() :: :ok | {:error, :not_found}
+  def detach do
+    :telemetry.detach(@handler_id)
+  end
+
+  @doc false
+  def handle_event(@event, _measurements, %{job: job} = metadata, _config) do
+    Logger.error(
+      "Oban job failed: #{job.worker} (attempt #{job.attempt}/#{job.max_attempts})",
+      oban_job_id: job.id,
+      oban_worker: job.worker,
+      oban_args: inspect(job.args),
+      oban_attempt: job.attempt,
+      oban_max_attempts: job.max_attempts,
+      oban_error: format_error(metadata)
+    )
+  end
+
+  def handle_event(_event, _measurements, _metadata, _config), do: :ok
+
+  defp format_error(%{kind: kind, reason: reason, stacktrace: stacktrace})
+       when is_list(stacktrace) do
+    Exception.format(kind, reason, stacktrace)
+  end
+
+  defp format_error(%{reason: reason}), do: inspect(reason)
+
+  defp format_error(_), do: "unknown"
+end

--- a/lib/mydia/jobs/error_logger.ex
+++ b/lib/mydia/jobs/error_logger.ex
@@ -2,11 +2,14 @@ defmodule Mydia.Jobs.ErrorLogger do
   @moduledoc """
   Logs Oban job failures.
 
-  Oban emits `[:oban, :job, :exception]` for every failed attempt, but nothing
-  in this application listened for it and `Oban.Telemetry.attach_default_logger/1`
-  was never called. A worker that raised produced no output at all: the crash
-  was recorded only in the `errors` column of `oban_jobs`, and a job that
-  exhausted `max_attempts` was discarded in silence.
+  Oban emits `[:oban, :job, :exception]` for every failed attempt.
+  `Mydia.Jobs.Broadcaster` already listens for it, but only to broadcast job
+  status over PubSub and to record the failure as an event for the UI and
+  audit trail. Nothing wrote the failure to the application log, and
+  `Oban.Telemetry.attach_default_logger/1` was never called. A worker that
+  raised produced no log output at all: the crash was recorded only in the
+  `errors` column of `oban_jobs`, and a job that exhausted `max_attempts` was
+  discarded in silence.
 
   That is how a TV search which crashed on every one of its three attempts
   looked, from the logs, exactly like a search that found nothing worth
@@ -31,14 +34,16 @@ defmodule Mydia.Jobs.ErrorLogger do
 
   @doc false
   def handle_event(@event, _measurements, %{job: job} = metadata, _config) do
+    reason = format_error(metadata)
+
     Logger.error(
-      "Oban job failed: #{job.worker} (attempt #{job.attempt}/#{job.max_attempts})",
+      "Oban job failed: #{job.worker} (attempt #{job.attempt}/#{job.max_attempts}): #{reason}",
       oban_job_id: job.id,
       oban_worker: job.worker,
       oban_args: inspect(job.args),
       oban_attempt: job.attempt,
       oban_max_attempts: job.max_attempts,
-      oban_error: format_error(metadata)
+      oban_error: reason
     )
   end
 

--- a/test/mydia/indexers/cardigann_download_test.exs
+++ b/test/mydia/indexers/cardigann_download_test.exs
@@ -307,6 +307,126 @@ defmodule Mydia.Indexers.CardigannDownloadTest do
 
       assert magnet =~ "VIALIVE"
     end
+
+    test "a download url that redirects to a magnet resolves to that magnet" do
+      bypass = Bypass.open()
+      magnet = "magnet:?xt=urn:btih:#{@info_hash}&dn=Harbour.Lights.S01"
+
+      Bypass.expect_once(bypass, "GET", "/dl/1", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", magnet)
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      definition = %Parsed{
+        id: "dl-magnet-redirect",
+        name: "DL Magnet Redirect",
+        description: "",
+        language: "en-US",
+        type: "public",
+        encoding: "UTF-8",
+        links: ["http://localhost:#{bypass.port}"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+        login: nil,
+        download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
+        settings: [],
+        request_delay: nil,
+        follow_redirect: true
+      }
+
+      assert {:ok, {:magnet, ^magnet}} =
+               CardigannDownload.resolve(
+                 definition,
+                 "http://localhost:#{bypass.port}/dl/1",
+                 %{base_url: "http://localhost:#{bypass.port}", config: %{}}
+               )
+    end
+
+    test "a redirect to a landing page still runs the download selectors" do
+      bypass = Bypass.open()
+      magnet = "magnet:?xt=urn:btih:#{@info_hash}&dn=Harbour.Lights.S01"
+
+      Bypass.expect_once(bypass, "GET", "/dl/2", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "/page/2")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      Bypass.expect_once(bypass, "GET", "/page/2", fn conn ->
+        Plug.Conn.resp(
+          conn,
+          200,
+          ~s(<html><body><a class="dl" href="#{magnet}">get</a></body></html>)
+        )
+      end)
+
+      definition = %Parsed{
+        id: "dl-page-redirect",
+        name: "DL Page Redirect",
+        description: "",
+        language: "en-US",
+        type: "public",
+        encoding: "UTF-8",
+        links: ["http://localhost:#{bypass.port}"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+        login: nil,
+        download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
+        settings: [],
+        request_delay: nil,
+        follow_redirect: true
+      }
+
+      assert {:ok, {:magnet, ^magnet}} =
+               CardigannDownload.resolve(
+                 definition,
+                 "http://localhost:#{bypass.port}/dl/2",
+                 %{base_url: "http://localhost:#{bypass.port}", config: %{}}
+               )
+    end
+
+    test "a session is not carried onto a cross-host redirect" do
+      site = Bypass.open()
+      foreign = Bypass.open()
+      test_pid = self()
+
+      Bypass.expect_once(site, "GET", "/dl/3", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://localhost:#{foreign.port}/get.torrent")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      Bypass.expect_once(foreign, "GET", "/get.torrent", fn conn ->
+        send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+        Plug.Conn.resp(conn, 200, ~s(<html><a class="dl" href="/x.torrent">get</a></html>))
+      end)
+
+      definition = %Parsed{
+        id: "dl-redirect-scope",
+        name: "DL Redirect Scope",
+        description: "",
+        language: "en-US",
+        type: "private",
+        encoding: "UTF-8",
+        links: ["http://localhost:#{site.port}"],
+        capabilities: %{modes: %{}},
+        search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+        login: nil,
+        download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
+        settings: [],
+        request_delay: nil,
+        follow_redirect: true
+      }
+
+      CardigannDownload.resolve(definition, "http://localhost:#{site.port}/dl/3", %{
+        cookies: ["session=secret"],
+        base_url: "http://localhost:#{site.port}",
+        config: %{}
+      })
+
+      assert_receive {:cookie_header, []}
+    end
   end
 
   describe "credential scope on downloads" do

--- a/test/mydia/indexers/cardigann_search_engine_redirect_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_redirect_test.exs
@@ -1,0 +1,111 @@
+defmodule Mydia.Indexers.CardigannSearchEngineRedirectTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.CardigannDefinition.Parsed
+  alias Mydia.Indexers.CardigannSearchEngine
+
+  @magnet "magnet:?xt=urn:btih:d2e202a5d71ea60b26203f2a9003a1e569382096&dn=Harbour.Lights.S01"
+
+  defp definition(port, opts \\ []) do
+    %Parsed{
+      id: "redirecttest",
+      name: "Redirect Test",
+      description: "",
+      language: "en-US",
+      type: Keyword.get(opts, :type, "public"),
+      encoding: "UTF-8",
+      links: ["http://localhost:#{port}"],
+      capabilities: %{modes: %{}},
+      search: %{paths: [%{path: "/search"}], inputs: %{}, rows: %{}, fields: %{}},
+      login: nil,
+      download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
+      settings: [],
+      request_delay: nil,
+      follow_redirect: true
+    }
+  end
+
+  defp params, do: %{query_params: %{}, headers: [], method: :get, decode_body: false}
+
+  test "a 302 to a magnet resolves to the magnet without a second request" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/dl/1", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", @magnet)
+      |> Plug.Conn.resp(302, "")
+    end)
+
+    assert {:ok, {:magnet, @magnet}} =
+             CardigannSearchEngine.execute_download_request(
+               definition(bypass.port),
+               "http://localhost:#{bypass.port}/dl/1",
+               params(),
+               %{},
+               %{}
+             )
+  end
+
+  test "an ordinary http redirect is still followed to the final body" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/dl/2", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", "/files/a.torrent")
+      |> Plug.Conn.resp(302, "")
+    end)
+
+    Bypass.expect_once(bypass, "GET", "/files/a.torrent", fn conn ->
+      Plug.Conn.resp(conn, 200, "d8:announce")
+    end)
+
+    assert {:ok, {:response, %{status: 200, body: "d8:announce"}}} =
+             CardigannSearchEngine.execute_download_request(
+               definition(bypass.port),
+               "http://localhost:#{bypass.port}/dl/2",
+               params(),
+               %{},
+               %{}
+             )
+  end
+
+  test "a redirect loop gives up rather than recursing forever" do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, "GET", "/loop", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", "/loop")
+      |> Plug.Conn.resp(302, "")
+    end)
+
+    assert {:error, %{message: message}} =
+             CardigannSearchEngine.execute_download_request(
+               definition(bypass.port),
+               "http://localhost:#{bypass.port}/loop",
+               params(),
+               %{},
+               %{}
+             )
+
+    assert message =~ "Too many redirects"
+  end
+
+  test "a 3xx with no Location header is an error, not a crash" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/nowhere", fn conn ->
+      Plug.Conn.resp(conn, 302, "")
+    end)
+
+    assert {:error, %{message: message}} =
+             CardigannSearchEngine.execute_download_request(
+               definition(bypass.port),
+               "http://localhost:#{bypass.port}/nowhere",
+               params(),
+               %{},
+               %{}
+             )
+
+    assert message =~ "no Location header"
+  end
+end

--- a/test/mydia/indexers/cardigann_search_engine_redirect_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_redirect_test.exs
@@ -108,4 +108,27 @@ defmodule Mydia.Indexers.CardigannSearchEngineRedirectTest do
 
     assert message =~ "no Location header"
   end
+
+  describe "execute_http_request/5 error containment" do
+    test "a redirect to an unsupported scheme returns an error instead of raising" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "ftp://example.invalid/x")
+        |> Plug.Conn.resp(302, "")
+      end)
+
+      assert {:error, %{message: message}} =
+               CardigannSearchEngine.execute_http_request(
+                 definition(bypass.port),
+                 "http://localhost:#{bypass.port}/search",
+                 params(),
+                 %{},
+                 %{}
+               )
+
+      assert message =~ "Request failed" or message =~ "Connection failed"
+    end
+  end
 end

--- a/test/mydia/indexers/cardigann_search_engine_redirect_test.exs
+++ b/test/mydia/indexers/cardigann_search_engine_redirect_test.exs
@@ -21,7 +21,7 @@ defmodule Mydia.Indexers.CardigannSearchEngineRedirectTest do
       download: %{selectors: [%{selector: "a.dl", attribute: "href"}]},
       settings: [],
       request_delay: nil,
-      follow_redirect: true
+      follow_redirect: Keyword.get(opts, :follow_redirect, true)
     }
   end
 
@@ -88,6 +88,52 @@ defmodule Mydia.Indexers.CardigannSearchEngineRedirectTest do
              )
 
     assert message =~ "Too many redirects"
+  end
+
+  test "with follow_redirect: false, a 302 to a magnet still resolves to the magnet" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/dl/4", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", @magnet)
+      |> Plug.Conn.resp(302, "")
+    end)
+
+    assert {:ok, {:magnet, @magnet}} =
+             CardigannSearchEngine.execute_download_request(
+               definition(bypass.port, follow_redirect: false),
+               "http://localhost:#{bypass.port}/dl/4",
+               params(),
+               %{},
+               %{}
+             )
+  end
+
+  test "with follow_redirect: false, a 302 to an http url errors without hitting the target" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/dl/5", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("location", "/files/b.torrent")
+      |> Plug.Conn.resp(302, "")
+    end)
+
+    # No route registered for /files/b.torrent: Bypass fails the test if it
+    # receives a request that was never expected or stubbed, so a redirect
+    # hop taken here fails the test rather than passing quietly.
+
+    assert {:error, %{message: message}} =
+             CardigannSearchEngine.execute_download_request(
+               definition(bypass.port, follow_redirect: false),
+               "http://localhost:#{bypass.port}/dl/5",
+               params(),
+               %{},
+               %{}
+             )
+
+    assert message =~ "Redirected (HTTP 302)"
+    assert message =~ "/files/b.torrent"
+    assert message =~ "redirect was not followed"
   end
 
   test "a 3xx with no Location header is an error, not a crash" do

--- a/test/mydia/jobs/error_logger_test.exs
+++ b/test/mydia/jobs/error_logger_test.exs
@@ -6,9 +6,20 @@ defmodule Mydia.Jobs.ErrorLoggerTest do
   alias Mydia.Jobs.ErrorLogger
 
   setup do
-    _ = ErrorLogger.detach()
-    :ok = ErrorLogger.attach()
-    on_exit(fn -> ErrorLogger.detach() end)
+    # Mydia.Application.start/2 already attached this handler at boot, so
+    # attach/0 here normally returns {:error, :already_exists} and this test
+    # must leave the application's handler alone. Only detach on exit when
+    # this test's own attach/0 call is the one that succeeded (a standalone
+    # run, or a run where a prior test left it detached) - unconditionally
+    # detaching first, as this used to, left ErrorLogger globally detached
+    # for the rest of the suite process once the application's own attach had
+    # already happened.
+    on_exit_detach? = ErrorLogger.attach() == :ok
+
+    on_exit(fn ->
+      if on_exit_detach?, do: ErrorLogger.detach()
+    end)
+
     :ok
   end
 

--- a/test/mydia/jobs/error_logger_test.exs
+++ b/test/mydia/jobs/error_logger_test.exs
@@ -1,0 +1,42 @@
+defmodule Mydia.Jobs.ErrorLoggerTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mydia.Jobs.ErrorLogger
+
+  setup do
+    _ = ErrorLogger.detach()
+    :ok = ErrorLogger.attach()
+    on_exit(fn -> ErrorLogger.detach() end)
+    :ok
+  end
+
+  test "logs the worker, attempt and reason for a failed job" do
+    job = %Oban.Job{
+      id: 554_560,
+      worker: "Mydia.Jobs.TVShowSearch",
+      args: %{"mode" => "show"},
+      attempt: 3,
+      max_attempts: 3
+    }
+
+    log =
+      capture_log(fn ->
+        :telemetry.execute(
+          [:oban, :job, :exception],
+          %{duration: 1_000},
+          %{
+            job: job,
+            kind: :error,
+            reason: %ArgumentError{message: ~s(invalid scheme "magnet")},
+            stacktrace: []
+          }
+        )
+      end)
+
+    assert log =~ "Mydia.Jobs.TVShowSearch"
+    assert log =~ "3/3"
+    assert log =~ "invalid scheme"
+  end
+end

--- a/test/mydia/jobs/error_logger_test.exs
+++ b/test/mydia/jobs/error_logger_test.exs
@@ -12,31 +12,66 @@ defmodule Mydia.Jobs.ErrorLoggerTest do
     :ok
   end
 
-  test "logs the worker, attempt and reason for a failed job" do
-    job = %Oban.Job{
-      id: 554_560,
-      worker: "Mydia.Jobs.TVShowSearch",
-      args: %{"mode" => "show"},
-      attempt: 3,
-      max_attempts: 3
-    }
+  @job %Oban.Job{
+    id: 554_560,
+    worker: "Mydia.Jobs.TVShowSearch",
+    args: %{"mode" => "show"},
+    attempt: 3,
+    max_attempts: 3
+  }
 
+  @event_metadata %{
+    job: @job,
+    kind: :error,
+    reason: %ArgumentError{message: ~s(invalid scheme "magnet")},
+    stacktrace: []
+  }
+
+  test "attach/0 wires the handler to real Oban telemetry dispatch" do
     log =
       capture_log(fn ->
-        :telemetry.execute(
+        :telemetry.execute([:oban, :job, :exception], %{duration: 1_000}, @event_metadata)
+      end)
+
+    # Mydia.CrashReporter.TowerReporter also listens on this event and dumps
+    # the raw metadata (worker name included) into its own warning line, so
+    # this only proves attach/0 reaches handle_event/4 through the real
+    # telemetry pipeline. It does not prove where the failure reason ends up;
+    # see the test below for that.
+    assert log =~ "Mydia.Jobs.TVShowSearch"
+    assert log =~ "3/3"
+  end
+
+  test "the failure reason is in the log message, not only in metadata" do
+    # Calling handle_event/4 directly, instead of going through
+    # :telemetry.execute/3, isolates this module's own log line.
+    # Mydia.Jobs.Broadcaster and Mydia.CrashReporter.TowerReporter both also
+    # attach to [:oban, :job, :exception]; going through the real dispatch
+    # here would mix their output into the capture. Tower in particular logs
+    # a raw inspect of the full event metadata (reason included) as its own
+    # message text, which previously made `log =~ "invalid scheme"` pass
+    # against this module's OLD code even though that code never put the
+    # reason anywhere but an unwhitelisted :oban_error metadata key, which
+    # config/config.exs and config/dev.exs never render. This test proves
+    # only what this module's own handler writes.
+    log =
+      capture_log(fn ->
+        ErrorLogger.handle_event(
           [:oban, :job, :exception],
           %{duration: 1_000},
-          %{
-            job: job,
-            kind: :error,
-            reason: %ArgumentError{message: ~s(invalid scheme "magnet")},
-            stacktrace: []
-          }
+          @event_metadata,
+          nil
         )
       end)
 
-    assert log =~ "Mydia.Jobs.TVShowSearch"
-    assert log =~ "3/3"
-    assert log =~ "invalid scheme"
+    # The default formatter is "$time $metadata[$level] $message\n", so
+    # everything after "[error] " is this line's :message, and everything
+    # before it is :time plus whatever :metadata keys are on the app's
+    # whitelist (config/config.exs, config/dev.exs). None of this module's
+    # oban_* keys are on that whitelist, so if the reason only reached
+    # Logger via metadata, it would not appear past this split.
+    [_prefix, message] = String.split(log, "[error] ", parts: 2)
+
+    assert message =~ "invalid scheme"
   end
 end


### PR DESCRIPTION
## The bug

A monitored show searched, ranked 100 results, selected a season pack, and then never downloaded it. No download row was created, no error surfaced, and the application log showed nothing at all.

The cause, recovered from `oban_jobs.errors` on a production instance:

```
** (ArgumentError) invalid scheme "magnet" for url: magnet:?xt=urn:btih:...
    (finch 0.23.0) lib/finch/request.ex:152: Finch.Request.parse_url/1
    (req 0.7.1) lib/req/steps.ex:1482: Req.Steps.redirect/1
```

`CardigannDownload.resolve/3` fetched the download URL through `execute_http_request/5`, which passes `redirect: definition.follow_redirect`. That defaults to `true` (`cardigann_parser.ex:180`), and the indexer had no stored cookies, so the `attach_cookies/4` branch that forces `redirect: false` never ran. The tracker answered `302 Location: magnet:?xt=...`, Req followed it, and Finch rejected the scheme.

`execute_http_request/5` converts returned error tuples only, so the raise passed straight through `initiate_season_pack_download/5` without reaching either its success or its failure branch. It killed the Oban worker, retried identically twice, and discarded. On the instance where this was found, all 6 failed `TVShowSearch` jobs carried this same error.

Both cookie states were broken, differently:

- **No cookies:** `redirect: true`, Req follows and raises. This is the observed crash.
- **Cookies present:** `redirect: false` already, so the 302 returns an empty body, every selector matches nothing, and the grab fails with "no download selector matched the response".

## What changed

**`execute_download_request/6`** (`cardigann_search_engine.ex`) resolves redirects one hop at a time with `redirect: false` and short-circuits the moment a `Location` names a magnet, without issuing a second request. Each hop rebuilds its options through the existing `build_request_options/5`, so `attach_cookies/4` re-runs `cookie_disposition/2` against the new URL. That is the per-hop origin check 126cdead9 deliberately deferred: a session cookie is re-authorised for every hop rather than carried across one blindly. A magnet `Location` resolves with no further request, so no credential reaches the host that named it.

**`CardigannDownload`** consumes the new tagged shapes and short-circuits on a magnet in both the infohash and selector arms. `resolve/3`'s public contract is unchanged, so no caller outside the file needed an edit.

**`safe_request/3`** converts a raised Req/Finch error into the `{:error, %Error{}}` the Indexers contract already promises, and both request paths now use it. An indexer controls both the URL it advertises and the `Location` it redirects to, so a raise there is remote input reaching the top of an Oban worker.

**`Mydia.Jobs.ErrorLogger`** logs Oban job failures. `Mydia.Jobs.Broadcaster` already listened for `[:oban, :job, :exception]`, but only to broadcast status over PubSub and record an audit event. Nothing wrote the failure to the application log and `Oban.Telemetry.attach_default_logger/1` was never called, which is why three crashed attempts and a permanent discard were indistinguishable from a job that had nothing to do.

## Why not reuse the existing redirect follower

`Mydia.Downloads.Queue` has one (`follow_to_final_url/3`, `queue.ex:1573`) that also terminates on `magnet:`. It is not shared here on purpose. It probes with HEAD and returns a final URL for the caller to re-fetch, and it carries one flat cookie header across every hop. The Cardigann path needs the body from the final hop and needs its cookie decision re-evaluated per hop against the definition's trusted origins. Reusing it as-is would have reintroduced the cross-host cookie leak that 126cdead9 closed. Happy to revisit if a reviewer prefers a shared resolver taking an opts-builder closure.

## Testing

Full suite green. Format and Credo clean. Eight tests added:

- 302 to a magnet resolves to the magnet without a second request
- an ordinary http redirect is still followed to the final body
- a redirect loop gives up rather than recursing forever
- a 3xx with no `Location` header errors rather than crashing
- a redirect to an unsupported scheme returns an error instead of raising
- end to end through `resolve/3`: magnet redirect, landing-page redirect, and a session not carried onto a cross-host redirect
- `ErrorLogger` puts the worker, attempt and failure reason in the log message

Two false-greens were caught and fixed during review, both of which passed while proving nothing:

- The first `ErrorLogger` test's `"invalid scheme"` assertion was satisfied by `CrashReporter.TowerReporter`'s telemetry handler dumping raw metadata into a separate warning line, not by this module. The test now calls `handle_event/4` directly so only this module's output can satisfy it.
- The handler originally passed the failure reason as `oban_error:` metadata, but this app's Logger formatter whitelists metadata keys and no `oban_*` key is registered in `config.exs`, `dev.exs` or `test.exs`. A real operator line would have read `Oban job failed: <worker> (attempt 3/3)` with the exception invisible. `ExUnit.CaptureLog` does not apply that whitelist, so the test was green. The reason is now interpolated into the message string, and the replacement test was verified to fail when it is moved back to metadata.

## Known follow-ups, deliberately not in this PR

- `run_req/3` uses a bare `rescue exception ->`, broader than the single documented failure mode. It now covers every Cardigann **search** request, not just downloads, so a future malformed-options bug would surface as a generic "search failed" rather than crashing loudly. It fails safe (logged, reason preserved in the returned tuple) and `exit`/`throw` are unaffected. Narrowing it to `rescue e in ArgumentError` and re-raising the rest is the obvious improvement.
- No test covers the infohash arm's magnet short-circuit (`cardigann_download.ex:150`); all three end-to-end tests drive the selectors arm. Verified correct by inspection, structurally symmetric to the tested arm.
- Pre-existing and untouched here: when `[:oban, :job, :exception]` fires outside a sandboxed process in the test env, `Broadcaster`'s handler crashes on a missing Ecto sandbox checkout and `:telemetry` permanently auto-detaches it for the rest of that suite run. Worth its own issue.
- `execute_http_request/5` and `execute_download_request/6` still carry near-identical `Req.TransportError` conversion clauses.
- `apply_rate_limit/1` runs per redirect hop, so a definition with `request_delay` pays it up to 5 times on a maxed chain. Defensible, since each hop is a real outbound request to a rate-limited host.

## Not fixed, and why

`TorrentHash.download_torrent/1` (`torrent_hash.ex:294`) and `Blackhole` (`blackhole.ex:241`) both call `Req.get/2` with no redirect guard and carry the same crash. Both are reachable only through `TorrentHash.extract({:url, url})`, and `Queue.prepare_torrent_input/2` produces a `{:url, _}` only from its "Unknown format" fallback, which no configured indexer currently hits. Fixing them now would be speculative work on an unreachable path. If a magnet-scheme `ArgumentError` ever appears in `oban_jobs.errors` with a `TorrentHash` or `Blackhole` frame, that is the trigger.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Download links can follow redirects, resolve directly to magnet links, and continue processing redirected landing pages.
  - Cross-site redirects no longer carry session cookies.
- **Bug Fixes**
  - Download and search requests now handle network errors, redirect loops, missing destinations, unsupported redirect schemes, and disabled redirect following without crashing.
  - Failed background jobs are now clearly recorded in application logs with useful failure details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->