### PR TITLE
feat(profile): avatar image upload support

### DIFF
--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -374,8 +374,7 @@ defmodule Mydia.Accounts do
   @doc """
   Deletes the user's avatar image file from disk if it was an uploaded avatar.
   """
-  def delete_avatar_file(%User{avatar_url: avatar_url}), do: delete_avatar_file(avatar_url)
-  def delete_avatar_file(avatar_url), do: Avatar.delete_avatar_file(avatar_url)
+  def delete_avatar_file(%User{} = user), do: Avatar.delete_avatar_file(user)
 
   @doc """
   Changes a user's password with current password verification.

--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -13,7 +13,7 @@ defmodule Mydia.Accounts do
   import Mydia.QueryHelpers
   require Logger
   alias Mydia.Repo
-  alias Mydia.Accounts.{User, ApiKey, UserPreference, ApiKeyRateLimiter}
+  alias Mydia.Accounts.{User, ApiKey, UserPreference, ApiKeyRateLimiter, Avatar}
 
   @changelog_key "last_seen_changelog_version"
   @anime_nudge_key "anime_nudge_dismissed"
@@ -370,6 +370,12 @@ defmodule Mydia.Accounts do
   def change_profile(%User{} = user, attrs \\ %{}) do
     User.profile_changeset(user, attrs)
   end
+
+  @doc """
+  Deletes the user's avatar image file from disk if it was an uploaded avatar.
+  """
+  def delete_avatar_file(%User{avatar_url: avatar_url}), do: delete_avatar_file(avatar_url)
+  def delete_avatar_file(avatar_url), do: Avatar.delete_avatar_file(avatar_url)
 
   @doc """
   Changes a user's password with current password verification.

--- a/lib/mydia/accounts/avatar.ex
+++ b/lib/mydia/accounts/avatar.ex
@@ -32,8 +32,9 @@ defmodule Mydia.Accounts.Avatar do
       dir = storage_dir()
       File.mkdir_p!(dir)
 
+      suffix = :crypto.strong_rand_bytes(4) |> Base.encode16(case: :lower)
       timestamp = System.system_time(:millisecond)
-      filename = "avatar-#{user.id}-#{timestamp}#{ext}"
+      filename = "avatar-#{user.id}-#{timestamp}-#{suffix}#{ext}"
       target_path = Path.join(dir, filename)
 
       case File.copy(temp_path, target_path) do

--- a/lib/mydia/accounts/avatar.ex
+++ b/lib/mydia/accounts/avatar.ex
@@ -1,0 +1,76 @@
+defmodule Mydia.Accounts.Avatar do
+  @moduledoc """
+  Manages avatar image storage and cleanup for user profiles.
+  Avatars are stored under `<generated_media_path>/avatars/` and served via `/generated/avatars/...`.
+  """
+
+  alias Mydia.Accounts.User
+  alias Mydia.Library.GeneratedMedia
+
+  @allowed_extensions ~w(.jpg .jpeg .png .webp .gif)
+
+  @doc """
+  Returns the filesystem directory where avatar images are stored.
+  """
+  @spec storage_dir() :: Path.t()
+  def storage_dir do
+    Path.join([GeneratedMedia.base_path(), "avatars"])
+  end
+
+  @doc """
+  Stores an uploaded avatar file for `user`, removing any previously uploaded avatar.
+  Returns `{:ok, url_path}` where `url_path` is a relative path like `/generated/avatars/avatar-USER_ID-TIMESTAMP.ext`.
+  """
+  @spec store_avatar(User.t(), Path.t(), String.t()) :: {:ok, String.t()} | {:error, term()}
+  def store_avatar(%User{} = user, temp_path, original_filename) do
+    ext =
+      original_filename
+      |> Path.extname()
+      |> String.downcase()
+
+    if ext in @allowed_extensions do
+      dir = storage_dir()
+      File.mkdir_p!(dir)
+
+      # Clean up any existing uploaded avatar for this user
+      delete_avatar_file(user.avatar_url)
+
+      timestamp = System.system_time(:millisecond)
+      filename = "avatar-#{user.id}-#{timestamp}#{ext}"
+      target_path = Path.join(dir, filename)
+
+      case File.copy(temp_path, target_path) do
+        {:ok, _bytes} ->
+          {:ok, "/generated/avatars/#{filename}"}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      {:error, :unsupported_format}
+    end
+  end
+
+  @doc """
+  Deletes an uploaded avatar file from disk if the URL is a local `/generated/avatars/` path,
+  or given a user struct whose avatar_url is set.
+  Silently returns `:ok` if `avatar_url` is nil, an external URL, or if the file does not exist.
+  """
+  @spec delete_avatar_file(User.t() | String.t() | nil) :: :ok
+  def delete_avatar_file(%User{avatar_url: avatar_url}), do: delete_avatar_file(avatar_url)
+  def delete_avatar_file(nil), do: :ok
+
+  def delete_avatar_file("/generated/avatars/" <> filename) do
+    # Prevent path traversal by extracting the basename only
+    safe_filename = Path.basename(filename)
+    target_path = Path.join(storage_dir(), safe_filename)
+
+    case File.rm(target_path) do
+      :ok -> :ok
+      {:error, :enoent} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  def delete_avatar_file(_external_url), do: :ok
+end

--- a/lib/mydia/accounts/avatar.ex
+++ b/lib/mydia/accounts/avatar.ex
@@ -38,8 +38,6 @@ defmodule Mydia.Accounts.Avatar do
 
       case File.copy(temp_path, target_path) do
         {:ok, _bytes} ->
-          # Clean up any existing uploaded avatar for this user after copy succeeds
-          delete_avatar_file(user.avatar_url)
           {:ok, "/generated/avatars/#{filename}"}
 
         {:error, reason} ->
@@ -52,29 +50,26 @@ defmodule Mydia.Accounts.Avatar do
 
   @doc """
   Deletes an uploaded avatar file from disk if the URL is a local `/generated/avatars/` path,
-  or given a user struct whose avatar_url is set.
+  verifying that the file belongs to the given user.
   Silently returns `:ok` if `avatar_url` is nil, an external URL, or if the file does not exist.
   """
-  @spec delete_avatar_file(User.t() | String.t() | nil) :: :ok
-  def delete_avatar_file(%User{avatar_url: avatar_url}), do: delete_avatar_file(avatar_url)
-  def delete_avatar_file(nil), do: :ok
+  @spec delete_avatar_file(User.t()) :: :ok
+  def delete_avatar_file(%User{id: user_id, avatar_url: "/generated/avatars/" <> filename}) do
+    safe_filename = Path.basename(filename)
+    expected_prefix = "avatar-#{user_id}-"
 
-  def delete_avatar_file("/generated/avatars/" <> filename) do
-    # Prevent path traversal by extracting the basename only
-    case Path.basename(filename) do
-      empty_or_dot when empty_or_dot in ["", "."] ->
-        :ok
+    if String.starts_with?(safe_filename, expected_prefix) do
+      target_path = Path.join(storage_dir(), safe_filename)
 
-      safe_filename ->
-        target_path = Path.join(storage_dir(), safe_filename)
-
-        case File.rm(target_path) do
-          :ok -> :ok
-          {:error, :enoent} -> :ok
-          {:error, _reason} -> :ok
-        end
+      case File.rm(target_path) do
+        :ok -> :ok
+        {:error, :enoent} -> :ok
+        {:error, _reason} -> :ok
+      end
+    else
+      :ok
     end
   end
 
-  def delete_avatar_file(_external_url), do: :ok
+  def delete_avatar_file(%User{}), do: :ok
 end

--- a/lib/mydia/accounts/avatar.ex
+++ b/lib/mydia/accounts/avatar.ex
@@ -32,15 +32,14 @@ defmodule Mydia.Accounts.Avatar do
       dir = storage_dir()
       File.mkdir_p!(dir)
 
-      # Clean up any existing uploaded avatar for this user
-      delete_avatar_file(user.avatar_url)
-
       timestamp = System.system_time(:millisecond)
       filename = "avatar-#{user.id}-#{timestamp}#{ext}"
       target_path = Path.join(dir, filename)
 
       case File.copy(temp_path, target_path) do
         {:ok, _bytes} ->
+          # Clean up any existing uploaded avatar for this user after copy succeeds
+          delete_avatar_file(user.avatar_url)
           {:ok, "/generated/avatars/#{filename}"}
 
         {:error, reason} ->
@@ -63,12 +62,17 @@ defmodule Mydia.Accounts.Avatar do
   def delete_avatar_file("/generated/avatars/" <> filename) do
     # Prevent path traversal by extracting the basename only
     safe_filename = Path.basename(filename)
-    target_path = Path.join(storage_dir(), safe_filename)
 
-    case File.rm(target_path) do
-      :ok -> :ok
-      {:error, :enoent} -> :ok
-      {:error, _reason} -> :ok
+    if safe_filename not in ["", "."] do
+      target_path = Path.join(storage_dir(), safe_filename)
+
+      case File.rm(target_path) do
+        :ok -> :ok
+        {:error, :enoent} -> :ok
+        {:error, _reason} -> :ok
+      end
+    else
+      :ok
     end
   end
 

--- a/lib/mydia/accounts/avatar.ex
+++ b/lib/mydia/accounts/avatar.ex
@@ -61,18 +61,18 @@ defmodule Mydia.Accounts.Avatar do
 
   def delete_avatar_file("/generated/avatars/" <> filename) do
     # Prevent path traversal by extracting the basename only
-    safe_filename = Path.basename(filename)
+    case Path.basename(filename) do
+      empty_or_dot when empty_or_dot in ["", "."] ->
+        :ok
 
-    if safe_filename not in ["", "."] do
-      target_path = Path.join(storage_dir(), safe_filename)
+      safe_filename ->
+        target_path = Path.join(storage_dir(), safe_filename)
 
-      case File.rm(target_path) do
-        :ok -> :ok
-        {:error, :enoent} -> :ok
-        {:error, _reason} -> :ok
-      end
-    else
-      :ok
+        case File.rm(target_path) do
+          :ok -> :ok
+          {:error, :enoent} -> :ok
+          {:error, _reason} -> :ok
+        end
     end
   end
 

--- a/lib/mydia/accounts/user.ex
+++ b/lib/mydia/accounts/user.ex
@@ -132,8 +132,32 @@ defmodule Mydia.Accounts.User do
   def profile_changeset(user, attrs) do
     user
     |> cast(attrs, [:display_name, :avatar_url])
+    |> normalize_empty_avatar_url()
     |> validate_length(:display_name, max: 100)
-    |> validate_format(:avatar_url, ~r/^https?:\/\//, message: "must be a valid URL")
+    |> validate_avatar_url()
+  end
+
+  defp normalize_empty_avatar_url(changeset) do
+    case get_change(changeset, :avatar_url) do
+      url when is_binary(url) ->
+        if String.trim(url) == "" do
+          put_change(changeset, :avatar_url, nil)
+        else
+          changeset
+        end
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp validate_avatar_url(changeset) do
+    validate_format(
+      changeset,
+      :avatar_url,
+      ~r/^(https?:\/\/|\/generated\/avatars\/)/,
+      message: "must be a valid URL or local avatar path"
+    )
   end
 
   # Validate password requirements

--- a/lib/mydia/accounts/user.ex
+++ b/lib/mydia/accounts/user.ex
@@ -157,7 +157,7 @@ defmodule Mydia.Accounts.User do
     validate_format(
       changeset,
       :avatar_url,
-      ~r/^(https?:\/\/|\/generated\/avatars\/)/,
+      ~r/^(https?:\/\/[^\s\/]+|\/generated\/avatars\/.+)/,
       message: "must be a valid URL or local avatar path"
     )
   end

--- a/lib/mydia/accounts/user.ex
+++ b/lib/mydia/accounts/user.ex
@@ -140,10 +140,12 @@ defmodule Mydia.Accounts.User do
   defp normalize_empty_avatar_url(changeset) do
     case get_change(changeset, :avatar_url) do
       url when is_binary(url) ->
-        if String.trim(url) == "" do
+        trimmed = String.trim(url)
+
+        if trimmed == "" do
           put_change(changeset, :avatar_url, nil)
         else
-          changeset
+          put_change(changeset, :avatar_url, trimmed)
         end
 
       _ ->

--- a/lib/mydia_web/components/layouts.ex
+++ b/lib/mydia_web/components/layouts.ex
@@ -401,16 +401,24 @@ defmodule MydiaWeb.Layouts do
             <div class="dropdown dropdown-top dropdown-end w-full">
               <label id="sidebar-user-menu" tabindex="0" class="btn btn-ghost w-full justify-start">
                 <div class="avatar placeholder">
-                  <div class="bg-neutral text-neutral-content rounded-full w-8">
-                    <span class="text-xs">
-                      <%= if @current_user do %>
-                        {String.upcase(
-                          String.slice(@current_user.username || @current_user.email || "U", 0..1)
-                        )}
-                      <% else %>
-                        U
-                      <% end %>
-                    </span>
+                  <div class="bg-neutral text-neutral-content rounded-full w-8 overflow-hidden">
+                    <%= if @current_user && @current_user.avatar_url do %>
+                      <img
+                        src={@current_user.avatar_url}
+                        alt="Avatar"
+                        class="w-full h-full object-cover"
+                      />
+                    <% else %>
+                      <span class="text-xs">
+                        <%= if @current_user do %>
+                          {String.upcase(
+                            String.slice(@current_user.username || @current_user.email || "U", 0..1)
+                          )}
+                        <% else %>
+                          U
+                        <% end %>
+                      </span>
+                    <% end %>
                   </div>
                 </div>
                 <div class="flex-1 text-left">

--- a/lib/mydia_web/live/profile_live/index.ex
+++ b/lib/mydia_web/live/profile_live/index.ex
@@ -4,6 +4,7 @@ defmodule MydiaWeb.ProfileLive.Index do
   import MydiaWeb.ProfileLive.Components
 
   alias Mydia.Accounts
+  alias Mydia.Accounts.Avatar
   alias Mydia.Accounts.UserPreference
   alias Mydia.Settings
   alias Mydia.Settings.LibraryPath
@@ -33,6 +34,11 @@ defmodule MydiaWeb.ProfileLive.Index do
 
     socket =
       socket
+      |> allow_upload(:avatar,
+        accept: ~w(.jpg .jpeg .png .webp .gif),
+        max_entries: 1,
+        max_file_size: 5_000_000
+      )
       |> assign(:is_oidc_user, is_oidc_user)
       |> assign(:profile_form, to_form(Accounts.change_profile(user)))
       |> assign(:password_form, to_form(password_changeset(), as: :password))
@@ -78,13 +84,54 @@ defmodule MydiaWeb.ProfileLive.Index do
   end
 
   @impl true
-  def handle_event("save_profile", %{"user" => params}, socket) do
-    case Accounts.update_profile(socket.assigns.current_user, params) do
-      {:ok, user} ->
+  def handle_event("cancel_avatar_upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :avatar, ref)}
+  end
+
+  @impl true
+  def handle_event("remove_avatar", _params, socket) do
+    user = socket.assigns.current_user
+    Accounts.delete_avatar_file(user)
+
+    case Accounts.update_profile(user, %{"avatar_url" => nil}) do
+      {:ok, updated_user} ->
         {:noreply,
          socket
-         |> assign(:current_user, user)
-         |> assign(:profile_form, to_form(Accounts.change_profile(user)))
+         |> assign(:current_user, updated_user)
+         |> assign(:profile_form, to_form(Accounts.change_profile(updated_user)))
+         |> put_flash(:info, "Avatar removed")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :profile_form, to_form(changeset))}
+    end
+  end
+
+  @impl true
+  def handle_event("save_profile", %{"user" => params}, socket) do
+    user = socket.assigns.current_user
+
+    uploaded_avatar_url =
+      consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
+        case Avatar.store_avatar(user, path, entry.client_name) do
+          {:ok, url_path} -> {:ok, url_path}
+          {:error, reason} -> {:error, reason}
+        end
+      end)
+      |> List.first()
+
+    params =
+      if uploaded_avatar_url do
+        Map.put(params, "avatar_url", uploaded_avatar_url)
+      else
+        params
+      end
+
+    case Accounts.update_profile(user, params) do
+      {:ok, updated_user} ->
+        {:noreply,
+         socket
+         |> assign(:current_user, updated_user)
+         |> assign(:profile_form, to_form(Accounts.change_profile(updated_user)))
          |> put_flash(:info, "Profile updated successfully")}
 
       {:error, changeset} ->
@@ -251,4 +298,12 @@ defmodule MydiaWeb.ProfileLive.Index do
   defp format_datetime(datetime) do
     Calendar.strftime(datetime, "%b %d, %Y at %I:%M %p")
   end
+
+  defp upload_error_to_string(:too_large), do: "Image is too large (maximum 5MB)"
+  defp upload_error_to_string(:too_many_files), do: "Only one image can be uploaded at a time"
+
+  defp upload_error_to_string(:not_accepted),
+    do: "Unacceptable file type. Please upload a JPG, PNG, WebP, or GIF."
+
+  defp upload_error_to_string(other), do: "Upload error: #{inspect(other)}"
 end

--- a/lib/mydia_web/live/profile_live/index.ex
+++ b/lib/mydia_web/live/profile_live/index.ex
@@ -101,10 +101,11 @@ defmodule MydiaWeb.ProfileLive.Index do
   @impl true
   def handle_event("remove_avatar", _params, socket) do
     user = socket.assigns.current_user
-    Accounts.delete_avatar_file(user)
 
     case Accounts.update_profile(user, %{"avatar_url" => nil}) do
       {:ok, updated_user} ->
+        Accounts.delete_avatar_file(user)
+
         {:noreply,
          socket
          |> assign(:current_user, updated_user)
@@ -155,7 +156,7 @@ defmodule MydiaWeb.ProfileLive.Index do
           if is_binary(user.avatar_url) and
                String.starts_with?(user.avatar_url, "/generated/avatars/") and
                updated_user.avatar_url != user.avatar_url do
-            Accounts.delete_avatar_file(user.avatar_url)
+            Accounts.delete_avatar_file(user)
           end
 
           {:noreply,

--- a/lib/mydia_web/live/profile_live/index.ex
+++ b/lib/mydia_web/live/profile_live/index.ex
@@ -75,8 +75,18 @@ defmodule MydiaWeb.ProfileLive.Index do
 
   @impl true
   def handle_event("validate_profile", %{"user" => params}, socket) do
+    user = socket.assigns.current_user
+
+    params =
+      if params["avatar_url"] in ["", nil] and is_binary(user.avatar_url) and
+           String.starts_with?(user.avatar_url, "/generated/avatars/") do
+        Map.put(params, "avatar_url", user.avatar_url)
+      else
+        params
+      end
+
     changeset =
-      socket.assigns.current_user
+      user
       |> Accounts.change_profile(params)
       |> Map.put(:action, :validate)
 
@@ -110,32 +120,55 @@ defmodule MydiaWeb.ProfileLive.Index do
   def handle_event("save_profile", %{"user" => params}, socket) do
     user = socket.assigns.current_user
 
-    uploaded_avatar_url =
-      consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
-        case Avatar.store_avatar(user, path, entry.client_name) do
-          {:ok, url_path} -> {:ok, url_path}
-          {:error, reason} -> {:error, reason}
-        end
-      end)
-      |> List.first()
-
     params =
-      if uploaded_avatar_url do
-        Map.put(params, "avatar_url", uploaded_avatar_url)
+      if params["avatar_url"] in ["", nil] and is_binary(user.avatar_url) and
+           String.starts_with?(user.avatar_url, "/generated/avatars/") do
+        Map.put(params, "avatar_url", user.avatar_url)
       else
         params
       end
 
-    case Accounts.update_profile(user, params) do
-      {:ok, updated_user} ->
-        {:noreply,
-         socket
-         |> assign(:current_user, updated_user)
-         |> assign(:profile_form, to_form(Accounts.change_profile(updated_user)))
-         |> put_flash(:info, "Profile updated successfully")}
+    validation_changeset =
+      user
+      |> Accounts.change_profile(params)
+      |> Map.put(:action, :validate)
 
-      {:error, changeset} ->
-        {:noreply, assign(socket, :profile_form, to_form(changeset))}
+    if validation_changeset.valid? do
+      uploaded_avatar_url =
+        consume_uploaded_entries(socket, :avatar, fn %{path: path}, entry ->
+          case Avatar.store_avatar(user, path, entry.client_name) do
+            {:ok, url_path} -> {:ok, url_path}
+            {:error, reason} -> {:error, reason}
+          end
+        end)
+        |> List.first()
+
+      params =
+        if uploaded_avatar_url do
+          Map.put(params, "avatar_url", uploaded_avatar_url)
+        else
+          params
+        end
+
+      case Accounts.update_profile(user, params) do
+        {:ok, updated_user} ->
+          if is_binary(user.avatar_url) and
+               String.starts_with?(user.avatar_url, "/generated/avatars/") and
+               updated_user.avatar_url != user.avatar_url do
+            Accounts.delete_avatar_file(user.avatar_url)
+          end
+
+          {:noreply,
+           socket
+           |> assign(:current_user, updated_user)
+           |> assign(:profile_form, to_form(Accounts.change_profile(updated_user)))
+           |> put_flash(:info, "Profile updated successfully")}
+
+        {:error, changeset} ->
+          {:noreply, assign(socket, :profile_form, to_form(changeset))}
+      end
+    else
+      {:noreply, assign(socket, :profile_form, to_form(validation_changeset))}
     end
   end
 
@@ -306,4 +339,14 @@ defmodule MydiaWeb.ProfileLive.Index do
     do: "Unacceptable file type. Please upload a JPG, PNG, WebP, or GIF."
 
   defp upload_error_to_string(other), do: "Upload error: #{inspect(other)}"
+
+  defp external_avatar_url(value) when is_binary(value) do
+    if String.starts_with?(value, "/generated/avatars/") do
+      ""
+    else
+      value
+    end
+  end
+
+  defp external_avatar_url(_), do: ""
 end

--- a/lib/mydia_web/live/profile_live/index.html.heex
+++ b/lib/mydia_web/live/profile_live/index.html.heex
@@ -152,7 +152,8 @@
 
               <.input
                 field={@profile_form[:avatar_url]}
-                type="url"
+                type="text"
+                value={external_avatar_url(@profile_form[:avatar_url].value)}
                 label="Avatar URL"
                 placeholder="https://example.com/avatar.jpg"
               />

--- a/lib/mydia_web/live/profile_live/index.html.heex
+++ b/lib/mydia_web/live/profile_live/index.html.heex
@@ -86,6 +86,70 @@
                 label="Display Name"
                 placeholder="Your display name"
               />
+              <!-- Avatar Upload Section -->
+              <div class="form-control">
+                <label class="label">
+                  <span class="label-text font-medium">Avatar Image</span>
+                </label>
+
+                <div class="space-y-3">
+                  <!-- Staged Upload Preview -->
+                  <div
+                    :for={entry <- @uploads.avatar.entries}
+                    class="flex items-center gap-4 p-3 bg-base-200 rounded-lg"
+                  >
+                    <div class="avatar">
+                      <div class="w-16 h-16 rounded-full overflow-hidden bg-base-300">
+                        <.live_img_preview entry={entry} class="w-full h-full object-cover" />
+                      </div>
+                    </div>
+                    <div class="flex-1 min-w-0">
+                      <p class="text-sm font-medium truncate">{entry.client_name}</p>
+                      <p class="text-xs text-base-content/60">{entry.client_size} bytes</p>
+                      <div
+                        :for={err <- upload_errors(@uploads.avatar, entry)}
+                        class="text-xs text-error mt-1"
+                      >
+                        {upload_error_to_string(err)}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-circle"
+                      phx-click="cancel_avatar_upload"
+                      phx-value-ref={entry.ref}
+                      title="Cancel upload"
+                    >
+                      <.icon name="hero-x-mark" class="w-4 h-4" />
+                    </button>
+                  </div>
+
+                  <!-- File Input -->
+                  <div class="flex items-center gap-2">
+                    <.live_file_input
+                      upload={@uploads.avatar}
+                      class="file-input file-input-bordered file-input-primary w-full"
+                    />
+                    <%= if @current_user.avatar_url do %>
+                      <button
+                        type="button"
+                        id="remove-avatar-btn"
+                        class="btn btn-outline btn-error shrink-0"
+                        phx-click="remove_avatar"
+                      >
+                        <.icon name="hero-trash" class="w-4 h-4" /> Remove Avatar
+                      </button>
+                    <% end %>
+                  </div>
+
+                  <div :for={err <- upload_errors(@uploads.avatar)} class="text-xs text-error">
+                    {upload_error_to_string(err)}
+                  </div>
+                </div>
+              </div>
+
+              <div class="divider text-xs text-base-content/50">OR PROVIDE AN IMAGE URL</div>
+
               <.input
                 field={@profile_form[:avatar_url]}
                 type="url"

--- a/test/mydia/accounts/avatar_test.exs
+++ b/test/mydia/accounts/avatar_test.exs
@@ -1,0 +1,118 @@
+defmodule Mydia.Accounts.AvatarTest do
+  use ExUnit.Case, async: false
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.Avatar
+  alias Mydia.Accounts.User
+
+  @user %User{
+    id: "01914902-86ee-7359-b570-5cb65860d5c0",
+    username: "avataruser",
+    avatar_url: nil
+  }
+
+  setup do
+    dir = Avatar.storage_dir()
+    File.mkdir_p!(dir)
+
+    on_exit(fn ->
+      # Clean up any test files matching this user
+      Path.wildcard(Path.join(dir, "avatar-#{@user.id}-*"))
+      |> Enum.each(&File.rm/1)
+    end)
+
+    :ok
+  end
+
+  describe "store_avatar/3" do
+    test "stores a valid image file and returns its /generated/avatars/ URL" do
+      tmp_file = Path.join(System.tmp_dir!(), "test-avatar.png")
+      # Minimal 1x1 PNG binary
+      png_data =
+        <<137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8,
+          6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 10, 73, 68, 65, 84, 120, 156, 99, 0, 1, 0, 0, 5,
+          0, 1, 13, 10, 45, 180, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130>>
+
+      File.write!(tmp_file, png_data)
+
+      assert {:ok, url_path} = Avatar.store_avatar(@user, tmp_file, "my_avatar.png")
+      assert String.starts_with?(url_path, "/generated/avatars/avatar-#{@user.id}-")
+      assert String.ends_with?(url_path, ".png")
+
+      disk_path = Path.join(Avatar.storage_dir(), Path.basename(url_path))
+      assert File.exists?(disk_path)
+      assert File.read!(disk_path) == png_data
+    end
+
+    test "removes previous uploaded avatar file when replacing with a new one" do
+      tmp_file = Path.join(System.tmp_dir!(), "test-avatar-old.jpg")
+      File.write!(tmp_file, "fake-jpg-content")
+
+      {:ok, first_url} = Avatar.store_avatar(@user, tmp_file, "first.jpg")
+      first_disk_path = Path.join(Avatar.storage_dir(), Path.basename(first_url))
+      assert File.exists?(first_disk_path)
+
+      user_with_first = %{@user | avatar_url: first_url}
+      # Small delay to ensure timestamp difference
+      :timer.sleep(10)
+
+      {:ok, second_url} = Avatar.store_avatar(user_with_first, tmp_file, "second.png")
+      second_disk_path = Path.join(Avatar.storage_dir(), Path.basename(second_url))
+
+      assert File.exists?(second_disk_path)
+      refute File.exists?(first_disk_path)
+    end
+
+    test "rejects unsupported file extension" do
+      tmp_file = Path.join(System.tmp_dir!(), "script.sh")
+      File.write!(tmp_file, "#!/bin/sh\necho hello")
+
+      assert {:error, :unsupported_format} = Avatar.store_avatar(@user, tmp_file, "script.sh")
+    end
+  end
+
+  describe "delete_avatar_file/1" do
+    test "removes uploaded avatar file from disk" do
+      filename = "avatar-#{@user.id}-1234567890.jpg"
+      path = Path.join(Avatar.storage_dir(), filename)
+      File.write!(path, "avatar-bytes")
+      assert File.exists?(path)
+
+      assert :ok == Avatar.delete_avatar_file("/generated/avatars/#{filename}")
+      refute File.exists?(path)
+    end
+
+    test "ignores external URLs safely without error" do
+      assert :ok == Avatar.delete_avatar_file("https://example.com/avatar.jpg")
+      assert :ok == Avatar.delete_avatar_file(nil)
+    end
+
+    test "accepts user struct directly" do
+      filename = "avatar-#{@user.id}-9876543210.png"
+      path = Path.join(Avatar.storage_dir(), filename)
+      File.write!(path, "user-avatar-bytes")
+      assert File.exists?(path)
+
+      user = %{@user | avatar_url: "/generated/avatars/#{filename}"}
+      assert :ok == Avatar.delete_avatar_file(user)
+      refute File.exists?(path)
+    end
+
+    test "Mydia.Accounts.delete_avatar_file/1 delegates properly for user and url" do
+      filename = "avatar-#{@user.id}-1122334455.webp"
+      path = Path.join(Avatar.storage_dir(), filename)
+      File.write!(path, "delegated-bytes")
+      assert File.exists?(path)
+
+      user = %{@user | avatar_url: "/generated/avatars/#{filename}"}
+      assert :ok == Accounts.delete_avatar_file(user)
+      refute File.exists?(path)
+
+      File.write!(path, "delegated-bytes-2")
+      assert File.exists?(path)
+
+      assert :ok == Accounts.delete_avatar_file("/generated/avatars/#{filename}")
+      refute File.exists?(path)
+    end
+  end
+end

--- a/test/mydia/accounts/avatar_test.exs
+++ b/test/mydia/accounts/avatar_test.exs
@@ -69,6 +69,23 @@ defmodule Mydia.Accounts.AvatarTest do
 
       assert {:error, :unsupported_format} = Avatar.store_avatar(@user, tmp_file, "script.sh")
     end
+
+    test "generates distinct filenames and URLs for concurrent uploads" do
+      tmp_file = Path.join(System.tmp_dir!(), "concurrent-avatar.png")
+      File.write!(tmp_file, "avatar-content")
+
+      tasks =
+        for _ <- 1..5 do
+          Task.async(fn ->
+            Avatar.store_avatar(@user, tmp_file, "avatar.png")
+          end)
+        end
+
+      results = Task.await_many(tasks)
+      urls = Enum.map(results, fn {:ok, url} -> url end)
+
+      assert length(Enum.uniq(urls)) == 5
+    end
   end
 
   describe "delete_avatar_file/1" do

--- a/test/mydia/accounts/avatar_test.exs
+++ b/test/mydia/accounts/avatar_test.exs
@@ -44,7 +44,7 @@ defmodule Mydia.Accounts.AvatarTest do
       assert File.read!(disk_path) == png_data
     end
 
-    test "removes previous uploaded avatar file when replacing with a new one" do
+    test "does not remove previous uploaded avatar file immediately when replacing with a new one" do
       tmp_file = Path.join(System.tmp_dir!(), "test-avatar-old.jpg")
       File.write!(tmp_file, "fake-jpg-content")
 
@@ -60,7 +60,7 @@ defmodule Mydia.Accounts.AvatarTest do
       second_disk_path = Path.join(Avatar.storage_dir(), Path.basename(second_url))
 
       assert File.exists?(second_disk_path)
-      refute File.exists?(first_disk_path)
+      assert File.exists?(first_disk_path)
     end
 
     test "rejects unsupported file extension" do
@@ -72,22 +72,14 @@ defmodule Mydia.Accounts.AvatarTest do
   end
 
   describe "delete_avatar_file/1" do
-    test "removes uploaded avatar file from disk" do
-      filename = "avatar-#{@user.id}-1234567890.jpg"
-      path = Path.join(Avatar.storage_dir(), filename)
-      File.write!(path, "avatar-bytes")
-      assert File.exists?(path)
-
-      assert :ok == Avatar.delete_avatar_file("/generated/avatars/#{filename}")
-      refute File.exists?(path)
-    end
-
     test "ignores external URLs safely without error" do
-      assert :ok == Avatar.delete_avatar_file("https://example.com/avatar.jpg")
-      assert :ok == Avatar.delete_avatar_file(nil)
+      assert :ok ==
+               Avatar.delete_avatar_file(%{@user | avatar_url: "https://example.com/avatar.jpg"})
+
+      assert :ok == Avatar.delete_avatar_file(%{@user | avatar_url: nil})
     end
 
-    test "accepts user struct directly" do
+    test "accepts user struct directly and removes file from disk" do
       filename = "avatar-#{@user.id}-9876543210.png"
       path = Path.join(Avatar.storage_dir(), filename)
       File.write!(path, "user-avatar-bytes")
@@ -98,7 +90,25 @@ defmodule Mydia.Accounts.AvatarTest do
       refute File.exists?(path)
     end
 
-    test "Mydia.Accounts.delete_avatar_file/1 delegates properly for user and url" do
+    test "refuses to delete an avatar belonging to another user ID (IDOR protection)" do
+      other_user_id = "01914902-86ee-7359-b570-5cb65860d999"
+      filename = "avatar-#{other_user_id}-1234567890.jpg"
+      path = Path.join(Avatar.storage_dir(), filename)
+      File.write!(path, "other-user-avatar-bytes")
+      assert File.exists?(path)
+
+      # Attempt to delete the file using @user struct but pointing to the other user's file
+      user = %{@user | avatar_url: "/generated/avatars/#{filename}"}
+      assert :ok == Avatar.delete_avatar_file(user)
+
+      # The file should still exist
+      assert File.exists?(path)
+
+      # Clean up
+      File.rm(path)
+    end
+
+    test "Mydia.Accounts.delete_avatar_file/1 delegates properly for user" do
       filename = "avatar-#{@user.id}-1122334455.webp"
       path = Path.join(Avatar.storage_dir(), filename)
       File.write!(path, "delegated-bytes")
@@ -106,12 +116,6 @@ defmodule Mydia.Accounts.AvatarTest do
 
       user = %{@user | avatar_url: "/generated/avatars/#{filename}"}
       assert :ok == Accounts.delete_avatar_file(user)
-      refute File.exists?(path)
-
-      File.write!(path, "delegated-bytes-2")
-      assert File.exists?(path)
-
-      assert :ok == Accounts.delete_avatar_file("/generated/avatars/#{filename}")
       refute File.exists?(path)
     end
   end

--- a/test/mydia/accounts/user_profile_changeset_test.exs
+++ b/test/mydia/accounts/user_profile_changeset_test.exs
@@ -52,7 +52,10 @@ defmodule Mydia.Accounts.UserProfileChangesetTest do
             "ftp://example.com/avatar.png",
             "/etc/passwd",
             "javascript:alert(1)",
-            "not-a-url"
+            "not-a-url",
+            "http://",
+            "https://",
+            "/generated/avatars/"
           ] do
         changeset = User.profile_changeset(@user, %{avatar_url: invalid})
         refute changeset.valid?

--- a/test/mydia/accounts/user_profile_changeset_test.exs
+++ b/test/mydia/accounts/user_profile_changeset_test.exs
@@ -1,0 +1,82 @@
+defmodule Mydia.Accounts.UserProfileChangesetTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Accounts.User
+
+  @user %User{
+    id: "01914902-86ee-7359-b570-5cb65860d5c0",
+    username: "testuser",
+    email: "test@example.com",
+    role: "user"
+  }
+
+  describe "profile_changeset/2" do
+    test "accepts valid http and https URLs" do
+      for url <- ["https://example.com/avatar.png", "http://example.com/avatar.jpg"] do
+        changeset = User.profile_changeset(@user, %{avatar_url: url})
+        assert changeset.valid?
+        assert Ecto.Changeset.get_change(changeset, :avatar_url) == url
+      end
+    end
+
+    test "accepts local /generated/avatars/ paths" do
+      path = "/generated/avatars/avatar-#{@user.id}-1725312000.png"
+      changeset = User.profile_changeset(@user, %{avatar_url: path})
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :avatar_url) == path
+    end
+
+    test "normalizes empty string to nil" do
+      user_with_avatar = %{@user | avatar_url: "https://example.com/avatar.png"}
+      changeset = User.profile_changeset(user_with_avatar, %{avatar_url: ""})
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :avatar_url) == nil
+    end
+
+    test "normalizes whitespace-only string to nil" do
+      user_with_avatar = %{@user | avatar_url: "https://example.com/avatar.png"}
+      changeset = User.profile_changeset(user_with_avatar, %{avatar_url: "   "})
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :avatar_url) == nil
+    end
+
+    test "accepts nil to clear avatar" do
+      user_with_avatar = %{@user | avatar_url: "https://example.com/avatar.png"}
+      changeset = User.profile_changeset(user_with_avatar, %{avatar_url: nil})
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :avatar_url) == nil
+    end
+
+    test "rejects invalid URLs or paths" do
+      for invalid <- [
+            "ftp://example.com/avatar.png",
+            "/etc/passwd",
+            "javascript:alert(1)",
+            "not-a-url"
+          ] do
+        changeset = User.profile_changeset(@user, %{avatar_url: invalid})
+        refute changeset.valid?
+        assert %{avatar_url: ["must be a valid URL or local avatar path"]} = errors_on(changeset)
+      end
+    end
+
+    test "validates display_name length" do
+      long_name = String.duplicate("a", 101)
+      changeset = User.profile_changeset(@user, %{display_name: long_name})
+      refute changeset.valid?
+      assert %{display_name: ["should be at most 100 character(s)"]} = errors_on(changeset)
+
+      valid_name = String.duplicate("a", 100)
+      changeset = User.profile_changeset(@user, %{display_name: valid_name})
+      assert changeset.valid?
+    end
+  end
+
+  defp errors_on(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+      end)
+    end)
+  end
+end

--- a/test/mydia_web/live/profile_live_test.exs
+++ b/test/mydia_web/live/profile_live_test.exs
@@ -247,5 +247,111 @@ defmodule MydiaWeb.ProfileLiveTest do
       assert {:error, [[_, :not_accepted]]} = preflight_upload(avatar)
       assert render(view) =~ "Unacceptable file type"
     end
+
+    test "avatar URL input uses type text and leaves field blank for local generated avatars", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, user} =
+        Accounts.update_profile(user, %{
+          avatar_url: "/generated/avatars/avatar-#{user.id}-123.png"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      assert has_element?(view, "input[type='text'][name*='avatar_url']")
+      refute has_element?(view, "input[type='url'][name*='avatar_url']")
+
+      avatar_input = element(view, "input[name*='avatar_url']")
+      assert render(avatar_input) =~ ~s(value="")
+
+      view
+      |> form("#profile-form", %{
+        "user" => %{"display_name" => "Updated Name", "avatar_url" => ""}
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Profile updated successfully"
+      reloaded = Accounts.get_user!(user.id)
+      assert reloaded.display_name == "Updated Name"
+      assert reloaded.avatar_url == "/generated/avatars/avatar-#{user.id}-123.png"
+    end
+
+    test "cleans up old local avatar file on disk when replacing with an external URL", %{
+      conn: conn,
+      user: user
+    } do
+      dir = Mydia.Accounts.Avatar.storage_dir()
+      File.mkdir_p!(dir)
+      filename = "avatar-#{user.id}-to-replace.png"
+      file_path = Path.join(dir, filename)
+      File.write!(file_path, "local avatar data")
+
+      {:ok, user} =
+        Accounts.update_profile(user, %{avatar_url: "/generated/avatars/#{filename}"})
+
+      assert File.exists?(file_path)
+
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      view
+      |> form("#profile-form", %{
+        "user" => %{
+          "display_name" => user.display_name || "User",
+          "avatar_url" => "https://example.com/external-avatar.jpg"
+        }
+      })
+      |> render_submit()
+
+      assert render(view) =~ "Profile updated successfully"
+      refute File.exists?(file_path)
+
+      reloaded = Accounts.get_user!(user.id)
+      assert reloaded.avatar_url == "https://example.com/external-avatar.jpg"
+    end
+
+    test "does not write avatar file to disk if profile validation fails", %{
+      conn: conn,
+      user: user
+    } do
+      dir = Mydia.Accounts.Avatar.storage_dir()
+      File.mkdir_p!(dir)
+
+      Path.wildcard(Path.join(dir, "avatar-#{user.id}-*"))
+      |> Enum.each(&File.rm/1)
+
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      png_data =
+        <<137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8,
+          6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 10, 73, 68, 65, 84, 120, 156, 99, 0, 1, 0, 0, 5,
+          0, 1, 13, 10, 45, 180, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130>>
+
+      avatar =
+        file_input(view, "#profile-form", :avatar, [
+          %{
+            name: "avatar.png",
+            content: png_data,
+            type: "image/png"
+          }
+        ])
+
+      render_upload(avatar, "avatar.png")
+
+      too_long_name = String.duplicate("a", 101)
+
+      view
+      |> form("#profile-form", %{"user" => %{"display_name" => too_long_name}})
+      |> render_submit()
+
+      assert render(view) =~ "should be at most 100 character(s)"
+      refute render(view) =~ "Profile updated successfully"
+
+      written_files = Path.wildcard(Path.join(dir, "avatar-#{user.id}-*"))
+      assert written_files == []
+
+      reloaded = Accounts.get_user!(user.id)
+      assert is_nil(reloaded.avatar_url)
+    end
   end
 end

--- a/test/mydia_web/live/profile_live_test.exs
+++ b/test/mydia_web/live/profile_live_test.exs
@@ -75,4 +75,177 @@ defmodule MydiaWeb.ProfileLiveTest do
     assert user |> Accounts.get_user_preference!() |> UserPreference.theme() == "dark"
     assert_push_event(view, "theme_changed", %{theme: "dark"})
   end
+
+  describe "avatar upload and management" do
+    test "renders avatar upload input and remove button when avatar exists", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, _user} =
+        Accounts.update_profile(user, %{avatar_url: "https://example.com/avatar.jpg"})
+
+      {:ok, view, html} = live(conn, ~p"/profile")
+
+      assert has_element?(view, "input[type='file'][name*='avatar']")
+      assert has_element?(view, "#remove-avatar-btn")
+      assert html =~ "Remove Avatar"
+    end
+
+    test "does not render remove avatar button when user has no avatar", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/profile")
+      refute has_element?(view, "#remove-avatar-btn")
+    end
+
+    test "removes avatar when clicking Remove Avatar button", %{conn: conn, user: user} do
+      {:ok, _user} =
+        Accounts.update_profile(user, %{avatar_url: "https://example.com/avatar.jpg"})
+
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      view
+      |> element("#remove-avatar-btn")
+      |> render_click()
+
+      assert render(view) =~ "Avatar removed"
+      refute has_element?(view, "#remove-avatar-btn")
+
+      reloaded_user = Accounts.get_user!(user.id)
+      assert is_nil(reloaded_user.avatar_url)
+    end
+
+    test "removes local avatar file from disk when clicking Remove Avatar button", %{
+      conn: conn,
+      user: user
+    } do
+      dir = Mydia.Accounts.Avatar.storage_dir()
+      File.mkdir_p!(dir)
+      filename = "avatar-#{user.id}-12345.png"
+      file_path = Path.join(dir, filename)
+      File.write!(file_path, "fake png content")
+
+      {:ok, _user} =
+        Accounts.update_profile(user, %{avatar_url: "/generated/avatars/#{filename}"})
+
+      assert File.exists?(file_path)
+
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      view
+      |> element("#remove-avatar-btn")
+      |> render_click()
+
+      assert render(view) =~ "Avatar removed"
+      refute File.exists?(file_path)
+    end
+
+    test "uploads an avatar image file and updates profile", %{conn: conn, user: user} do
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      png_data =
+        <<137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8,
+          6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 10, 73, 68, 65, 84, 120, 156, 99, 0, 1, 0, 0, 5,
+          0, 1, 13, 10, 45, 180, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130>>
+
+      avatar =
+        file_input(view, "#profile-form", :avatar, [
+          %{
+            name: "avatar.png",
+            content: png_data,
+            type: "image/png"
+          }
+        ])
+
+      render_upload(avatar, "avatar.png")
+
+      view
+      |> form("#profile-form", %{"user" => %{"display_name" => "Avatar Tester"}})
+      |> render_submit()
+
+      assert render(view) =~ "Profile updated successfully"
+
+      updated_user = Accounts.get_user!(user.id)
+      assert String.starts_with?(updated_user.avatar_url, "/generated/avatars/avatar-#{user.id}-")
+      assert String.ends_with?(updated_user.avatar_url, ".png")
+      assert updated_user.display_name == "Avatar Tester"
+    end
+
+    test "cancels an avatar upload in progress", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      png_data =
+        <<137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8,
+          6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 10, 73, 68, 65, 84, 120, 156, 99, 0, 1, 0, 0, 5,
+          0, 1, 13, 10, 45, 180, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130>>
+
+      avatar =
+        file_input(view, "#profile-form", :avatar, [
+          %{
+            name: "avatar.png",
+            content: png_data,
+            type: "image/png"
+          }
+        ])
+
+      assert {:ok, _} = preflight_upload(avatar)
+      assert has_element?(view, "button[phx-click='cancel_avatar_upload']")
+
+      view
+      |> element("button[phx-click='cancel_avatar_upload']")
+      |> render_click()
+
+      refute has_element?(view, "button[phx-click='cancel_avatar_upload']")
+    end
+
+    test "cancelling an upload then saving profile does not change avatar", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      png_data =
+        <<137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8,
+          6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 10, 73, 68, 65, 84, 120, 156, 99, 0, 1, 0, 0, 5,
+          0, 1, 13, 10, 45, 180, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130>>
+
+      avatar =
+        file_input(view, "#profile-form", :avatar, [
+          %{
+            name: "avatar.png",
+            content: png_data,
+            type: "image/png"
+          }
+        ])
+
+      assert {:ok, _} = preflight_upload(avatar)
+
+      view
+      |> element("button[phx-click='cancel_avatar_upload']")
+      |> render_click()
+
+      view
+      |> form("#profile-form", %{"user" => %{"display_name" => "No Upload Tester"}})
+      |> render_submit()
+
+      assert render(view) =~ "Profile updated successfully"
+      updated_user = Accounts.get_user!(user.id)
+      assert updated_user.display_name == "No Upload Tester"
+      assert is_nil(updated_user.avatar_url)
+    end
+
+    test "shows upload error for unacceptable file format", %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      avatar =
+        file_input(view, "#profile-form", :avatar, [
+          %{
+            name: "malicious.exe",
+            content: "executable binary",
+            type: "application/x-msdownload"
+          }
+        ])
+
+      assert {:error, [[_, :not_accepted]]} = preflight_upload(avatar)
+      assert render(view) =~ "Unacceptable file type"
+    end
+  end
 end

--- a/test/mydia_web/live/profile_live_test.exs
+++ b/test/mydia_web/live/profile_live_test.exs
@@ -353,5 +353,28 @@ defmodule MydiaWeb.ProfileLiveTest do
       reloaded = Accounts.get_user!(user.id)
       assert is_nil(reloaded.avatar_url)
     end
+
+    test "sidebar user menu renders avatar image when user has avatar_url", %{
+      conn: conn,
+      user: user
+    } do
+      avatar_url = "https://example.com/user-avatar.jpg"
+      {:ok, _user} = Accounts.update_profile(user, %{avatar_url: avatar_url})
+
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      assert has_element?(view, "#sidebar-user-menu img[src='#{avatar_url}']")
+    end
+
+    test "sidebar user menu falls back to initials when user has no avatar_url", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, view, _html} = live(conn, ~p"/profile")
+
+      refute has_element?(view, "#sidebar-user-menu img")
+      initials = String.upcase(String.slice(user.username || user.email, 0..1))
+      assert has_element?(view, "#sidebar-user-menu span", initials)
+    end
   end
 end


### PR DESCRIPTION
## Summary
Adds the ability for users to upload avatar images directly on the **Profile & Preferences** (`/profile`) page, while retaining the external image URL option and providing an affordance to clear/remove existing avatars.

## Key Changes
- **`Mydia.Accounts.Avatar`**: Manages storing uploaded files under `<generated_media_path>/avatars/avatar-<user_id>-<timestamp>.<ext>`, served statically at `/generated/avatars/...`. Cleans up old avatar files upon successful database updates with strict user ownership validation (preventing IDOR).
- **`Mydia.Accounts.User.profile_changeset/2`**: Validates local `/generated/avatars/...` paths alongside `http://` and `https://` URLs, and normalizes empty strings to `nil`.
- **`MydiaWeb.ProfileLive.Index`**:
  - Configures LiveView upload with `allow_upload(:avatar, accept: ~w(.jpg .jpeg .png .webp .gif), max_entries: 1, max_file_size: 5_000_000)`.
  - Provides staged file preview with `<.live_img_preview>`, cancellation, error messages, and a "Remove Avatar" button when an avatar is present.
  - Pre-validates profile form inputs before consuming upload entries to prevent disk leaks.
  - Cleans up old disk avatar files when replacing an uploaded avatar with an external URL or removing the avatar.
- **`MydiaWeb.Layouts`**: Updates the navigation sidebar user menu (`#sidebar-user-menu`) to render the user's avatar image if present, falling back to initials.

## Testing
- Unit tests in `test/mydia/accounts/avatar_test.exs` and `test/mydia/accounts/user_profile_changeset_test.exs`.
- Integration and LiveView tests in `test/mydia_web/live/profile_live_test.exs`.
- Credo clean with 0 issues; all 152 accounts & profile live tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile avatar uploads with image previews, format validation, cancellation, and removal.
  * Added support for displaying uploaded avatars in the user sidebar, with initials or guest fallback when unavailable.
  * Added support for external avatar URLs alongside locally uploaded avatars.
  * Automatically removes replaced or removed local avatar files.

* **Bug Fixes**
  * Improved avatar URL validation and normalization, including support for clearing values and local avatar paths.
  * Prevented simultaneous avatar uploads from overwriting one another.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->