### PR TITLE
fix(media): size media file rows from their column, not the window

### DIFF
--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -969,8 +969,11 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   width. --%>
             <ul class="menu w-full flex-nowrap bg-base-100 rounded-box p-0 mt-2">
               <li :for={file <- @extras} id={"extra-#{file.id}"} class="min-w-0 flex-nowrap">
-                <div class="min-w-0 items-stretch flex flex-col gap-2 p-4 rounded-none sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-                  <div class="min-w-0 sm:flex-1 flex flex-col gap-1">
+                <div
+                  id={"extra-row-#{file.id}"}
+                  class="min-w-0 items-stretch flex flex-col gap-2 p-4 rounded-none @lg/mfrow:flex-row @lg/mfrow:items-center @lg/mfrow:justify-between @lg/mfrow:gap-4"
+                >
+                  <div class="min-w-0 @lg/mfrow:flex-1 flex flex-col gap-1">
                     <p
                       id={"extra-name-#{file.id}"}
                       class="text-sm font-mono truncate"
@@ -989,7 +992,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   <button
                     id={"promote-#{file.id}"}
                     type="button"
-                    class="btn btn-ghost self-end sm:self-auto sm:btn-sm"
+                    class="btn btn-ghost self-end @lg/mfrow:self-auto @lg/mfrow:btn-sm"
                     title="This is a version, not an extra"
                     phx-click="promote_to_version"
                     phx-value-id={file.id}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -743,7 +743,19 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               about the phone and wrong about everything else: at 1024px the
               app drawer and the page rail both open, the card drops to 312px,
               and a 248px button strip left the filename 16px. That rendered
-              two characters of an 84-character name. --%>
+              two characters of an 84-character name.
+
+              The threshold below is `@md` (28rem / 448px), raised from `@lg`
+              (32rem / 512px) originally. A container query measures the
+              container's content box, so the padding on this element
+              (`p-4 md:p-6`) is not part of what the threshold compares
+              against -- content-box width runs well below the border-box
+              numbers measured above. At `@lg`, this card's content box was
+              only 509px at a 900px viewport, on the wrong side of 512px, so
+              a vertical scrollbar appearing was enough to flip the layout
+              between stacked and one-line. `@md`/448px clears that case by
+              61px and still leaves 768px 71px clear on the other side; 448
+              has no significance beyond that margin. --%>
         <div class="@container/mfrow card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">Media Files</h2>
           <%!-- DaisyUI list component.

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -745,7 +745,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               and a 248px button strip left the filename 16px. That rendered
               two characters of an 84-character name.
 
-              The threshold below is `@md` (28rem / 448px), raised from `@lg`
+              The threshold below is `@md` (28rem / 448px), lowered from `@lg`
               (32rem / 512px) originally. A container query measures the
               container's content box, so the padding on this element
               (`p-4 md:p-6`) is not part of what the threshold compares

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -546,10 +546,10 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           four lines. --%>
     <div
       id={"episode-file-row-#{@file.id}"}
-      class="flex flex-col gap-3 py-1 @lg/eprow:flex-row @lg/eprow:items-start @lg/eprow:justify-between @lg/eprow:gap-4"
+      class="flex flex-col gap-3 py-1 @md/eprow:flex-row @md/eprow:items-start @md/eprow:justify-between @md/eprow:gap-4"
     >
       <%!-- File info --%>
-      <div class="flex flex-col gap-1 min-w-0 @lg/eprow:flex-1">
+      <div class="flex flex-col gap-1 min-w-0 @md/eprow:flex-1">
         <%!-- Filename row --%>
         <div class="flex items-center gap-2 min-w-0">
           <.icon name="hero-document" class="w-4 h-4 text-base-content/50 flex-shrink-0" />
@@ -562,7 +562,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           </span>
         </div>
         <%!-- Technical details row --%>
-        <div class="flex flex-wrap items-center gap-1.5 pl-0 text-xs @lg/eprow:pl-6">
+        <div class="flex flex-wrap items-center gap-1.5 pl-0 text-xs @md/eprow:pl-6">
           <span class="badge badge-primary badge-xs">{@file.resolution || "?"}</span>
           <%= if @file.codec do %>
             <span class="text-base-content/60" title={@file.codec}>
@@ -591,7 +591,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           type="button"
           phx-click="open_subtitle_manage"
           phx-value-media-file-id={@file.id}
-          class="btn btn-ghost btn-square @lg/eprow:btn-xs"
+          class="btn btn-ghost btn-square @md/eprow:btn-xs"
           aria-label="Manage subtitles"
           title="Subtitles"
         >
@@ -607,7 +607,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             <div
               tabindex="0"
               role="button"
-              class="btn btn-ghost btn-square @lg/eprow:btn-xs"
+              class="btn btn-ghost btn-square @md/eprow:btn-xs"
               title="Pre-transcode"
             >
               <.icon name="hero-wrench" class="w-4 h-4" />
@@ -634,7 +634,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             href={
               flutter_player_url("episode", @episode.id, file_id: @file.id, title: @episode.title)
             }
-            class="btn btn-ghost btn-square @lg/eprow:btn-xs"
+            class="btn btn-ghost btn-square @md/eprow:btn-xs"
             title="Play this file"
           >
             <.icon name="hero-play-solid" class="w-4 h-4" />
@@ -644,7 +644,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           type="button"
           phx-click="mark_file_preferred"
           phx-value-file-id={@file.id}
-          class="btn btn-ghost btn-square @lg/eprow:btn-xs"
+          class="btn btn-ghost btn-square @md/eprow:btn-xs"
           title="Mark as preferred"
         >
           <.icon name="hero-star" class="w-4 h-4" />
@@ -654,7 +654,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           type="button"
           phx-click="show_file_delete_confirm"
           phx-value-file-id={@file.id}
-          class="btn btn-ghost btn-square text-error hover:bg-error hover:text-error-content @lg/eprow:btn-xs"
+          class="btn btn-ghost btn-square text-error hover:bg-error hover:text-error-content @md/eprow:btn-xs"
           title="Delete file"
         >
           <.icon name="hero-trash" class="w-4 h-4" />
@@ -663,7 +663,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
     </div>
     <%!-- Transcode job badges --%>
     <%= if @transcode_jobs != [] do %>
-      <div class="flex flex-wrap items-center gap-2 pl-0 mt-1 @lg/eprow:pl-6">
+      <div class="flex flex-wrap items-center gap-2 pl-0 mt-1 @md/eprow:pl-6">
         <.transcode_badge
           :for={job <- @transcode_jobs}
           job={job}
@@ -783,10 +783,10 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               <div class="min-w-0 items-stretch flex flex-col gap-3 p-4 hover:bg-base-200 rounded-none transition-colors">
                 <div
                   id={"version-row-#{file.id}"}
-                  class="min-w-0 flex flex-col gap-3 @lg/mfrow:flex-row @lg/mfrow:items-start @lg/mfrow:justify-between @lg/mfrow:gap-4"
+                  class="min-w-0 flex flex-col gap-3 @md/mfrow:flex-row @md/mfrow:items-start @md/mfrow:justify-between @md/mfrow:gap-4"
                 >
                   <%!-- Left side: File info --%>
-                  <div class="min-w-0 @lg/mfrow:flex-1 flex flex-col gap-2">
+                  <div class="min-w-0 @md/mfrow:flex-1 flex flex-col gap-2">
                     <%!-- File name. The full path lives on the title attribute
                           and in the file details modal. Rendered here it left
                           about 90px of column beside the button strip on a
@@ -842,7 +842,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="open_subtitle_manage"
                       phx-value-media-file-id={file.id}
-                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
+                      class="btn btn-ghost btn-square @md/mfrow:btn-sm"
                       aria-label="Manage subtitles"
                       title="Subtitles"
                     >
@@ -858,7 +858,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                         <div
                           tabindex="0"
                           role="button"
-                          class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
+                          class="btn btn-ghost btn-square @md/mfrow:btn-sm"
                           title="Pre-transcode"
                         >
                           <.icon name="hero-wrench" class="w-5 h-5" />
@@ -884,7 +884,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="show_file_details"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
+                      class="btn btn-ghost btn-square @md/mfrow:btn-sm"
                       aria-label="View file details"
                       title="View file details"
                     >
@@ -894,7 +894,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="mark_file_preferred"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
+                      class="btn btn-ghost btn-square @md/mfrow:btn-sm"
                       aria-label="Mark this file as preferred"
                       title="Mark as preferred"
                     >
@@ -909,7 +909,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="not_this_item"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
+                      class="btn btn-ghost btn-square @md/mfrow:btn-sm"
                       aria-label={
                         if @media_item.type == "movie",
                           do: "This file is not this movie",
@@ -928,7 +928,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="show_file_delete_confirm"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square text-error hover:bg-error hover:text-error-content @lg/mfrow:btn-sm"
+                      class="btn btn-ghost btn-square text-error hover:bg-error hover:text-error-content @md/mfrow:btn-sm"
                       aria-label="Delete this file"
                       title="Delete file"
                     >
@@ -940,7 +940,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                     <button
                       id={"demote-#{file.id}"}
                       type="button"
-                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
+                      class="btn btn-ghost btn-square @md/mfrow:btn-sm"
                       aria-label="Move this file to extras"
                       title="This is an extra, not a version"
                       phx-click="demote_to_extra"
@@ -971,9 +971,9 @@ defmodule MydiaWeb.MediaLive.Show.Components do
               <li :for={file <- @extras} id={"extra-#{file.id}"} class="min-w-0 flex-nowrap">
                 <div
                   id={"extra-row-#{file.id}"}
-                  class="min-w-0 items-stretch flex flex-col gap-2 p-4 rounded-none @lg/mfrow:flex-row @lg/mfrow:items-center @lg/mfrow:justify-between @lg/mfrow:gap-4"
+                  class="min-w-0 items-stretch flex flex-col gap-2 p-4 rounded-none @md/mfrow:flex-row @md/mfrow:items-center @md/mfrow:justify-between @md/mfrow:gap-4"
                 >
-                  <div class="min-w-0 @lg/mfrow:flex-1 flex flex-col gap-1">
+                  <div class="min-w-0 @md/mfrow:flex-1 flex flex-col gap-1">
                     <p
                       id={"extra-name-#{file.id}"}
                       class="text-sm font-mono truncate"
@@ -992,7 +992,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                   <button
                     id={"promote-#{file.id}"}
                     type="button"
-                    class="btn btn-ghost self-end @lg/mfrow:self-auto @lg/mfrow:btn-sm"
+                    class="btn btn-ghost self-end @md/mfrow:self-auto @md/mfrow:btn-sm"
                     title="This is a version, not an extra"
                     phx-click="promote_to_version"
                     phx-value-id={file.id}

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -734,7 +734,17 @@ defmodule MydiaWeb.MediaLive.Show.Components do
     ~H"""
     <%= if @files != [] do %>
       <div id="media-files-section" class="card bg-base-200 shadow-lg mb-4 md:mb-6">
-        <div class="card-body p-4 md:p-6">
+        <%!-- The `mfrow` size container. Named, not bare: show.html.heex
+              declares an unnamed `@container` around the whole page grid, and
+              a bare `@lg:` here would query that instead. It measures 744px at
+              a 1024px viewport, where this card is 312px wide.
+
+              PR #616 fixed this card on a phone with `sm:`, which was right
+              about the phone and wrong about everything else: at 1024px the
+              app drawer and the page rail both open, the card drops to 312px,
+              and a 248px button strip left the filename 16px. That rendered
+              two characters of an 84-character name. --%>
+        <div class="@container/mfrow card-body p-4 md:p-6">
           <h2 class="card-title text-lg md:text-xl mb-3 md:mb-4">Media Files</h2>
           <%!-- DaisyUI list component.
 
@@ -771,9 +781,12 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           <ul class="menu w-full flex-nowrap bg-base-100 rounded-box p-0">
             <li :for={file <- @versions} id={"version-#{file.id}"} class="min-w-0 flex-nowrap">
               <div class="min-w-0 items-stretch flex flex-col gap-3 p-4 hover:bg-base-200 rounded-none transition-colors">
-                <div class="min-w-0 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+                <div
+                  id={"version-row-#{file.id}"}
+                  class="min-w-0 flex flex-col gap-3 @lg/mfrow:flex-row @lg/mfrow:items-start @lg/mfrow:justify-between @lg/mfrow:gap-4"
+                >
                   <%!-- Left side: File info --%>
-                  <div class="min-w-0 sm:flex-1 flex flex-col gap-2">
+                  <div class="min-w-0 @lg/mfrow:flex-1 flex flex-col gap-2">
                     <%!-- File name. The full path lives on the title attribute
                           and in the file details modal. Rendered here it left
                           about 90px of column beside the button strip on a
@@ -829,7 +842,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="open_subtitle_manage"
                       phx-value-media-file-id={file.id}
-                      class="btn btn-ghost btn-square sm:btn-sm"
+                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
                       aria-label="Manage subtitles"
                       title="Subtitles"
                     >
@@ -845,7 +858,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                         <div
                           tabindex="0"
                           role="button"
-                          class="btn btn-ghost btn-square sm:btn-sm"
+                          class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
                           title="Pre-transcode"
                         >
                           <.icon name="hero-wrench" class="w-5 h-5" />
@@ -871,7 +884,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="show_file_details"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square sm:btn-sm"
+                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
                       aria-label="View file details"
                       title="View file details"
                     >
@@ -881,7 +894,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="mark_file_preferred"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square sm:btn-sm"
+                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
                       aria-label="Mark this file as preferred"
                       title="Mark as preferred"
                     >
@@ -896,7 +909,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="not_this_item"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square sm:btn-sm"
+                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
                       aria-label={
                         if @media_item.type == "movie",
                           do: "This file is not this movie",
@@ -915,7 +928,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                       type="button"
                       phx-click="show_file_delete_confirm"
                       phx-value-file-id={file.id}
-                      class="btn btn-ghost btn-square sm:btn-sm text-error hover:bg-error hover:text-error-content"
+                      class="btn btn-ghost btn-square text-error hover:bg-error hover:text-error-content @lg/mfrow:btn-sm"
                       aria-label="Delete this file"
                       title="Delete file"
                     >
@@ -927,7 +940,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
                     <button
                       id={"demote-#{file.id}"}
                       type="button"
-                      class="btn btn-ghost btn-square sm:btn-sm"
+                      class="btn btn-ghost btn-square @lg/mfrow:btn-sm"
                       aria-label="Move this file to extras"
                       title="This is an extra, not a version"
                       phx-click="demote_to_extra"

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -535,13 +535,26 @@ defmodule MydiaWeb.MediaLive.Show.Components do
 
   def episode_file_row(assigns) do
     ~H"""
-    <div class="flex items-start justify-between gap-4 py-1">
+    <%!-- Stacked by default, one row once there is room for one. The container
+          is `eprow`, declared on the episode wrapper in
+          SeasonComponents.episode_rows/1, not here: this row's own width is
+          what the query decides, so it cannot be the thing being queried.
+
+          The strip below is `flex-shrink-0` at 136px. Against a 245px row on a
+          375px phone that left the filename 69px, which rendered 8 characters
+          of a 92-character name and wrapped the badge line underneath onto
+          four lines. --%>
+    <div
+      id={"episode-file-row-#{@file.id}"}
+      class="flex flex-col gap-3 py-1 @lg/eprow:flex-row @lg/eprow:items-start @lg/eprow:justify-between @lg/eprow:gap-4"
+    >
       <%!-- File info --%>
-      <div class="flex flex-col gap-1 min-w-0 flex-1">
+      <div class="flex flex-col gap-1 min-w-0 @lg/eprow:flex-1">
         <%!-- Filename row --%>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 min-w-0">
           <.icon name="hero-document" class="w-4 h-4 text-base-content/50 flex-shrink-0" />
           <span
+            id={"episode-file-name-#{@file.id}"}
             class="font-mono text-sm truncate"
             title={Mydia.Library.MediaFile.display_path(@file)}
           >
@@ -549,7 +562,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           </span>
         </div>
         <%!-- Technical details row --%>
-        <div class="flex flex-wrap items-center gap-1.5 pl-6 text-xs">
+        <div class="flex flex-wrap items-center gap-1.5 pl-0 text-xs @lg/eprow:pl-6">
           <span class="badge badge-primary badge-xs">{@file.resolution || "?"}</span>
           <%= if @file.codec do %>
             <span class="text-base-content/60" title={@file.codec}>
@@ -572,13 +585,13 @@ defmodule MydiaWeb.MediaLive.Show.Components do
         />
       </div>
       <%!-- File actions --%>
-      <div class="flex items-center gap-1 flex-shrink-0">
+      <div class="flex items-center justify-end gap-1 flex-shrink-0">
         <button
           id={"subtitle-open-#{@file.id}"}
           type="button"
           phx-click="open_subtitle_manage"
           phx-value-media-file-id={@file.id}
-          class="btn btn-ghost btn-xs btn-square"
+          class="btn btn-ghost btn-square @lg/eprow:btn-xs"
           aria-label="Manage subtitles"
           title="Subtitles"
         >
@@ -594,7 +607,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             <div
               tabindex="0"
               role="button"
-              class="btn btn-ghost btn-xs btn-square"
+              class="btn btn-ghost btn-square @lg/eprow:btn-xs"
               title="Pre-transcode"
             >
               <.icon name="hero-wrench" class="w-4 h-4" />
@@ -621,7 +634,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
             href={
               flutter_player_url("episode", @episode.id, file_id: @file.id, title: @episode.title)
             }
-            class="btn btn-ghost btn-xs btn-square"
+            class="btn btn-ghost btn-square @lg/eprow:btn-xs"
             title="Play this file"
           >
             <.icon name="hero-play-solid" class="w-4 h-4" />
@@ -631,7 +644,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           type="button"
           phx-click="mark_file_preferred"
           phx-value-file-id={@file.id}
-          class="btn btn-ghost btn-xs btn-square"
+          class="btn btn-ghost btn-square @lg/eprow:btn-xs"
           title="Mark as preferred"
         >
           <.icon name="hero-star" class="w-4 h-4" />
@@ -641,7 +654,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           type="button"
           phx-click="show_file_delete_confirm"
           phx-value-file-id={@file.id}
-          class="btn btn-ghost btn-xs btn-square text-error hover:bg-error hover:text-error-content"
+          class="btn btn-ghost btn-square text-error hover:bg-error hover:text-error-content @lg/eprow:btn-xs"
           title="Delete file"
         >
           <.icon name="hero-trash" class="w-4 h-4" />
@@ -650,7 +663,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
     </div>
     <%!-- Transcode job badges --%>
     <%= if @transcode_jobs != [] do %>
-      <div class="flex flex-wrap items-center gap-2 pl-6 mt-1">
+      <div class="flex flex-wrap items-center gap-2 pl-0 mt-1 @lg/eprow:pl-6">
         <.transcode_badge
           :for={job <- @transcode_jobs}
           job={job}

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -140,7 +140,26 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
       status = get_episode_status(episode)
       quality = get_episode_quality_badge(episode) %>
 
-      <div class={["py-2 px-3", has_files && "border-l-2 border-l-success"]}>
+      <%!-- The `eprow` size container. Everything from here down that needs to
+            know how much room it has queries this element rather than the
+            viewport, because two layout switches sit between the window and
+            this column: the app drawer becomes permanent at `lg`
+            (layouts.ex, `drawer lg:drawer-open`, 256px) and this page's own
+            left rail appears at `md` and widens to 20rem at `lg`
+            (show.html.heex). Both take width away at the moment a viewport
+            breakpoint grants it, so this column is 328px wide at a 1024px
+            viewport and 576px wide at 640px. Measured, both.
+
+            It has to be this element and not the detail panel below, because
+            the query changes that panel's margin and a container whose own
+            size depends on the query is not resolvable. --%>
+      <div
+        id={"episode-#{episode.id}-row"}
+        class={[
+          "@container/eprow py-2 px-3",
+          has_files && "border-l-2 border-l-success"
+        ]}
+      >
         <%!-- Mobile keeps two stacked rows. From sm up every wrapper collapses to
               `display: contents`, which dissolves the boxes and promotes the cells
               to items of one grid with fixed tracks. That is what makes quality,
@@ -326,7 +345,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
         </div>
 
         <%= if is_expanded do %>
-          <div id={"episode-#{episode.id}-detail"} class="mt-2 ml-8 space-y-1">
+          <div id={"episode-#{episode.id}-detail"} class="mt-2 ml-2 @lg/eprow:ml-8 space-y-1">
             <%= if has_files do %>
               <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">
                 <Components.episode_file_row

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -154,7 +154,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             the query changes that panel's margin and a container whose own
             size depends on the query is not resolvable.
 
-            The threshold below is `@md` (28rem / 448px), raised from `@lg`
+            The threshold below is `@md` (28rem / 448px), lowered from `@lg`
             (32rem / 512px) originally. A container query measures the
             container's content box, so the `px-3` padding on this element is
             not part of what the threshold compares against -- content-box

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -152,7 +152,19 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
 
             It has to be this element and not the detail panel below, because
             the query changes that panel's margin and a container whose own
-            size depends on the query is not resolvable. --%>
+            size depends on the query is not resolvable.
+
+            The threshold below is `@md` (28rem / 448px), raised from `@lg`
+            (32rem / 512px) originally. A container query measures the
+            container's content box, so the `px-3` padding on this element is
+            not part of what the threshold compares against -- content-box
+            width runs well below the border-box numbers measured above. At
+            `@lg`, this row's content box was only 501px at a 900px viewport,
+            on the wrong side of 512px, so a vertical scrollbar appearing was
+            enough to flip the layout between stacked and one-line.
+            `@md`/448px clears that case by 53px and still leaves 768px 79px
+            clear on the other side; 448 has no significance beyond that
+            margin. --%>
       <div
         id={"episode-#{episode.id}-row"}
         class={[

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -176,11 +176,11 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
           id={"episode-#{episode.id}-grid"}
           class={[
             "flex flex-col gap-1",
-            "@lg/eprow:grid @lg/eprow:items-center @lg/eprow:gap-x-3 @lg/eprow:gap-y-0",
-            "@lg/eprow:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
+            "@md/eprow:grid @md/eprow:items-center @md/eprow:gap-x-3 @md/eprow:gap-y-0",
+            "@md/eprow:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
           ]}
         >
-          <div class="flex items-center gap-1 flex-1 min-w-0 @lg/eprow:contents">
+          <div class="flex items-center gap-1 flex-1 min-w-0 @md/eprow:contents">
             <%!-- Chevron and number share one cell so they stay a single
                   toggle_episode_expanded target. ml-auto right-aligns the number,
                   which keeps two- and three-digit episodes in column: the chunk
@@ -193,7 +193,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                   disclosure is reachable by keyboard. --%>
             <button
               type="button"
-              class="flex items-center gap-1 flex-shrink-0 @lg/eprow:w-full cursor-pointer hover:text-primary"
+              class="flex items-center gap-1 flex-shrink-0 @md/eprow:w-full cursor-pointer hover:text-primary"
               phx-click="toggle_episode_expanded"
               phx-value-episode-id={episode.id}
               aria-expanded={to_string(is_expanded)}
@@ -203,7 +203,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                 name={if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"}
                 class="w-3 h-3 text-base-content/40"
               />
-              <span class="font-mono text-sm font-medium text-base-content/70 tabular-nums @lg/eprow:ml-auto">
+              <span class="font-mono text-sm font-medium text-base-content/70 tabular-nums @md/eprow:ml-auto">
                 {episode.episode_number}
               </span>
             </button>
@@ -224,19 +224,19 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             </button>
           </div>
 
-          <div class="flex items-center justify-between gap-2 @lg/eprow:contents">
-            <div class="flex items-center gap-2 @lg/eprow:contents">
-              <div class="flex items-center @lg/eprow:justify-end">
+          <div class="flex items-center justify-between gap-2 @md/eprow:contents">
+            <div class="flex items-center gap-2 @md/eprow:contents">
+              <div class="flex items-center @md/eprow:justify-end">
                 <span :if={quality} class="badge badge-sm badge-ghost font-mono tabular-nums">
                   {quality}
                 </span>
               </div>
-              <div class="text-xs text-base-content/50 tabular-nums @lg/eprow:text-right">
+              <div class="text-xs text-base-content/50 tabular-nums @md/eprow:text-right">
                 {episode.air_date && format_date(episode.air_date)}
               </div>
             </div>
 
-            <div class="flex items-center gap-2 @lg/eprow:contents">
+            <div class="flex items-center gap-2 @md/eprow:contents">
               <%!-- A 16px dot of colour, at every width. A visible state label
                     repeated down 170 rows is noise, and the row already says it
                     twice: the left border is green when files exist, and the
@@ -247,7 +247,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                     The tooltip wraps the chip from the outside, never a
                     join-item. --%>
               <div
-                class="tooltip tooltip-left @lg/eprow:justify-self-end"
+                class="tooltip tooltip-left @md/eprow:justify-self-end"
                 data-tip={episode_status_tooltip(episode)}
               >
                 <span
@@ -263,7 +263,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                     the container because btn-ghost has no border of its own and
                     the first item varies: the play slot is absent whenever
                     playback is off. --%>
-              <div class="flex-shrink-0 @lg/eprow:justify-self-end @lg/eprow:border-l @lg/eprow:border-base-300 @lg/eprow:pl-3">
+              <div class="flex-shrink-0 @md/eprow:justify-self-end @md/eprow:border-l @md/eprow:border-base-300 @md/eprow:pl-3">
                 <div
                   id={"episode-#{episode.id}-actions"}
                   class="join border border-base-300 rounded-lg [&>*:not(:first-child)]:border-l [&>*:not(:first-child)]:border-base-300"
@@ -355,7 +355,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
         </div>
 
         <%= if is_expanded do %>
-          <div id={"episode-#{episode.id}-detail"} class="mt-2 ml-2 @lg/eprow:ml-8 space-y-1">
+          <div id={"episode-#{episode.id}-detail"} class="mt-2 ml-2 @md/eprow:ml-8 space-y-1">
             <%= if has_files do %>
               <div :for={file <- episode.media_files} class="bg-base-200/50 rounded p-2">
                 <Components.episode_file_row

--- a/lib/mydia_web/live/media_live/show/season_components.ex
+++ b/lib/mydia_web/live/media_live/show/season_components.ex
@@ -160,17 +160,27 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
           has_files && "border-l-2 border-l-success"
         ]}
       >
-        <%!-- Mobile keeps two stacked rows. From sm up every wrapper collapses to
-              `display: contents`, which dissolves the boxes and promotes the cells
-              to items of one grid with fixed tracks. That is what makes quality,
-              air date and status form columns down the whole season instead of
-              drifting with each row's content. --%>
-        <div class={[
-          "flex flex-col gap-1",
-          "sm:grid sm:items-center sm:gap-x-3 sm:gap-y-0",
-          "sm:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
-        ]}>
-          <div class="flex items-center gap-1 flex-1 min-w-0 sm:contents">
+        <%!-- Mobile keeps two stacked rows. Once the `eprow` container is wide
+              enough every wrapper collapses to `display: contents`, which
+              dissolves the boxes and promotes the cells to items of one grid
+              with fixed tracks. That is what makes quality, air date and
+              status form columns down the whole season instead of drifting
+              with each row's content.
+
+              The container, not a viewport breakpoint: these tracks need about
+              500px, and at a 1024px viewport this column is 328px wide because
+              the app drawer and the page rail both open at `lg`. The old
+              breakpoint sent the toolbar 50px past the right edge of the
+              window. --%>
+        <div
+          id={"episode-#{episode.id}-grid"}
+          class={[
+            "flex flex-col gap-1",
+            "@lg/eprow:grid @lg/eprow:items-center @lg/eprow:gap-x-3 @lg/eprow:gap-y-0",
+            "@lg/eprow:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
+          ]}
+        >
+          <div class="flex items-center gap-1 flex-1 min-w-0 @lg/eprow:contents">
             <%!-- Chevron and number share one cell so they stay a single
                   toggle_episode_expanded target. ml-auto right-aligns the number,
                   which keeps two- and three-digit episodes in column: the chunk
@@ -183,7 +193,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                   disclosure is reachable by keyboard. --%>
             <button
               type="button"
-              class="flex items-center gap-1 flex-shrink-0 sm:w-full cursor-pointer hover:text-primary"
+              class="flex items-center gap-1 flex-shrink-0 @lg/eprow:w-full cursor-pointer hover:text-primary"
               phx-click="toggle_episode_expanded"
               phx-value-episode-id={episode.id}
               aria-expanded={to_string(is_expanded)}
@@ -193,7 +203,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                 name={if is_expanded, do: "hero-chevron-down", else: "hero-chevron-right"}
                 class="w-3 h-3 text-base-content/40"
               />
-              <span class="font-mono text-sm font-medium text-base-content/70 tabular-nums sm:ml-auto">
+              <span class="font-mono text-sm font-medium text-base-content/70 tabular-nums @lg/eprow:ml-auto">
                 {episode.episode_number}
               </span>
             </button>
@@ -214,19 +224,19 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
             </button>
           </div>
 
-          <div class="flex items-center justify-between gap-2 sm:contents">
-            <div class="flex items-center gap-2 sm:contents">
-              <div class="flex items-center sm:justify-end">
+          <div class="flex items-center justify-between gap-2 @lg/eprow:contents">
+            <div class="flex items-center gap-2 @lg/eprow:contents">
+              <div class="flex items-center @lg/eprow:justify-end">
                 <span :if={quality} class="badge badge-sm badge-ghost font-mono tabular-nums">
                   {quality}
                 </span>
               </div>
-              <div class="text-xs text-base-content/50 tabular-nums sm:text-right">
+              <div class="text-xs text-base-content/50 tabular-nums @lg/eprow:text-right">
                 {episode.air_date && format_date(episode.air_date)}
               </div>
             </div>
 
-            <div class="flex items-center gap-2 sm:contents">
+            <div class="flex items-center gap-2 @lg/eprow:contents">
               <%!-- A 16px dot of colour, at every width. A visible state label
                     repeated down 170 rows is noise, and the row already says it
                     twice: the left border is green when files exist, and the
@@ -237,7 +247,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                     The tooltip wraps the chip from the outside, never a
                     join-item. --%>
               <div
-                class="tooltip tooltip-left sm:justify-self-end"
+                class="tooltip tooltip-left @lg/eprow:justify-self-end"
                 data-tip={episode_status_tooltip(episode)}
               >
                 <span
@@ -253,7 +263,7 @@ defmodule MydiaWeb.MediaLive.Show.SeasonComponents do
                     the container because btn-ghost has no border of its own and
                     the first item varies: the play slot is absent whenever
                     playback is off. --%>
-              <div class="flex-shrink-0 sm:justify-self-end sm:border-l sm:border-base-300 sm:pl-3">
+              <div class="flex-shrink-0 @lg/eprow:justify-self-end @lg/eprow:border-l @lg/eprow:border-base-300 @lg/eprow:pl-3">
                 <div
                   id={"episode-#{episode.id}-actions"}
                   class="join border border-base-300 rounded-lg [&>*:not(:first-child)]:border-l [&>*:not(:first-child)]:border-base-300"

--- a/test/mydia_web/features/media_file_row_width_test.exs
+++ b/test/mydia_web/features/media_file_row_width_test.exs
@@ -1,0 +1,167 @@
+defmodule MydiaWeb.Features.MediaFileRowWidthTest do
+  @moduledoc """
+  Both media file surfaces keep a readable filename column at every width.
+
+  The numbers this guards, all measured on the running app before the fix:
+
+  | viewport | episode filename | movie filename |
+  | -------- | ---------------- | -------------- |
+  | 375      | 69px  (8 chars)  | 287px, correct |
+  | 768      | 158px (19 chars) | 96px           |
+  | 1024     | 78px  (9 chars)  | 16px (2 chars) |
+  | 1440     | 494px            | 432px          |
+
+  1024px is the worst case on both, not the phone: the app drawer becomes
+  permanent and the page rail widens to 20rem while the window grows by 124px,
+  so the content column collapses from 584px to 312px. A `sm:` variant calls
+  that wide. See
+  docs/superpowers/specs/2026-09-02-media-file-rows-narrow-columns-design.md.
+  """
+  use MydiaWeb.FeatureCase, async: false
+
+  @moduletag :feature
+
+  # 92 characters, matching the release names this actually breaks on.
+  @episode_file "/media/series/Ashvale Hollow/Season 01/" <>
+                  "Ashvale.Hollow.S01E01.The.Salt.Lantern.2160p.WEB-DL.DDP5.1.Atmos.HDR.H.265-GROUP.mkv"
+
+  @show_file "/media/series/Ashvale Hollow/" <>
+               "Ashvale.Hollow.S01.COMPLETE.2160p.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-GROUP.mkv"
+
+  # Anything under this and the label is decorative rather than readable: it is
+  # roughly 25 characters of the text-sm monospace this row uses.
+  @readable_px 200
+
+  defp width_of(session, selector) do
+    eval_js(
+      session,
+      """
+      var el = document.querySelector(arguments[0]);
+      if (!el) return -1;
+      return Math.round(el.getBoundingClientRect().width);
+      """,
+      [selector]
+    )
+  end
+
+  defp doc_overflows?(session) do
+    eval_js(session, """
+    return document.documentElement.scrollWidth >
+           document.documentElement.clientWidth + 1;
+    """)
+  end
+
+  setup do
+    show = insert(:tv_show, title: "Ashvale Hollow")
+    episode = insert(:episode, media_item: show, season_number: 1, episode_number: 1)
+
+    insert(:media_file,
+      episode: episode,
+      path: @episode_file,
+      resolution: "2160p",
+      codec: "h265"
+    )
+
+    # episode: nil makes this a show-level file, which is what
+    # media_files_section/1 renders. It is the same component the movie page
+    # uses, so it exercises the mfrow container without needing a movie.
+    show_file =
+      insert(:media_file,
+        episode: nil,
+        media_item: show,
+        path: @show_file,
+        resolution: "2160p",
+        codec: "h265"
+      )
+
+    %{show: show, episode: episode, show_file: show_file}
+  end
+
+  describe "the episode file row" do
+    @tag :feature
+    test "keeps a readable filename at every width", ctx do
+      %{session: session, show: show, episode: episode} = ctx
+
+      login_as_admin(session)
+
+      for {w, h} <- [
+            {375, 812},
+            {414, 896},
+            {640, 960},
+            {768, 1024},
+            {900, 900},
+            {1024, 768},
+            {1280, 800},
+            {1440, 900}
+          ] do
+        session
+        |> resize_window(w, h)
+        |> visit("/media/#{show.id}")
+        |> wait_for_liveview()
+
+        js_click(session, ~s([aria-controls="episode-#{episode.id}-detail"]))
+
+        assert Wallaby.Browser.has_css?(session, "#episode-#{episode.id}-detail")
+
+        width = width_of(session, "[id^='episode-file-name-']")
+
+        assert width >= @readable_px,
+               "at #{w}px the episode filename column was #{width}px, " <>
+                 "which is below the #{@readable_px}px readable floor"
+      end
+    end
+  end
+
+  describe "the Media Files card" do
+    @tag :feature
+    test "keeps a readable filename at every width", ctx do
+      %{session: session, show: show, show_file: show_file} = ctx
+
+      login_as_admin(session)
+
+      for {w, h} <- [
+            {375, 812},
+            {414, 896},
+            {640, 960},
+            {768, 1024},
+            {900, 900},
+            {1024, 768},
+            {1280, 800},
+            {1440, 900}
+          ] do
+        session
+        |> resize_window(w, h)
+        |> visit("/media/#{show.id}")
+        |> wait_for_liveview()
+
+        assert Wallaby.Browser.has_css?(session, "#version-#{show_file.id}")
+
+        width = width_of(session, "#file-name-#{show_file.id}")
+
+        assert width >= @readable_px,
+               "at #{w}px the Media Files filename column was #{width}px, " <>
+                 "which is below the #{@readable_px}px readable floor"
+      end
+    end
+  end
+
+  describe "the episode row toolbar" do
+    @tag :feature
+    test "does not push the document sideways at 1024px", ctx do
+      %{session: session, show: show} = ctx
+
+      login_as_admin(session)
+
+      session
+      |> resize_window(1024, 768)
+      |> visit("/media/#{show.id}")
+      |> wait_for_liveview()
+
+      assert Wallaby.Browser.has_css?(session, "[id^='episode-'][id$='-row']")
+
+      refute doc_overflows?(session),
+             "the episode row toolbar overflowed the viewport, which is the " <>
+               "50px of horizontal scroll this fix removed"
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/episode_file_row_layout_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_file_row_layout_test.exs
@@ -77,7 +77,7 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeFileRowLayoutTest do
     class
   end
 
-  # Matches the bare utility only, so "@lg/eprow:btn-xs" does not count as
+  # Matches the bare utility only, so "@md/eprow:btn-xs" does not count as
   # "btn-xs". Without this every assertion below passes on the broken markup.
   defp has_bare?(class, utility) do
     Regex.match?(~r/(^|\s)#{Regex.escape(utility)}(\s|$)/, class)
@@ -96,8 +96,8 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeFileRowLayoutTest do
       class = class_of(render_expanded(), "#episode-file-row-file-1")
 
       assert class =~ "flex-col"
-      assert class =~ "@lg/eprow:flex-row"
-      assert class =~ "@lg/eprow:justify-between"
+      assert class =~ "@md/eprow:flex-row"
+      assert class =~ "@md/eprow:justify-between"
     end
 
     test "carries no viewport breakpoint, which is the whole point" do
@@ -112,7 +112,7 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeFileRowLayoutTest do
     test "gives the action buttons a full-size tap target until the column is wide" do
       class = class_of(render_expanded(), "#subtitle-open-file-1")
 
-      assert class =~ "@lg/eprow:btn-xs"
+      assert class =~ "@md/eprow:btn-xs"
 
       refute has_bare?(class, "btn-xs"),
              "btn-xs unconditionally is a 24px target on a phone"
@@ -122,7 +122,7 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeFileRowLayoutTest do
       class = class_of(render_expanded(), "#episode-ep-1-detail")
 
       assert class =~ "ml-2"
-      assert class =~ "@lg/eprow:ml-8"
+      assert class =~ "@md/eprow:ml-8"
 
       refute has_bare?(class, "ml-8"),
              "a 32px indent is 8.5% of a 375px screen"

--- a/test/mydia_web/live/media_live/show/episode_file_row_layout_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_file_row_layout_test.exs
@@ -1,0 +1,140 @@
+defmodule MydiaWeb.MediaLive.Show.EpisodeFileRowLayoutTest do
+  @moduledoc """
+  The episode file row stacks its action strip whenever the column it sits in
+  is narrow, driven by a container query rather than a viewport breakpoint.
+
+  Measured before this landed: at a 375px viewport the filename column was
+  69px and showed 8 characters of a 92-character basename. At 1024px it was
+  78px and showed 9, because the app drawer becomes permanent and the page
+  rail widens to 20rem while the window grows by only 124px. `sm:` calls both
+  of those wide, which is why the breakpoint had to go.
+
+  These assertions are class-level and cheap. The widths themselves live in
+  test/mydia_web/features/media_file_row_width_test.exs, which needs a real
+  browser. See docs/superpowers/specs/2026-09-02-media-file-rows-narrow-columns-design.md.
+  """
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media.Episode
+  alias MydiaWeb.MediaLive.Show.SeasonComponents
+
+  # library_path: nil rather than an unloaded association, matching
+  # episode_row_test.exs: MediaFile.absolute_path/1 logs a warning per file per
+  # render for the unloaded case, which would bury the real output.
+  defp media_file(attrs \\ []) do
+    struct!(
+      %MediaFile{
+        id: "file-1",
+        resolution: "1080p",
+        codec: "h265",
+        audio_codec: "eac3",
+        size: 9_876_543_210,
+        library_path: nil,
+        relative_path:
+          "Ashvale.Hollow.S01E01.The.Salt.Lantern.2160p.WEB-DL.DDP5.1.Atmos.HDR.H.265-GROUP.mkv"
+      },
+      attrs
+    )
+  end
+
+  defp episode(attrs \\ []) do
+    struct!(
+      %Episode{
+        id: "ep-1",
+        season_number: 1,
+        episode_number: 1,
+        title: "The Salt Lantern",
+        monitored: true,
+        air_date: ~D[2024-01-01],
+        media_files: [],
+        downloads: []
+      },
+      attrs
+    )
+  end
+
+  defp render_expanded do
+    render_component(&SeasonComponents.season_section/1,
+      season_number: 1,
+      episodes: [episode(media_files: [media_file()])],
+      expanded?: true,
+      expanded_episodes: MapSet.new(["ep-1"]),
+      playback_enabled: true,
+      segment_detection_available: false
+    )
+  end
+
+  defp class_of(html, selector) do
+    [class] =
+      html
+      |> LazyHTML.from_fragment()
+      |> LazyHTML.query(selector)
+      |> LazyHTML.attribute("class")
+
+    class
+  end
+
+  # Matches the bare utility only, so "@lg/eprow:btn-xs" does not count as
+  # "btn-xs". Without this every assertion below passes on the broken markup.
+  defp has_bare?(class, utility) do
+    Regex.match?(~r/(^|\s)#{Regex.escape(utility)}(\s|$)/, class)
+  end
+
+  describe "the eprow container" do
+    test "is declared on the episode wrapper, which the query cannot resize" do
+      class = class_of(render_expanded(), "#episode-ep-1-row")
+
+      assert class =~ "@container/eprow"
+    end
+  end
+
+  describe "the file row" do
+    test "stacks by default and becomes a row only above the container threshold" do
+      class = class_of(render_expanded(), "#episode-file-row-file-1")
+
+      assert class =~ "flex-col"
+      assert class =~ "@lg/eprow:flex-row"
+      assert class =~ "@lg/eprow:justify-between"
+    end
+
+    test "carries no viewport breakpoint, which is the whole point" do
+      html = render_expanded()
+
+      for selector <- ~w(#episode-file-row-file-1 #episode-ep-1-detail) do
+        refute class_of(html, selector) =~ "sm:",
+               "#{selector} still switches on the viewport, not on its column"
+      end
+    end
+
+    test "gives the action buttons a full-size tap target until the column is wide" do
+      class = class_of(render_expanded(), "#subtitle-open-file-1")
+
+      assert class =~ "@lg/eprow:btn-xs"
+
+      refute has_bare?(class, "btn-xs"),
+             "btn-xs unconditionally is a 24px target on a phone"
+    end
+
+    test "reclaims the detail indent below the threshold and restores it above" do
+      class = class_of(render_expanded(), "#episode-ep-1-detail")
+
+      assert class =~ "ml-2"
+      assert class =~ "@lg/eprow:ml-8"
+
+      refute has_bare?(class, "ml-8"),
+             "a 32px indent is 8.5% of a 375px screen"
+    end
+
+    test "labels the filename with a queryable id so widths can be asserted" do
+      html = render_expanded()
+
+      assert html
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query("#episode-file-name-file-1")
+             |> Enum.any?()
+    end
+  end
+end

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -146,6 +146,31 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
       # count passes on the header alone even if this toolbar were removed.
       assert html |> query("#episode-ep-1-actions > .join-item") |> Enum.count() == 4
     end
+
+    test "the row grid is driven by the eprow container, not the viewport" do
+      html = render_season([episode(media_files: [media_file()])])
+
+      [class] =
+        html |> query("#episode-ep-1-grid") |> LazyHTML.attribute("class")
+
+      assert class =~ "@lg/eprow:grid"
+      assert class =~ "@lg/eprow:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
+
+      refute class =~ "sm:",
+             "at 1024px the drawer and rail leave this column 328px wide, " <>
+               "and sm: calls that wide"
+    end
+
+    test "no part of the episode row switches on the viewport" do
+      # The twelve sm: utilities in season_components.ex are one mechanism:
+      # sm:contents dissolves the wrapper boxes so the cells become grid items.
+      # Half-migrating them produces a layout that is worse than either end
+      # state, so assert the file has none left rather than spot-checking.
+      source = File.read!("lib/mydia_web/live/media_live/show/season_components.ex")
+
+      refute source =~ "sm:",
+             "season_components.ex still contains a viewport breakpoint"
+    end
   end
 
   describe "season header actions" do

--- a/test/mydia_web/live/media_live/show/episode_row_test.exs
+++ b/test/mydia_web/live/media_live/show/episode_row_test.exs
@@ -153,8 +153,8 @@ defmodule MydiaWeb.MediaLive.Show.EpisodeRowTest do
       [class] =
         html |> query("#episode-ep-1-grid") |> LazyHTML.attribute("class")
 
-      assert class =~ "@lg/eprow:grid"
-      assert class =~ "@lg/eprow:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
+      assert class =~ "@md/eprow:grid"
+      assert class =~ "@md/eprow:grid-cols-[2.75rem_minmax(0,1fr)_3.5rem_5.5rem_1.5rem_auto]"
 
       refute class =~ "sm:",
              "at 1024px the drawer and rail leave this column 328px wide, " <>

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -242,7 +242,7 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
     end
   end
 
-  # Matches the bare utility only, so "@lg/mfrow:btn-sm" does not count as
+  # Matches the bare utility only, so "@md/mfrow:btn-sm" does not count as
   # "btn-sm". Without this the refutes below pass on the broken markup.
   defp has_bare?(class, utility) do
     Regex.match?(~r/(^|\s)#{Regex.escape(utility)}(\s|$)/, class)
@@ -278,7 +278,7 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
       class = class_of(html, "#version-row-file-1")
 
       assert class =~ "flex-col"
-      assert class =~ "@lg/mfrow:flex-row"
+      assert class =~ "@md/mfrow:flex-row"
 
       refute class =~ "sm:",
              "at 1024px this column is 312px wide and sm: calls it wide"
@@ -287,7 +287,7 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
     test "action buttons stay full-size until the column is wide", %{html: html} do
       class = class_of(html, "#file-delete-file-1")
 
-      assert class =~ "@lg/mfrow:btn-sm"
+      assert class =~ "@md/mfrow:btn-sm"
       refute has_bare?(class, "btn-sm")
     end
 
@@ -309,11 +309,11 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
       html = section_html(media_item)
 
       row_class = class_of(html, "#extra-row-extra-1")
-      assert row_class =~ "@lg/mfrow:flex-row"
+      assert row_class =~ "@md/mfrow:flex-row"
       refute row_class =~ "sm:"
 
       button_class = class_of(html, "#promote-extra-1")
-      assert button_class =~ "@lg/mfrow:btn-sm"
+      assert button_class =~ "@md/mfrow:btn-sm"
       refute has_bare?(button_class, "btn-sm")
     end
   end

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -290,6 +290,32 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
       assert class =~ "@lg/mfrow:btn-sm"
       refute has_bare?(class, "btn-sm")
     end
+
+    test "the extras row switches on the same container as the versions row" do
+      media_item = %Mydia.Media.MediaItem{
+        id: "item-1",
+        type: "movie",
+        title: "Ashvale Hollow",
+        episodes: [],
+        media_files: [
+          %{
+            file("extra-1", "Ashvale.Hollow.2024.Behind.The.Lantern.Featurette.1080p.mkv")
+            | extra_kind: "featurette",
+              extra_source: "filename"
+          }
+        ]
+      }
+
+      html = section_html(media_item)
+
+      row_class = class_of(html, "#extra-row-extra-1")
+      assert row_class =~ "@lg/mfrow:flex-row"
+      refute row_class =~ "sm:"
+
+      button_class = class_of(html, "#promote-extra-1")
+      assert button_class =~ "@lg/mfrow:btn-sm"
+      refute has_bare?(button_class, "btn-sm")
+    end
   end
 
   describe "refresh_all_file_metadata/2" do

--- a/test/mydia_web/live/media_live/show/media_files_section_test.exs
+++ b/test/mydia_web/live/media_live/show/media_files_section_test.exs
@@ -242,6 +242,56 @@ defmodule MydiaWeb.MediaLive.Show.MediaFilesSectionTest do
     end
   end
 
+  # Matches the bare utility only, so "@lg/mfrow:btn-sm" does not count as
+  # "btn-sm". Without this the refutes below pass on the broken markup.
+  defp has_bare?(class, utility) do
+    Regex.match?(~r/(^|\s)#{Regex.escape(utility)}(\s|$)/, class)
+  end
+
+  defp class_of(html, selector) do
+    [class] =
+      html |> LazyHTML.from_fragment() |> LazyHTML.query(selector) |> LazyHTML.attribute("class")
+
+    class
+  end
+
+  describe "narrow-column layout" do
+    setup do
+      media_item = %Mydia.Media.MediaItem{
+        id: "item-1",
+        type: "movie",
+        title: "Ashvale Hollow",
+        episodes: [],
+        media_files: [
+          file("file-1", "Ashvale.Hollow.2024.2160p.WEB-DL.DDP5.1.Atmos.DV.HDR.H.265-GROUP.mkv")
+        ]
+      }
+
+      %{html: section_html(media_item)}
+    end
+
+    test "the card body declares the mfrow container", %{html: html} do
+      assert class_of(html, "#media-files-section .card-body") =~ "@container/mfrow"
+    end
+
+    test "the version row switches on the container, not the viewport", %{html: html} do
+      class = class_of(html, "#version-row-file-1")
+
+      assert class =~ "flex-col"
+      assert class =~ "@lg/mfrow:flex-row"
+
+      refute class =~ "sm:",
+             "at 1024px this column is 312px wide and sm: calls it wide"
+    end
+
+    test "action buttons stay full-size until the column is wide", %{html: html} do
+      class = class_of(html, "#file-delete-file-1")
+
+      assert class =~ "@lg/mfrow:btn-sm"
+      refute has_bare?(class, "btn-sm")
+    end
+  end
+
   describe "refresh_all_file_metadata/2" do
     test "reports nothing to refresh when a TV show really has no files" do
       show = media_item_fixture(%{type: "tv_show"})


### PR DESCRIPTION
The Media Files card was fixed for phones in #616 by stacking its action strip below `sm:`. This does the same for the TV episode file row, and in the process replaces the `sm:` breakpoint on both surfaces, because measuring the page showed `sm:` is the wrong signal here.

## Why `sm:` was wrong

Two layout switches sit between the browser window and these columns: the app drawer becomes permanent at `lg` (256px), and the show page's own left rail appears at `md` and widens to 20rem at `lg`. Both take width away at the moment a viewport breakpoint grants it, so a wide window does not mean a wide column. The episode column is 537px at a 640px viewport and 274px at 1024px.

Filename column widths measured on the running app, with a 92-character episode basename and an 84-character show-level one:

| viewport | episode | movie |
| --- | --- | --- |
| 375 | 69px (8 chars) | 287px |
| 640 | 326px | 280px |
| 768 | 158px (19 chars) | 96px (11 chars) |
| 1024 | 78px (9 chars) | **16px (2 chars)** |
| 1440 | 494px | 432px |

1024px is the worst case on both, not the phone. The Media Files card, already "fixed", rendered two characters of an 84-character filename on a 1024px laptop.

Separately, the collapsed episode row's toolbar rendered 50px past the right edge of a 1024px viewport, scrolling the document sideways with every episode closed.

## What changed

Two named Tailwind container queries replace `sm:`: `eprow` on the per-episode wrapper, `mfrow` on the Media Files card body. Each row now responds to the width of the column it is in.

The container is named rather than bare because `show.html.heex` already declares an unnamed `@container` around the whole page grid; a bare `@lg:` would silently query that instead, and it measures 744px where these columns measure under 300px.

Below the threshold the row stacks, the action strip takes its own line, and its buttons grow from 24px to 40px. Above it, everything renders as it does today.

The threshold is `@md` (28rem / 448px), against the container's **content box**. That distinction is the subtle part and is now recorded in a comment at both declarations: an earlier `@lg` (512px) left the 900px case clearing by 3px, where a vertical scrollbar appearing was enough to flip the layout.

## Result

| viewport | episode | movie | stacked |
| --- | --- | --- | --- |
| 375 | 245px | 287px | yes |
| 414 | 284px | 326px | yes |
| 640 | 311px | 265px | no |
| 768 | 319px | 345px | yes |
| 900 | 275px | 213px | no |
| 1024 | 224px | 250px | yes |
| 1280 | 304px | 242px | no |
| 1440 | 464px | 402px | no |

Behaviour at 640, 900, 1280 and 1440 is unchanged. Horizontal document scroll at 1024px is gone.

## Testing

- `test/mydia_web/features/media_file_row_width_test.exs` measures rendered widths in a real browser across all eight viewports and asserts a 200px readable floor, plus a document-overflow check at 1024px. Each assertion was proved able to fail by reinstating `sm:`, since a geometry probe whose selector misses passes silently.
- Class-level assertions in the three LiveView test files use a regex helper so that `@md/eprow:btn-xs` does not satisfy a check for a bare `btn-xs`.
- `mix precommit`: 10,599 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media file and episode row layouts in narrow columns, including when side panels reduce available space.
  * Prevented long filenames and row actions from causing horizontal page overflow.
  * Preserved readable filename widths across common screen sizes.
  * Improved responsive behavior for episode details, status information, extras, versions, and action buttons.

* **Tests**
  * Added coverage for responsive layouts, readable filenames, tap targets, and overflow prevention across multiple viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->