### PR TITLE
fix(discover): refill the grid to a full page when hiding owned titles

### DIFF
--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -43,9 +43,11 @@ defmodule MydiaWeb.DiscoverLive.Index do
     {"primary_release_date.asc", "Oldest First"}
   ]
 
-  # The provider returns fixed-size pages. Removing owned titles from one can
-  # empty it entirely, which would look like the end of the results. Fetch the
-  # next page when that happens, bounded so a fully-owned category cannot spin.
+  # The provider returns fixed-size pages of this many results. Removing owned
+  # titles from one leaves a short grid, or an empty one, which looks like the
+  # end of the results. Keep fetching until the grid holds a page worth of
+  # unowned titles, bounded so a fully-owned category cannot spin.
+  @page_size 20
   @max_auto_advance 3
 
   @unsupported_media_type "That media type is not supported."
@@ -214,7 +216,8 @@ defmodule MydiaWeb.DiscoverLive.Index do
   def handle_event("load_more", _, socket) do
     if socket.assigns.has_more and not socket.assigns.loading_more do
       next_page = socket.assigns.page + 1
-      send(self(), {:load_page, next_page, 0})
+      target = length(socket.assigns.visible_items) + @page_size
+      send(self(), {:load_page, next_page, 0, target})
       {:noreply, assign(socket, :loading_more, true)}
     else
       {:noreply, socket}
@@ -337,7 +340,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
          socket
          |> assign(:hide_owned, value)
          |> assign_visible_items()
-         |> maybe_auto_advance(0)}
+         |> maybe_auto_advance(0, @page_size)}
 
       :error ->
         {:noreply, put_flash(socket, :error, "Could not save that filter preference")}
@@ -401,12 +404,12 @@ defmodule MydiaWeb.DiscoverLive.Index do
     socket =
       socket
       |> handle_load_result(result, :replace)
-      |> maybe_auto_advance(0)
+      |> maybe_auto_advance(0, @page_size)
 
     {:noreply, socket}
   end
 
-  def handle_info({:load_page, page, advances}, socket) do
+  def handle_info({:load_page, page, advances, target}, socket) do
     %{
       media_type: media_type,
       search_mode: search_mode,
@@ -432,7 +435,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
       socket
       |> handle_load_result(result, :append)
       |> assign(:loading_more, false)
-      |> maybe_auto_advance(advances)
+      |> maybe_auto_advance(advances, target)
 
     {:noreply, socket}
   end
@@ -788,7 +791,11 @@ defmodule MydiaWeb.DiscoverLive.Index do
     assign(socket, :visible_items, visible)
   end
 
-  defp maybe_auto_advance(socket, advances) do
+  # `target` is how many unowned titles the grid should end up holding. A fresh
+  # load asks for a full page; "Load more" asks for a full page on top of what
+  # is already on screen, so a click always buys roughly a page of new titles
+  # however many of them turn out to be owned.
+  defp maybe_auto_advance(socket, advances, target) do
     cond do
       not socket.assigns.hide_owned ->
         socket
@@ -796,14 +803,14 @@ defmodule MydiaWeb.DiscoverLive.Index do
       advances >= @max_auto_advance ->
         socket
 
-      socket.assigns.visible_items != [] ->
+      length(socket.assigns.visible_items) >= target ->
         socket
 
       not socket.assigns.has_more ->
         socket
 
       true ->
-        send(self(), {:load_page, socket.assigns.page + 1, advances + 1})
+        send(self(), {:load_page, socket.assigns.page + 1, advances + 1, target})
         assign(socket, :loading_more, true)
     end
   end

--- a/test/mydia_web/live/discover_live/hide_owned_test.exs
+++ b/test/mydia_web/live/discover_live/hide_owned_test.exs
@@ -233,15 +233,75 @@ defmodule MydiaWeb.DiscoverLive.HideOwnedTest do
 
       {:noreply, socket} = Index.handle_info(:load_data, socket)
 
-      assert_received {:load_page, 2, 1}
+      assert_received {:load_page, 2, 1, 20}
       assert socket.assigns.visible_items == []
       assert socket.assigns.loading_more == true
 
-      {:noreply, socket} = Index.handle_info({:load_page, 2, 1}, socket)
+      {:noreply, socket} = Index.handle_info({:load_page, 2, 1, 20}, socket)
 
-      refute_received {:load_page, _page, _advances}
+      refute_received {:load_page, _page, _advances, _target}
       assert [%{title: "Paper Comet"}] = socket.assigns.visible_items
       assert socket.assigns.loading_more == false
+    end
+
+    test "keeps fetching while a partly-owned page leaves the grid short" do
+      owned_a = unique_provider_id()
+      owned_b = unique_provider_id()
+      survivor = unique_provider_id()
+      next_page_id = unique_provider_id()
+
+      seed_curated_page(1, 2, [
+        curated_result(owned_a, "Marooned Aurora"),
+        curated_result(owned_b, "Tin Meridian"),
+        curated_result(survivor, "Paper Comet")
+      ])
+
+      seed_curated_page(2, 2, [curated_result(next_page_id, "Velvet Static")])
+
+      library_status_map = %{
+        owned_a => %{in_library: true, monitored: true, type: "movie", id: "a"},
+        owned_b => %{in_library: true, monitored: true, type: "movie", id: "b"}
+      }
+
+      socket = curated_socket(%{library_status_map: library_status_map})
+
+      {:noreply, socket} = Index.handle_info(:load_data, socket)
+
+      # One survivor out of three is not a full grid, so the page that is
+      # partly owned must advance just like a fully-owned one.
+      assert [%{title: "Paper Comet"}] = socket.assigns.visible_items
+      assert_received {:load_page, 2, 1, 20}
+      assert socket.assigns.loading_more == true
+
+      {:noreply, socket} = Index.handle_info({:load_page, 2, 1, 20}, socket)
+
+      # Page 2 was the last one, so the chain stops without reaching the target.
+      refute_received {:load_page, _page, _advances, _target}
+      assert [%{title: "Paper Comet"}, %{title: "Velvet Static"}] = socket.assigns.visible_items
+      assert socket.assigns.loading_more == false
+    end
+
+    test "load_more aims for a full page of new titles on top of what is shown" do
+      owned_id = unique_provider_id()
+      shown = for n <- 1..5, do: curated_result(unique_provider_id(), "Shown #{n}")
+
+      seed_curated_page(2, 9, [curated_result(owned_id, "Marooned Aurora")])
+
+      library_status_map = %{
+        owned_id => %{in_library: true, monitored: true, type: "movie", id: "owned"}
+      }
+
+      socket =
+        curated_socket(%{
+          library_status_map: library_status_map,
+          items: shown,
+          visible_items: shown
+        })
+
+      {:noreply, _socket} = Index.handle_event("load_more", %{}, socket)
+
+      # Five already on screen, so the click is asking for twenty-five.
+      assert_received {:load_page, 2, 0, 25}
     end
 
     test "gives up after three fetches so a fully-owned category cannot spin forever" do
@@ -258,16 +318,16 @@ defmodule MydiaWeb.DiscoverLive.HideOwnedTest do
       socket = curated_socket(%{library_status_map: library_status_map})
 
       {:noreply, socket} = Index.handle_info(:load_data, socket)
-      assert_received {:load_page, 2, 1}
+      assert_received {:load_page, 2, 1, 20}
 
-      {:noreply, socket} = Index.handle_info({:load_page, 2, 1}, socket)
-      assert_received {:load_page, 3, 2}
+      {:noreply, socket} = Index.handle_info({:load_page, 2, 1, 20}, socket)
+      assert_received {:load_page, 3, 2, 20}
 
-      {:noreply, socket} = Index.handle_info({:load_page, 3, 2}, socket)
-      assert_received {:load_page, 4, 3}
+      {:noreply, socket} = Index.handle_info({:load_page, 3, 2, 20}, socket)
+      assert_received {:load_page, 4, 3, 20}
 
-      {:noreply, socket} = Index.handle_info({:load_page, 4, 3}, socket)
-      refute_received {:load_page, _page, _advances}
+      {:noreply, socket} = Index.handle_info({:load_page, 4, 3, 20}, socket)
+      refute_received {:load_page, _page, _advances, _target}
 
       # Still owned, still more pages available: the bound stopped it, not the
       # data running out.


### PR DESCRIPTION
## The bug

With **Hide in library** on, Discover opens showing only the handful of titles that survived the filter — four or five instead of twenty — and a refresh or a fresh browser session shows the same short grid.

## Why

`maybe_auto_advance/2` already backfilled, but its guard was `visible_items != [] -> socket`. It fetched the next page only when filtering emptied the page *outright*. A page keeping four of its twenty titles satisfies that guard, so the chain stopped on page 1.

Reloading cannot help: the provider page is cached and the filter is deterministic, so the same short grid is recomputed identically every time.

## The fix

Replace the emptiness test with a target count, threaded through the `{:load_page, ...}` chain:

- A fresh load aims for a full page (20) of unowned titles.
- **Load more** aims for `currently visible + 20`, so a click buys roughly a page of *new* titles however many turn out to be owned.

The existing `@max_auto_advance 3` bound is untouched, so a fully-owned category still cannot spin. All three provider paths (`discover`, `fetch_curated_list`, `search_cached`) are cached with a 15-30 minute TTL, so the extra pages are not re-fetched from the relay on every open. The grid renders page 1 immediately and the Load-more spinner shows while the rest streams in.

## Tests

Two new cases in `hide_owned_test.exs`, alongside the existing fully-owned ones:

- a partly-owned page advances (before the fix this asserted against an **empty mailbox** — no fetch was attempted at all)
- `load_more` sets its target relative to what is already on screen

56/56 pass in `discover_live/`. Full `mix precommit` is green apart from `PlexPositionTest` (Bypass timeout under load) and `FileIngestTest` (SQLite `database is locked`) — both documented in `.github/ci-flakes.md`, both pass in isolation on this tree, and neither has any connection to a LiveView filter change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discover pagination so loading more content fills the requested page size, even when some items are hidden.
  * Automatically loads additional results when filtering leaves a page with too few visible items.
  * Preserved consistent result counts while navigating through Discover content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->