### PR TITLE
fix(library): link multi-episode files to every episode they contain

### DIFF
--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -1525,8 +1525,14 @@ defmodule Mydia.ImportCandidates do
     }
 
     case %MediaFile{} |> MediaFile.changeset(attrs) |> Repo.insert() do
-      {:ok, _media_file} -> Repo.delete(candidate)
-      {:error, _changeset} -> :ok
+      {:ok, media_file} ->
+        # Episode.media_files reads through media_file_episodes, so a bare
+        # episode_id would leave the file invisible on the episode page.
+        {:ok, _} = Mydia.Library.ensure_episode_link(media_file)
+        Repo.delete(candidate)
+
+      {:error, _changeset} ->
+        :ok
     end
   end
 

--- a/lib/mydia/library.ex
+++ b/lib/mydia/library.ex
@@ -7,7 +7,7 @@ defmodule Mydia.Library do
   import Mydia.DB
   import Mydia.QueryHelpers
   alias Mydia.Repo
-  alias Mydia.Library.{MediaFile, FileAnalyzer, Text, TrashStore}
+  alias Mydia.Library.{MediaFile, MediaFileEpisode, FileAnalyzer, Text, TrashStore}
   alias Mydia.Library.ReleaseParser, as: FileParser
   alias Mydia.Library.Structs.FileMetadata
 
@@ -196,6 +196,7 @@ defmodule Mydia.Library do
     %MediaFile{}
     |> MediaFile.changeset(attrs)
     |> Repo.insert()
+    |> tap_episode_link()
   end
 
   @doc """
@@ -212,6 +213,7 @@ defmodule Mydia.Library do
     %MediaFile{}
     |> MediaFile.scan_changeset(attrs)
     |> Repo.insert()
+    |> tap_episode_link()
   end
 
   @doc """
@@ -223,6 +225,7 @@ defmodule Mydia.Library do
     media_file
     |> MediaFile.changeset(attrs)
     |> Repo.update()
+    |> tap_episode_link()
   end
 
   @doc """
@@ -237,7 +240,17 @@ defmodule Mydia.Library do
     media_file
     |> MediaFile.scan_changeset(attrs)
     |> Repo.update()
+    |> tap_episode_link()
   end
+
+  # Keeps media_file_episodes in step with whatever a write left in
+  # `episode_id`. See `ensure_episode_link/1`.
+  defp tap_episode_link({:ok, %MediaFile{} = media_file} = result) do
+    {:ok, _} = ensure_episode_link(media_file)
+    result
+  end
+
+  defp tap_episode_link(other), do: other
 
   @doc """
   Marks a media file as verified.
@@ -1306,32 +1319,40 @@ defmodule Mydia.Library do
   end
 
   defp match_parsed_episode(media_file, media_item_id, filename, season, episode_numbers) do
-    # For multi-episode files, we'll just match to the first episode
-    episode_number = List.first(episode_numbers)
+    # A multi-episode release (S01E09E10) holds every episode it names. Resolve
+    # all of them: the first becomes `episode_id` (the primary, which existing
+    # queries join on), and every one gets a media_file_episodes row so no
+    # episode of the file reads as missing.
+    episodes =
+      episode_numbers
+      |> Enum.map(&Mydia.Media.get_episode_by_number(media_item_id, season, &1))
+      |> Enum.reject(&is_nil/1)
 
-    # Find the matching episode
-    case Mydia.Media.get_episode_by_number(media_item_id, season, episode_number) do
-      nil ->
+    case episodes do
+      [] ->
         Logger.debug("No episode found for file",
           filename: filename,
           season: season,
-          episode: episode_number
+          episode: List.first(episode_numbers)
         )
 
         {:error, :episode_not_found}
 
-      episode ->
+      [primary | _] = matched ->
         # Update the media file with the episode_id
         case update_media_file(media_file, %{
                media_item_id: nil,
-               episode_id: episode.id
+               episode_id: primary.id
              }) do
           {:ok, updated_file} ->
+            {:ok, _} = link_file_to_episodes(updated_file, matched)
+
             Logger.debug("Matched file to episode",
               filename: filename,
               season: season,
-              episode: episode_number,
-              episode_id: episode.id
+              episode: primary.episode_number,
+              episode_id: primary.id,
+              covers: Enum.map(matched, & &1.episode_number)
             )
 
             {:ok, updated_file}
@@ -1345,6 +1366,89 @@ defmodule Mydia.Library do
             {:error, reason}
         end
     end
+  end
+
+  @doc """
+  Records the full set of episodes a media file covers.
+
+  Authoritative, and idempotent: re-running a scan over an already-linked file
+  inserts nothing new, and any episode the file no longer covers has its link
+  removed, so a corrected filename does not leave a stale episode still holding
+  the file. Use `add_episode_links/2` when the caller only knows part of the set.
+
+  Returns `{:ok, count}` where count is the number of episodes now linked.
+  """
+  def link_file_to_episodes(%MediaFile{} = media_file, episodes) when is_list(episodes) do
+    episode_ids = episodes |> Enum.map(& &1.id) |> Enum.uniq()
+
+    {:ok, _} = add_episode_links(media_file, episode_ids)
+
+    from(mfe in MediaFileEpisode,
+      where: mfe.media_file_id == ^media_file.id and mfe.episode_id not in ^episode_ids
+    )
+    |> Repo.delete_all()
+
+    {:ok, length(episode_ids)}
+  end
+
+  @doc """
+  Adds episode links without removing any, and without duplicating existing ones.
+
+  Use this when the caller knows some of the episodes a file covers but not
+  necessarily all of them. `link_file_to_episodes/2` is the authoritative
+  version and prunes links the file no longer covers.
+  """
+  def add_episode_links(%MediaFile{} = media_file, episode_ids) when is_list(episode_ids) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    rows =
+      episode_ids
+      |> Enum.uniq()
+      |> Enum.map(fn episode_id ->
+        %{
+          id: Ecto.UUID.generate(),
+          media_file_id: media_file.id,
+          episode_id: episode_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    {count, _} = Repo.insert_all(MediaFileEpisode, rows, on_conflict: :nothing)
+
+    {:ok, count}
+  end
+
+  @doc """
+  Ensures the file's primary `episode_id` is represented in the join table.
+
+  `Episode.media_files` reads through `media_file_episodes`, so a writer that
+  sets `episode_id` without a join row would make the file invisible on the
+  episode page. Every generic media-file write funnels through here.
+
+  Purely additive: it never removes links, so it cannot clobber the richer set
+  a multi-episode match recorded via `link_file_to_episodes/2`.
+  """
+  def ensure_episode_link(%MediaFile{episode_id: nil} = media_file), do: {:ok, media_file}
+
+  def ensure_episode_link(%MediaFile{} = media_file) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.insert_all(
+      MediaFileEpisode,
+      [
+        %{
+          id: Ecto.UUID.generate(),
+          media_file_id: media_file.id,
+          episode_id: media_file.episode_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      ],
+      on_conflict: :nothing
+    )
+
+    {:ok, media_file}
   end
 
   @doc """

--- a/lib/mydia/library/candidate_promotion.ex
+++ b/lib/mydia/library/candidate_promotion.ex
@@ -241,8 +241,14 @@ defmodule Mydia.Library.CandidatePromotion do
       })
 
     case %MediaFile{} |> MediaFile.changeset(attrs) |> Repo.insert() do
-      {:ok, media_file} -> {:ok, media_file}
-      {:error, changeset} -> {:error, changeset}
+      {:ok, media_file} ->
+        # Episode.media_files reads through media_file_episodes, so a bare
+        # episode_id would leave the file invisible on the episode page.
+        {:ok, _} = Mydia.Library.ensure_episode_link(media_file)
+        {:ok, media_file}
+
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
 

--- a/lib/mydia/library/media_file.ex
+++ b/lib/mydia/library/media_file.ex
@@ -128,7 +128,15 @@ defmodule Mydia.Library.MediaFile do
     belongs_to :library_path, Mydia.Settings.LibraryPath
 
     belongs_to :media_item, Mydia.Media.MediaItem
+
+    # The primary (first) episode of this file. A multi-episode release covers
+    # more than one; `episodes` below is the full set.
     belongs_to :episode, Mydia.Media.Episode
+
+    many_to_many :episodes, Mydia.Media.Episode,
+      join_through: Mydia.Library.MediaFileEpisode,
+      on_replace: :delete
+
     belongs_to :quality_profile, Mydia.Settings.QualityProfile
     has_many :segments, Mydia.Library.MediaSegment
     belongs_to :supersedes_media_file, __MODULE__, foreign_key: :supersedes_media_file_id

--- a/lib/mydia/library/media_file_episode.ex
+++ b/lib/mydia/library/media_file_episode.ex
@@ -1,0 +1,43 @@
+defmodule Mydia.Library.MediaFileEpisode do
+  @moduledoc """
+  Join between a media file and every episode it contains.
+
+  Most files hold one episode and have exactly one row here. A multi-episode
+  release (`S01E09E10`) holds several, and gets one row per episode, so none of
+  them reads as missing while the content sits on disk.
+
+  `media_files.episode_id` remains the primary (first) episode for the many
+  callers that join on it directly; this table is the complete set.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @type t :: %__MODULE__{
+          id: binary(),
+          media_file_id: binary() | nil,
+          episode_id: binary() | nil,
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "media_file_episodes" do
+    belongs_to :media_file, Mydia.Library.MediaFile
+    belongs_to :episode, Mydia.Media.Episode
+
+    timestamps(type: :utc_datetime)
+  end
+
+  def changeset(media_file_episode, attrs) do
+    media_file_episode
+    |> cast(attrs, [:media_file_id, :episode_id])
+    |> validate_required([:media_file_id, :episode_id])
+    |> foreign_key_constraint(:media_file_id)
+    |> foreign_key_constraint(:episode_id)
+    |> unique_constraint([:media_file_id, :episode_id],
+      name: :media_file_episodes_media_file_id_episode_id_index
+    )
+  end
+end

--- a/lib/mydia/library/multi_episode_relink.ex
+++ b/lib/mydia/library/multi_episode_relink.ex
@@ -27,24 +27,25 @@ defmodule Mydia.Library.MultiEpisodeRelink do
 
   require Logger
 
+  # Rows are read a page at a time, keyed on media_file id, so a large library
+  # is never held in memory at once and each page is written before the next is
+  # read. Only files whose *name* parses to more than one episode cost any
+  # episode lookups, which on a real library is a small minority.
+  @batch_size 500
+
   @doc """
   Adds the missing episode links across the whole library.
 
+  ## Options
+
+    * `:batch_size` - rows per page (default #{@batch_size}). Exists so tests can
+      force the pagination boundary without inserting a full page of fixtures.
+
   Returns `{:ok, %{files_relinked: n, links_added: m}}`.
   """
-  def run do
-    result =
-      candidates()
-      |> Enum.reduce(%{files_relinked: 0, links_added: 0}, fn {media_file, media_item_id, season},
-                                                              acc ->
-        case relink(media_file, media_item_id, season) do
-          {:ok, added} when added > 0 ->
-            %{acc | files_relinked: acc.files_relinked + 1, links_added: acc.links_added + added}
-
-          _ ->
-            acc
-        end
-      end)
+  def run(opts \\ []) do
+    batch_size = Keyword.get(opts, :batch_size, @batch_size)
+    result = reduce_batches(nil, %{files_relinked: 0, links_added: 0}, batch_size)
 
     if result.files_relinked > 0 do
       Logger.info(
@@ -56,22 +57,50 @@ defmodule Mydia.Library.MultiEpisodeRelink do
     {:ok, result}
   end
 
-  # Every matched, untrashed TV file, paired with the show and season its
-  # primary episode belongs to. The parse decides whether it is interesting;
-  # SQLite has no portable regex, so the filter happens in Elixir.
-  defp candidates do
+  defp reduce_batches(after_id, acc, batch_size) do
+    case candidates(after_id, batch_size) do
+      [] ->
+        acc
+
+      batch ->
+        acc = Enum.reduce(batch, acc, &relink_row/2)
+        {last_id, _, _, _} = List.last(batch)
+        reduce_batches(last_id, acc, batch_size)
+    end
+  end
+
+  defp relink_row({id, relative_path, media_item_id, season}, acc) do
+    case relink(id, relative_path, media_item_id, season) do
+      {:ok, added} when added > 0 ->
+        %{acc | files_relinked: acc.files_relinked + 1, links_added: acc.links_added + added}
+
+      _ ->
+        acc
+    end
+  end
+
+  # One page of matched, untrashed TV files, paired with the show and season the
+  # primary episode belongs to. Only the four columns the parse needs are read;
+  # the parse decides whether a row is interesting, since SQLite has no portable
+  # regex to filter multi-episode names in SQL.
+  defp candidates(after_id, batch_size) do
     from(mf in MediaFile,
       join: e in Episode,
       on: e.id == mf.episode_id,
       where: is_nil(mf.trashed_at),
       where: not is_nil(mf.relative_path),
-      select: {mf, e.media_item_id, e.season_number}
+      order_by: [asc: mf.id],
+      limit: ^batch_size,
+      select: {mf.id, mf.relative_path, e.media_item_id, e.season_number}
     )
+    |> then(fn query ->
+      if after_id, do: where(query, [mf], mf.id > ^after_id), else: query
+    end)
     |> Repo.all()
   end
 
-  defp relink(%MediaFile{} = media_file, media_item_id, season) do
-    parsed = media_file.relative_path |> Path.basename() |> ReleaseParser.parse()
+  defp relink(id, relative_path, media_item_id, season) do
+    parsed = relative_path |> Path.basename() |> ReleaseParser.parse()
 
     episode_numbers = parsed.episodes || []
 
@@ -84,16 +113,17 @@ defmodule Mydia.Library.MultiEpisodeRelink do
         |> Enum.map(&Media.get_episode_by_number(media_item_id, season, &1))
         |> Enum.reject(&is_nil/1)
 
-      link_if_new(media_file, episodes)
+      link_if_new(id, episodes)
     else
       {:ok, 0}
     end
   end
 
-  defp link_if_new(_media_file, episodes) when length(episodes) < 2, do: {:ok, 0}
+  defp link_if_new(_id, episodes) when length(episodes) < 2, do: {:ok, 0}
 
-  defp link_if_new(%MediaFile{} = media_file, episodes) do
+  defp link_if_new(id, episodes) do
     # Strictly additive, so a link this repair does not know about survives.
-    Library.add_episode_links(media_file, Enum.map(episodes, & &1.id))
+    # Only the id is needed; the row itself was never loaded.
+    Library.add_episode_links(%MediaFile{id: id}, Enum.map(episodes, & &1.id))
   end
 end

--- a/lib/mydia/library/multi_episode_relink.ex
+++ b/lib/mydia/library/multi_episode_relink.ex
@@ -1,0 +1,99 @@
+defmodule Mydia.Library.MultiEpisodeRelink do
+  @moduledoc """
+  Repairs libraries that were scanned before multi-episode files were supported.
+
+  A release such as `S01E09E10` holds two episodes. Until `media_file_episodes`
+  existed, the matcher bound the file to the first episode only and dropped the
+  rest, so every trailing episode read as un-downloaded while its content sat on
+  disk in the very file the previous episode was playing.
+
+  Re-scanning does not fix those files: `Library.match_files_to_episodes/1` only
+  considers rows where `episode_id IS NULL`, and these already have one. This
+  module walks the already-matched files and adds the links that were dropped.
+
+  Safe to run repeatedly. It only ever adds links for episodes the filename
+  actually names, and never touches a file whose filename names a single
+  episode.
+  """
+
+  import Ecto.Query
+
+  alias Mydia.Library
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.ReleaseParser
+  alias Mydia.Media
+  alias Mydia.Media.Episode
+  alias Mydia.Repo
+
+  require Logger
+
+  @doc """
+  Adds the missing episode links across the whole library.
+
+  Returns `{:ok, %{files_relinked: n, links_added: m}}`.
+  """
+  def run do
+    result =
+      candidates()
+      |> Enum.reduce(%{files_relinked: 0, links_added: 0}, fn {media_file, media_item_id, season},
+                                                              acc ->
+        case relink(media_file, media_item_id, season) do
+          {:ok, added} when added > 0 ->
+            %{acc | files_relinked: acc.files_relinked + 1, links_added: acc.links_added + added}
+
+          _ ->
+            acc
+        end
+      end)
+
+    if result.files_relinked > 0 do
+      Logger.info(
+        "Relinked #{result.files_relinked} multi-episode files, " <>
+          "adding #{result.links_added} episode links"
+      )
+    end
+
+    {:ok, result}
+  end
+
+  # Every matched, untrashed TV file, paired with the show and season its
+  # primary episode belongs to. The parse decides whether it is interesting;
+  # SQLite has no portable regex, so the filter happens in Elixir.
+  defp candidates do
+    from(mf in MediaFile,
+      join: e in Episode,
+      on: e.id == mf.episode_id,
+      where: is_nil(mf.trashed_at),
+      where: not is_nil(mf.relative_path),
+      select: {mf, e.media_item_id, e.season_number}
+    )
+    |> Repo.all()
+  end
+
+  defp relink(%MediaFile{} = media_file, media_item_id, season) do
+    parsed = media_file.relative_path |> Path.basename() |> ReleaseParser.parse()
+
+    episode_numbers = parsed.episodes || []
+
+    # Only multi-episode filenames are of interest. Trust the season already
+    # recorded on the primary episode over the parse, which can misread a
+    # folder-less path.
+    if length(episode_numbers) > 1 do
+      episodes =
+        episode_numbers
+        |> Enum.map(&Media.get_episode_by_number(media_item_id, season, &1))
+        |> Enum.reject(&is_nil/1)
+
+      link_if_new(media_file, episodes)
+    else
+      {:ok, 0}
+    end
+  end
+
+  defp link_if_new(_media_file, episodes) when length(episodes) < 2, do: {:ok, 0}
+
+  defp link_if_new(%MediaFile{} = media_file, episodes) do
+    # Strictly additive, so a link this repair does not know about survives.
+    Library.add_episode_links(media_file, Enum.map(episodes, & &1.id))
+  end
+end

--- a/lib/mydia/media/README.md
+++ b/lib/mydia/media/README.md
@@ -25,6 +25,38 @@ fixture passes either way, which is why both bugs shipped green. The same split
 applies to `Mydia.Playback.Progress` rows (`validate_one_parent/1`) and to
 `Streaming.progress_content_id/1`.
 
+## One file can cover several episodes, and episode.media_files is many_to_many
+
+A release such as `S01E09E10` is a single file holding two episodes. Because
+`media_files.episode_id` is one FK, the matcher used to keep only the first
+episode it parsed (`List.first(episode_numbers)`) and drop the rest, so every
+trailing episode of such a file read as un-downloaded while its content was
+already on disk, inside the file the previous episode was playing. On galactica
+that was 49 files across two shows, and it presented as "the season downloaded
+everything but the last episode" with no download row to explain it, since the
+grab was a season pack attached to the show rather than the episode.
+
+`Mydia.Library.MediaFileEpisode` (`media_file_episodes`) now records the full
+set, and `Episode.media_files` is a `many_to_many` through it. That association
+is the reason the fix reaches the whole UI at once, and it is also the trap:
+
+**A media file whose `episode_id` has no `media_file_episodes` row is invisible
+on the episode page.** It will still be found by every query that joins
+`media_files.episode_id` directly, so the row looks fine in the database and
+fine in half the app.
+
+`episode_id` is still written, and still means the primary (first) episode, so
+the ~268 call sites that join on it keep working untouched. Anything that
+*creates* a media file must also record the link: the funnels in `Mydia.Library`
+do it via `ensure_episode_link/1`, and the two modules that build a
+`MediaFile.changeset` directly (`Library.CandidatePromotion`, `ImportCandidates`)
+call it themselves. `test/mydia/library/episode_link_invariant_test.exs` fails if
+a new direct writer forgets.
+
+Re-scanning does not repair old rows: `Library.match_files_to_episodes/1` only
+considers files where `episode_id IS NULL`, and a half-linked file already has
+one. `Mydia.Library.MultiEpisodeRelink` is the repair, run once from a migration.
+
 ## media_files.path is nil on every row
 
 The legacy `media_files.path` column is nil on every production row (verified

--- a/lib/mydia/media/episode.ex
+++ b/lib/mydia/media/episode.ex
@@ -39,7 +39,17 @@ defmodule Mydia.Media.Episode do
     field :last_upgrade_check_at, :utc_datetime
 
     belongs_to :media_item, Mydia.Media.MediaItem
-    has_many :media_files, Mydia.Library.MediaFile
+
+    # many_to_many, not has_many: a multi-episode release (S01E09E10) is one
+    # file that belongs to several episodes. Joining through
+    # media_file_episodes is what stops the trailing episode of such a file
+    # from reading as missing. `media_files.episode_id` still names the primary
+    # episode for callers that join on it directly.
+    many_to_many :media_files, Mydia.Library.MediaFile,
+      join_through: Mydia.Library.MediaFileEpisode,
+      on_replace: :delete,
+      preload_order: [asc: :id]
+
     has_many :downloads, Mydia.Downloads.Download
 
     timestamps(type: :utc_datetime)

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -157,15 +157,19 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                   which keeps two- and three-digit episodes in column: the chunk
                   threshold is 50, and TVDB puts 170 Black Clover episodes in one
                   season. --%>
-            <div
+            <%!-- Every row expands, files or not. An episode with no file is
+                  the one a viewer most needs to ask about, and gating the
+                  disclosure on has_files used to leave exactly that row inert
+                  with nothing to click. Buttons rather than divs, so the
+                  disclosure is reachable by keyboard. --%>
+            <button
+              type="button"
               class="flex items-center gap-1 flex-shrink-0 sm:w-full cursor-pointer hover:text-primary"
               phx-click="toggle_episode_expanded"
               phx-value-episode-id={episode.id}
+              aria-expanded={to_string(is_expanded)}
+              aria-controls={"episode-#{episode.id}-detail"}
             >
-              <%!-- Every row expands, files or not. An episode with no file is
-                    the one a viewer most needs to ask about, and gating the
-                    disclosure on has_files used to leave exactly that row inert
-                    with nothing to click. --%>
               <.icon
                 name={if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"}
                 class="w-3 h-3 text-base-content/40"
@@ -173,17 +177,22 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
               <span class="font-mono text-sm font-medium text-base-content/70 tabular-nums sm:ml-auto">
                 {episode.episode_number}
               </span>
-            </div>
+            </button>
 
-            <div
-              class="flex-1 min-w-0 cursor-pointer"
+            <%!-- text-left because a button centres its text by default, which
+                  would break the title column. --%>
+            <button
+              type="button"
+              class="flex-1 min-w-0 cursor-pointer text-left"
               phx-click="toggle_episode_expanded"
               phx-value-episode-id={episode.id}
+              aria-expanded={to_string(is_expanded)}
+              aria-controls={"episode-#{episode.id}-detail"}
             >
               <span class="text-sm font-medium truncate block hover:text-primary">
                 {episode.title || "TBA"}
               </span>
-            </div>
+            </button>
           </div>
 
           <div class="flex items-center justify-between gap-2 sm:contents">
@@ -317,7 +326,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
         </div>
 
         <%= if is_expanded do %>
-          <div class="mt-2 ml-8 space-y-1">
+          <div id={"episode-#{episode.id}-detail"} class="mt-2 ml-8 space-y-1">
             <%= if has_files do %>
               <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">
                 <Components.episode_file_row

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -158,15 +158,15 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                   threshold is 50, and TVDB puts 170 Black Clover episodes in one
                   season. --%>
             <div
-              class={[
-                "flex items-center gap-1 flex-shrink-0 sm:w-full",
-                has_files && "cursor-pointer hover:text-primary"
-              ]}
-              phx-click={has_files && "toggle_episode_expanded"}
+              class="flex items-center gap-1 flex-shrink-0 sm:w-full cursor-pointer hover:text-primary"
+              phx-click="toggle_episode_expanded"
               phx-value-episode-id={episode.id}
             >
+              <%!-- Every row expands, files or not. An episode with no file is
+                    the one a viewer most needs to ask about, and gating the
+                    disclosure on has_files used to leave exactly that row inert
+                    with nothing to click. --%>
               <.icon
-                :if={has_files}
                 name={if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"}
                 class="w-3 h-3 text-base-content/40"
               />
@@ -176,14 +176,11 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             </div>
 
             <div
-              class={["flex-1 min-w-0", has_files && "cursor-pointer"]}
-              phx-click={has_files && "toggle_episode_expanded"}
+              class="flex-1 min-w-0 cursor-pointer"
+              phx-click="toggle_episode_expanded"
               phx-value-episode-id={episode.id}
             >
-              <span class={[
-                "text-sm font-medium truncate block",
-                has_files && "hover:text-primary"
-              ]}>
+              <span class="text-sm font-medium truncate block hover:text-primary">
                 {episode.title || "TBA"}
               </span>
             </div>
@@ -319,23 +316,92 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
           </div>
         </div>
 
-        <%= if is_expanded && has_files do %>
+        <%= if is_expanded do %>
           <div class="mt-2 ml-8 space-y-1">
-            <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">
-              <Components.episode_file_row
-                file={file}
-                episode={episode}
-                playback_enabled={@playback_enabled}
-                transcode_jobs={Map.get(@transcode_jobs, file.id, [])}
-                subtitle_tracks={Map.get(@media_file_subtitle_tracks, file.id, [])}
-              />
-            </div>
+            <%= if has_files do %>
+              <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">
+                <Components.episode_file_row
+                  file={file}
+                  episode={episode}
+                  playback_enabled={@playback_enabled}
+                  transcode_jobs={Map.get(@transcode_jobs, file.id, [])}
+                  subtitle_tracks={Map.get(@media_file_subtitle_tracks, file.id, [])}
+                />
+              </div>
+            <% else %>
+              <.episode_without_file episode={episode} />
+            <% end %>
           </div>
         <% end %>
       </div>
     <% end %>
     """
   end
+
+  @doc """
+  What an episode with no file has to say for itself.
+
+  Before this existed the row simply did not open, so the one episode a viewer
+  actually has a question about was the one the page refused to explain. It
+  answers the question in order: what the state is, whether a download is
+  already working on it, and what to do if nothing is.
+  """
+  attr :episode, :map, required: true
+
+  def episode_without_file(assigns) do
+    downloads =
+      case assigns.episode.downloads do
+        downloads when is_list(downloads) -> downloads
+        _ -> []
+      end
+
+    assigns = assign(assigns, :downloads, downloads)
+
+    ~H"""
+    <div id={"episode-#{@episode.id}-no-file"} class="bg-base-200/50 rounded p-3 space-y-2">
+      <div class="flex items-center gap-2">
+        <.icon name="hero-information-circle" class="w-4 h-4 text-base-content/50 shrink-0" />
+        <span class="text-sm">{episode_status_details(@episode)}</span>
+      </div>
+
+      <%= if @downloads != [] do %>
+        <div class="space-y-1">
+          <div class="text-xs font-medium text-base-content/60">Downloads for this episode</div>
+          <div
+            :for={download <- @downloads}
+            class="text-xs bg-base-100 rounded p-2 flex flex-col gap-1"
+          >
+            <span class="font-mono truncate">{download.title}</span>
+            <span :if={download_note(download)} class="text-base-content/60">
+              {download_note(download)}
+            </span>
+          </div>
+        </div>
+      <% else %>
+        <p class="text-xs text-base-content/60">
+          No download has been recorded for this episode. Use search to look for a release.
+        </p>
+      <% end %>
+    </div>
+    """
+  end
+
+  # The one line worth reading about a download that has not produced a file.
+  defp download_note(%{import_failure_reason: reason}) when is_binary(reason) and reason != "",
+    do: "Import failed: #{reason}"
+
+  defp download_note(%{import_last_error: error}) when is_binary(error) and error != "",
+    do: "Import error: #{error}"
+
+  defp download_note(%{error_message: message}) when is_binary(message) and message != "",
+    do: "Error: #{message}"
+
+  defp download_note(%{imported_at: %DateTime{} = at}),
+    do: "Imported #{format_relative_time_short(at)}"
+
+  defp download_note(%{completed_at: %DateTime{}}), do: "Completed, waiting to import"
+
+  defp download_note(_), do: "In progress"
 
   @doc """
   The disclosure row: a toggle button carrying the chevron, badge, counts,

--- a/priv/repo/migrations/20260902200319_create_media_file_episodes.exs
+++ b/priv/repo/migrations/20260902200319_create_media_file_episodes.exs
@@ -1,0 +1,82 @@
+defmodule Mydia.Repo.Migrations.CreateMediaFileEpisodes do
+  use Ecto.Migration
+
+  import Mydia.Repo.Migrations.Helpers
+
+  @moduledoc """
+  Lets one media file cover more than one episode.
+
+  A release such as `S01E09E10` holds two episodes in a single file, but
+  `media_files.episode_id` is a single FK, so only the first episode could ever
+  claim it. Every trailing episode of a multi-episode file therefore looked
+  un-downloaded even though its content was already on disk.
+
+  `media_files.episode_id` stays as the primary (first) episode so existing
+  queries keep working unchanged. This join table records the full set.
+  """
+
+  def up do
+    create table(:media_file_episodes, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :media_file_id,
+          references(:media_files, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      add :episode_id,
+          references(:episodes, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:media_file_episodes, [:media_file_id, :episode_id])
+    create index(:media_file_episodes, [:episode_id])
+
+    # Backfill the existing one-file-one-episode links so the new association
+    # returns exactly what the old `has_many` returned. Plain SQL on purpose:
+    # portable across SQLite and PostgreSQL, and independent of app code.
+    execute("""
+    INSERT INTO media_file_episodes (id, media_file_id, episode_id, inserted_at, updated_at)
+    SELECT
+      #{uuid_expr()},
+      mf.id,
+      mf.episode_id,
+      #{now_expr()},
+      #{now_expr()}
+    FROM media_files mf
+    WHERE mf.episode_id IS NOT NULL
+    """)
+  end
+
+  def down do
+    drop table(:media_file_episodes)
+  end
+
+  # SQLite has no gen_random_uuid(). Build a dashed, v4-shaped string, because
+  # the ids Ecto reads back are dashed UUIDs; a bare hex blob would not load.
+  defp uuid_expr do
+    if postgres?() do
+      "gen_random_uuid()"
+    else
+      """
+      lower(
+        hex(randomblob(4)) || '-' ||
+        hex(randomblob(2)) || '-4' ||
+        substr(hex(randomblob(2)), 2) || '-' ||
+        substr('89ab', abs(random()) % 4 + 1, 1) ||
+        substr(hex(randomblob(2)), 2) || '-' ||
+        hex(randomblob(6))
+      )
+      """
+    end
+  end
+
+  defp now_expr do
+    if postgres?() do
+      "NOW()"
+    else
+      "STRFTIME('%Y-%m-%dT%H:%M:%SZ', 'now')"
+    end
+  end
+end

--- a/priv/repo/migrations/20260902200320_relink_existing_multi_episode_files.exs
+++ b/priv/repo/migrations/20260902200320_relink_existing_multi_episode_files.exs
@@ -1,0 +1,28 @@
+defmodule Mydia.Repo.Migrations.RelinkExistingMultiEpisodeFiles do
+  use Ecto.Migration
+
+  @moduledoc """
+  Adds the episode links that were dropped before multi-episode files were
+  supported.
+
+  The previous migration backfills `media_file_episodes` one row per existing
+  `media_files.episode_id`, which reproduces the old behaviour exactly: a
+  `S01E09E10` file still claims only episode 9. This pass re-reads those
+  filenames and adds the episodes that were discarded.
+
+  It cannot be left to a re-scan: `Library.match_files_to_episodes/1` only
+  considers files with `episode_id IS NULL`, and these already have one.
+  """
+
+  def up do
+    # Parsing lives in Mydia.Library.MultiEpisodeRelink so it can be tested
+    # like ordinary code rather than only through a migration.
+    {:ok, _} = Mydia.Library.MultiEpisodeRelink.run()
+  end
+
+  def down do
+    # The links are additive and harmless; dropping the join table in the
+    # previous migration's `down` removes them.
+    :ok
+  end
+end

--- a/test/mydia/library/episode_link_invariant_test.exs
+++ b/test/mydia/library/episode_link_invariant_test.exs
@@ -1,0 +1,116 @@
+defmodule Mydia.Library.EpisodeLinkInvariantTest do
+  @moduledoc """
+  Every writer that puts an `episode_id` on a media file must also record the
+  link in `media_file_episodes`.
+
+  `Episode.media_files` is a `many_to_many` through that join table, which is
+  what lets a `S01E09E10` file belong to both of its episodes. The cost of that
+  design is this invariant: a row with an `episode_id` but no join row is
+  invisible on the episode page. That is a worse bug than the one the join
+  table fixes, so it is guarded rather than left to review.
+
+  Two checks, because neither alone is sufficient:
+
+    * The behavioural check proves the funnels in `Mydia.Library` maintain the
+      link. It cannot see a module that bypasses them.
+    * The source check catches exactly that bypass: a direct
+      `MediaFile.changeset(...) |> Repo.insert()` in a module that never calls
+      `ensure_episode_link/1`.
+  """
+  use Mydia.DataCase, async: true
+
+  import Mydia.Factory
+
+  alias Mydia.Library
+  alias Mydia.Library.MediaFile
+  alias Mydia.Repo
+
+  describe "the Library write funnels" do
+    setup do
+      show = insert(:tv_show, %{title: "Fathom Rift", year: 2015})
+      episode = insert(:episode, %{media_item: show, season_number: 2, episode_number: 3})
+      library_path = insert(:library_path, %{type: :series})
+
+      {:ok, show: show, episode: episode, library_path: library_path}
+    end
+
+    test "create_media_file/1 links the episode", %{
+      episode: episode,
+      library_path: library_path
+    } do
+      {:ok, _file} =
+        Library.create_media_file(%{
+          episode_id: episode.id,
+          library_path_id: library_path.id,
+          relative_path: "Fathom Rift S02E03.mkv",
+          path: "/series/Fathom Rift S02E03.mkv",
+          size: 1_000
+        })
+
+      assert [%MediaFile{}] = Repo.preload(episode, :media_files).media_files
+    end
+
+    test "update_media_file/2 links an episode attached after creation", %{
+      episode: episode,
+      library_path: library_path,
+      show: show
+    } do
+      {:ok, file} =
+        Library.create_media_file(%{
+          media_item_id: show.id,
+          library_path_id: library_path.id,
+          relative_path: "Fathom Rift S02E03 unmatched.mkv",
+          path: "/series/Fathom Rift S02E03 unmatched.mkv",
+          size: 1_000
+        })
+
+      assert [] = Repo.preload(episode, :media_files).media_files
+
+      {:ok, _} = Library.update_media_file(file, %{media_item_id: nil, episode_id: episode.id})
+
+      assert [%MediaFile{}] = Repo.preload(episode, :media_files).media_files
+    end
+  end
+
+  describe "modules that insert media files directly" do
+    # Modules allowed to build a MediaFile changeset without calling
+    # ensure_episode_link: they either never set an episode_id, or they are the
+    # linker itself.
+    @exempt [
+      # The funnels live here and maintain the link themselves.
+      "lib/mydia/library.ex",
+      # Classifies extras; never assigns an episode.
+      "lib/mydia/jobs/extra_classification.ex"
+    ]
+
+    test "each one also calls ensure_episode_link/1" do
+      offenders =
+        "lib/**/*.ex"
+        |> Path.wildcard()
+        |> Enum.reject(&(&1 in @exempt))
+        |> Enum.filter(fn path ->
+          source = File.read!(path)
+
+          builds_media_file? =
+            String.contains?(source, "MediaFile.changeset") and
+              String.contains?(source, "Repo.insert")
+
+          builds_media_file? and not String.contains?(source, "ensure_episode_link")
+        end)
+
+      assert offenders == [],
+             """
+             These modules insert a media file without recording the episode link:
+
+             #{Enum.map_join(offenders, "\n", &"  - #{&1}")}
+
+             A media file whose episode_id has no media_file_episodes row does
+             not appear on the episode page at all, because Episode.media_files
+             reads through that join table.
+
+             Call Mydia.Library.ensure_episode_link/1 after the insert, or add
+             the module to @exempt if it never assigns an episode_id.
+             """
+    end
+  end
+end

--- a/test/mydia/library/episode_matching_test.exs
+++ b/test/mydia/library/episode_matching_test.exs
@@ -80,4 +80,62 @@ defmodule Mydia.Library.EpisodeMatchingTest do
       assert reloaded.episode_id == episode.id
     end
   end
+
+  describe "match_files_to_episodes/1 multi-episode files" do
+    setup do
+      show = insert(:tv_show, %{title: "Fathom Rift", year: 2015})
+      library_path = insert(:library_path, %{type: :series})
+
+      ep9 = insert(:episode, %{media_item: show, season_number: 1, episode_number: 9})
+      ep10 = insert(:episode, %{media_item: show, season_number: 1, episode_number: 10})
+
+      {:ok, show: show, library_path: library_path, ep9: ep9, ep10: ep10}
+    end
+
+    test "a file covering two episodes is linked to both of them", %{
+      show: show,
+      library_path: library_path,
+      ep9: ep9,
+      ep10: ep10
+    } do
+      # A single release carrying both episodes (S01E09E10) must not leave the
+      # trailing episode looking un-downloaded: its content is in this file.
+      file =
+        media_file_for(
+          show,
+          library_path,
+          "Fathom Rift S01E09E10 Tidewater (1080p x265 10bit).mkv"
+        )
+
+      assert {:ok, 1} = Library.match_files_to_episodes(show.id)
+
+      # episode_id stays the primary (first) episode for existing callers.
+      reloaded = Repo.get!(MediaFile, file.id)
+      assert reloaded.episode_id == ep9.id
+
+      # Both episodes surface the file through the association the UI reads.
+      assert [%MediaFile{id: id9}] = Repo.preload(ep9, :media_files).media_files
+      assert [%MediaFile{id: id10}] = Repo.preload(ep10, :media_files).media_files
+      assert id9 == file.id
+      assert id10 == file.id
+    end
+
+    test "a single-episode file links to exactly one episode", %{
+      show: show,
+      library_path: library_path,
+      ep9: ep9,
+      ep10: ep10
+    } do
+      file = media_file_for(show, library_path, "Fathom Rift S01E09 Tidewater.mkv")
+
+      assert {:ok, 1} = Library.match_files_to_episodes(show.id)
+
+      reloaded = Repo.get!(MediaFile, file.id)
+      assert reloaded.episode_id == ep9.id
+
+      assert [%MediaFile{id: linked_id}] = Repo.preload(ep9, :media_files).media_files
+      assert linked_id == file.id
+      assert [] = Repo.preload(ep10, :media_files).media_files
+    end
+  end
 end

--- a/test/mydia/library/multi_episode_relink_test.exs
+++ b/test/mydia/library/multi_episode_relink_test.exs
@@ -1,0 +1,105 @@
+defmodule Mydia.Library.MultiEpisodeRelinkTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.Factory
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.MultiEpisodeRelink
+  alias Mydia.Repo
+
+  defp legacy_file(show, library_path, relative_path, primary_episode) do
+    # A row as the old matcher left it: episode_id set to the first episode,
+    # and a single join row, with the rest of the file's episodes dropped.
+    {:ok, file} =
+      %MediaFile{}
+      |> MediaFile.changeset(%{
+        episode_id: primary_episode.id,
+        library_path_id: library_path.id,
+        relative_path: relative_path,
+        path: "/series/#{relative_path}",
+        size: 1_000_000
+      })
+      |> Repo.insert()
+
+    {:ok, _} = Mydia.Library.ensure_episode_link(file)
+
+    _ = show
+    file
+  end
+
+  describe "run/0" do
+    setup do
+      show = insert(:tv_show, %{title: "Fathom Rift", year: 2015})
+      library_path = insert(:library_path, %{type: :series})
+
+      ep9 = insert(:episode, %{media_item: show, season_number: 1, episode_number: 9})
+      ep10 = insert(:episode, %{media_item: show, season_number: 1, episode_number: 10})
+
+      {:ok, show: show, library_path: library_path, ep9: ep9, ep10: ep10}
+    end
+
+    test "adds the dropped episode of a legacy multi-episode file", %{
+      show: show,
+      library_path: library_path,
+      ep9: ep9,
+      ep10: ep10
+    } do
+      file =
+        legacy_file(
+          show,
+          library_path,
+          "Fathom Rift S01E09E10 Tidewater (1080p x265 10bit).mkv",
+          ep9
+        )
+
+      # Precondition: the trailing episode looks un-downloaded.
+      assert [] = Repo.preload(ep10, :media_files).media_files
+
+      assert {:ok, %{files_relinked: 1, links_added: 1}} = MultiEpisodeRelink.run()
+
+      assert [%MediaFile{id: id10}] = Repo.preload(ep10, :media_files).media_files
+      assert id10 == file.id
+
+      # The primary episode keeps the file, and is not duplicated.
+      assert [%MediaFile{id: id9}] = Repo.preload(ep9, :media_files).media_files
+      assert id9 == file.id
+    end
+
+    test "is idempotent", %{show: show, library_path: library_path, ep9: ep9, ep10: ep10} do
+      legacy_file(show, library_path, "Fathom Rift S01E09E10 Tidewater.mkv", ep9)
+
+      assert {:ok, %{files_relinked: 1}} = MultiEpisodeRelink.run()
+      assert {:ok, %{files_relinked: 0, links_added: 0}} = MultiEpisodeRelink.run()
+
+      assert [_only_one] = Repo.preload(ep10, :media_files).media_files
+    end
+
+    test "leaves single-episode files alone", %{
+      show: show,
+      library_path: library_path,
+      ep9: ep9,
+      ep10: ep10
+    } do
+      legacy_file(show, library_path, "Fathom Rift S01E09 Tidewater.mkv", ep9)
+
+      assert {:ok, %{files_relinked: 0, links_added: 0}} = MultiEpisodeRelink.run()
+
+      assert [_] = Repo.preload(ep9, :media_files).media_files
+      assert [] = Repo.preload(ep10, :media_files).media_files
+    end
+
+    test "does not invent a link for an episode the show does not have", %{
+      show: show,
+      library_path: library_path,
+      ep9: ep9
+    } do
+      # E11 does not exist on this show; only the real episodes get linked.
+      legacy_file(show, library_path, "Fathom Rift S01E09E11 Tidewater.mkv", ep9)
+
+      assert {:ok, %{links_added: added}} = MultiEpisodeRelink.run()
+      assert added == 0
+
+      assert [_] = Repo.preload(ep9, :media_files).media_files
+    end
+  end
+end

--- a/test/mydia/library/multi_episode_relink_test.exs
+++ b/test/mydia/library/multi_episode_relink_test.exs
@@ -88,6 +88,37 @@ defmodule Mydia.Library.MultiEpisodeRelinkTest do
       assert [] = Repo.preload(ep10, :media_files).media_files
     end
 
+    test "relinks every file when the work spans several batches", %{
+      show: show,
+      library_path: library_path
+    } do
+      # Four two-episode files read with batch_size 2, so the keyset loop has to
+      # page three times. With a bug in the cursor this either loops forever or
+      # relinks only the first page.
+      pairs =
+        for {first, second} <- [{1, 2}, {3, 4}, {5, 6}, {7, 8}] do
+          ep_a = insert(:episode, %{media_item: show, season_number: 2, episode_number: first})
+          ep_b = insert(:episode, %{media_item: show, season_number: 2, episode_number: second})
+
+          legacy_file(
+            show,
+            library_path,
+            "Fathom Rift S02E0#{first}E0#{second} Tidewater.mkv",
+            ep_a
+          )
+
+          {ep_a, ep_b}
+        end
+
+      assert {:ok, %{files_relinked: 4, links_added: 4}} =
+               MultiEpisodeRelink.run(batch_size: 2)
+
+      for {ep_a, ep_b} <- pairs do
+        assert [_] = Repo.preload(ep_a, :media_files).media_files
+        assert [_] = Repo.preload(ep_b, :media_files).media_files
+      end
+    end
+
     test "does not invent a link for an episode the show does not have", %{
       show: show,
       library_path: library_path,

--- a/test/mydia_web/controllers/api/player/v1/subtitle_controller_test.exs
+++ b/test/mydia_web/controllers/api/player/v1/subtitle_controller_test.exs
@@ -68,6 +68,10 @@ defmodule MydiaWeb.Api.Player.V1.SubtitleControllerTest do
         audio_codec: "AAC"
       })
 
+    # Episode.media_files is a many_to_many through media_file_episodes, so a
+    # raw insert carrying only episode_id is invisible on the episode.
+    {:ok, _} = Mydia.Library.ensure_episode_link(episode_file)
+
     # Create external subtitle for testing
     {:ok, external_subtitle} =
       Repo.insert(%Mydia.Subtitles.Subtitle{

--- a/test/mydia_web/live/media_live/show/episode_without_file_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_without_file_test.exs
@@ -1,0 +1,86 @@
+defmodule MydiaWeb.MediaLive.Show.EpisodeWithoutFileTest do
+  @moduledoc """
+  An episode with no file must still open and say why.
+
+  The season list used to gate its disclosure on `has_files`, rendering
+  `phx-click={false}` for a file-less episode. The row that most needed
+  explaining was the only one that could not be opened, which is what a
+  multi-episode release turns into: the trailing episode looks un-downloaded
+  and the page has nothing to say about it.
+  """
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Downloads.Download
+  alias Mydia.Media.Episode
+  alias MydiaWeb.MediaLive.Show.SeasonComponents
+
+  @episode_id "11111111-1111-4111-8111-111111111111"
+
+  defp episode(attrs) do
+    struct!(
+      %Episode{
+        id: @episode_id,
+        season_number: 1,
+        episode_number: 10,
+        title: "Tidewater",
+        monitored: true,
+        air_date: ~D[2024-01-01],
+        media_files: [],
+        downloads: []
+      },
+      attrs
+    )
+  end
+
+  defp render_season(episodes) do
+    render_component(&SeasonComponents.season_section/1,
+      season_number: 1,
+      episodes: episodes,
+      expanded?: true,
+      expanded_episodes: MapSet.new(Enum.map(episodes, & &1.id)),
+      playback_enabled: false,
+      segment_detection_available: false
+    )
+  end
+
+  describe "the row is openable" do
+    test "a file-less episode still carries the expand handler" do
+      html = render_season([episode(%{})])
+
+      assert html =~ "toggle_episode_expanded"
+      assert html =~ "episode-#{@episode_id}-no-file"
+    end
+  end
+
+  describe "what the open row says" do
+    test "names the state when nothing has been downloaded" do
+      html = render_season([episode(%{})])
+
+      assert html =~ "Missing"
+      assert html =~ "No download has been recorded"
+    end
+
+    test "surfaces an import failure instead of silence" do
+      download = %Download{
+        id: "22222222-2222-4222-8222-222222222222",
+        title: "Fathom Rift S01E10 1080p",
+        import_failure_reason: "no matching episode"
+      }
+
+      html = render_season([episode(%{downloads: [download]})])
+
+      assert html =~ "Downloads for this episode"
+      assert html =~ "Fathom Rift S01E10 1080p"
+      assert html =~ "Import failed: no matching episode"
+      refute html =~ "No download has been recorded"
+    end
+
+    test "says an episode is not monitored when it is not" do
+      html = render_season([episode(%{monitored: false})])
+
+      assert html =~ "Not monitored"
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -11,6 +11,29 @@ defmodule Mydia.Factory do
   alias Mydia.Settings.LibraryPath
   alias Mydia.Accounts.User
 
+  defoverridable insert: 1, insert: 2, insert: 3
+
+  # Inserts, then records the episode link a media file needs to be visible.
+  #
+  # `Episode.media_files` is a `many_to_many` through `media_file_episodes`, so
+  # a row carrying only `episode_id` is invisible on the episode page.
+  # Production writers go through `Mydia.Library`, which maintains the link;
+  # ExMachina inserts the struct straight into the repo, so it has to do the
+  # same, or every factory-built file would be a fixture that cannot occur in
+  # production. All three arities are wrapped: `insert(:media_file, attrs)` is
+  # the common call.
+  def insert(record), do: link_episode(super(record))
+  def insert(record, attrs), do: link_episode(super(record, attrs))
+  def insert(record, attrs, opts), do: link_episode(super(record, attrs, opts))
+
+  defp link_episode(%MediaFile{episode_id: episode_id} = media_file)
+       when not is_nil(episode_id) do
+    {:ok, _} = Mydia.Library.ensure_episode_link(media_file)
+    media_file
+  end
+
+  defp link_episode(other), do: other
+
   def user_factory do
     %User{
       email: sequence(:email, &"user#{&1}@example.com"),


### PR DESCRIPTION
## What went wrong

A season pack downloaded "everything except the last episode". Nothing had failed: the last episode's content was already on disk, inside a combined `S01E09E10` file, which was double the size of every single-episode file beside it.

Two defects combined:

**The matcher dropped every episode but the first.** `media_files.episode_id` is a single FK, so `match_parsed_episode/5` took `List.first(episode_numbers)` and discarded the rest. The parser was correct all along and returns `[9, 10]`; the trailing episode simply never got a file, so it rendered as missing.

**The one row worth explaining was the only one that could not be opened.** The season list gated its disclosure on `has_files`, which renders `phx-click={false}`, so a file-less episode was inert. There was no download row to fall back on either: the grab is a season pack attached to the show, with `episode_id` NULL.

On the library that reported this, 49 files across 2 shows were affected. One show is paired across entire seasons, so it was hiding far more than a single episode.

## The fix

`media_file_episodes` records every episode a file covers, and `Episode.media_files` becomes a `many_to_many` through it. That one association change carries the fix to every reader at once (episode status, season counts, the show page, the player subtitle API), because they all read that association.

`episode_id` still holds the primary (first) episode, so the ~268 call sites that join on it directly are untouched. This is deliberately not a clean break: removing the column would have meant rewriting scanning, promotion, prune, streaming and GraphQL in one pass.

### The invariant this buys, and how it is held

A media file whose `episode_id` has no join row is **invisible on the episode page**, while still looking perfectly correct in the database and to every direct `episode_id` query. That is a worse failure than the bug being fixed, so it is guarded rather than left to review:

- `Mydia.Library`'s create/update funnels maintain it via `ensure_episode_link/1`.
- The two modules that build a `MediaFile.changeset` directly (`CandidatePromotion`, `ImportCandidates`) call it themselves.
- `test/mydia/library/episode_link_invariant_test.exs` fails if a new direct writer forgets, and covers the funnels behaviourally.
- `Mydia.Factory` does the same on insert, so a factory-built file cannot be a fixture that could never occur in production.

This is documented in `lib/mydia/media/README.md` alongside the other media-model traps.

### Repairing existing libraries

Re-scanning cannot fix already-imported files: `match_files_to_episodes/1` only looks at rows where `episode_id IS NULL`, and a half-linked file already has one. `Mydia.Library.MultiEpisodeRelink` re-reads those filenames and adds the dropped links, run once from a migration so nobody has to run anything by hand. It parses 2622 files in 163 ms, so it is not a meaningful addition to boot time. It is additive and idempotent, and will not invent a link for an episode the show does not have.

### UI

Every episode row now expands. A file-less one states its status, lists any downloads attached to it, and surfaces import failures instead of silence.

## Testing

- Full suite: **10561 tests + 13 doctests, 0 failures**.
- New: multi-episode matching, the relink repair (including idempotency and the "episode does not exist" case), the link invariant, and the expanded panel.
- Migrations verified from an empty database on SQLite; the Postgres branch uses the existing `postgres?()` helper, and the SQLite UUID expression was checked to produce valid dashed v4 ids, since a bare hex blob would not load back through Ecto.
- One real regression was caught and fixed on the way: the player subtitle API returned 404 for episodes because its test inserted a raw `%MediaFile{}` struct with no link. Production writers were already covered; the fixture was not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Media files can now be associated with multiple episodes, improving multi-episode release matching and episode availability.
  - Existing multi-episode files are automatically relinked to the episodes they contain.
  - Episodes without files can now be expanded to view download history, import errors, status details, or search guidance.

- **Documentation**
  - Added guidance on multi-episode media handling and episode associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->