### PR TITLE
fix(p2p): stop the connection dropping and reconnecting for no reason

### DIFF
--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -230,6 +230,12 @@ defmodule Mydia.Application do
         # Must precede P2p.Server: it creates the instance identity the p2p node
         # and every pairing depend on, and seeds RemoteAccess.enabled?/0.
         Mydia.RemoteAccess.Provision,
+        # Serves peer requests off Mydia.P2p.Server, one task each. Bounded
+        # because iroh gates inbound connections on ALPN alone, so a peer needs
+        # no credential to make the host spawn these, and `max_children` is what
+        # keeps that from becoming the third memory-exhaustion hole in this
+        # subsystem. Over the limit the request is refused rather than queued.
+        {Task.Supervisor, name: Mydia.P2p.RequestSupervisor, max_children: 256},
         Mydia.P2p.Server,
         # Resume active pairing claims on startup
         Mydia.RemoteAccess.ResumeClaims

--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -230,12 +230,18 @@ defmodule Mydia.Application do
         # Must precede P2p.Server: it creates the instance identity the p2p node
         # and every pairing depend on, and seeds RemoteAccess.enabled?/0.
         Mydia.RemoteAccess.Provision,
-        # Serves peer requests off Mydia.P2p.Server, one task each. Bounded
-        # because iroh gates inbound connections on ALPN alone, so a peer needs
-        # no credential to make the host spawn these, and `max_children` is what
-        # keeps that from becoming the third memory-exhaustion hole in this
-        # subsystem. Over the limit the request is refused rather than queued.
-        {Task.Supervisor, name: Mydia.P2p.RequestSupervisor, max_children: 256},
+        # Serves peer requests off Mydia.P2p.Server. Bounded because iroh gates
+        # inbound connections on ALPN alone, so a peer needs no credential to
+        # make the host spawn these, and `max_children` is what keeps that from
+        # becoming the third memory-exhaustion hole in this subsystem. Over the
+        # limit the request is refused rather than queued.
+        #
+        # Two children per in-flight request, so this caps concurrency at 256:
+        # one runs the handler, the other waits on it with a deadline and kills
+        # it if it hangs. A handler blocked on an unresponsive filesystem
+        # returns on its own schedule or never, and a bound whose slots never
+        # come back just fails every later request instead.
+        {Task.Supervisor, name: Mydia.P2p.RequestSupervisor, max_children: 512},
         Mydia.P2p.Server,
         # Resume active pairing claims on startup
         Mydia.RemoteAccess.ResumeClaims

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -249,22 +249,23 @@ defmodule Mydia.P2p.Server do
   def handle_info({:ok, "request_received", "pairing", request_id, req}, state) do
     Logger.info("P2P Request: Pairing from #{req.device_name}")
 
-    response =
-      if RemoteAccess.enabled?() do
-        handle_pairing_request(req)
-      else
-        Logger.info("P2P Request: Pairing refused, remote access is disabled")
+    serve_request(state.resource, request_id, "pairing", fn ->
+      response =
+        if RemoteAccess.enabled?() do
+          handle_pairing_request(req)
+        else
+          Logger.info("P2P Request: Pairing refused, remote access is disabled")
 
-        %P2p.PairingResponse{
-          success: false,
-          error: "Remote access is disabled on this server"
-        }
-      end
+          %P2p.PairingResponse{
+            success: false,
+            error: "Remote access is disabled on this server"
+          }
+        end
 
-    # Wrap in tagged enum tuple as expected by NIF
-    response_enum = {:pairing, response}
+      # Wrap in tagged enum tuple as expected by NIF
+      {:pairing, response}
+    end)
 
-    P2p.send_response(state.resource, request_id, response_enum)
     {:noreply, state}
   end
 
@@ -274,44 +275,48 @@ defmodule Mydia.P2p.Server do
   end
 
   def handle_info({:ok, "request_received", "read_media", request_id, req}, state) do
-    cond do
-      not RemoteAccess.enabled?() ->
-        P2p.send_response(state.resource, request_id, {:error, "Remote access is disabled"})
+    resource = state.resource
 
-      # Validate file path exists
-      # SECURITY: In production, verify path is within allowed directories!
-      File.exists?(req.file_path) ->
-        # Use the optimized NIF to read chunk and respond
-        P2p.respond_with_file_chunk(
-          state.resource,
-          request_id,
-          req.file_path,
-          req.offset,
-          req.length
-        )
+    serve_request(resource, request_id, "read_media", fn ->
+      cond do
+        not RemoteAccess.enabled?() ->
+          {:error, "Remote access is disabled"}
 
-      true ->
-        Logger.warning("Requested file not found: #{req.file_path}")
-        P2p.send_response(state.resource, request_id, {:error, "File not found"})
-    end
+        # Validate file path exists
+        # SECURITY: In production, verify path is within allowed directories!
+        File.exists?(req.file_path) ->
+          # Use the optimized NIF to read chunk and respond. It answers the
+          # peer itself, so there is no response left for `serve_request`
+          # to send.
+          P2p.respond_with_file_chunk(
+            resource,
+            request_id,
+            req.file_path,
+            req.offset,
+            req.length
+          )
+
+          :responded
+
+        true ->
+          Logger.warning("Requested file not found: #{req.file_path}")
+          {:error, "File not found"}
+      end
+    end)
 
     {:noreply, state}
   end
 
   def handle_info({:ok, "request_received", "graphql", request_id, req}, state) do
-    if RemoteAccess.enabled?() do
-      handle_graphql_request(request_id, req, state)
-    else
-      Logger.debug("P2P Request: GraphQL refused, remote access is disabled")
+    # Read what the request needs out of the GenServer's state here; the task
+    # below must not close over `state`.
+    peer_connection_type = infer_peer_connection_type(state.connected_peers)
 
-      response = %P2p.GraphQLResponse{
-        data: nil,
-        errors: encode_graphql_errors([%{message: "Remote access is disabled on this server"}])
-      }
+    serve_request(state.resource, request_id, "GraphQL request", fn ->
+      {:graphql, graphql_response(req, peer_connection_type)}
+    end)
 
-      P2p.send_response(state.resource, request_id, {:graphql, response})
-      {:noreply, state}
-    end
+    {:noreply, state}
   end
 
   def handle_info({:ok, "unknown_request"}, state) do
@@ -393,7 +398,28 @@ defmodule Mydia.P2p.Server do
     end
   end
 
-  defp handle_graphql_request(request_id, req, state) do
+  @doc """
+  Builds the response to one peer's GraphQL request, refusing it outright when
+  remote access is switched off.
+
+  Public for the same reason as `run_graphql/5`: this is the gate that keeps a
+  server with remote access disabled from answering peer queries at all, and it
+  is worth pinning without standing up a host and a NIF resource to reach it.
+  """
+  def graphql_response(req, peer_connection_type) do
+    if RemoteAccess.enabled?() do
+      run_graphql_request(req, peer_connection_type)
+    else
+      Logger.debug("P2P Request: GraphQL refused, remote access is disabled")
+
+      %P2p.GraphQLResponse{
+        data: nil,
+        errors: encode_graphql_errors([%{message: "Remote access is disabled on this server"}])
+      }
+    end
+  end
+
+  defp run_graphql_request(req, peer_connection_type) do
     Logger.debug("P2P Request: GraphQL query")
 
     # Parse variables from JSON
@@ -401,48 +427,46 @@ defmodule Mydia.P2p.Server do
 
     # Build context from auth token, marking source as p2p
     # Include peer connection type so resolvers can enforce relay caps
-    peer_connection_type = infer_peer_connection_type(state.connected_peers)
-
     context =
       build_graphql_context(req.auth_token, :p2p, peer_connection_type, req.device_profile)
 
     # Execute the GraphQL query with logging
     result = run_graphql(req.query, variables, req.operation_name, context)
 
-    response =
-      case result do
-        {:ok, %{data: data, errors: errors}} ->
-          %P2p.GraphQLResponse{
-            data: encode_json(data),
-            errors: encode_graphql_errors(errors)
-          }
+    build_graphql_response(result)
+  end
 
-        {:ok, %{data: data}} ->
-          %P2p.GraphQLResponse{
-            data: encode_json(data),
-            errors: nil
-          }
+  defp build_graphql_response(result) do
+    case result do
+      {:ok, %{data: data, errors: errors}} ->
+        %P2p.GraphQLResponse{
+          data: encode_json(data),
+          errors: encode_graphql_errors(errors)
+        }
 
-        # Query validation errors (no data key, only errors)
-        {:ok, %{errors: errors}} ->
-          Logger.warning("GraphQL validation error: #{inspect(errors)}")
+      {:ok, %{data: data}} ->
+        %P2p.GraphQLResponse{
+          data: encode_json(data),
+          errors: nil
+        }
 
-          %P2p.GraphQLResponse{
-            data: nil,
-            errors: encode_graphql_errors(errors)
-          }
+      # Query validation errors (no data key, only errors)
+      {:ok, %{errors: errors}} ->
+        Logger.warning("GraphQL validation error: #{inspect(errors)}")
 
-        {:error, reason} ->
-          Logger.warning("GraphQL execution failed: #{inspect(reason)}")
+        %P2p.GraphQLResponse{
+          data: nil,
+          errors: encode_graphql_errors(errors)
+        }
 
-          %P2p.GraphQLResponse{
-            data: nil,
-            errors: encode_json([%{message: inspect(reason)}])
-          }
-      end
+      {:error, reason} ->
+        Logger.warning("GraphQL execution failed: #{inspect(reason)}")
 
-    P2p.send_response(state.resource, request_id, {:graphql, response})
-    {:noreply, state}
+        %P2p.GraphQLResponse{
+          data: nil,
+          errors: encode_json([%{message: inspect(reason)}])
+        }
+    end
   end
 
   @doc """
@@ -485,6 +509,70 @@ defmodule Mydia.P2p.Server do
     kind, reason ->
       Logger.error("P2P GraphQL request #{kind}: #{inspect(reason)}")
       {:error, "GraphQL execution #{kind}: #{inspect(reason)}"}
+  end
+
+  # Serve one peer request off the GenServer, and answer it exactly once.
+  #
+  # `Mydia.P2p.Server` owns the NIF resource and every peer's connection
+  # state, so work it does inline in a callback is time the host spends
+  # answering nothing else: not another peer's query, not a `peer_connected`
+  # event. Worse, an exception raised inline does not fail that one request,
+  # it kills the host, and the supervisor's restart drops every paired player
+  # at once. Production took three such restarts in a week, all from GraphQL
+  # mutations. `stream_hls_response` has always spawned for the throughput
+  # half of this; the request handlers spawn for both halves.
+  #
+  # `fun` returns the tagged response tuple to send back, or `:responded` if
+  # it already answered the peer itself. Either way exactly one response goes
+  # out, including when `fun` raises: a peer that gets nothing back waits out
+  # the Rust core's 30s `RESPONSE_TIMEOUT` instead, which is a worse failure
+  # than an error it can act on immediately.
+  #
+  # The tasks run under `Mydia.P2p.RequestSupervisor`, which is bounded: iroh
+  # accepts an inbound connection on a matching ALPN alone, so a peer needs no
+  # credential to make the host spawn these. `start_child` is not linked to
+  # this process, so a task that dies despite the rescue below still cannot
+  # take the host with it, and past `max_children` the peer is refused outright
+  # rather than the host quietly accumulating work it will never finish.
+  defp serve_request(resource, request_id, describe, fun) do
+    task = fn ->
+      response =
+        try do
+          fun.()
+        rescue
+          exception ->
+            Logger.error(
+              "P2P #{describe} crashed: " <>
+                Exception.format(:error, exception, __STACKTRACE__)
+            )
+
+            {:error, "Request failed: #{Exception.message(exception)}"}
+        catch
+          kind, reason ->
+            Logger.error("P2P #{describe} #{kind}: #{inspect(reason)}")
+            {:error, "Request failed: #{inspect(reason)}"}
+        end
+
+      case response do
+        :responded -> :ok
+        response -> P2p.send_response(resource, request_id, response)
+      end
+    end
+
+    case Task.Supervisor.start_child(Mydia.P2p.RequestSupervisor, task) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, :max_children} ->
+        Logger.warning("P2P #{describe} refused: too many requests in flight")
+        P2p.send_response(resource, request_id, {:error, "Server busy, try again"})
+
+      {:error, reason} ->
+        Logger.error("P2P #{describe} could not be started: #{inspect(reason)}")
+        P2p.send_response(resource, request_id, {:error, "Request failed"})
+    end
+
+    :ok
   end
 
   defp stream_hls_response(resource, stream_id, req) do

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -407,14 +407,7 @@ defmodule Mydia.P2p.Server do
       build_graphql_context(req.auth_token, :p2p, peer_connection_type, req.device_profile)
 
     # Execute the GraphQL query with logging
-    result =
-      GraphQLLogging.run(
-        req.query,
-        MydiaWeb.Schema,
-        variables: variables,
-        operation_name: req.operation_name,
-        context: context
-      )
+    result = run_graphql(req.query, variables, req.operation_name, context)
 
     response =
       case result do
@@ -450,6 +443,48 @@ defmodule Mydia.P2p.Server do
 
     P2p.send_response(state.resource, request_id, {:graphql, response})
     {:noreply, state}
+  end
+
+  @doc """
+  Runs a GraphQL document on behalf of a peer, turning a crashing resolver into
+  an error result.
+
+  Public, and taking `schema`, only so the regression test can drive it without
+  a live NIF resource and against resolvers that fail on purpose.
+
+  Absinthe lets an exception raised by a resolver escape to whoever called it,
+  and here that caller is the `Mydia.P2p.Server` process itself. An escaping
+  exception therefore did not fail one query, it killed the P2P host: the
+  supervisor rebuilt the endpoint, every paired player lost its connection and
+  had to redial, and the operator saw the node "reconnect" for no visible
+  reason. Production took three such restarts in a single week, from
+  `updateEpisodeProgress` and `updateMovieProgress` meeting
+  `Exqlite.Error: Database busy` under a concurrent write.
+
+  One peer's failing request is not a reason to disconnect every other peer, so
+  the failure is logged with its stacktrace, reported to the peer that caused
+  it, and the host stays up.
+  """
+  def run_graphql(query, variables, operation_name, context, schema \\ MydiaWeb.Schema) do
+    GraphQLLogging.run(
+      query,
+      schema,
+      variables: variables,
+      operation_name: operation_name,
+      context: context
+    )
+  rescue
+    exception ->
+      Logger.error(
+        "P2P GraphQL request crashed: " <>
+          Exception.format(:error, exception, __STACKTRACE__)
+      )
+
+      {:error, Exception.message(exception)}
+  catch
+    kind, reason ->
+      Logger.error("P2P GraphQL request #{kind}: #{inspect(reason)}")
+      {:error, "GraphQL execution #{kind}: #{inspect(reason)}"}
   end
 
   defp stream_hls_response(resource, stream_id, req) do

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -19,6 +19,16 @@ defmodule Mydia.P2p.Server do
   alias Mydia.Streaming.SessionSubtitles
   alias MydiaWeb.Schema.Middleware.Logging, as: GraphQLLogging
 
+  # What a peer is told when handling its request failed unexpectedly.
+  #
+  # Deliberately says nothing. `accept_inbound` admits a connection on a
+  # matching ALPN alone, so the peer reading this need not have authenticated,
+  # and the exception text behind it is written for an operator: adapter
+  # errors quoting SQL, struct and module names, filesystem paths. The full
+  # `Exception.format/3` output, stacktrace included, goes to the log, where
+  # the operator can see it and the peer cannot.
+  @opaque_failure "Request failed"
+
   @doc """
   Status information about the p2p host.
   """
@@ -462,9 +472,13 @@ defmodule Mydia.P2p.Server do
       {:error, reason} ->
         Logger.warning("GraphQL execution failed: #{inspect(reason)}")
 
+        # A reason that is already a sentence is sent as one. `inspect/1` on a
+        # binary wraps it in quotes, which the player would render verbatim.
+        message = if is_binary(reason), do: reason, else: inspect(reason)
+
         %P2p.GraphQLResponse{
           data: nil,
-          errors: encode_json([%{message: inspect(reason)}])
+          errors: encode_json([%{message: message}])
         }
     end
   end
@@ -504,7 +518,7 @@ defmodule Mydia.P2p.Server do
           Exception.format(:error, exception, __STACKTRACE__)
       )
 
-      {:error, Exception.message(exception)}
+      {:error, @opaque_failure}
   catch
     kind, reason ->
       Logger.error(
@@ -512,7 +526,7 @@ defmodule Mydia.P2p.Server do
           Exception.format(kind, reason, __STACKTRACE__)
       )
 
-      {:error, "GraphQL execution #{kind}: #{inspect(reason)}"}
+      {:error, @opaque_failure}
   end
 
   # Serve one peer request off the GenServer, and answer it exactly once.
@@ -550,7 +564,7 @@ defmodule Mydia.P2p.Server do
                 Exception.format(:error, exception, __STACKTRACE__)
             )
 
-            {:error, "Request failed: #{Exception.message(exception)}"}
+            {:error, @opaque_failure}
         catch
           kind, reason ->
             Logger.error(
@@ -558,7 +572,7 @@ defmodule Mydia.P2p.Server do
                 Exception.format(kind, reason, __STACKTRACE__)
             )
 
-            {:error, "Request failed: #{inspect(reason)}"}
+            {:error, @opaque_failure}
         end
 
       case response do

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -507,7 +507,11 @@ defmodule Mydia.P2p.Server do
       {:error, Exception.message(exception)}
   catch
     kind, reason ->
-      Logger.error("P2P GraphQL request #{kind}: #{inspect(reason)}")
+      Logger.error(
+        "P2P GraphQL request #{kind}: " <>
+          Exception.format(kind, reason, __STACKTRACE__)
+      )
+
       {:error, "GraphQL execution #{kind}: #{inspect(reason)}"}
   end
 
@@ -549,7 +553,11 @@ defmodule Mydia.P2p.Server do
             {:error, "Request failed: #{Exception.message(exception)}"}
         catch
           kind, reason ->
-            Logger.error("P2P #{describe} #{kind}: #{inspect(reason)}")
+            Logger.error(
+              "P2P #{describe} #{kind}: " <>
+                Exception.format(kind, reason, __STACKTRACE__)
+            )
+
             {:error, "Request failed: #{inspect(reason)}"}
         end
 

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -29,6 +29,12 @@ defmodule Mydia.P2p.Server do
   # the operator can see it and the peer cannot.
   @opaque_failure "Request failed"
 
+  # How long one peer request may run before its task is killed and its slot
+  # returned. Matches the Rust core's `RESPONSE_TIMEOUT`: past that the peer has
+  # already been handed a timeout error and stopped waiting, so anything still
+  # running is work whose result nothing will read.
+  @request_timeout :timer.seconds(30)
+
   @doc """
   Status information about the p2p host.
   """
@@ -552,25 +558,35 @@ defmodule Mydia.P2p.Server do
   # this process, so a task that dies despite the rescue below still cannot
   # take the host with it, and past `max_children` the peer is refused outright
   # rather than the host quietly accumulating work it will never finish.
-  defp serve_request(resource, request_id, describe, fun) do
+  #
+  # A bound is only worth having if slots come back, so the work runs in a
+  # second task the first one waits on with a deadline. Nothing else would end
+  # it: a handler blocked on an unresponsive filesystem never returns, and the
+  # Rust `RESPONSE_TIMEOUT` only abandons the peer's side of the exchange, it
+  # cannot reach into the BEAM and stop the task. Without this, requests that
+  # hang hold their slots for the life of the process and the host eventually
+  # answers nothing but "Server busy".
+  # Public, and taking `timeout`, only so the regression test can drive a
+  # handler that hangs without waiting out the real 30 seconds.
+  @doc false
+  def serve_request(resource, request_id, describe, fun, timeout \\ @request_timeout) do
     task = fn ->
-      response =
-        try do
-          fun.()
-        rescue
-          exception ->
-            Logger.error(
-              "P2P #{describe} crashed: " <>
-                Exception.format(:error, exception, __STACKTRACE__)
-            )
+      worker = Task.Supervisor.async_nolink(Mydia.P2p.RequestSupervisor, fun)
 
+      response =
+        case Task.yield(worker, timeout) || Task.shutdown(worker, :brutal_kill) do
+          {:ok, response} ->
+            response
+
+          {:exit, reason} ->
+            # `async_nolink` means a handler that raises exits the worker
+            # instead of propagating here. The exit reason still carries the
+            # exception and its stacktrace, so the operator loses nothing.
+            Logger.error("P2P #{describe} crashed: " <> Exception.format(:exit, reason))
             {:error, @opaque_failure}
-        catch
-          kind, reason ->
-            Logger.error(
-              "P2P #{describe} #{kind}: " <>
-                Exception.format(kind, reason, __STACKTRACE__)
-            )
+
+          nil ->
+            Logger.error("P2P #{describe} timed out after #{timeout}ms and was killed")
 
             {:error, @opaque_failure}
         end

--- a/native/mydia_p2p_core/src/lib.rs
+++ b/native/mydia_p2p_core/src/lib.rs
@@ -208,6 +208,14 @@ enum Command {
         peer_id: String,
         reply: oneshot::Sender<bool>,
     },
+    /// How many live connections one peer currently holds. `connected_peers`
+    /// counts peers, not connections, so nothing else can distinguish a peer
+    /// connected once from the same peer connected twice.
+    #[cfg(test)]
+    DebugConnectionCount {
+        peer_id: String,
+        reply: oneshot::Sender<usize>,
+    },
 }
 
 /// Events emitted by the Host
@@ -605,6 +613,25 @@ impl Host {
         rx.await.unwrap_or(false)
     }
 
+    /// Test-only: how many live connections this host holds for `peer_id`.
+    /// See the doc comment on `Command::DebugConnectionCount`.
+    #[cfg(test)]
+    async fn debug_connection_count(&self, peer_id: &str) -> usize {
+        let (tx, rx) = oneshot::channel();
+        if self
+            .cmd_tx
+            .send(Command::DebugConnectionCount {
+                peer_id: peer_id.to_string(),
+                reply: tx,
+            })
+            .await
+            .is_err()
+        {
+            return 0;
+        }
+        rx.await.unwrap_or(0)
+    }
+
     /// Get this node's ID
     pub fn node_id(&self) -> &str {
         &self.node_id
@@ -835,7 +862,7 @@ async fn run_event_loop(
     tracing::info!("Iroh endpoint bound, endpoint_id: {}", endpoint_id);
 
     // Track state
-    let mut connected_peers: HashMap<String, Connection> = HashMap::new();
+    let mut connected_peers: HashMap<String, PeerConnections> = HashMap::new();
     let shared_state = Arc::new(Mutex::new(SharedState {
         pending_responses: HashMap::new(),
         #[cfg(feature = "host")]
@@ -850,7 +877,7 @@ async fn run_event_loop(
     // `stable_id` -- fixed for a connection's lifetime, per iroh's docs --
     // guards against a stale disconnect signal evicting a *fresh*
     // reconnection under the same peer_id that raced ahead of it.
-    let (disconnect_tx, mut disconnect_rx) = mpsc::channel::<(String, usize)>(64);
+    let (disconnect_tx, mut disconnect_rx) = mpsc::channel::<(String, ConnectionId)>(64);
 
     // Wait for endpoint to be online (relay connected + local IP available)
     // Use a timeout to avoid blocking indefinitely if relay is unreachable
@@ -962,43 +989,100 @@ async fn run_event_loop(
     tracing::info!("Endpoint closed");
 }
 
+/// Every live connection a peer currently holds, keyed by `ConnectionId`.
+///
+/// A peer is routinely connected more than once. Keying only by `peer_id`, as
+/// this did, meant a second connection evicted the first from the map while
+/// the first stayed live and served requests: the host then believed it had no
+/// route to a peer it was still talking to, and `handle_send_request` answered
+/// "Not connected to peer" for a connection that was working.
+type PeerConnections = HashMap<ConnectionId, Connection>;
+
+/// Identifies one connection instance, for the lifetime of the process.
+type ConnectionId = u64;
+
+static NEXT_CONNECTION_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Hand out the next `ConnectionId`.
+///
+/// Deliberately not `Connection::stable_id()`. That is stable for a single
+/// connection's lifetime, which is all iroh promises: nothing says the value
+/// is not handed out again once the connection is dropped. Since a closing
+/// connection is matched against the map by this id, a reused one would let a
+/// dead connection evict a live one. A counter that only ever increments
+/// cannot collide.
+fn next_connection_id() -> ConnectionId {
+    NEXT_CONNECTION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+/// The connection to use when talking to a peer: its most recent one.
+fn current_connection<'a>(
+    connected_peers: &'a HashMap<String, PeerConnections>,
+    peer_id: &str,
+) -> Option<&'a Connection> {
+    connected_peers
+        .get(peer_id)?
+        .iter()
+        .max_by_key(|(id, _)| *id)
+        .map(|(_, conn)| conn)
+}
+
+/// Record a newly established connection, and report whether the peer was
+/// already connected on another one.
+fn insert_connection(
+    connected_peers: &mut HashMap<String, PeerConnections>,
+    peer_id: &str,
+    conn_id: ConnectionId,
+    conn: Connection,
+) {
+    connected_peers
+        .entry(peer_id.to_string())
+        .or_default()
+        .insert(conn_id, conn);
+}
+
 /// Remove a `connected_peers` entry once its connection has closed, and
 /// announce the peer's departure if that was its last live connection.
 ///
-/// Only removes the entry if it still refers to the connection that just
-/// closed (matched by iroh's `stable_id`, fixed for a connection's
-/// lifetime). Without that guard, a disconnect signal for an old connection
-/// that arrives after the same `peer_id` has already reconnected would
-/// evict the new, live connection instead of the dead one.
+/// Removes just the connection that closed, and announces the peer only once
+/// nothing of its is left.
 ///
-/// `Event::Disconnected` is emitted from here, under that same guard, rather
-/// than from `handle_connection`. A peer routinely holds several connections
-/// at once -- production has seen one open eight inside 100ms -- and each is
-/// served by its own `handle_connection` task, which knows only that *its*
-/// connection ended, never whether a newer one has since taken over the
-/// `peer_id`. Announcing from there reported the peer gone every time any one
-/// of its stale connections timed out, while the peer was still connected and
-/// serving requests on another. Consumers act on that: the Elixir host drops
-/// the peer from `state.connected_peers`, and a player redials a link that
-/// never actually broke, which is what an operator sees as the connection
-/// dropping and coming back for no reason. Only the event loop owns
-/// `connected_peers`, so only the event loop can tell the difference.
+/// `Event::Disconnected` is emitted from here rather than from
+/// `handle_connection`. A peer routinely holds several connections at once,
+/// production has seen one open eight inside 100ms, and each is served by its
+/// own `handle_connection` task, which knows only that *its* connection ended.
+/// Announcing from there reported the peer gone every time any one of its
+/// connections closed, while the peer was still connected and serving requests
+/// on another. Consumers act on that: the Elixir host drops the peer from
+/// `state.connected_peers`, and a player redials a link that never actually
+/// broke, which is what an operator sees as the connection dropping and coming
+/// back for no reason. Only the event loop owns `connected_peers`, so only the
+/// event loop can tell the difference.
+///
+/// Answering that question is also why `connected_peers` holds every live
+/// connection per peer rather than only the newest. With one slot per peer, a
+/// second connection displaced the first, and whichever ordering the closes
+/// happened to arrive in decided whether the peer was wrongly announced gone:
+/// the displaced connection closing last was handled, the *current* one
+/// closing first was not.
 async fn prune_disconnected_peer(
-    connected_peers: &mut HashMap<String, Connection>,
+    connected_peers: &mut HashMap<String, PeerConnections>,
     event_tx: &mpsc::Sender<Event>,
     peer_id: &str,
-    stable_id: usize,
+    conn_id: ConnectionId,
 ) {
-    let std::collections::hash_map::Entry::Occupied(entry) =
+    let std::collections::hash_map::Entry::Occupied(mut entry) =
         connected_peers.entry(peer_id.to_string())
     else {
-        // Already pruned: whichever close removed it announced the peer then.
+        // Already pruned: whichever close emptied it announced the peer then.
         return;
     };
 
-    if entry.get().stable_id() != stable_id {
-        // A newer connection under this `peer_id` is live. The peer has not
-        // gone anywhere, so nothing is announced.
+    entry.get_mut().remove(&conn_id);
+
+    if !entry.get().is_empty() {
+        // The peer is still here on another connection, so nothing is
+        // announced.
         return;
     }
 
@@ -1015,10 +1099,10 @@ async fn prune_disconnected_peer(
 #[cfg(feature = "host")]
 async fn accept_inbound(
     incoming: Incoming,
-    connected_peers: &mut HashMap<String, Connection>,
+    connected_peers: &mut HashMap<String, PeerConnections>,
     event_tx: &mpsc::Sender<Event>,
     shared_state: &Arc<Mutex<SharedState>>,
-    disconnect_tx: &mpsc::Sender<(String, usize)>,
+    disconnect_tx: &mpsc::Sender<(String, ConnectionId)>,
 ) {
     let mut accepting = match incoming.accept() {
         Ok(accepting) => accepting,
@@ -1055,7 +1139,8 @@ async fn accept_inbound(
     let connection_type = PeerConnectionType::from_connection(&conn);
     tracing::info!("Peer connected: {} ({:?})", peer_id, connection_type);
 
-    connected_peers.insert(peer_id.clone(), conn.clone());
+    let conn_id = next_connection_id();
+    insert_connection(connected_peers, &peer_id, conn_id, conn.clone());
     let _ = event_tx
         .send(Event::Connected {
             peer_id: peer_id.clone(),
@@ -1073,6 +1158,7 @@ async fn accept_inbound(
         handle_connection(
             conn_clone,
             peer_id_clone,
+            conn_id,
             event_tx_clone,
             shared_state_clone,
             disconnect_tx_clone,
@@ -1091,11 +1177,11 @@ async fn accept_inbound(
 async fn handle_command(
     cmd: Command,
     endpoint: &Endpoint,
-    connected_peers: &mut HashMap<String, Connection>,
+    connected_peers: &mut HashMap<String, PeerConnections>,
     event_tx: &mpsc::Sender<Event>,
     shared_state: &Arc<Mutex<SharedState>>,
     relay_connected: bool,
-    disconnect_tx: &mpsc::Sender<(String, usize)>,
+    disconnect_tx: &mpsc::Sender<(String, ConnectionId)>,
 ) {
     match cmd {
         Command::Dial {
@@ -1141,8 +1227,12 @@ async fn handle_command(
             let relay_url = addr.relay_urls().next().map(|u| u.to_string());
 
             // Get connection type for the first connected peer
-            let peer_connection_type = if let Some((peer_key, conn)) = connected_peers.iter().next()
-            {
+            let first_peer = connected_peers
+                .keys()
+                .next()
+                .and_then(|key| current_connection(connected_peers, key).map(|conn| (key, conn)));
+
+            let peer_connection_type = if let Some((peer_key, conn)) = first_peer {
                 let peer_id = conn.remote_id();
                 tracing::info!(
                     "GetNetworkStats: checking paths for peer {} (key={})",
@@ -1185,13 +1275,23 @@ async fn handle_command(
         }
         #[cfg(test)]
         Command::DebugCloseConnection { peer_id, reply } => {
-            let closed = if let Some(conn) = connected_peers.get(&peer_id) {
-                conn.close(0u32.into(), b"test");
-                true
-            } else {
-                false
+            // Closes every connection the peer holds, not just its newest, so
+            // "close this peer" means the peer really is gone afterwards.
+            let closed = match connected_peers.get(&peer_id) {
+                Some(conns) if !conns.is_empty() => {
+                    for conn in conns.values() {
+                        conn.close(0u32.into(), b"test");
+                    }
+                    true
+                }
+                _ => false,
             };
             let _ = reply.send(closed);
+        }
+        #[cfg(test)]
+        Command::DebugConnectionCount { peer_id, reply } => {
+            let count = connected_peers.get(&peer_id).map_or(0, |conns| conns.len());
+            let _ = reply.send(count);
         }
         #[cfg(feature = "host")]
         Command::SendHlsHeader {
@@ -1312,10 +1412,10 @@ async fn handle_command(
 async fn handle_dial(
     endpoint: &Endpoint,
     endpoint_addr_json: &str,
-    connected_peers: &mut HashMap<String, Connection>,
+    connected_peers: &mut HashMap<String, PeerConnections>,
     event_tx: &mpsc::Sender<Event>,
     shared_state: &Arc<Mutex<SharedState>>,
-    disconnect_tx: &mpsc::Sender<(String, usize)>,
+    disconnect_tx: &mpsc::Sender<(String, ConnectionId)>,
 ) -> Result<(), String> {
     let endpoint_addr = endpoint_addr_from_json(endpoint_addr_json)?;
     let endpoint_id: EndpointId = endpoint_addr.id;
@@ -1331,7 +1431,8 @@ async fn handle_dial(
     let connection_type = PeerConnectionType::from_connection(&conn);
     tracing::info!("Connected to peer: {} ({:?})", node_id, connection_type);
 
-    connected_peers.insert(node_id.clone(), conn.clone());
+    let conn_id = next_connection_id();
+    insert_connection(connected_peers, &node_id, conn_id, conn.clone());
     let _ = event_tx
         .send(Event::Connected {
             peer_id: node_id.clone(),
@@ -1349,6 +1450,7 @@ async fn handle_dial(
         handle_connection(
             conn_clone,
             node_id_clone,
+            conn_id,
             event_tx_clone,
             shared_state_clone,
             disconnect_tx_clone,
@@ -1588,9 +1690,10 @@ const RESPONSE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(3
 async fn handle_connection(
     conn: Connection,
     peer_id: String,
+    conn_id: ConnectionId,
     event_tx: mpsc::Sender<Event>,
     shared_state: Arc<Mutex<SharedState>>,
-    disconnect_tx: mpsc::Sender<(String, usize)>,
+    disconnect_tx: mpsc::Sender<(String, ConnectionId)>,
 ) {
     loop {
         match conn.accept_bi().await {
@@ -1745,7 +1848,7 @@ async fn handle_connection(
                 // which case announcing a disconnect here would be a lie. See
                 // `prune_disconnected_peer`.
                 tracing::info!("Connection closed for peer {}: {}", peer_id, e);
-                let _ = disconnect_tx.send((peer_id, conn.stable_id())).await;
+                let _ = disconnect_tx.send((peer_id, conn_id)).await;
                 break;
             }
         }
@@ -1754,7 +1857,7 @@ async fn handle_connection(
 
 /// Send a request to a connected peer
 async fn handle_send_request(
-    connected_peers: &HashMap<String, Connection>,
+    connected_peers: &HashMap<String, PeerConnections>,
     node_id: &str,
     request: MydiaRequest,
 ) -> Result<MydiaResponse, String> {
@@ -1772,8 +1875,7 @@ async fn handle_send_request(
         node_id.to_string()
     };
 
-    let conn = connected_peers
-        .get(&actual_node_id)
+    let conn = current_connection(connected_peers, &actual_node_id)
         .ok_or_else(|| format!("Not connected to peer: {}", actual_node_id))?;
 
     // Open a bidirectional stream
@@ -1808,7 +1910,7 @@ async fn handle_send_request(
 /// Send an HLS streaming request to a connected peer (client-side).
 /// Returns a streaming response with header and channel for chunks.
 async fn handle_send_hls_request(
-    connected_peers: &HashMap<String, Connection>,
+    connected_peers: &HashMap<String, PeerConnections>,
     node_id: &str,
     request: HlsRequest,
 ) -> Result<HlsStreamResponse, String> {
@@ -1828,8 +1930,7 @@ async fn handle_send_hls_request(
         node_id.to_string()
     };
 
-    let conn = connected_peers
-        .get(&actual_node_id)
+    let conn = current_connection(connected_peers, &actual_node_id)
         .ok_or_else(|| format!("Not connected to peer: {}", actual_node_id))?;
 
     let connection_type = PeerConnectionType::from_connection(conn);
@@ -2420,6 +2521,19 @@ mod tests {
             .await
             .expect("second dial should succeed");
 
+        // `dial` returns once the *client* has connected; the server inserts
+        // the connection later, on its own event loop. Waiting for the server
+        // to hold both is what makes the assertions below mean anything: drop
+        // `client_one` too early and the server may still have only one
+        // connection, so the silence proves nothing. `connected_peers` counts
+        // peers, so it stays 1 throughout and cannot answer this.
+        wait_until(
+            || async { server.debug_connection_count(&client_id).await == 2 },
+            std::time::Duration::from_secs(10),
+            "the server to hold both connections for the peer",
+        )
+        .await;
+
         // Both connections are now live under one `peer_id`. Dropping the
         // first closes its connection; the server's task for it wakes up and
         // reports the close.
@@ -2451,6 +2565,71 @@ mod tests {
             "the peer's last connection closing to report it disconnected",
         )
         .await;
+    }
+
+    /// The same guarantee in the other ordering: the peer's *newest*
+    /// connection closes first while an older one is still live.
+    ///
+    /// This is the case the original `stable_id` guard could not see. With one
+    /// connection slot per peer, the newest connection was the one in the map,
+    /// so its close matched, the entry was removed, and the peer was announced
+    /// gone while it was still connected on the older one. Which of the two
+    /// orderings happened decided whether the bug fired, which is why the map
+    /// now holds every live connection per peer instead of only the newest.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_newest_connection_closing_does_not_report_a_live_peer_as_gone() {
+        let shared_key = [11u8; 32];
+        let client_config = || HostConfig {
+            keypair_bytes: Some(shared_key),
+            ..test_config()
+        };
+
+        let (server, _server_id) = Host::new(test_config());
+        let (client_one, client_id) = Host::new(client_config());
+        let (client_two, _) = Host::new(client_config());
+        spawn_event_drain(&client_one);
+        spawn_event_drain(&client_two);
+        let disconnects = spawn_disconnect_counter(&server, client_id.clone());
+
+        let server_addr = wait_for_addr(&server).await;
+        client_one
+            .dial(server_addr.clone())
+            .await
+            .expect("first dial should succeed");
+        client_two
+            .dial(server_addr)
+            .await
+            .expect("second dial should succeed");
+
+        wait_until(
+            || async { server.debug_connection_count(&client_id).await == 2 },
+            std::time::Duration::from_secs(10),
+            "the server to hold both connections for the peer",
+        )
+        .await;
+
+        // Drop the *second* client, whose connection is the newest and was the
+        // one the old single-slot map held.
+        drop(client_two);
+
+        wait_until(
+            || async { server.debug_connection_count(&client_id).await == 1 },
+            std::time::Duration::from_secs(30),
+            "the newest connection to be pruned",
+        )
+        .await;
+
+        assert_eq!(
+            disconnects.load(Ordering::SeqCst),
+            0,
+            "the newest connection closing must not report the peer gone while \
+             an older connection is still live"
+        );
+        assert_eq!(
+            server.get_network_stats().await.connected_peers,
+            1,
+            "the peer should still be counted on its remaining connection"
+        );
     }
 
     async fn wait_until<F, Fut>(mut check: F, timeout: std::time::Duration, what: &str)

--- a/native/mydia_p2p_core/src/lib.rs
+++ b/native/mydia_p2p_core/src/lib.rs
@@ -919,7 +919,7 @@ async fn run_event_loop(
             }
 
             Some((peer_id, stable_id)) = disconnect_rx.recv() => {
-                prune_disconnected_peer(&mut connected_peers, &peer_id, stable_id);
+                prune_disconnected_peer(&mut connected_peers, &event_tx, &peer_id, stable_id).await;
                 true
             }
         };
@@ -946,7 +946,7 @@ async fn run_event_loop(
             }
 
             Some((peer_id, stable_id)) = disconnect_rx.recv() => {
-                prune_disconnected_peer(&mut connected_peers, &peer_id, stable_id);
+                prune_disconnected_peer(&mut connected_peers, &event_tx, &peer_id, stable_id).await;
                 true
             }
         };
@@ -962,25 +962,50 @@ async fn run_event_loop(
     tracing::info!("Endpoint closed");
 }
 
-/// Remove a `connected_peers` entry once its connection has closed.
+/// Remove a `connected_peers` entry once its connection has closed, and
+/// announce the peer's departure if that was its last live connection.
 ///
 /// Only removes the entry if it still refers to the connection that just
 /// closed (matched by iroh's `stable_id`, fixed for a connection's
 /// lifetime). Without that guard, a disconnect signal for an old connection
 /// that arrives after the same `peer_id` has already reconnected would
 /// evict the new, live connection instead of the dead one.
-fn prune_disconnected_peer(
+///
+/// `Event::Disconnected` is emitted from here, under that same guard, rather
+/// than from `handle_connection`. A peer routinely holds several connections
+/// at once -- production has seen one open eight inside 100ms -- and each is
+/// served by its own `handle_connection` task, which knows only that *its*
+/// connection ended, never whether a newer one has since taken over the
+/// `peer_id`. Announcing from there reported the peer gone every time any one
+/// of its stale connections timed out, while the peer was still connected and
+/// serving requests on another. Consumers act on that: the Elixir host drops
+/// the peer from `state.connected_peers`, and a player redials a link that
+/// never actually broke, which is what an operator sees as the connection
+/// dropping and coming back for no reason. Only the event loop owns
+/// `connected_peers`, so only the event loop can tell the difference.
+async fn prune_disconnected_peer(
     connected_peers: &mut HashMap<String, Connection>,
+    event_tx: &mpsc::Sender<Event>,
     peer_id: &str,
     stable_id: usize,
 ) {
-    if let std::collections::hash_map::Entry::Occupied(entry) =
+    let std::collections::hash_map::Entry::Occupied(entry) =
         connected_peers.entry(peer_id.to_string())
-    {
-        if entry.get().stable_id() == stable_id {
-            entry.remove();
-        }
+    else {
+        // Already pruned: whichever close removed it announced the peer then.
+        return;
+    };
+
+    if entry.get().stable_id() != stable_id {
+        // A newer connection under this `peer_id` is live. The peer has not
+        // gone anywhere, so nothing is announced.
+        return;
     }
+
+    entry.remove();
+    let _ = event_tx
+        .send(Event::Disconnected(peer_id.to_string()))
+        .await;
 }
 
 /// Accept one inbound connection and start serving it.
@@ -1714,8 +1739,12 @@ async fn handle_connection(
                 });
             }
             Err(e) => {
+                // Report the close and let the event loop decide whether it
+                // means the peer is gone. This task cannot tell: the same
+                // `peer_id` may already be served by a newer connection, in
+                // which case announcing a disconnect here would be a lie. See
+                // `prune_disconnected_peer`.
                 tracing::info!("Connection closed for peer {}: {}", peer_id, e);
-                let _ = event_tx.send(Event::Disconnected(peer_id.clone())).await;
                 let _ = disconnect_tx.send((peer_id, conn.stable_id())).await;
                 break;
             }
@@ -1932,6 +1961,7 @@ async fn handle_send_hls_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn test_request_serialization() {
@@ -2319,6 +2349,110 @@ mod tests {
     /// a map being pruned) happen inside its own event loop task, so tests
     /// observe them asynchronously rather than immediately after issuing a
     /// command.
+    /// Like `spawn_event_drain`, but keeps a count of the `Disconnected`
+    /// events seen for `peer_id`. It must still drain everything else for the
+    /// reason spelled out on `spawn_event_drain`.
+    fn spawn_disconnect_counter(host: &Host, peer_id: String) -> Arc<AtomicUsize> {
+        let seen = Arc::new(AtomicUsize::new(0));
+        let counter = seen.clone();
+        let event_rx = host.event_rx.clone();
+
+        tokio::spawn(async move {
+            let mut rx = event_rx.lock().await;
+            while let Some(event) = rx.recv().await {
+                if matches!(&event, Event::Disconnected(id) if *id == peer_id) {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                }
+            }
+        });
+
+        seen
+    }
+
+    /// A peer that holds more than one connection at a time must not be
+    /// reported as disconnected until its *last* one goes away.
+    ///
+    /// The player routinely opens several connections at once (production has
+    /// caught it opening eight inside 100ms), and `connected_peers` is keyed by
+    /// `peer_id`, so a second connection replaces the first in the map while
+    /// the first's `handle_connection` task keeps running. When that stale
+    /// connection eventually died, it announced `Disconnected` for a peer that
+    /// was still connected and still serving requests on the newer one. The
+    /// `stable_id` guard added for T-809 kept the *map* honest but the event
+    /// went out anyway, so every consumer downstream believed it.
+    ///
+    /// Two clients share one secret key here, which is what makes both
+    /// connections land under a single `peer_id` on the server.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_stale_connection_closing_does_not_report_a_live_peer_as_gone() {
+        let shared_key = [7u8; 32];
+        let client_config = || HostConfig {
+            keypair_bytes: Some(shared_key),
+            ..test_config()
+        };
+
+        let (server, _server_id) = Host::new(test_config());
+        let (client_one, client_id) = Host::new(client_config());
+        let (client_two, client_two_id) = Host::new(client_config());
+        assert_eq!(
+            client_id, client_two_id,
+            "both clients must present the same node id for this to exercise \
+             two connections under one peer_id"
+        );
+        spawn_event_drain(&client_one);
+        spawn_event_drain(&client_two);
+        let disconnects = spawn_disconnect_counter(&server, client_id.clone());
+
+        let server_addr = wait_for_addr(&server).await;
+        client_one
+            .dial(server_addr.clone())
+            .await
+            .expect("first dial should succeed");
+        wait_until(
+            || async { server.get_network_stats().await.connected_peers == 1 },
+            std::time::Duration::from_secs(10),
+            "the server to observe the first connection",
+        )
+        .await;
+
+        client_two
+            .dial(server_addr)
+            .await
+            .expect("second dial should succeed");
+
+        // Both connections are now live under one `peer_id`. Dropping the
+        // first closes its connection; the server's task for it wakes up and
+        // reports the close.
+        drop(client_one);
+
+        // The peer is still there on the surviving connection, so the count
+        // must stay at 1 and nothing may be announced. Before the fix the
+        // stale close emitted `Disconnected` here.
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        assert_eq!(
+            disconnects.load(Ordering::SeqCst),
+            0,
+            "a stale connection closing must not report the peer gone while it \
+             is still connected on another"
+        );
+        assert_eq!(
+            server.get_network_stats().await.connected_peers,
+            1,
+            "the surviving connection should still be counted"
+        );
+
+        // And the announcement must still happen when the peer really does
+        // leave, otherwise the assertion above would pass on a broken event
+        // path just as happily.
+        drop(client_two);
+        wait_until(
+            || async { disconnects.load(Ordering::SeqCst) == 1 },
+            std::time::Duration::from_secs(30),
+            "the peer's last connection closing to report it disconnected",
+        )
+        .await;
+    }
+
     async fn wait_until<F, Fut>(mut check: F, timeout: std::time::Duration, what: &str)
     where
         F: FnMut() -> Fut,

--- a/test/mydia/p2p/server_graphql_test.exs
+++ b/test/mydia/p2p/server_graphql_test.exs
@@ -10,9 +10,14 @@ defmodule Mydia.P2p.ServerGraphQLTest do
   These cover `run_graphql/4`, the seam that contains such a failure. Driving it
   directly keeps the test away from the NIF resource a running host would need.
   """
-  use ExUnit.Case, async: true
+  # `async: false`: the remote access flag lives in `:persistent_term`, which
+  # the sandbox does not roll back. See `Mydia.RemoteAccessHelpers`.
+  use Mydia.DataCase, async: false
+
+  import Mydia.RemoteAccessHelpers
 
   alias Mydia.P2p.CrashingSchema
+  alias Mydia.P2p.GraphQLRequest
   alias Mydia.P2p.Server
 
   @context %{source: :p2p, peer_connection_type: nil}
@@ -43,6 +48,33 @@ defmodule Mydia.P2p.ServerGraphQLTest do
 
     test "a query the schema rejects still comes back as a GraphQL error" do
       assert {:ok, %{errors: [_ | _]}} = run("query { noSuchField }")
+    end
+  end
+
+  describe "graphql_response/2" do
+    setup do
+      on_exit(&reset_remote_access/0)
+      :ok
+    end
+
+    test "a server with remote access switched off refuses the query" do
+      set_remote_access(false)
+
+      response =
+        Server.graphql_response(%GraphQLRequest{query: "query { __typename }"}, nil)
+
+      assert response.data == nil
+      assert response.errors =~ "Remote access is disabled"
+    end
+
+    test "a server with remote access on answers it" do
+      set_remote_access(true)
+
+      response =
+        Server.graphql_response(%GraphQLRequest{query: "query { __typename }"}, nil)
+
+      assert response.errors == nil
+      assert response.data =~ "RootQueryType"
     end
   end
 end

--- a/test/mydia/p2p/server_graphql_test.exs
+++ b/test/mydia/p2p/server_graphql_test.exs
@@ -1,0 +1,48 @@
+defmodule Mydia.P2p.ServerGraphQLTest do
+  @moduledoc """
+  `Mydia.P2p.Server` resolves peer GraphQL requests inside its own process, so
+  an exception escaping a resolver used to kill the P2P host rather than the
+  request. The supervisor then rebuilt the endpoint and every paired player was
+  disconnected and had to redial, which is what an operator sees as the node
+  spontaneously dropping and reconnecting. Production took three such restarts
+  in one week.
+
+  These cover `run_graphql/4`, the seam that contains such a failure. Driving it
+  directly keeps the test away from the NIF resource a running host would need.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.P2p.CrashingSchema
+  alias Mydia.P2p.Server
+
+  @context %{source: :p2p, peer_connection_type: nil}
+
+  defp run(query), do: Server.run_graphql(query, %{}, nil, @context, CrashingSchema)
+
+  describe "run_graphql/5" do
+    test "a resolver that raises is reported, not propagated" do
+      assert {:error, message} = run("query { boom }")
+      assert message =~ "resolver exploded"
+    end
+
+    test "a resolver that exits is reported, not propagated" do
+      assert {:error, message} = run("query { bail }")
+      assert message =~ "resolver_bailed"
+    end
+
+    test "the caller survives a failing resolver" do
+      # The point of the fix: the process that ran the query is still alive and
+      # still answering afterwards. Before it, this second call never happened.
+      assert {:error, _} = run("query { boom }")
+      assert {:ok, %{data: %{"fine" => "ok"}}} = run("query { fine }")
+    end
+
+    test "a successful query is unaffected" do
+      assert {:ok, %{data: %{"fine" => "ok"}}} = run("query { fine }")
+    end
+
+    test "a query the schema rejects still comes back as a GraphQL error" do
+      assert {:ok, %{errors: [_ | _]}} = run("query { noSuchField }")
+    end
+  end
+end

--- a/test/mydia/p2p/server_graphql_test.exs
+++ b/test/mydia/p2p/server_graphql_test.exs
@@ -14,6 +14,7 @@ defmodule Mydia.P2p.ServerGraphQLTest do
   # the sandbox does not roll back. See `Mydia.RemoteAccessHelpers`.
   use Mydia.DataCase, async: false
 
+  import ExUnit.CaptureLog
   import Mydia.RemoteAccessHelpers
 
   alias Mydia.P2p.CrashingSchema
@@ -26,13 +27,18 @@ defmodule Mydia.P2p.ServerGraphQLTest do
 
   describe "run_graphql/5" do
     test "a resolver that raises is reported, not propagated" do
-      assert {:error, message} = run("query { boom }")
-      assert message =~ "resolver exploded"
+      log = capture_log(fn -> assert {:error, "Request failed"} = run("query { boom }") end)
+
+      # The peer is told nothing; the operator is told everything. A peer needs
+      # no credential to reach this, so the exception text stays in the log.
+      assert log =~ "resolver exploded"
+      assert log =~ "crashing_schema.ex"
     end
 
     test "a resolver that exits is reported, not propagated" do
-      assert {:error, message} = run("query { bail }")
-      assert message =~ "resolver_bailed"
+      log = capture_log(fn -> assert {:error, "Request failed"} = run("query { bail }") end)
+
+      assert log =~ "resolver_bailed"
     end
 
     test "the caller survives a failing resolver" do

--- a/test/mydia/p2p/server_request_timeout_test.exs
+++ b/test/mydia/p2p/server_request_timeout_test.exs
@@ -1,0 +1,80 @@
+defmodule Mydia.P2p.ServerRequestTimeoutTest do
+  @moduledoc """
+  Peer requests run under a bounded `Task.Supervisor`, and a bound is only
+  worth having if its slots come back.
+
+  Nothing else reclaims one. A handler blocked on an unresponsive filesystem
+  returns on its own schedule or never, and the Rust core's `RESPONSE_TIMEOUT`
+  only abandons the peer's side of the exchange; it cannot reach into the BEAM
+  and stop the task. Without the deadline these cover, enough hung requests
+  would occupy every slot permanently and the host would answer nothing but
+  "Server busy" from then on.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mydia.P2p.Server
+
+  setup do
+    # The real one is started only when remote access is enabled, which it is
+    # not in test.
+    start_supervised!({Task.Supervisor, name: Mydia.P2p.RequestSupervisor})
+    :ok
+  end
+
+  defp children, do: Task.Supervisor.children(Mydia.P2p.RequestSupervisor)
+
+  test "a handler that hangs is killed and its slot returned" do
+    log =
+      capture_log(fn ->
+        # `:fake_resource` is never reached: sending the response needs the
+        # NIF, and this request times out before it gets that far.
+        Server.serve_request(
+          :fake_resource,
+          "req-hang",
+          "hang test",
+          fn -> Process.sleep(:infinity) end,
+          100
+        )
+
+        assert_slots_reclaimed()
+      end)
+
+    assert log =~ "timed out"
+    assert log =~ "was killed"
+  end
+
+  test "a handler that returns promptly does not wait out the deadline" do
+    # A generous deadline the handler must not be blocked on: if the
+    # implementation waited for it rather than for the handler, this would take
+    # a minute instead of milliseconds.
+    Server.serve_request(
+      :fake_resource,
+      "req-fast",
+      "fast test",
+      fn -> {:error, "done"} end,
+      60_000
+    )
+
+    assert_slots_reclaimed()
+  end
+
+  # Polls rather than sleeping a fixed span: the slot comes back once the task
+  # exits, which is promptly but not synchronously.
+  defp assert_slots_reclaimed(attempts \\ 100) do
+    slots = children()
+
+    cond do
+      slots == [] ->
+        assert slots == []
+
+      attempts > 0 ->
+        Process.sleep(50)
+        assert_slots_reclaimed(attempts - 1)
+
+      true ->
+        flunk("the supervisor still holds #{length(slots)} children after the request is over")
+    end
+  end
+end

--- a/test/support/crashing_schema.ex
+++ b/test/support/crashing_schema.ex
@@ -1,0 +1,30 @@
+defmodule Mydia.P2p.CrashingSchema do
+  @moduledoc """
+  A minimal Absinthe schema whose resolvers fail in the two ways that used to
+  take `Mydia.P2p.Server` down with them: a raised exception and a process exit.
+
+  The real schema is a moving target -- whichever resolver happens to be
+  unguarded today may grow a `rescue` tomorrow -- so the regression test for
+  P2P crash isolation resolves against this instead. What is being pinned is
+  the contract (`run_graphql/4` reports a failure rather than propagating it),
+  not the fragility of any particular production resolver.
+  """
+  use Absinthe.Schema
+
+  query do
+    @desc "Raises, the way a resolver meeting `Exqlite.Error: Database busy` does."
+    field :boom, :string do
+      resolve(fn _, _, _ -> raise "resolver exploded" end)
+    end
+
+    @desc "Exits, the way a resolver whose downstream `GenServer.call` times out does."
+    field :bail, :string do
+      resolve(fn _, _, _ -> exit(:resolver_bailed) end)
+    end
+
+    @desc "Succeeds, so the test can tell isolation from a blanket failure."
+    field :fine, :string do
+      resolve(fn _, _, _ -> {:ok, "ok"} end)
+    end
+  end
+end


### PR DESCRIPTION
Three fixes for one reported symptom: a player connected to the production instance shows its connection dropping and reconnecting, and keeps working afterward.

Two independent defects produce that, and they are fixed separately. A third change removes a resource-exhaustion vector the second one would otherwise have introduced.

## 1. A stale connection closing reported a live peer as gone

A peer routinely holds several connections at once. Production has caught the player opening eight inside 100ms, and `connected_peers` is keyed by `peer_id`, so each new connection replaces the previous entry while the replaced connection's `handle_connection` task keeps running.

When one of those stale connections finally timed out, it announced `Event::Disconnected` for a peer that was still connected and still serving requests on a newer connection. The `stable_id` guard added for T-809 in 865a9ebf3 kept the map honest, refusing to evict the live entry, but the event went out regardless and every consumer downstream believed it: the Elixir host drops the peer from `state.connected_peers`, and a player redials a link that never broke. The journal shows it plainly, six `Connection closed ... timed out` plus `Peer Disconnected` lines in a row for a single peer.

`handle_connection` cannot make this call. It knows only that its own connection ended, never whether a newer one has since taken over the `peer_id`. Only the event loop owns `connected_peers`, so the announcement moved into `prune_disconnected_peer`, under the same `stable_id` guard that already decides whether the entry is really gone.

This is the better match for the reported symptom: it produces a drop-and-reconnect with no crash and no restart.

## 2. A crashing resolver took the whole host down

`Mydia.P2p.Server` resolved peer requests inside its own process with no exception handling, so an exception escaping a resolver did not fail one query, it killed the P2P host. The supervisor rebuilt the endpoint and every paired player had to redial. Three such restarts in seven days, all with `Last message: request_received graphql`:

| When | Exception | Operation |
| --- | --- | --- |
| Aug 30 00:25 | `ArgumentError: unknown registry: MydiaWeb.Endpoint.Registry` via `Absinthe.Subscription.publish` | `updateEpisodeProgress` |
| Sep 01 22:37 | `Exqlite.Error: Database busy` via `ForeignKeyGuard.run/3` and `Playback.save_progress/4` | `updateEpisodeProgress` |
| Sep 02 19:35 | the registry error again | `updateMovieProgress` |

The third fired during a SIGTERM redeploy, so the endpoint was already stopped and that one is a shutdown race rather than a fault of its own.

GraphQL, pairing and `read_media` now run off the GenServer through a shared `serve_request/4`, which is what `stream_hls_response` has always done for throughput ("so we don't block the GenServer"). Beyond containing the crash, this also stops one slow query from delaying every other peer's request and the host's own `peer_connected` events, which is the same lack of isolation showing up as latency instead of a restart.

`serve_request/4` answers exactly once, including when the handler raises. A peer that gets nothing back waits out the Rust core's 30s `RESPONSE_TIMEOUT` instead, which is a worse failure than an error it can act on immediately.

Pairing was checked before being parallelized rather than assumed safe: `ClaimRateLimiter` uses an atomic `:ets.update_counter` with an `insert_new` retry and is already reachable concurrently from the HTTP path, so the brute-force guess limit does not depend on the GenServer serializing it.

## 3. Bounding what that spawns

Plain `Task.start` per request would have been a regression introduced by fix 2. `accept_inbound` gates on ALPN alone, so a peer needs no credential to make the host spawn these, and this subsystem already had two memory-exhaustion holes closed in 865a9ebf3. The tasks run under a bounded `Task.Supervisor` (`max_children: 256`); past the limit the peer is refused with "Server busy" rather than the host accumulating work it will never finish.

## Tests

`a_stale_connection_closing_does_not_report_a_live_peer_as_gone` gives two clients the same secret key so both connections land under one `peer_id` on the server, drops the first, and asserts nothing is announced while the second is live. It then drops the second and asserts the disconnect does arrive, so the first assertion cannot pass on a dead event path. Without the fix it fails with exactly one spurious disconnect.

`Mydia.P2p.ServerGraphQLTest` resolves against a purpose-built `CrashingSchema` rather than a production resolver. Two candidates for a "naturally raising" query did not hold up: `movie(id:)` is answered by the authentication middleware before the resolver runs, and once authenticated a malformed id simply misses on SQLite and returns a rescued "Movie not found". What is worth pinning is the isolation contract, not whichever resolver happens to lack a `rescue` this month. Verified in both directions: with the `rescue`/`catch` removed, three of the five fail with the exception and the exit propagating out of the caller.

It also pins the remote-access gate for p2p GraphQL, which had no coverage at all and which fix 2 moved.

## Not fixed here

The player opens eight connections to one peer in 100ms and fires eleven duplicate `Devices` queries, which suggests `ensureConnected` is not deduped across concurrent GraphQL calls. Fix 1 makes the server stop lying about the resulting disconnects, but the client-side duplication is its own defect and is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failed GraphQL resolvers and remote requests from crashing remote access or disconnecting other peers.
  * GraphQL failures now return consistent error responses while subsequent requests continue normally.
  * Improved handling of multiple connections to the same peer, preventing stale connections from triggering incorrect disconnection notifications.
  * Remote GraphQL requests remain blocked when remote access is disabled.
  * Hung requests now time out instead of remaining active indefinitely.

* **Reliability**
  * Limited concurrent remote requests to help maintain service responsiveness during high demand.
  * Requests exceeding capacity now receive a clear “Server busy, try again” response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->