### PR TITLE
fix(playback): require real viewing before an episode is a resume point

### DIFF
--- a/lib/mydia/playback/next_episode.ex
+++ b/lib/mydia/playback/next_episode.ex
@@ -14,6 +14,7 @@ defmodule Mydia.Playback.NextEpisode do
 
   @watched_threshold 90.0
   @default_min_position_seconds 120
+  @min_completion_percentage 10.0
 
   @doc """
   Returns the next episode to play and why.
@@ -31,20 +32,28 @@ defmodule Mydia.Playback.NextEpisode do
   A resume point outranks the unwatched frontier: half an episode of season
   three beats an untouched season one, because that is where the viewer
   actually is. That only holds for a position someone could have reached by
-  watching. A few seconds on the clock is what a mis-click, a preview, or a
-  glance at the wrong title leaves behind, and treating one as a resume point
-  pins the card to an episode the viewer never started while the episode they
-  are really on sits unwatched behind it.
+  watching. A second or two on the clock is what sampling a show and backing
+  out leaves behind, and treating one as a resume point pins the card to an
+  episode the viewer never started while the episode they are really on sits
+  unwatched behind it.
 
-  So a row under the floor is not a resume point. The episode still shows up
-  as the first unwatched one when the frontier is where it sits, and the row
+  So a row has to clear one of two bars, `resume_point?/2`: far enough in by
+  the clock, or far enough in as a fraction of the episode. Either alone is
+  wrong. Seconds alone demote someone halfway through a five-minute episode,
+  which two minutes can exceed outright. A fraction alone is noise on a long
+  episode, where a percent of a feature-length runtime is still the cold open.
+  Taken as a union they only ever admit more than the stricter arm, so no row
+  either bar accepts is ever demoted.
+
+  A row under both bars is not a resume point. The episode still comes back as
+  the first unwatched one when the frontier is where it sits, and the row
   itself survives, so the seconds are still there to resume from once the
   viewer chooses to play it.
 
-  The floor matches On Deck's own definition of real viewing, which already
-  refuses to put a show on the rail on the strength of a row like this. Before
-  this, a show could reach the rail on one episode's history and then name a
-  different episode the same rule had just called noise.
+  The seconds bar matches On Deck's own definition of real viewing, which
+  already refuses to put a show on the rail on the strength of a row like
+  this. Before this, a show could reach the rail on one episode's history and
+  then name a different episode the same rule had just called noise.
   """
   def determine(episodes, progress_map, opts \\ []) do
     min_position = Keyword.get(opts, :min_position_seconds, @default_min_position_seconds)
@@ -54,7 +63,7 @@ defmodule Mydia.Playback.NextEpisode do
         case Map.get(progress_map, episode.id) do
           %Progress{watched: false, completion_percentage: pct} = progress
           when pct < @watched_threshold ->
-            (progress.position_seconds || 0) >= min_position
+            resume_point?(progress, min_position)
 
           _ ->
             false
@@ -85,5 +94,15 @@ defmodule Mydia.Playback.NextEpisode do
           end
       end
     end
+  end
+
+  # Either bar is enough. See the union argument in `determine/3`.
+  #
+  # Both sides tolerate a nil, which is not hypothetical: the media-server sync
+  # writes rows carrying no position of their own, and a nil there must read as
+  # "nowhere near a resume point" rather than crash the rail.
+  defp resume_point?(%Progress{} = progress, min_position) do
+    (progress.position_seconds || 0) >= min_position or
+      (progress.completion_percentage || 0.0) >= @min_completion_percentage
   end
 end

--- a/lib/mydia/playback/next_episode.ex
+++ b/lib/mydia/playback/next_episode.ex
@@ -13,6 +13,7 @@ defmodule Mydia.Playback.NextEpisode do
   alias Mydia.Playback.Progress
 
   @watched_threshold 90.0
+  @default_min_position_seconds 120
 
   @doc """
   Returns the next episode to play and why.
@@ -21,13 +22,39 @@ defmodule Mydia.Playback.NextEpisode do
   - `{:next, episode}` the first unwatched episode, with history present
   - `{:start, episode}` the first episode, with no history at all
   - `:all_watched` nothing is left
+
+  ## Options
+
+    * `:min_position_seconds` - how far into an episode counts as a resume
+      point (default #{@default_min_position_seconds})
+
+  A resume point outranks the unwatched frontier: half an episode of season
+  three beats an untouched season one, because that is where the viewer
+  actually is. That only holds for a position someone could have reached by
+  watching. A few seconds on the clock is what a mis-click, a preview, or a
+  glance at the wrong title leaves behind, and treating one as a resume point
+  pins the card to an episode the viewer never started while the episode they
+  are really on sits unwatched behind it.
+
+  So a row under the floor is not a resume point. The episode still shows up
+  as the first unwatched one when the frontier is where it sits, and the row
+  itself survives, so the seconds are still there to resume from once the
+  viewer chooses to play it.
+
+  The floor matches On Deck's own definition of real viewing, which already
+  refuses to put a show on the rail on the strength of a row like this. Before
+  this, a show could reach the rail on one episode's history and then name a
+  different episode the same rule had just called noise.
   """
-  def determine(episodes, progress_map) do
+  def determine(episodes, progress_map, opts \\ []) do
+    min_position = Keyword.get(opts, :min_position_seconds, @default_min_position_seconds)
+
     in_progress_episode =
       Enum.find(episodes, fn episode ->
         case Map.get(progress_map, episode.id) do
-          %Progress{watched: false, completion_percentage: pct} when pct < @watched_threshold ->
-            true
+          %Progress{watched: false, completion_percentage: pct} = progress
+          when pct < @watched_threshold ->
+            (progress.position_seconds || 0) >= min_position
 
           _ ->
             false

--- a/lib/mydia/playback/on_deck.ex
+++ b/lib/mydia/playback/on_deck.ex
@@ -61,7 +61,7 @@ defmodule Mydia.Playback.OnDeck do
 
     dismissals = load_dismissals(user_id)
 
-    (movie_entries(counting) ++ show_entries(counting, user_id))
+    (movie_entries(counting) ++ show_entries(counting, user_id, min_position))
     |> Enum.reject(&dismissed?(&1, dismissals))
     |> Enum.sort_by(&sort_key/1, :desc)
     |> Enum.take(limit)
@@ -130,7 +130,7 @@ defmodule Mydia.Playback.OnDeck do
     end
   end
 
-  defp show_entries(counting, user_id) do
+  defp show_entries(counting, user_id, min_position) do
     episode_rows = Enum.filter(counting, &(not is_nil(&1.episode_id)))
     episode_ids = Enum.map(episode_rows, & &1.episode_id)
     episode_to_show = load_episode_show_ids(episode_ids)
@@ -160,14 +160,15 @@ defmodule Mydia.Playback.OnDeck do
             show,
             Map.get(episodes_by_show, show_id, []),
             progress_by_episode,
-            sort_at_by_show[show_id]
+            sort_at_by_show[show_id],
+            min_position
           ),
         not is_nil(entry) do
       entry
     end
   end
 
-  defp build_show_entry(show, episodes, progress_by_episode, sort_at) do
+  defp build_show_entry(show, episodes, progress_by_episode, sort_at, min_position) do
     progress_map =
       Enum.reduce(episodes, %{}, fn episode, acc ->
         case Map.get(progress_by_episode, episode.id) do
@@ -176,7 +177,10 @@ defmodule Mydia.Playback.OnDeck do
         end
       end)
 
-    case NextEpisode.determine(episodes, progress_map) do
+    # The same floor that decided the show belongs on the rail also decides
+    # which episode it names, so a row too small to count as viewing cannot
+    # become the card's resume point.
+    case NextEpisode.determine(episodes, progress_map, min_position_seconds: min_position) do
       {:continue, episode} ->
         episode_entry(show, episode, :continue, Map.get(progress_map, episode.id), sort_at)
 

--- a/test/mydia/playback/next_episode_test.exs
+++ b/test/mydia/playback/next_episode_test.exs
@@ -111,9 +111,53 @@ defmodule Mydia.Playback.NextEpisodeTest do
       assert {:next, %Episode{id: "b"}} = NextEpisode.determine(episodes, progress)
     end
 
-    test "the resume floor is configurable" do
+    test "half of a short episode is a resume point despite being under the seconds bar" do
+      # 98 seconds of a three-and-a-half minute episode. Judged on the clock
+      # alone this is noise, but two minutes is most of the runtime, so the
+      # clock is the wrong bar to judge it by.
+      episodes = [ep("a", 1, 1), ep("b", 1, 2), ep("c", 1, 3)]
+
+      progress = %{
+        "a" => watched("a"),
+        "c" => partial("c", 45.79, 214)
+      }
+
+      assert {:continue, %Episode{id: "c"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "a small fraction of a long episode is a resume point on the seconds bar" do
+      # Three minutes into a feature-length episode is a real position to
+      # resume from, and 5% would dismiss it.
+      episodes = [ep("a", 1, 1), ep("b", 1, 2), ep("c", 1, 3)]
+
+      progress = %{
+        "a" => watched("a"),
+        "c" => partial("c", 5.0, 3600)
+      }
+
+      assert {:continue, %Episode{id: "c"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "a short episode barely started clears neither bar" do
+      # 43 seconds of a seven minute episode: under two minutes and under a
+      # tenth of the runtime.
+      episodes = [ep("a", 1, 1), ep("b", 1, 2), ep("c", 1, 3)]
+
+      progress = %{
+        "a" => watched("a"),
+        "c" => partial("c", 9.84, 437)
+      }
+
+      assert {:next, %Episode{id: "b"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "the seconds bar is configurable" do
       episodes = [ep("a", 1, 1), ep("b", 1, 2)]
-      progress = %{"a" => partial("a", 5.0, 1400)}
+      # Three minutes in, but only 5% through, so the percentage bar cannot
+      # carry it and the seconds bar decides on its own.
+      progress = %{"a" => partial("a", 5.0, 3600)}
+
+      assert {:continue, %Episode{id: "a"}} = NextEpisode.determine(episodes, progress)
 
       assert {:next, %Episode{id: "a"}} =
                NextEpisode.determine(episodes, progress, min_position_seconds: 300)

--- a/test/mydia/playback/next_episode_test.exs
+++ b/test/mydia/playback/next_episode_test.exs
@@ -13,8 +13,17 @@ defmodule Mydia.Playback.NextEpisodeTest do
     %Progress{episode_id: episode_id, watched: true, completion_percentage: 100.0}
   end
 
-  defp partial(episode_id, pct) do
-    %Progress{episode_id: episode_id, watched: false, completion_percentage: pct}
+  # `position_seconds` is derived from the percentage so a helper-built row is
+  # internally consistent. A percentage with no position would sit under the
+  # resume floor and read as a stray scrub rather than as real viewing.
+  defp partial(episode_id, pct, duration \\ 1400) do
+    %Progress{
+      episode_id: episode_id,
+      watched: false,
+      position_seconds: round(duration * pct / 100),
+      duration_seconds: duration,
+      completion_percentage: pct
+    }
   end
 
   describe "determine/2" do
@@ -58,6 +67,56 @@ defmodule Mydia.Playback.NextEpisodeTest do
       # auto-marks watched at 90%, but a sync passing `authoritative_watched:
       # true` preserves the remote's own unwatched flag at any percentage.
       assert {:next, %Episode{id: "a"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "a few seconds on a much later episode does not outrank the first unwatched one" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2), ep("c", 1, 3), ep("d", 3, 6)]
+
+      progress = %{
+        "a" => watched("a"),
+        "b" => watched("b"),
+        "d" => partial("d", 0.63, 1422)
+      }
+
+      assert {:next, %Episode{id: "c"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "real viewing on a later episode still wins over an earlier unwatched one" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2), ep("c", 1, 3), ep("d", 3, 6)]
+
+      progress = %{
+        "a" => watched("a"),
+        "b" => watched("b"),
+        "d" => partial("d", 30.0, 1422)
+      }
+
+      assert {:continue, %Episode{id: "d"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "a stray scrub on the first unwatched episode still returns that episode" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+      progress = %{"a" => watched("a"), "b" => partial("b", 0.5, 1400)}
+
+      assert {:next, %Episode{id: "b"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "a row with no position at all is not a resume point" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+
+      progress = %{
+        "a" => watched("a"),
+        "b" => %Progress{episode_id: "b", watched: false, completion_percentage: 0.0}
+      }
+
+      assert {:next, %Episode{id: "b"}} = NextEpisode.determine(episodes, progress)
+    end
+
+    test "the resume floor is configurable" do
+      episodes = [ep("a", 1, 1), ep("b", 1, 2)]
+      progress = %{"a" => partial("a", 5.0, 1400)}
+
+      assert {:next, %Episode{id: "a"}} =
+               NextEpisode.determine(episodes, progress, min_position_seconds: 300)
     end
   end
 end


### PR DESCRIPTION
## The bug

Continue Watching named a season three episode for a show whose viewer was two episodes into season one. The episode it should have named had a file, no progress row, and sat right at the frontier.

## Root cause

`NextEpisode.determine/2` scanned the whole series for any progress row with `watched: false` under 90% and returned the first match as `{:continue, ...}` before it ever looked for the first unwatched episode. There was no bar on how far into an episode counts as being partway through it.

The three progress rows behind the report:

| ep | watched | position | duration | pct | last watched |
| --- | --- | --- | --- | --- | --- |
| S01E01 | yes | 2s | 1420 | 0.14% | 2026-09-02 |
| S01E02 | yes | 1339s | 1420 | 94.3% | 2026-09-02 |
| S03E06 | **no** | **9s** | 1422 | **0.63%** | 2026-08-11 |

S01E03 has no row, so the in-progress scan skipped it (`nil` matches the catch-all) and landed on nine seconds left behind three weeks earlier. That returns immediately, so the frontier was never reached.

What makes this a contradiction rather than a gap: `OnDeck.counting_row?/3` already defines real viewing as watched-or-at-least-two-minutes, and that rule is exactly what put the show on the rail on the strength of the two season one rows while rejecting the stray one. But `load_progress_for_episodes/2` reloads every row unfiltered for the per-episode decision, so the row the rail had just called noise became the card's resume point.

The write side is not implicated. Across the fifteen unwatched episode rows in one production library the positions run 1s, 4s, 5s, 5s, 8s, 8s, 9s, 17s, 24s, 43s, 90s, 98s, 668s, 932s, 935s, spread over twelve shows and mostly on season premieres. That is a bail-out decay curve from people sampling a show, not a fabricated constant from a page-open or a handshake. The data is faithful; only the reading of it was wrong.

## The fix

`determine/3` takes `:min_position_seconds` (default 120), and `resume_point?/2` asks whether a row clears either of two bars: far enough in by the clock, or far enough in as a fraction of the episode (10%). `OnDeck` passes its own configured seconds bar, so one rule now governs both which shows appear on the rail and which episode each one names.

Either bar alone is wrong. Seconds alone demote someone halfway through a five-minute episode, which two minutes can exceed outright — production has exactly such a row, 98 seconds of a 214 second episode at 45.79%. A fraction alone is noise on a long episode, where one percent of a feature-length runtime is still the cold open. As a union they only ever admit more than the stricter arm, so no row either bar accepts is ever demoted.

The two bars separate the fifteen real rows cleanly: everything from 1s/0.03% through 90s/3.04% falls outside, the four genuine resume points fall inside.

A genuine mid-series jump still outranks an earlier unwatched episode, because someone who watched half of a later episode really is there. Sub-bar rows fall through, and when such a row is itself the frontier the same episode comes back labelled `:next`, with the row intact to resume from. So the change never moves the card to a different episode except in the case it exists to fix.

## Verification

Eight new tests in `next_episode_test.exs`, one encoding the exact production row shape above and two covering each bar in isolation (a short episode carried by the fraction, a long one carried by the clock). Neutralising the fraction bar fails exactly one test, the short-episode case, so both arms are load-bearing rather than decorative. The `partial/3` helper now derives `position_seconds` from the percentage and duration so helper-built rows are internally consistent.

`mix precommit`: 10595 tests, 0 failures, credo and format clean.

## Note

The stale row itself stays in the database. It no longer affects the card, and it is still there to resume from if that episode is ever chosen deliberately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume-point detection so episodes qualify based on either the minimum viewing time or 10% completion threshold.
  * Playback progress with insufficient time and completion is no longer treated as resumable.
  * On Deck episode selection now applies the configured minimum viewing threshold consistently.

* **Enhancements**
  * Added configurable minimum viewing time for resume points, defaulting to 120 seconds.
  * Episodes with valid percentage-based progress can now be recognized as resume points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->