### PR TITLE
feat(ui): add DaisyUI hover poster effects

### DIFF
--- a/lib/mydia_web/components/collection_components.ex
+++ b/lib/mydia_web/components/collection_components.ex
@@ -179,19 +179,15 @@ defmodule MydiaWeb.CollectionComponents do
     """
   end
 
-  # Renders a poster collage from multiple poster paths.
-  # Displays:
-  # - 4 posters: 2x2 grid
-  # - 3 posters: 1 large + 2 small on right
-  # - 2 posters: side by side
-  # - 1 poster: full size
-  # - 0 posters: placeholder icon
+  # Renders the collection artwork as a DaisyUI hover gallery. The component
+  # reveals each image in a horizontal hover zone. The collection grid supplies
+  # at most four paths; a collection with no artwork keeps the placeholder.
   attr :poster_paths, :list, required: true
   attr :collection_type, :string, default: "manual"
 
   defp poster_collage(%{poster_paths: []} = assigns) do
     ~H"""
-    <div class="w-full h-full flex flex-col items-center justify-center bg-gradient-to-br from-base-200 to-base-300 group-hover:scale-105 transition-transform duration-300">
+    <div class="w-full h-full flex flex-col items-center justify-center bg-gradient-to-br from-base-200 to-base-300">
       <.icon
         name={if @collection_type == "smart", do: "hero-sparkles", else: "hero-folder"}
         class="w-16 h-16 text-base-content/20"
@@ -200,67 +196,22 @@ defmodule MydiaWeb.CollectionComponents do
     """
   end
 
-  defp poster_collage(%{poster_paths: [path]} = assigns) do
-    assigns = assign(assigns, :url, tmdb_poster_url(path))
+  defp poster_collage(assigns) do
+    posters =
+      assigns.poster_paths
+      |> Enum.map(&tmdb_poster_url/1)
+      |> Enum.with_index()
+
+    assigns = assign(assigns, :posters, posters)
 
     ~H"""
-    <img
-      src={@url}
-      alt="Collection poster"
-      class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-      loading="lazy"
-    />
-    """
-  end
-
-  defp poster_collage(%{poster_paths: [path1, path2]} = assigns) do
-    assigns =
-      assigns
-      |> assign(:url1, tmdb_poster_url(path1))
-      |> assign(:url2, tmdb_poster_url(path2))
-
-    ~H"""
-    <div class="grid grid-cols-2 w-full h-full group-hover:scale-105 transition-transform duration-300">
-      <img src={@url1} alt="" class="w-full h-full object-cover" loading="lazy" />
-      <img src={@url2} alt="" class="w-full h-full object-cover" loading="lazy" />
-    </div>
-    """
-  end
-
-  defp poster_collage(%{poster_paths: [path1, path2, path3]} = assigns) do
-    assigns =
-      assigns
-      |> assign(:url1, tmdb_poster_url(path1))
-      |> assign(:url2, tmdb_poster_url(path2))
-      |> assign(:url3, tmdb_poster_url(path3))
-
-    ~H"""
-    <div class="grid grid-cols-2 w-full h-full group-hover:scale-105 transition-transform duration-300">
-      <img src={@url1} alt="" class="w-full h-full object-cover row-span-2" loading="lazy" />
-      <div class="flex flex-col">
-        <img src={@url2} alt="" class="w-full h-1/2 object-cover" loading="lazy" />
-        <img src={@url3} alt="" class="w-full h-1/2 object-cover" loading="lazy" />
-      </div>
-    </div>
-    """
-  end
-
-  defp poster_collage(%{poster_paths: paths} = assigns) when length(paths) >= 4 do
-    [path1, path2, path3, path4 | _] = paths
-
-    assigns =
-      assigns
-      |> assign(:url1, tmdb_poster_url(path1))
-      |> assign(:url2, tmdb_poster_url(path2))
-      |> assign(:url3, tmdb_poster_url(path3))
-      |> assign(:url4, tmdb_poster_url(path4))
-
-    ~H"""
-    <div class="grid grid-cols-2 grid-rows-2 w-full h-full group-hover:scale-105 transition-transform duration-300">
-      <img src={@url1} alt="" class="w-full h-full object-cover" loading="lazy" />
-      <img src={@url2} alt="" class="w-full h-full object-cover" loading="lazy" />
-      <img src={@url3} alt="" class="w-full h-full object-cover" loading="lazy" />
-      <img src={@url4} alt="" class="w-full h-full object-cover" loading="lazy" />
+    <div class="hover-gallery w-full h-full">
+      <img
+        :for={{url, index} <- @posters}
+        src={url}
+        alt={if index == 0, do: "Collection poster", else: ""}
+        loading="lazy"
+      />
     </div>
     """
   end

--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -450,11 +450,13 @@ defmodule MydiaWeb.CoreComponents do
   end
 
   @doc """
-  A 2:3 poster in a hover-scaling figure.
+  A 2:3 poster in DaisyUI's 3D hover wrapper.
 
-  The hover transform used to be hand-written at every poster grid in the app,
-  which is why three of them had it and five did not. It lives here now so a
-  new grid gets it by construction.
+  The hover effect used to be hand-written at every poster grid in the app,
+  which is why three of them had it and five did not. It lives here so a new
+  grid gets the same interaction by construction. DaisyUI's `hover-3d`
+  component requires the content followed by eight empty hover zones; keeping
+  that structure here prevents callers from drifting.
 
   The `group` class stays on the caller's own wrapper rather than moving in
   here. Those wrappers differ per page: some are a plain `relative group`, the
@@ -486,25 +488,29 @@ defmodule MydiaWeb.CoreComponents do
 
   def poster_figure(assigns) do
     ~H"""
-    <figure class={["relative aspect-[2/3] overflow-hidden bg-base-300", @class]}>
-      <img
-        :if={@src}
-        src={@src}
-        alt={@alt}
-        loading={@loading}
-        class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
-      />
-      <%!-- The fallback carries the same hover transform as the img above. A card
-            whose poster is missing is still a link, and a grid where only some
-            cards lift on hover reads as broken rather than as a distinction. --%>
-      <div
-        :if={is_nil(@src)}
-        class="w-full h-full flex items-center justify-center group-hover:scale-105 transition-transform duration-300"
-      >
-        <.icon name={@fallback_icon} class="w-16 h-16 text-base-content/20" />
-      </div>
-      {render_slot(@overlay)}
-    </figure>
+    <div class="hover-3d w-full">
+      <figure class={["relative aspect-[2/3] overflow-hidden bg-base-300", @class]}>
+        <img
+          :if={@src}
+          src={@src}
+          alt={@alt}
+          loading={@loading}
+          class="w-full h-full object-cover"
+        />
+        <div :if={is_nil(@src)} class="w-full h-full flex items-center justify-center">
+          <.icon name={@fallback_icon} class="w-16 h-16 text-base-content/20" />
+        </div>
+        {render_slot(@overlay)}
+      </figure>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </div>
     """
   end
 

--- a/test/mydia_web/components/collection_components_test.exs
+++ b/test/mydia_web/components/collection_components_test.exs
@@ -1,0 +1,37 @@
+defmodule MydiaWeb.CollectionComponentsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias MydiaWeb.CollectionComponents
+
+  test "a collection with multiple posters renders a DaisyUI hover gallery" do
+    collection = %{
+      id: "collection-1",
+      name: "Midnight Movies",
+      type: "manual",
+      visibility: "private",
+      is_system: false
+    }
+
+    html =
+      render_component(&CollectionComponents.collection_card/1,
+        collection: collection,
+        href: "/collections/collection-1",
+        poster_paths: ["/first.jpg", "/second.jpg", "/third.jpg"]
+      )
+
+    fragment = LazyHTML.from_fragment(html)
+    galleries = LazyHTML.query(fragment, ".hover-gallery")
+    posters = LazyHTML.query(fragment, ".hover-gallery > img")
+
+    assert Enum.count(galleries) == 1
+    assert Enum.count(posters) == 3
+
+    assert LazyHTML.attribute(posters, "src")
+           |> Enum.map(&URI.decode/1)
+           |> Enum.map(&Path.basename/1) == ["first.jpg", "second.jpg", "third.jpg"]
+
+    refute html =~ "group-hover:scale-105"
+  end
+end

--- a/test/mydia_web/components/poster_figure_test.exs
+++ b/test/mydia_web/components/poster_figure_test.exs
@@ -1,8 +1,8 @@
 defmodule MydiaWeb.CoreComponents.PosterFigureTest do
   @moduledoc """
-  The hover transform is the assertion that matters. It is the thing that was
-  hand-copied across eight files and drifted, and the only reason this
-  component exists.
+  The hover structure is the assertion that matters. It is the behavior that
+  was hand-copied across eight files and drifted, and the reason this component
+  exists.
   """
 
   use ExUnit.Case, async: true
@@ -11,15 +11,21 @@ defmodule MydiaWeb.CoreComponents.PosterFigureTest do
   import Phoenix.LiveViewTest
   import MydiaWeb.CoreComponents
 
-  test "renders the poster with the shared hover transform" do
+  test "renders the poster with DaisyUI's 3D hover structure" do
     html =
       render_component(&poster_figure/1, src: "/p.jpg", alt: "Aftersun")
 
     assert html =~ ~s(src="/p.jpg")
     assert html =~ ~s(alt="Aftersun")
-    assert html =~ "group-hover:scale-105"
-    assert html =~ "transition-transform"
     assert html =~ "aspect-[2/3]"
+
+    fragment = LazyHTML.from_fragment(html)
+    hover_3d = LazyHTML.query(fragment, ".hover-3d")
+
+    assert Enum.count(hover_3d) == 1
+    assert fragment |> LazyHTML.query(".hover-3d > figure") |> Enum.count() == 1
+    assert fragment |> LazyHTML.query(".hover-3d > div") |> Enum.count() == 8
+    refute html =~ "group-hover:scale-105"
   end
 
   test "lazy loads by default" do
@@ -41,14 +47,15 @@ defmodule MydiaWeb.CoreComponents.PosterFigureTest do
     assert html =~ "hero-tv"
   end
 
-  # The fallback shipped without the transform at first, so a grid mixing
-  # poster-less cards with poster-bearing ones lifted only some of them on
-  # hover. Pinned here because nothing else would catch it coming back.
-  test "the fallback carries the same hover transform as the poster" do
+  # The fallback shipped outside the shared hover structure at first, so a
+  # grid mixing poster-less cards with poster-bearing ones lifted only some of
+  # them. Pinned here because nothing else would catch it coming back.
+  test "the fallback lives inside the same 3D hover structure as the poster" do
     html = render_component(&poster_figure/1, src: nil, alt: "A")
+    fragment = LazyHTML.from_fragment(html)
 
-    assert html =~ "group-hover:scale-105"
-    assert html =~ "transition-transform"
+    assert fragment |> LazyHTML.query(".hover-3d > figure") |> Enum.count() == 1
+    assert fragment |> LazyHTML.query(".hover-3d > div") |> Enum.count() == 8
   end
 
   test "appends caller classes to the figure" do


### PR DESCRIPTION
## Summary
- use DaisyUI Hover 3D for shared media poster figures
- use DaisyUI Hover Gallery for collection artwork
- add component regressions for both structures

## Verification
- `./dev mix test test/mydia_web/components/poster_figure_test.exs test/mydia_web/components/collection_components_test.exs test/mydia_web/components/discover_components_test.exs test/mydia_web/live/collection_live/index_test.exs`
- Tailwind build includes DaisyUI 5.7.7 `hover-3d` and `hover-gallery` rules
- `./dev mix precommit` was started but interrupted before its final summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Collection poster layouts now use a unified hover gallery for displaying multiple posters.
  * Poster images and fallback icons now use a DaisyUI 3D hover presentation.
  * Empty collection placeholders no longer apply the previous hover scale animation.

* **Tests**
  * Added coverage for gallery rendering, poster URLs, fallback content, and the updated hover structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->