### PR TITLE
Extract the shared Configure-dialog submit preamble

### DIFF
--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -169,37 +169,17 @@ defmodule MydiaWeb.DashboardLive.Index do
   end
 
   def handle_event("submit_add_config", %{"config" => params}, socket) do
-    with :ok <- LiveAuthorization.authorize_create_media(socket),
-         %{provider_id: provider_id, media_type: media_type} <- socket.assigns.add_config,
-         {:ok, opts} <-
-           MediaAddHelpers.add_opts_from_config(params, media_type, socket.assigns.current_user) do
-      socket = MediaAddHelpers.clear_add_config(socket)
-
-      if MapSet.member?(socket.assigns.adding_item_ids, provider_id) do
-        {:noreply, socket}
-      else
-        socket =
-          assign(
-            socket,
-            :adding_item_ids,
-            MapSet.put(socket.assigns.adding_item_ids, provider_id)
-          )
-
-        send(self(), {:add_media_to_library_with_opts, provider_id, media_type, opts})
-        {:noreply, socket}
-      end
-    else
-      {:unauthorized, socket} ->
-        {:noreply, socket}
-
-      nil ->
-        {:noreply, socket}
-
-      {:error, :unknown_library} ->
+    case MediaAddHelpers.resolve_add_config_submit(socket, params) do
+      {:ok, provider_id, media_type, opts, socket} ->
         {:noreply,
-         socket
-         |> MediaAddHelpers.clear_add_config()
-         |> put_flash(:error, "That library is no longer available. Nothing was added.")}
+         MediaAddHelpers.queue_add(
+           socket,
+           provider_id,
+           {:add_media_to_library_with_opts, provider_id, media_type, opts}
+         )}
+
+      {:halt, socket} ->
+        {:noreply, socket}
     end
   end
 
@@ -211,28 +191,12 @@ defmodule MydiaWeb.DashboardLive.Index do
     with :ok <- LiveAuthorization.authorize_create_media(socket) do
       case parse_event_media_type(media_type) do
         {:ok, media_type_atom} ->
-          # An impatient double-click sends the event twice before the first
-          # handle_info runs. Without this guard the second add lands on a title
-          # the first just created, and resolves to :already_in_library, flashing
-          # a false failure for a title the user only meant to add once.
-          if MapSet.member?(socket.assigns.adding_item_ids, provider_id) do
-            {:noreply, socket}
-          else
-            socket =
-              assign(
-                socket,
-                :adding_item_ids,
-                MapSet.put(socket.assigns.adding_item_ids, provider_id)
-              )
-
-            # Start async task to add media
-            send(
-              self(),
-              {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
-            )
-
-            {:noreply, socket}
-          end
+          {:noreply,
+           MediaAddHelpers.queue_add(
+             socket,
+             provider_id,
+             {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
+           )}
 
         :error ->
           {:noreply, put_flash(socket, :error, @unsupported_media_type)}

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -240,41 +240,21 @@ defmodule MydiaWeb.DiscoverLive.Index do
     {:noreply, MediaAddHelpers.clear_add_config(socket)}
   end
 
+  # Goes through the same in-flight guard a plain click uses. Before the merge
+  # this path bypassed it, so a double submit could race itself onto the
+  # tmdb_id unique index.
   def handle_event("submit_add_config", %{"config" => params}, socket) do
-    with :ok <- Authorization.authorize_create_media(socket),
-         %{provider_id: provider_id, media_type: media_type} <- socket.assigns.add_config,
-         {:ok, opts} <-
-           MediaAddHelpers.add_opts_from_config(params, media_type, socket.assigns.current_user) do
-      socket = MediaAddHelpers.clear_add_config(socket)
-
-      # Goes through the same in-flight guard a plain click uses. Before the
-      # merge this path bypassed it, so a double submit could race itself onto
-      # the tmdb_id unique index.
-      if MapSet.member?(socket.assigns.adding_item_ids, provider_id) do
-        {:noreply, socket}
-      else
-        socket =
-          assign(
-            socket,
-            :adding_item_ids,
-            MapSet.put(socket.assigns.adding_item_ids, provider_id)
-          )
-
-        send(self(), {:add_media_to_library_with_opts, provider_id, media_type, opts})
-        {:noreply, socket}
-      end
-    else
-      {:unauthorized, socket} ->
-        {:noreply, socket}
-
-      nil ->
-        {:noreply, socket}
-
-      {:error, :unknown_library} ->
+    case MediaAddHelpers.resolve_add_config_submit(socket, params) do
+      {:ok, provider_id, media_type, opts, socket} ->
         {:noreply,
-         socket
-         |> MediaAddHelpers.clear_add_config()
-         |> put_flash(:error, "That library is no longer available. Nothing was added.")}
+         MediaAddHelpers.queue_add(
+           socket,
+           provider_id,
+           {:add_media_to_library_with_opts, provider_id, media_type, opts}
+         )}
+
+      {:halt, socket} ->
+        {:noreply, socket}
     end
   end
 
@@ -286,27 +266,12 @@ defmodule MydiaWeb.DiscoverLive.Index do
     with :ok <- Authorization.authorize_create_media(socket) do
       case parse_event_media_type(media_type) do
         {:ok, media_type_atom} ->
-          # An impatient double-click sends the event twice before the first
-          # handle_info runs. Without this guard the second add lands on a title
-          # the first just created, and resolves to :already_in_library, flashing
-          # a false failure for a title the user only meant to add once.
-          if MapSet.member?(socket.assigns.adding_item_ids, provider_id) do
-            {:noreply, socket}
-          else
-            socket =
-              assign(
-                socket,
-                :adding_item_ids,
-                MapSet.put(socket.assigns.adding_item_ids, provider_id)
-              )
-
-            send(
-              self(),
-              {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
-            )
-
-            {:noreply, socket}
-          end
+          {:noreply,
+           MediaAddHelpers.queue_add(
+             socket,
+             provider_id,
+             {:add_media_to_library, provider_id, media_type_atom, params["library_path_id"]}
+           )}
 
         :error ->
           {:noreply, put_flash(socket, :error, @unsupported_media_type)}

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -15,6 +15,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   alias Mydia.Metadata
   alias Mydia.Metadata.Structs.SearchResult
   alias Mydia.Settings
+  alias MydiaWeb.Live.Authorization
+
+  @unknown_library_flash "That library is no longer available. Nothing was added."
 
   @doc """
   Libraries a caller may pick as the add-time target for `media_type`.
@@ -341,6 +344,92 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
        defaults
        |> AddDefaults.to_add_opts()
        |> Keyword.put(:search_on_add, defaults.search_on_add)}
+    end
+  end
+
+  @doc """
+  Resolves a submitted Configure dialog into add opts, or halts the event.
+
+  Every host of the dialog runs the same preamble: authorize, read the open
+  `:add_config`, turn the submitted `config[...]` params into
+  `Mydia.Media.Add` opts, and close the dialog. Only what happens after that
+  differs, so the completion stays with the host.
+
+  Returns `{:ok, provider_id, media_type, opts, socket}` with the dialog
+  already closed, or `{:halt, socket}` when the event must end without adding
+  anything. Three cases halt:
+
+    * The user may not create media. `authorize_create_media/1` has already
+      flashed the reason, and the dialog is deliberately left open so a
+      correction is one click away rather than a re-open. The caret that opens
+      the dialog is hidden from a guest, but the `handle_event` clause it fires
+      is live on the socket regardless of what the template renders, so this
+      guard has to run here rather than only in the UI.
+
+    * No dialog is open. A submit with no `:add_config` is a stale or forged
+      event and there is nothing to tell the user about.
+
+    * The submitted library is not a candidate for this media type, which
+      `add_opts_from_config/3` rejects as authorization rather than
+      convenience. Here the dialog closes and the rejection is flashed: the
+      user made a choice this server will not honour, and #458 was filed
+      because silently ignoring one is worse than having no picker at all.
+
+  Reads `socket.assigns[:add_config]` rather than the dotted form so a host
+  that never assigned the key halts instead of raising.
+  """
+  @spec resolve_add_config_submit(Phoenix.LiveView.Socket.t(), map()) ::
+          {:ok, term(), :movie | :tv_show, keyword(), Phoenix.LiveView.Socket.t()}
+          | {:halt, Phoenix.LiveView.Socket.t()}
+  def resolve_add_config_submit(socket, params) do
+    with :ok <- Authorization.authorize_create_media(socket),
+         %{provider_id: provider_id, media_type: media_type} <- socket.assigns[:add_config],
+         {:ok, opts} <- add_opts_from_config(params, media_type, socket.assigns.current_user) do
+      {:ok, provider_id, media_type, opts, clear_add_config(socket)}
+    else
+      {:unauthorized, socket} ->
+        {:halt, socket}
+
+      nil ->
+        {:halt, socket}
+
+      {:error, :unknown_library} ->
+        {:halt,
+         socket
+         |> clear_add_config()
+         |> Phoenix.LiveView.put_flash(:error, @unknown_library_flash)}
+    end
+  end
+
+  @doc """
+  Marks `provider_id` as in flight and sends `message` to the LiveView.
+
+  An impatient double-click sends the event twice before the first
+  `handle_info` runs. Without this guard the second add lands on a title the
+  first just created, resolves to `:already_in_library`, and flashes a false
+  failure for a title the user only meant to add once. A repeat for an id
+  already in flight is dropped and nothing is sent.
+
+  `message` is opaque so the two add paths can share the guard: a plain click
+  sends `{:add_media_to_library, ...}` and a configured submit sends
+  `{:add_media_to_library_with_opts, ...}`.
+
+  Only hosts that keep the shared `:adding_item_ids` set use this. The detail
+  page keys its franchise adds on an integer tmdb_id in its own set and guards
+  them itself.
+  """
+  @spec queue_add(Phoenix.LiveView.Socket.t(), term(), term()) :: Phoenix.LiveView.Socket.t()
+  def queue_add(socket, provider_id, message) do
+    if MapSet.member?(socket.assigns.adding_item_ids, provider_id) do
+      socket
+    else
+      send(self(), message)
+
+      Phoenix.Component.assign(
+        socket,
+        :adding_item_ids,
+        MapSet.put(socket.assigns.adding_item_ids, provider_id)
+      )
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/add_config_events.ex
+++ b/lib/mydia_web/live/media_live/show/add_config_events.ex
@@ -15,10 +15,7 @@ defmodule MydiaWeb.MediaLive.Show.AddConfigEvents do
   "Add to which library?" dialog.
   """
 
-  import Phoenix.LiveView, only: [put_flash: 3]
-
   alias Mydia.Media.FranchiseEntry
-  alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.MediaLive.Show.FranchiseEvents
   alias MydiaWeb.MediaLive.Show.RecommendationEvents
@@ -55,37 +52,18 @@ defmodule MydiaWeb.MediaLive.Show.AddConfigEvents do
   @doc """
   Dispatches a configured add to the rail the card belongs to.
 
-  The dialog is closed first, unconditionally on the way to a dispatched add:
-  leaving it open while an async add runs would let a second submit queue
-  behind the first.
+  The preamble every host of the dialog shares, authorization included, lives
+  in `MediaAddHelpers.resolve_add_config_submit/2`. It closes the dialog before
+  returning opts: leaving it open while an async add runs would let a second
+  submit queue behind the first.
 
-  Gated on `Authorization.authorize_create_media/1`, the same check every
-  sibling add path uses (`FranchiseEvents.add_franchise_movie/2`,
-  `RecommendationEvents.add_recommendation/2`, and both Discover's and
-  Dashboard's own `submit_add_config` handlers). The caret that opens this
-  dialog is hidden from a guest, but the `handle_event` clause it fires is
-  live on the socket regardless of what the template renders, so the guard
-  has to live here rather than only in the UI.
+  Only the dispatch below is local, because this page is the one host with two
+  rails to choose between.
   """
   def submit_add_config(%{"config" => params}, socket) do
-    with :ok <- Authorization.authorize_create_media(socket),
-         %{provider_id: tmdb_id, media_type: media_type} <- socket.assigns[:add_config],
-         {:ok, opts} <-
-           MediaAddHelpers.add_opts_from_config(params, media_type, socket.assigns.current_user) do
-      socket = MediaAddHelpers.clear_add_config(socket)
-      dispatch(tmdb_id, opts, socket)
-    else
-      {:unauthorized, socket} ->
-        {:noreply, socket}
-
-      nil ->
-        {:noreply, socket}
-
-      {:error, :unknown_library} ->
-        {:noreply,
-         socket
-         |> MediaAddHelpers.clear_add_config()
-         |> put_flash(:error, "That library is no longer available. Nothing was added.")}
+    case MediaAddHelpers.resolve_add_config_submit(socket, params) do
+      {:ok, tmdb_id, _media_type, opts, socket} -> dispatch(tmdb_id, opts, socket)
+      {:halt, socket} -> {:noreply, socket}
     end
   end
 

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -1,6 +1,7 @@
 defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
   use Mydia.DataCase, async: false
 
+  import Mydia.AccountsFixtures
   import Mydia.SettingsFixtures
 
   alias MydiaWeb.Live.Helpers.MediaAddHelpers
@@ -571,6 +572,110 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
       library_ids = Enum.map(updated.assigns.add_config.libraries, & &1.id)
 
       refute library.id in library_ids
+    end
+  end
+
+  describe "resolve_add_config_submit/2" do
+    setup do
+      library = library_path_fixture(%{type: :movies, monitored: true})
+      %{library: library, user: user_fixture()}
+    end
+
+    defp submit_socket(user, add_config) do
+      %Phoenix.LiveView.Socket{
+        assigns: %{
+          __changed__: %{},
+          flash: %{},
+          current_user: user,
+          add_config: add_config
+        }
+      }
+    end
+
+    defp movie_config, do: %{provider_id: "551", media_type: :movie}
+
+    test "returns opts and closes the dialog on the happy path", %{
+      library: library,
+      user: user
+    } do
+      params = %{
+        "library_path_id" => to_string(library.id),
+        "monitored" => "true",
+        "search_on_add" => "false"
+      }
+
+      assert {:ok, "551", :movie, opts, socket} =
+               MediaAddHelpers.resolve_add_config_submit(
+                 submit_socket(user, movie_config()),
+                 params
+               )
+
+      assert opts[:library_path_id] == to_string(library.id)
+      assert socket.assigns.add_config == nil
+    end
+
+    test "halts and leaves the dialog open when the user may not create media" do
+      readonly = user_fixture(%{role: "readonly"})
+
+      assert {:halt, socket} =
+               MediaAddHelpers.resolve_add_config_submit(
+                 submit_socket(readonly, movie_config()),
+                 %{"library_path_id" => "", "monitored" => "true"}
+               )
+
+      # Left open on purpose: authorize_create_media/1 has already flashed the
+      # reason and a correction should be one click away, not a re-open.
+      assert socket.assigns.add_config == movie_config()
+      assert socket.assigns.flash["error"] =~ "permission"
+    end
+
+    test "halts when no dialog is open", %{user: user} do
+      assert {:halt, socket} =
+               MediaAddHelpers.resolve_add_config_submit(
+                 submit_socket(user, nil),
+                 %{"library_path_id" => "", "monitored" => "true"}
+               )
+
+      assert socket.assigns.add_config == nil
+      assert socket.assigns.flash == %{}
+    end
+
+    test "halts, closes the dialog and flashes on a library the type does not allow", %{
+      library: library,
+      user: user
+    } do
+      params = %{"library_path_id" => to_string(library.id), "monitored" => "true"}
+
+      assert {:halt, socket} =
+               MediaAddHelpers.resolve_add_config_submit(
+                 submit_socket(user, %{provider_id: "551", media_type: :tv_show}),
+                 params
+               )
+
+      assert socket.assigns.add_config == nil
+      assert socket.assigns.flash["error"] =~ "no longer available"
+    end
+  end
+
+  describe "queue_add/3" do
+    defp queue_socket(in_flight) do
+      %Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}, adding_item_ids: MapSet.new(in_flight)}
+      }
+    end
+
+    test "sends the message and marks the id in flight" do
+      socket = MediaAddHelpers.queue_add(queue_socket([]), "551", {:add, "551"})
+
+      assert_received {:add, "551"}
+      assert MapSet.member?(socket.assigns.adding_item_ids, "551")
+    end
+
+    test "sends nothing for an id already in flight" do
+      socket = MediaAddHelpers.queue_add(queue_socket(["551"]), "551", {:add, "551"})
+
+      refute_received {:add, "551"}
+      assert MapSet.to_list(socket.assigns.adding_item_ids) == ["551"]
     end
   end
 end


### PR DESCRIPTION
Stacked on #676. Base is `worktree-brainstorm-merge-add-dialogs`, so review only the top commit; retarget to `master` once #676 lands.

#676 gave the merged Configure Before Adding dialog three hosts, and each one opened its submit handler with the same four steps and the same three-clause `else`: authorize, read the open `:add_config`, turn the `config[...]` params into `Mydia.Media.Add` opts, and close the dialog.

## What changed

**`MediaAddHelpers.resolve_add_config_submit/2`** owns that preamble. It returns `{:ok, provider_id, media_type, opts, socket}` with the dialog already closed, or `{:halt, socket}` for the three cases that end the event: the user may not create media, no dialog is open, or the submitted library is not a candidate for the media type.

The rationale that lived inside the duplicated bodies moves onto its `@doc` rather than being deleted with them: why #458 means a rejected library gets flashed, why an unauthorized submit deliberately leaves the dialog open while a rejected library closes it, and why the authorization guard cannot live only in the template when the `handle_event` clause is live on the socket regardless of what renders.

**`MediaAddHelpers.queue_add/3`** takes the in-flight guard. The completions were two things rather than three: Discover's and Dashboard's were byte-identical, and the same guard appears again in both `add_to_library` handlers with a different payload. It takes the message as an opaque term so all four call sites share one home for the double-click race.

`MediaLive.Show` keeps its own `dispatch/3`, which is genuinely different, along with its integer-keyed franchise in-flight set. `AddConfigEvents` sheds an `import` and an `alias` that existed only for the duplicated preamble.

| Host | Before | After |
| --- | --- | --- |
| `DiscoverLive.Index` | 53 lines | 18 |
| `DashboardLive.Index` | 51 lines | 15 |
| `MediaLive.Show.AddConfigEvents` | 31 lines | 9 |

## Behaviour

None intended. **No existing test was modified**, which was the bar: a test needing an edit would have been the tell that behaviour moved.

The one internal difference is that Discover and Dashboard now read `socket.assigns[:add_config]` instead of the dotted form, which is what `AddConfigEvents` already did. Both assign the key at mount, so nothing observable changes; the bracket form is the safe superset.

## Verification

`mix precommit`: 10437 tests, 0 failures. The 4 `add_config_flow` feature tests pass separately, since `--include feature` is outside the default run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of media additions from the dashboard, discovery, and media detail views.
  * Prevented duplicate in-progress additions when the same media item is submitted repeatedly.
  * Improved validation and feedback for unauthorized actions, unavailable libraries, invalid media types, and closed dialogs.
  * Ensured add dialogs close or remain open appropriately based on submission results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->