### PR TITLE
fix(profile): fix layout and alignment of add defaults preference selects

### DIFF
--- a/lib/mydia_web/live/profile_live/components.ex
+++ b/lib/mydia_web/live/profile_live/components.ex
@@ -16,19 +16,21 @@ defmodule MydiaWeb.ProfileLive.Components do
 
   def inherit_select(assigns) do
     ~H"""
-    <label class="form-control">
-      <span class="label-text">{@label}</span>
-      <select name={@name} class="select select-bordered select-sm">
-        <option value="">Use server default</option>
-        <option
-          :for={{value, label} <- @options}
-          value={to_string(value)}
-          selected={@value == value}
-        >
-          {label}
-        </option>
-      </select>
-    </label>
+    <div>
+      <label class="block">
+        <span class="label mb-1 text-sm font-medium text-base-content/80">{@label}</span>
+        <select name={@name} class="select select-bordered select-sm w-full">
+          <option value="">Use server default</option>
+          <option
+            :for={{value, label} <- @options}
+            value={to_string(value)}
+            selected={@value == value}
+          >
+            {label}
+          </option>
+        </select>
+      </label>
+    </div>
     """
   end
 end

--- a/lib/mydia_web/live/profile_live/index.html.heex
+++ b/lib/mydia_web/live/profile_live/index.html.heex
@@ -169,7 +169,7 @@
             <form
               id="profile-add-defaults-form"
               phx-change="update_add_defaults"
-              class="space-y-3"
+              class="space-y-4"
             >
               <.inherit_select
                 name="add_movie_library_path_id"

--- a/test/mydia_web/live/profile_live/add_defaults_test.exs
+++ b/test/mydia_web/live/profile_live/add_defaults_test.exs
@@ -17,6 +17,17 @@ defmodule MydiaWeb.ProfileLive.AddDefaultsTest do
     {:ok, view, _html} = live(conn, ~p"/profile")
 
     assert has_element?(view, "#profile-add-defaults-form")
+    assert has_element?(view, "#profile-add-defaults-form.space-y-4")
+    assert has_element?(view, "#profile-add-defaults-form label.block")
+
+    assert has_element?(
+             view,
+             "#profile-add-defaults-form select.w-full[name='add_movie_library_path_id']"
+           )
+
+    assert has_element?(view, "#profile-add-defaults-form label span.label", "Movie library")
+    refute has_element?(view, "#profile-add-defaults-form .form-control")
+    refute has_element?(view, "#profile-add-defaults-form .label-text")
   end
 
   test "saving a season monitoring override persists it", %{conn: conn, user: user} do


### PR DESCRIPTION
## What changed

In `Profile & Preferences > Add Defaults`, preference fields were misaligned because `inherit_select` used `.form-control` and `.label-text`.

In DaisyUI 5, `.form-control` and `.label-text` no longer exist. Because `<label>` and `<span>` default to `display: inline`, the label text and `<select>` dropboxes rendered inline side-by-side on the same line. Since each label ("Movie library", "TV library", "Search for a release on add", etc.) has a different character length, the dropdowns started at irregular horizontal positions and wrapped awkwardly.

- Wrapped `inherit_select/1` in `<label class="block">` with standard Mydia label styling (`<span class="label mb-1 text-sm font-medium text-base-content/80">`).
- Added `w-full` to the select element (`class="select select-bordered select-sm w-full"`).
- Updated the form container `#profile-add-defaults-form` from `space-y-3` to `space-y-4` to match the stacked layout rhythm of the Edit Profile card right above it.
- Added tests asserting stacked block layout, `w-full` selects, and absence of legacy `.form-control` / `.label-text` classes.

## Testing

- `test/mydia_web/live/profile_live/add_defaults_test.exs`: 8 tests, 0 failures.
- `test/mydia_web/live/profile_live_test.exs`: 4 tests, 0 failures.
- Full `./dev mix precommit`: 10,643 tests, 0 failures; formatting and strict Credo clean.