### PR TITLE
Configure before adding, on the approval system

### DIFF
--- a/docs/using/how-to/manage-users.md
+++ b/docs/using/how-to/manage-users.md
@@ -65,8 +65,10 @@ Guest users can request media:
 3. **The request lands in the admin queue** as pending
 4. **Admin reviews** and approves or rejects
 5. **If approved**, the admin chooses the library, quality profile and
-   monitoring for the item, and media is added to the library. A search starts
-   immediately unless the admin turns off **Search on Add**.
+   monitoring for the item, and media is added to the library. If the title
+   is already in the library, the request is linked to that existing item
+   instead and no search is queued. Otherwise a search starts immediately
+   unless the admin turns off **Search on Add**.
 6. **The guest sees the outcome** on their own requests page
 
 !!! warning "There are no notifications"
@@ -85,7 +87,10 @@ Admins can view and manage requests:
 4. Approving opens a dialog for the root folder, quality profile, monitoring,
    season monitoring (series only) and whether to search immediately. The
    fields are prefilled from your own add defaults, so approving with no
-   changes is still two clicks.
+   changes is still two clicks, as long as at least one library path is
+   already configured. Without one, the root folder field has nothing to
+   offer and approval is blocked until a library path is added under
+   **Admin > Configuration**, on the **Library** tab.
 5. A rejection requires a reason, which the requester can see
 
 ## Disabling Authentication

--- a/docs/using/how-to/manage-users.md
+++ b/docs/using/how-to/manage-users.md
@@ -64,7 +64,9 @@ Guest users can request media:
 2. **Guest clicks Request** on the search result
 3. **The request lands in the admin queue** as pending
 4. **Admin reviews** and approves or rejects
-5. **If approved**, media is added to library and download begins
+5. **If approved**, the admin chooses the library, quality profile and
+   monitoring for the item, and media is added to the library. A search starts
+   immediately unless the admin turns off **Search on Add**.
 6. **The guest sees the outcome** on their own requests page
 
 !!! warning "There are no notifications"
@@ -80,7 +82,11 @@ Admins can view and manage requests:
 1. Navigate to **Admin > Requests**
 2. View pending requests
 3. Approve or reject each request
-4. A rejection requires a reason, which the requester can see
+4. Approving opens a dialog for the root folder, quality profile, monitoring,
+   season monitoring (series only) and whether to search immediately. The
+   fields are prefilled from your own add defaults, so approving with no
+   changes is still two clicks.
+5. A rejection requires a reason, which the requester can see
 
 ## Disabling Authentication
 

--- a/lib/mydia/media/add_defaults.ex
+++ b/lib/mydia/media/add_defaults.ex
@@ -114,6 +114,21 @@ defmodule Mydia.Media.AddDefaults do
     ]
   end
 
+  @doc """
+  Same as `to_add_opts/1`, with `:search_on_add` put back on.
+
+  For the callers that queue the search themselves, or forward the opts to
+  one that will: `MediaAddHelpers.add_opts_from_config/3` pops it back off
+  before calling `Add`, and `AdminRequestsLive.Index.do_approve/4` passes it
+  straight through to `MediaRequests.approve_request/3`. Both used to build
+  this list inline with `to_add_opts(defaults) |> Keyword.put(:search_on_add,
+  defaults.search_on_add)`; kept here once so they cannot drift.
+  """
+  @spec to_add_opts_with_search(t()) :: keyword()
+  def to_add_opts_with_search(%__MODULE__{} = defaults) do
+    Keyword.put(to_add_opts(defaults), :search_on_add, defaults.search_on_add)
+  end
+
   defp preference_for(%User{} = user), do: Accounts.get_user_preference!(user)
   defp preference_for(_), do: nil
 

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -115,7 +115,14 @@ defmodule Mydia.MediaRequests do
     ref = MediaRequest.external_ref(request)
     media_type = if request.media_type == "movie", do: :movie, else: :tv_show
 
-    case Add.resolve_attrs(ref, media_type, opts[:config], monitored: true) do
+    # `monitored` defaults to true when the caller says nothing, which is what
+    # approval did unconditionally before the config dialog existed.
+    attr_opts =
+      opts
+      |> Keyword.take([:monitored, :quality_profile_id, :library_path_id])
+      |> Keyword.put_new(:monitored, true)
+
+    case Add.resolve_attrs(ref, media_type, opts[:config], attr_opts) do
       {:ok, media_attrs} ->
         {:ok, media_attrs}
 
@@ -131,9 +138,11 @@ defmodule Mydia.MediaRequests do
   defp insert_approval(request, media_attrs, attrs, opts) do
     Multi.new()
     |> Multi.run(:media_item, fn _repo, _changes ->
-      case Add.from_attrs(media_attrs, opts[:config],
-             actor_type: :user,
-             actor_id: attrs[:approved_by_id]
+      case Add.from_attrs(
+             media_attrs,
+             opts[:config],
+             [actor_type: :user, actor_id: attrs[:approved_by_id]] ++
+               Keyword.take(opts, [:season_monitoring])
            ) do
         {:ok, media_item} ->
           {:ok, media_item}

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -108,11 +108,18 @@ defmodule Mydia.MediaRequests do
   """
   def approve_request(%MediaRequest{} = request, attrs \\ %{}, opts \\ []) do
     with {:ok, media_attrs} <- resolve_media_attrs(request, opts),
-         {:ok, result} <- insert_approval(request, media_attrs, attrs, opts) do
+         {:ok, result, created?} <- insert_approval(request, media_attrs, attrs, opts) do
       # After the transaction, never inside it. Repo.transaction defers event
       # broadcasts until commit, and a search queued against an uncommitted
       # media item is a race.
-      Search.maybe_queue_search(result.media_item, Keyword.get(opts, :search_on_add, false))
+      #
+      # Only queued when the approval created a new media item. A request
+      # that linked to an already-in-library item must not enqueue a search
+      # for a row someone else set up; the Add flow makes the same
+      # distinction (see MediaAddHelpers.handle_add_media_to_library/5).
+      if created? do
+        Search.maybe_queue_search(result.media_item, Keyword.get(opts, :search_on_add, false))
+      end
 
       {:ok, result}
     end
@@ -142,6 +149,11 @@ defmodule Mydia.MediaRequests do
     end
   end
 
+  # Returns `{:ok, %{request: _, media_item: _}, created?}` on success, where
+  # `created?` is false when the request linked to a pre-existing media item
+  # rather than creating a new one. `approve_request/3` uses that flag to
+  # decide whether to queue a search; a linked request must not queue one for
+  # a media item someone else already added.
   defp insert_approval(request, media_attrs, attrs, opts) do
     Multi.new()
     |> Multi.run(:media_item, fn _repo, _changes ->
@@ -152,33 +164,33 @@ defmodule Mydia.MediaRequests do
                Keyword.take(opts, [:season_monitoring])
            ) do
         {:ok, media_item} ->
-          {:ok, media_item}
+          {:ok, %{item: media_item, created?: true}}
 
         # Not a failure: the request is asking for something already in the
         # library. Link the request to the existing row instead of bouncing
         # the approval off a unique constraint the admin can't act on.
         {:error, {:already_in_library, media_item}} ->
-          {:ok, media_item}
+          {:ok, %{item: media_item, created?: false}}
 
         {:error, {:changeset, changeset}} ->
           {:error, changeset}
       end
     end)
-    |> Multi.run(:request, fn _repo, %{media_item: media_item} ->
+    |> Multi.run(:request, fn _repo, %{media_item: %{item: media_item}} ->
       request
       |> MediaRequest.approve_changeset(Map.put(attrs, :media_item_id, media_item.id))
       |> Repo.update()
     end)
     |> Repo.transaction()
     |> case do
-      {:ok, %{request: updated_request, media_item: media_item}} ->
+      {:ok, %{request: updated_request, media_item: %{item: media_item, created?: created?}}} ->
         # "linked to", not "created": approval also lands here when the item
         # was already in the library and the request was pointed at it.
         Logger.info(
           "Request #{request.id} approved by user #{attrs[:approved_by_id]}, linked to media #{media_item.id}"
         )
 
-        {:ok, %{request: updated_request, media_item: media_item}}
+        {:ok, %{request: updated_request, media_item: media_item}, created?}
 
       {:error, :media_item, changeset, _changes} ->
         Logger.error("Failed to create media item for request #{request.id}")

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -18,6 +18,7 @@ defmodule Mydia.MediaRequests do
   alias Mydia.Media
   alias Mydia.Media.Add
   alias Mydia.Media.MediaRequest
+  alias Mydia.Search
   alias Ecto.Multi
 
   @doc """
@@ -106,8 +107,14 @@ defmodule Mydia.MediaRequests do
       `Metadata.default_relay_config/0`. Inject a Bypass config in tests.
   """
   def approve_request(%MediaRequest{} = request, attrs \\ %{}, opts \\ []) do
-    with {:ok, media_attrs} <- resolve_media_attrs(request, opts) do
-      insert_approval(request, media_attrs, attrs, opts)
+    with {:ok, media_attrs} <- resolve_media_attrs(request, opts),
+         {:ok, result} <- insert_approval(request, media_attrs, attrs, opts) do
+      # After the transaction, never inside it. Repo.transaction defers event
+      # broadcasts until commit, and a search queued against an uncommitted
+      # media item is a race.
+      Search.maybe_queue_search(result.media_item, Keyword.get(opts, :search_on_add, false))
+
+      {:ok, result}
     end
   end
 

--- a/lib/mydia/search.ex
+++ b/lib/mydia/search.ex
@@ -291,6 +291,36 @@ defmodule Mydia.Search do
   end
 
   @doc """
+  Queues an automatic search for a freshly added item, when asked to.
+
+  This is the shared home for auto-search-on-add. It lives here rather than in
+  `MydiaWeb.Live.Helpers.MediaAddHelpers` because `Mydia.MediaRequests` needs it
+  too, and a context calling into the web layer is the wrong direction.
+
+  A failure leaves the item added and returns `:ok` anyway. Adding the title is
+  what the user asked for; the search is a convenience.
+  """
+  @spec maybe_queue_search(Mydia.Media.MediaItem.t(), boolean()) :: :ok
+  def maybe_queue_search(media_item, search?)
+
+  def maybe_queue_search(_media_item, false), do: :ok
+
+  def maybe_queue_search(media_item, true) do
+    case queue_auto_searches([media_item]) do
+      {:ok, _count} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to queue search on add",
+          media_item_id: media_item.id,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
   Queues automatic release searches for the given media items.
 
   Movies queue `Mydia.Jobs.MovieSearch` in `"specific"` mode and TV shows queue

--- a/lib/mydia_web/components/add_media_components.ex
+++ b/lib/mydia_web/components/add_media_components.ex
@@ -18,6 +18,127 @@ defmodule MydiaWeb.AddMediaComponents do
   use MydiaWeb, :html
 
   @doc """
+  Renders the five controls that decide how an item is added.
+
+  Shared by `add_config_modal/1` and the approve dialog on
+  `/admin/requests`, which is the whole point: the two dialogs disagree
+  about their shell, their preview, their submit button and their extra
+  fields, but must never disagree about these.
+
+  Reads `defaults`, `libraries` and `media_type` off `config`. The `ref` and
+  `preview` keys belong to the callers' shells, not here.
+
+  Input names are `config[...]` in both hosts, unprefixed, so
+  `MediaAddHelpers.add_opts_from_config/3` and `resolve_add_defaults/3` take
+  the params map verbatim.
+  """
+  attr :config, :map, required: true
+  attr :quality_profiles, :list, default: []
+
+  def add_config_fields(assigns) do
+    ~H"""
+    <%!-- Library Path --%>
+    <div class="form-control mb-4">
+      <label class="label">
+        <span class="label-text font-semibold">Root Folder</span>
+        <span class="label-text-alt text-error">*</span>
+      </label>
+      <%= if @config.libraries == [] do %>
+        <div class="alert alert-warning">
+          <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
+          <span>No library paths configured. Please configure a library path first.</span>
+        </div>
+      <% else %>
+        <select name="config[library_path_id]" class="select select-bordered" required>
+          <option value="">Select a folder...</option>
+          <%= for path <- @config.libraries do %>
+            <option value={path.id} selected={@config.defaults.library_path_id == path.id}>
+              {Path.basename(path.path)} · {path.path}
+            </option>
+          <% end %>
+        </select>
+      <% end %>
+    </div>
+    <%!-- Quality Profile --%>
+    <div class="form-control mb-4">
+      <label class="label">
+        <span class="label-text font-semibold">Quality Profile</span>
+      </label>
+      <select name="config[quality_profile_id]" class="select select-bordered">
+        <option value="">Use server default</option>
+        <%= for profile <- @quality_profiles do %>
+          <option value={profile.id} selected={@config.defaults.quality_profile_id == profile.id}>
+            {profile.name}
+          </option>
+        <% end %>
+      </select>
+    </div>
+    <%!-- Monitoring --%>
+    <div class="form-control mb-4">
+      <label class="label cursor-pointer justify-start gap-4">
+        <input type="hidden" name="config[monitored]" value="false" />
+        <input
+          type="checkbox"
+          name="config[monitored]"
+          value="true"
+          class="toggle toggle-primary"
+          checked={@config.defaults.monitored}
+        />
+        <div>
+          <span class="label-text font-semibold">
+            Monitor this {(@config.media_type == :movie && "movie") || "series"}
+          </span>
+          <p class="text-xs text-base-content/60">
+            Automatically search for and download new releases
+          </p>
+        </div>
+      </label>
+    </div>
+    <%!-- Season Monitoring for TV --%>
+    <%= if @config.media_type == :tv_show do %>
+      <div class="form-control mb-4">
+        <label class="label">
+          <span class="label-text font-semibold">Season Monitoring</span>
+        </label>
+        <select name="config[season_monitoring]" class="select select-bordered">
+          <option value="all" selected={@config.defaults.season_monitoring == "all"}>
+            Monitor All Seasons
+          </option>
+          <option value="first" selected={@config.defaults.season_monitoring == "first"}>
+            Monitor First Season Only
+          </option>
+          <option value="future" selected={@config.defaults.season_monitoring == "future"}>
+            Monitor Future Seasons
+          </option>
+          <option value="none" selected={@config.defaults.season_monitoring == "none"}>
+            Don't Monitor Any Seasons
+          </option>
+        </select>
+      </div>
+    <% end %>
+    <%!-- Search on Add --%>
+    <div class="form-control mb-6">
+      <label class="label cursor-pointer justify-start gap-4">
+        <input type="hidden" name="config[search_on_add]" value="false" />
+        <input
+          type="checkbox"
+          name="config[search_on_add]"
+          value="true"
+          class="toggle toggle-primary"
+          checked={@config.defaults.search_on_add}
+        />
+        <div>
+          <span class="label-text font-semibold">Search on Add</span>
+          <p class="text-xs text-base-content/60">
+            Trigger an immediate search for this media after adding
+          </p>
+        </div>
+      </label>
+    </div>
+    """
+  end
+
+  @doc """
   Renders the dialog for the card in `config`, or nothing when `config` is nil.
 
   `config` is `%{ref:, media_type:, defaults:, preview:, libraries:}`,
@@ -71,110 +192,7 @@ defmodule MydiaWeb.AddMediaComponents do
         </div>
         <%!-- Configuration Form --%>
         <.form for={%{}} phx-submit="submit_add_config" id="add-config-form">
-          <%!-- Library Path --%>
-          <div class="form-control mb-4">
-            <label class="label">
-              <span class="label-text font-semibold">Root Folder</span>
-              <span class="label-text-alt text-error">*</span>
-            </label>
-            <%= if @config.libraries == [] do %>
-              <div class="alert alert-warning">
-                <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
-                <span>No library paths configured. Please configure a library path first.</span>
-              </div>
-            <% else %>
-              <select name="config[library_path_id]" class="select select-bordered" required>
-                <option value="">Select a folder...</option>
-                <%= for path <- @config.libraries do %>
-                  <option
-                    value={path.id}
-                    selected={@config.defaults.library_path_id == path.id}
-                  >
-                    {Path.basename(path.path)} · {path.path}
-                  </option>
-                <% end %>
-              </select>
-            <% end %>
-          </div>
-          <%!-- Quality Profile --%>
-          <div class="form-control mb-4">
-            <label class="label">
-              <span class="label-text font-semibold">Quality Profile</span>
-            </label>
-            <select name="config[quality_profile_id]" class="select select-bordered">
-              <option value="">Use server default</option>
-              <%= for profile <- @quality_profiles do %>
-                <option
-                  value={profile.id}
-                  selected={@config.defaults.quality_profile_id == profile.id}
-                >
-                  {profile.name}
-                </option>
-              <% end %>
-            </select>
-          </div>
-          <%!-- Monitoring --%>
-          <div class="form-control mb-4">
-            <label class="label cursor-pointer justify-start gap-4">
-              <input type="hidden" name="config[monitored]" value="false" />
-              <input
-                type="checkbox"
-                name="config[monitored]"
-                value="true"
-                class="toggle toggle-primary"
-                checked={@config.defaults.monitored}
-              />
-              <div>
-                <span class="label-text font-semibold">
-                  Monitor this {(@config.media_type == :movie && "movie") || "series"}
-                </span>
-                <p class="text-xs text-base-content/60">
-                  Automatically search for and download new releases
-                </p>
-              </div>
-            </label>
-          </div>
-          <%!-- Season Monitoring for TV --%>
-          <%= if @config.media_type == :tv_show do %>
-            <div class="form-control mb-4">
-              <label class="label">
-                <span class="label-text font-semibold">Season Monitoring</span>
-              </label>
-              <select name="config[season_monitoring]" class="select select-bordered">
-                <option value="all" selected={@config.defaults.season_monitoring == "all"}>
-                  Monitor All Seasons
-                </option>
-                <option value="first" selected={@config.defaults.season_monitoring == "first"}>
-                  Monitor First Season Only
-                </option>
-                <option value="future" selected={@config.defaults.season_monitoring == "future"}>
-                  Monitor Future Seasons
-                </option>
-                <option value="none" selected={@config.defaults.season_monitoring == "none"}>
-                  Don't Monitor Any Seasons
-                </option>
-              </select>
-            </div>
-          <% end %>
-          <%!-- Search on Add --%>
-          <div class="form-control mb-6">
-            <label class="label cursor-pointer justify-start gap-4">
-              <input type="hidden" name="config[search_on_add]" value="false" />
-              <input
-                type="checkbox"
-                name="config[search_on_add]"
-                value="true"
-                class="toggle toggle-primary"
-                checked={@config.defaults.search_on_add}
-              />
-              <div>
-                <span class="label-text font-semibold">Search on Add</span>
-                <p class="text-xs text-base-content/60">
-                  Trigger an immediate search for this media after adding
-                </p>
-              </div>
-            </label>
-          </div>
+          <.add_config_fields config={@config} quality_profiles={@quality_profiles} />
           <%!-- Modal Actions --%>
           <div class="modal-action">
             <button type="button" class="btn btn-ghost" phx-click="close_add_config">

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -87,43 +87,27 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
     {:noreply, assign(socket, :approve_form, to_form(changeset, as: :approve))}
   end
 
-  def handle_event("submit_approve", %{"approve" => approve_params}, socket) do
+  def handle_event("submit_approve", %{"approve" => approve_params} = params, socket) do
     request = socket.assigns.selected_request
+    media_type = MediaRequest.media_type_atom(request)
 
-    attrs = %{
-      approved_by_id: socket.assigns.current_user.id,
-      admin_notes: approve_params["admin_notes"]
-    }
+    case MediaAddHelpers.resolve_add_defaults(
+           params["config"] || %{},
+           media_type,
+           socket.assigns.current_user
+         ) do
+      {:ok, defaults} ->
+        do_approve(socket, request, approve_params, defaults)
 
-    case MediaRequests.approve_request(request, attrs) do
-      {:ok, %{request: _updated_request, media_item: media_item}} ->
+      # Per #458, never silently substitute a different library. The admin
+      # picked a library that has since been removed or unmonitored, so say so.
+      {:error, :unknown_library} ->
         {:noreply,
          socket
          |> assign(:show_approve_modal, false)
          |> assign(:selected_request, nil)
-         |> put_flash(
-           :info,
-           "Request approved! #{media_item.title} has been added to the library."
-         )
-         |> load_requests()}
-
-      {:error, {:metadata, reason}} ->
-        Logger.warning("Approval blocked by metadata failure: #{inspect(reason)}")
-
-        {:noreply,
-         socket
-         |> assign(:show_approve_modal, false)
-         |> assign(:selected_request, nil)
-         |> put_flash(
-           :error,
-           "Could not reach the metadata service, so the request was not approved. Please try again."
-         )}
-
-      {:error, changeset} ->
-        {:noreply,
-         socket
-         |> put_flash(:error, "Failed to approve request: #{inspect(changeset.errors)}")
-         |> assign(:approve_form, to_form(changeset, as: :approve))}
+         |> assign(:approve_config, nil)
+         |> put_flash(:error, "That library is no longer available. Please try again.")}
     end
   end
 
@@ -224,6 +208,50 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
   end
 
   ## Private Helpers
+
+  defp do_approve(socket, request, approve_params, defaults) do
+    attrs = %{
+      approved_by_id: socket.assigns.current_user.id,
+      admin_notes: approve_params["admin_notes"]
+    }
+
+    opts =
+      defaults
+      |> AddDefaults.to_add_opts()
+      |> Keyword.put(:search_on_add, defaults.search_on_add)
+
+    case MediaRequests.approve_request(request, attrs, opts) do
+      {:ok, %{request: _updated_request, media_item: media_item}} ->
+        {:noreply,
+         socket
+         |> assign(:show_approve_modal, false)
+         |> assign(:selected_request, nil)
+         |> assign(:approve_config, nil)
+         |> put_flash(
+           :info,
+           "Request approved! #{media_item.title} has been added to the library."
+         )
+         |> load_requests()}
+
+      {:error, {:metadata, reason}} ->
+        Logger.warning("Approval blocked by metadata failure: #{inspect(reason)}")
+
+        {:noreply,
+         socket
+         |> assign(:show_approve_modal, false)
+         |> assign(:selected_request, nil)
+         |> put_flash(
+           :error,
+           "Could not reach the metadata service, so the request was not approved. Please try again."
+         )}
+
+      {:error, changeset} ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "Failed to approve request: #{inspect(changeset.errors)}")
+         |> assign(:approve_form, to_form(changeset, as: :approve))}
+    end
+  end
 
   defp apply_filters(socket, params) do
     status = params["status"] || "pending"

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -2,8 +2,13 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
   use MydiaWeb, :live_view
 
   import MydiaWeb.MediaRequestComponents
+  import MydiaWeb.AddMediaComponents
 
+  alias Mydia.Media.AddDefaults
+  alias Mydia.Media.MediaRequest
   alias Mydia.MediaRequests
+  alias Mydia.Settings
+  alias MydiaWeb.Live.Helpers.MediaAddHelpers
   alias MydiaWeb.Live.Helpers.MediaRequestHelpers
   require Logger
 
@@ -21,6 +26,8 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
      |> assign(:detail_item, nil)
      |> assign(:detail_metadata, nil)
      |> assign(:detail_loading, false)
+     |> assign(:approve_config, nil)
+     |> assign(:quality_profiles, Settings.list_quality_profiles())
      |> load_requests()}
   end
 
@@ -44,14 +51,16 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
      |> close_details()
      |> assign(:show_approve_modal, true)
      |> assign(:selected_request, request)
-     |> assign_approve_form()}
+     |> assign_approve_form()
+     |> assign_approve_config(request)}
   end
 
   def handle_event("close_approve_modal", _params, socket) do
     {:noreply,
      socket
      |> assign(:show_approve_modal, false)
-     |> assign(:selected_request, nil)}
+     |> assign(:selected_request, nil)
+     |> assign(:approve_config, nil)}
   end
 
   def handle_event("open_reject_modal", %{"id" => id}, socket) do
@@ -314,6 +323,21 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
       )
 
     assign(socket, :approve_form, to_form(changeset, as: :approve))
+  end
+
+  # Built at open time, not at mount: a library added or unmonitored since the
+  # admin loaded the page must not appear as a stale option, and one deleted
+  # since must not still be offered. Defaults come from the approving admin,
+  # not the requester -- the preference in play is which disk files land on,
+  # and that is the admin's server.
+  defp assign_approve_config(socket, request) do
+    media_type = MediaRequest.media_type_atom(request)
+
+    assign(socket, :approve_config, %{
+      media_type: media_type,
+      defaults: AddDefaults.resolve(socket.assigns.current_user, media_type),
+      libraries: MediaAddHelpers.candidate_libraries(media_type)
+    })
   end
 
   defp assign_reject_form(socket) do

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -215,10 +215,7 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
       admin_notes: approve_params["admin_notes"]
     }
 
-    opts =
-      defaults
-      |> AddDefaults.to_add_opts()
-      |> Keyword.put(:search_on_add, defaults.search_on_add)
+    opts = AddDefaults.to_add_opts_with_search(defaults)
 
     case MediaRequests.approve_request(request, attrs, opts) do
       {:ok, %{request: _updated_request, media_item: media_item}} ->

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -96,6 +96,34 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
            media_type,
            socket.assigns.current_user
          ) do
+      # The template disables the submit button and marks the library select
+      # required only when @approve_config.libraries == [], but that
+      # handle_event clause is live on the socket regardless of what
+      # rendered, the same bug class #676 fixed twice already. With no
+      # candidate library for this media type, AddDefaults.resolve/3 has
+      # nothing left to fall back to and returns library_path_id: nil, so a
+      # crafted submit would otherwise approve the request with no library
+      # at all. Refuse here too.
+      #
+      # This is not a stale choice going bad between render and submit (the
+      # unknown-library branch below, whose admin picked a library that has
+      # since disappeared, so the dialog closes because there is nothing
+      # left worth showing). There was never a library to pick here, so
+      # nothing about a fresh render would change that. Keep the dialog open
+      # instead, the same as the other rejection branches in do_approve/4:
+      # closing it would only send the admin back to reopen the same modal
+      # and read the same warning.
+      {:ok, %AddDefaults{library_path_id: nil} = defaults} ->
+        Logger.warning("Approval blocked for #{request.id}: no library configured")
+
+        {:noreply,
+         socket
+         |> keep_approve_choices(defaults)
+         |> put_flash(
+           :error,
+           "No library path is configured. Please configure a library path before approving."
+         )}
+
       {:ok, defaults} ->
         do_approve(socket, request, approve_params, defaults)
 

--- a/lib/mydia_web/live/admin_requests_live/index.ex
+++ b/lib/mydia_web/live/admin_requests_live/index.ex
@@ -233,13 +233,16 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
          )
          |> load_requests()}
 
+      # The dialog stays open with the admin's own choices, not fresh defaults.
+      # config.defaults is an %AddDefaults{}, so assigning the resolved struct
+      # back is all it takes. Nothing was written: the metadata fetch happens
+      # before the Multi opens, so the request is still pending.
       {:error, {:metadata, reason}} ->
         Logger.warning("Approval blocked by metadata failure: #{inspect(reason)}")
 
         {:noreply,
          socket
-         |> assign(:show_approve_modal, false)
-         |> assign(:selected_request, nil)
+         |> keep_approve_choices(defaults)
          |> put_flash(
            :error,
            "Could not reach the metadata service, so the request was not approved. Please try again."
@@ -248,9 +251,14 @@ defmodule MydiaWeb.AdminRequestsLive.Index do
       {:error, changeset} ->
         {:noreply,
          socket
+         |> keep_approve_choices(defaults)
          |> put_flash(:error, "Failed to approve request: #{inspect(changeset.errors)}")
          |> assign(:approve_form, to_form(changeset, as: :approve))}
     end
+  end
+
+  defp keep_approve_choices(socket, defaults) do
+    assign(socket, :approve_config, %{socket.assigns.approve_config | defaults: defaults})
   end
 
   defp apply_filters(socket, params) do

--- a/lib/mydia_web/live/admin_requests_live/index.html.heex
+++ b/lib/mydia_web/live/admin_requests_live/index.html.heex
@@ -180,7 +180,7 @@
     <%!-- Approve Modal --%>
     <%= if @show_approve_modal and @selected_request do %>
       <div class="modal modal-open">
-        <div class="modal-box max-w-lg">
+        <div class="modal-box max-w-2xl">
           <h3 class="font-bold text-lg mb-4">Approve Request</h3>
           <div class="alert alert-success mb-4">
             <.icon name="hero-information-circle" class="w-5 h-5" />
@@ -195,6 +195,11 @@
             phx-submit="submit_approve"
             id="approve-form"
           >
+            <.add_config_fields
+              :if={@approve_config}
+              config={@approve_config}
+              quality_profiles={@quality_profiles}
+            />
             <div class="form-control mb-4">
               <label class="label">
                 <span class="label-text font-semibold">Admin Notes (Optional)</span>
@@ -209,7 +214,11 @@
               <button type="button" class="btn btn-ghost" phx-click="close_approve_modal">
                 Cancel
               </button>
-              <button type="submit" class="btn btn-success">
+              <button
+                type="submit"
+                class="btn btn-success"
+                disabled={@approve_config && @approve_config.libraries == []}
+              >
                 <.icon name="hero-check" class="w-5 h-5" /> Approve & Add to Library
               </button>
             </div>

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -7,8 +7,6 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   request approval shares.
   """
 
-  require Logger
-
   alias Mydia.Media.Add
   alias Mydia.Media.AddDefaults
   alias Mydia.Media.FranchiseEntry
@@ -148,7 +146,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
     case Add.from_provider(ref, media_type, config, add_opts) do
       {:ok, media_item} ->
-        maybe_queue_search(media_item, search_on_add)
+        Mydia.Search.maybe_queue_search(media_item, search_on_add)
 
         {:ok, media_item, update_library_status_map(library_status_map, media_item)}
 
@@ -160,32 +158,6 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
       {:error, _} = error ->
         error
-    end
-  end
-
-  # This is the shared home for auto-search-on-add. AddMediaLive used to carry
-  # a near-identical private maybe_queue_search/2, but that module was deleted
-  # once Discover absorbed one-click add, so this is the only copy now. Uses
-  # Search.queue_auto_searches/1 rather than enqueuing directly: it is already
-  # Oban-dedupe-safe (singular insert/1, not insert_all/1) and is what the
-  # media detail page uses.
-  #
-  # A failure leaves the item added. Adding the title is what the user asked
-  # for; the search is a convenience.
-  defp maybe_queue_search(_media_item, false), do: :ok
-
-  defp maybe_queue_search(media_item, true) do
-    case Mydia.Search.queue_auto_searches([media_item]) do
-      {:ok, _count} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("Failed to queue search on add",
-          media_item_id: media_item.id,
-          reason: inspect(reason)
-        )
-
-        :ok
     end
   end
 

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -349,17 +349,15 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   default, because a stale profile still produces a usable add where a
   wrong-type library path does not.
 
-  `:search_on_add` is put back onto the list after `to_add_opts/1`, which omits
-  it because `Add` does not accept it.
+  `:search_on_add` is put back onto the list by
+  `AddDefaults.to_add_opts_with_search/1`, since `to_add_opts/1` omits it
+  because `Add` does not accept it.
   """
   @spec add_opts_from_config(map(), :movie | :tv_show, Mydia.Accounts.User.t() | nil) ::
           {:ok, keyword()} | {:error, :unknown_library}
   def add_opts_from_config(params, media_type, user) do
     with {:ok, defaults} <- resolve_add_defaults(params, media_type, user) do
-      {:ok,
-       defaults
-       |> AddDefaults.to_add_opts()
-       |> Keyword.put(:search_on_add, defaults.search_on_add)}
+      {:ok, AddDefaults.to_add_opts_with_search(defaults)}
     end
   end
 

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -308,6 +308,35 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   end
 
   @doc """
+  Resolves the submitted config params into an `%AddDefaults{}` struct.
+
+  Split out of `add_opts_from_config/3` because a caller that has to re-render
+  the config dialog after a failure needs the struct itself: `config.defaults`
+  is an `%AddDefaults{}`, so assigning the resolved struct straight back is what
+  makes the dialog redisplay the user's own choices rather than reverting to
+  fresh defaults.
+
+  Propagates `{:error, :unknown_library}` from `library_path_opts/2` rather than
+  swallowing it. Per #458, silently substituting a different library is worse
+  than refusing.
+  """
+  @spec resolve_add_defaults(map(), :movie | :tv_show, Mydia.Accounts.User.t() | nil) ::
+          {:ok, AddDefaults.t()} | {:error, :unknown_library}
+  def resolve_add_defaults(params, media_type, user) do
+    with {:ok, library_opts} <-
+           library_path_opts(presence(params["library_path_id"]), media_type) do
+      {:ok,
+       AddDefaults.resolve(user, media_type,
+         library_path_id: library_opts[:library_path_id],
+         quality_profile_id: presence(params["quality_profile_id"]),
+         monitored: params["monitored"] == "true",
+         season_monitoring: presence(params["season_monitoring"]),
+         search_on_add: params["search_on_add"] == "true"
+       )}
+    end
+  end
+
+  @doc """
   Turns the dialog's submitted `config[...]` params into `Mydia.Media.Add` opts.
 
   `library_path_opts/2` runs first and its rejection is propagated rather than
@@ -326,17 +355,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   @spec add_opts_from_config(map(), :movie | :tv_show, Mydia.Accounts.User.t() | nil) ::
           {:ok, keyword()} | {:error, :unknown_library}
   def add_opts_from_config(params, media_type, user) do
-    with {:ok, library_opts} <-
-           library_path_opts(presence(params["library_path_id"]), media_type) do
-      defaults =
-        AddDefaults.resolve(user, media_type,
-          library_path_id: library_opts[:library_path_id],
-          quality_profile_id: presence(params["quality_profile_id"]),
-          monitored: params["monitored"] == "true",
-          season_monitoring: presence(params["season_monitoring"]),
-          search_on_add: params["search_on_add"] == "true"
-        )
-
+    with {:ok, defaults} <- resolve_add_defaults(params, media_type, user) do
       {:ok,
        defaults
        |> AddDefaults.to_add_opts()

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -1,5 +1,6 @@
 defmodule Mydia.MediaRequestsTest do
   use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
 
   import ExUnit.CaptureLog
   import Mydia.SettingsFixtures
@@ -382,6 +383,34 @@ defmodule Mydia.MediaRequestsTest do
       assert media_item.id == incumbent.id
       assert Repo.get!(MediaItem, incumbent.id).library_path_id == incumbent_library.id
       assert Repo.get!(MediaItem, incumbent.id).monitored == true
+    end
+
+    test "queues an automatic search when search_on_add is set", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: config,
+                 search_on_add: true
+               )
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{mode: "specific", media_item_id: media_item.id}
+      )
+    end
+
+    test "queues nothing when search_on_add is absent", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id}, config: config)
+
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch, args: %{media_item_id: media_item.id})
     end
   end
 

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -2,6 +2,7 @@ defmodule Mydia.MediaRequestsTest do
   use Mydia.DataCase, async: false
 
   import ExUnit.CaptureLog
+  import Mydia.SettingsFixtures
 
   alias Mydia.MediaRequests
   alias Mydia.{Accounts, Media, Repo}
@@ -305,6 +306,124 @@ defmodule Mydia.MediaRequestsTest do
 
       assert Repo.aggregate(MediaItem, :count) == before_count
       assert Media.get_media_item_by_tmdb(tmdb_id).id == movie.id
+    end
+  end
+
+  describe "approve_request/3 configuration" do
+    setup do
+      user = create_user()
+      admin = create_user(%{role: "admin"})
+      request = create_request(user)
+      bypass = Bypass.open()
+      stub_tmdb_movie(bypass, request.tmdb_id, request.title, "/stub.jpg")
+      %{admin: admin, request: request, config: relay_config(bypass)}
+    end
+
+    test "applies the library, quality profile and monitored flag", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      library = library_path_fixture(%{type: "movies"})
+      profile = quality_profile_fixture()
+
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: config,
+                 library_path_id: library.id,
+                 quality_profile_id: profile.id,
+                 monitored: false
+               )
+
+      assert media_item.library_path_id == library.id
+      assert media_item.quality_profile_id == profile.id
+      assert media_item.monitored == false
+    end
+
+    test "still defaults to monitored when no flag is given", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id}, config: config)
+
+      assert media_item.monitored == true
+    end
+
+    test "does not reconfigure an item that is already in the library", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      incumbent_library = library_path_fixture(%{type: "movies"})
+
+      {:ok, incumbent} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: request.title,
+          year: request.year,
+          tmdb_id: request.tmdb_id,
+          library_path_id: incumbent_library.id,
+          monitored: true
+        })
+
+      other_library = library_path_fixture(%{type: "movies"})
+
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: config,
+                 library_path_id: other_library.id,
+                 monitored: false
+               )
+
+      # Linked, not reconfigured. Approving a request must not silently move or
+      # unmonitor a library item somebody else set up.
+      assert media_item.id == incumbent.id
+      assert Repo.get!(MediaItem, incumbent.id).library_path_id == incumbent_library.id
+      assert Repo.get!(MediaItem, incumbent.id).monitored == true
+    end
+  end
+
+  describe "approve_request/3 season monitoring" do
+    setup do
+      user = create_user()
+      admin = create_user(%{role: "admin"})
+
+      {:ok, request} =
+        MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "Beacons Over Ilmarry",
+          tmdb_id: 771_002,
+          requester_id: user.id
+        })
+
+      bypass = Bypass.open()
+      stub_tmdb_tv_show(bypass, request.tmdb_id, request.title)
+      # A TMDB-sourced show with no tvdb_id triggers maybe_discover_tvdb_id
+      # during the episode refresh; this stub keeps that lookup off the network.
+      stub_tvdb_search_empty(bypass)
+
+      %{admin: admin, request: request, config: relay_config(bypass)}
+    end
+
+    test "creates no episodes when season monitoring is none", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: config,
+                 season_monitoring: "none"
+               )
+
+      assert media_item.type == "tv_show"
+
+      assert Repo.aggregate(
+               from(e in Mydia.Media.Episode, where: e.media_item_id == ^media_item.id),
+               :count
+             ) == 0
     end
   end
 

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -399,7 +399,19 @@ defmodule Mydia.MediaRequestsTest do
         })
 
       bypass = Bypass.open()
-      stub_tmdb_tv_show(bypass, request.tmdb_id, request.title)
+
+      # Two real seasons, so "none" (fetch nothing) and "all" (fetch
+      # everything) actually diverge. `stub_tmdb_tv_show/4`'s seasons list
+      # only needs to name the seasons; the episodes themselves come from the
+      # per-season endpoint stubbed below.
+      stub_tmdb_tv_show(bypass, request.tmdb_id, request.title, [
+        %{"season_number" => 1, "episode_count" => 2},
+        %{"season_number" => 2, "episode_count" => 3}
+      ])
+
+      stub_tmdb_season(bypass, request.tmdb_id, 1, 2)
+      stub_tmdb_season(bypass, request.tmdb_id, 2, 3)
+
       # A TMDB-sourced show with no tvdb_id triggers maybe_discover_tvdb_id
       # during the episode refresh; this stub keeps that lookup off the network.
       stub_tvdb_search_empty(bypass)
@@ -424,6 +436,27 @@ defmodule Mydia.MediaRequestsTest do
                from(e in Mydia.Media.Episode, where: e.media_item_id == ^media_item.id),
                :count
              ) == 0
+    end
+
+    test "creates episodes for every season when season monitoring is all", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: config,
+                 season_monitoring: "all"
+               )
+
+      assert media_item.type == "tv_show"
+
+      # The stub offers 2 + 3 = 5 episodes across two seasons; "all" must
+      # fetch every one of them, in contrast to "none" fetching zero above.
+      assert Repo.aggregate(
+               from(e in Mydia.Media.Episode, where: e.media_item_id == ^media_item.id),
+               :count
+             ) == 5
     end
   end
 
@@ -605,18 +638,45 @@ defmodule Mydia.MediaRequestsTest do
     end)
   end
 
-  defp stub_tmdb_tv_show(bypass, id, title) do
+  defp stub_tmdb_tv_show(bypass, id, title, seasons \\ []) do
     body = %{
       "id" => id,
       "name" => title,
       "first_air_date" => "2021-03-04",
       "overview" => "x",
       "credits" => %{"cast" => [], "crew" => []},
-      "seasons" => [],
+      "seasons" => seasons,
       "genres" => []
     }
 
     Bypass.stub(bypass, "GET", "/tmdb/tv/shows/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  # Backs the per-season fetch `refresh_episodes_for_tv_show/2` makes for a
+  # TMDB-sourced show (relay.ex's `fetch_season_tmdb/4`), independent of the
+  # season list on the show-level stub above. `episode_count` episodes are
+  # numbered 1.., which is all `EpisodeData.from_api_response/1` requires.
+  defp stub_tmdb_season(bypass, tmdb_id, season_number, episode_count) do
+    episodes =
+      for episode_number <- 1..episode_count do
+        %{
+          "season_number" => season_number,
+          "episode_number" => episode_number,
+          "name" => "Episode #{episode_number}"
+        }
+      end
+
+    body = %{
+      "season_number" => season_number,
+      "name" => "Season #{season_number}",
+      "episodes" => episodes
+    }
+
+    Bypass.stub(bypass, "GET", "/tmdb/tv/shows/#{tmdb_id}/#{season_number}", fn conn ->
       conn
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.resp(200, Jason.encode!(body))

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -385,6 +385,37 @@ defmodule Mydia.MediaRequestsTest do
       assert Repo.get!(MediaItem, incumbent.id).monitored == true
     end
 
+    test "does not queue a search for an item that is already in the library", %{
+      request: request,
+      admin: admin,
+      config: config
+    } do
+      incumbent_library = library_path_fixture(%{type: "movies"})
+
+      {:ok, incumbent} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: request.title,
+          year: request.year,
+          tmdb_id: request.tmdb_id,
+          library_path_id: incumbent_library.id,
+          monitored: true
+        })
+
+      assert {:ok, %{media_item: media_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: config,
+                 search_on_add: true
+               )
+
+      assert media_item.id == incumbent.id
+
+      # search_on_add is true, but the item was already in the library. No
+      # job may be queued against a row someone else set up.
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch, args: %{media_item_id: incumbent.id})
+      refute_enqueued(worker: Mydia.Jobs.TVShowSearch, args: %{media_item_id: incumbent.id})
+    end
+
     test "queues an automatic search when search_on_add is set", %{
       request: request,
       admin: admin,

--- a/test/mydia/search_test.exs
+++ b/test/mydia/search_test.exs
@@ -84,5 +84,22 @@ defmodule Mydia.SearchTest do
 
       assert :ok = Search.maybe_queue_search(unsupported, true)
     end
+
+    test "reports success even when the queue insert genuinely fails" do
+      # A PID cannot be JSON-encoded, so Ecto's dump step raises
+      # Ecto.ChangeError rather than returning an invalid changeset.
+      # queue_auto_searches/1 catches it and returns a real {:error, reason}
+      # (not the {:ok, 0} "nothing to queue" case above), which this must
+      # still swallow: adding the title succeeded, the search is a
+      # convenience on top of it.
+      bad_item = %Mydia.Media.MediaItem{type: "movie", id: self()}
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok = Search.maybe_queue_search(bad_item, true)
+        end)
+
+      assert log =~ "Failed to queue search on add"
+    end
   end
 end

--- a/test/mydia/search_test.exs
+++ b/test/mydia/search_test.exs
@@ -55,4 +55,34 @@ defmodule Mydia.SearchTest do
       refute_enqueued(worker: Mydia.Jobs.TVShowSearch, args: %{media_item_id: unsupported.id})
     end
   end
+
+  describe "maybe_queue_search/2" do
+    test "queues nothing when the flag is false" do
+      movie = insert(:media_item, type: "movie")
+
+      assert :ok = Search.maybe_queue_search(movie, false)
+
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch, args: %{media_item_id: movie.id})
+    end
+
+    test "queues the search when the flag is true" do
+      movie = insert(:media_item, type: "movie")
+
+      assert :ok = Search.maybe_queue_search(movie, true)
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{mode: "specific", media_item_id: movie.id}
+      )
+    end
+
+    test "reports success even when nothing could be queued" do
+      # An unsupported type is skipped by queue_auto_searches/1, so this
+      # returns {:ok, 0} rather than an error. Either way the caller gets :ok:
+      # adding the title is what was asked for, the search is convenience.
+      unsupported = insert(:media_item, type: "documentary")
+
+      assert :ok = Search.maybe_queue_search(unsupported, true)
+    end
+  end
 end

--- a/test/mydia_web/features/guest_test.exs
+++ b/test/mydia_web/features/guest_test.exs
@@ -16,6 +16,7 @@ defmodule MydiaWeb.Features.GuestTest do
 
   import Mydia.MetadataStub
   import Mydia.MetadataCacheHelpers
+  import Mydia.SettingsFixtures
 
   alias Mydia.Media.MediaRequest
   alias Mydia.MetadataStubProvider
@@ -32,8 +33,14 @@ defmodule MydiaWeb.Features.GuestTest do
   # without a warm cache the run reaches the live relay and the network guard
   # fails the job even though every test passed. Warmed after the stub setup,
   # which clears the cache on its way in.
+  #
+  # A real install always has a library path before anyone can approve a
+  # request. Without one here, the approve dialog has no root folder to
+  # offer and the server-side guard in AdminRequestsLive.Index refuses the
+  # approval, which this test is not about.
   setup do
     warm_genre_cache(:movie, [])
+    library_path_fixture(%{type: "movies"})
     :ok
   end
 

--- a/test/mydia_web/live/admin_requests_live_test.exs
+++ b/test/mydia_web/live/admin_requests_live_test.exs
@@ -128,4 +128,48 @@ defmodule MydiaWeb.AdminRequestsLiveTest do
       assert MediaRequests.get_request!(request.id).status == "pending"
     end
   end
+
+  describe "a failed approval keeps the dialog open" do
+    test "a metadata failure preserves the admin's choices", %{
+      conn: conn,
+      guest: guest
+    } do
+      library = library_path_fixture(%{type: "movies"})
+      profile = quality_profile_fixture()
+
+      # missing_id/0 is the stub provider's "this does not resolve" id, the
+      # same one guest_request_flow_test uses for its unreachable-provider case.
+      {:ok, unresolvable} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "Unresolvable Movie",
+          tmdb_id: MetadataStubProvider.missing_id(),
+          requester_id: guest.id
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/admin/requests")
+      open_approve(view, unresolvable)
+
+      html =
+        view
+        |> form("#approve-form", %{
+          "approve" => %{"admin_notes" => "keep me"},
+          "config" => %{
+            "library_path_id" => library.id,
+            "quality_profile_id" => profile.id,
+            "monitored" => "false",
+            "search_on_add" => "false"
+          }
+        })
+        |> render_submit()
+
+      assert html =~ "Could not reach the metadata service"
+      assert MediaRequests.get_request!(unresolvable.id).status == "pending"
+
+      # The dialog is still open, still showing what was picked.
+      assert has_element?(view, "#approve-form")
+      assert has_element?(view, ~s(option[value="#{library.id}"][selected]))
+      assert has_element?(view, ~s(option[value="#{profile.id}"][selected]))
+    end
+  end
 end

--- a/test/mydia_web/live/admin_requests_live_test.exs
+++ b/test/mydia_web/live/admin_requests_live_test.exs
@@ -72,4 +72,60 @@ defmodule MydiaWeb.AdminRequestsLiveTest do
       assert has_element?(view, "#approve-form button[type=submit][disabled]")
     end
   end
+
+  describe "approving with a configuration" do
+    test "the chosen library and profile land on the created item", %{
+      conn: conn,
+      request: request
+    } do
+      library = library_path_fixture(%{type: "movies"})
+      profile = quality_profile_fixture()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/requests")
+      open_approve(view, request)
+
+      view
+      |> form("#approve-form", %{
+        "approve" => %{"admin_notes" => ""},
+        "config" => %{
+          "library_path_id" => library.id,
+          "quality_profile_id" => profile.id,
+          "monitored" => "true",
+          "search_on_add" => "false"
+        }
+      })
+      |> render_submit()
+
+      updated = MediaRequests.get_request!(request.id, preload: [:media_item])
+
+      assert updated.status == "approved"
+      assert updated.media_item.library_path_id == library.id
+      assert updated.media_item.quality_profile_id == profile.id
+    end
+
+    test "an unavailable library flashes and closes without approving", %{
+      conn: conn,
+      request: request
+    } do
+      library_path_fixture(%{type: "movies"})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/requests")
+      open_approve(view, request)
+
+      # render_submit/3 (view + event name), not form/3: the scenario is a
+      # library removed server-side after the dialog rendered, so the admin's
+      # browser still holds a now-stale <option> the current DOM no longer
+      # offers. form/3 validates the submitted value against the live
+      # rendered <select> and would reject it before the event even reaches
+      # the server, defeating the point of the test.
+      html =
+        render_submit(view, "submit_approve", %{
+          "approve" => %{"admin_notes" => ""},
+          "config" => %{"library_path_id" => Ecto.UUID.generate()}
+        })
+
+      assert html =~ "no longer available"
+      assert MediaRequests.get_request!(request.id).status == "pending"
+    end
+  end
 end

--- a/test/mydia_web/live/admin_requests_live_test.exs
+++ b/test/mydia_web/live/admin_requests_live_test.exs
@@ -71,6 +71,26 @@ defmodule MydiaWeb.AdminRequestsLiveTest do
       assert html =~ "No library paths configured"
       assert has_element?(view, "#approve-form button[type=submit][disabled]")
     end
+
+    test "the server refuses to approve when no library path exists, even bypassing the disabled button",
+         %{conn: conn, request: request} do
+      {:ok, view, _html} = live(conn, ~p"/admin/requests")
+      open_approve(view, request)
+
+      # render_submit/3 (view + event name), not form/3: the disabled button
+      # would stop form/3 from ever sending the event, which is exactly the
+      # client-side-only guard this test exists to prove is not the only
+      # guard. See the "an unavailable library" test above for the same
+      # reasoning.
+      html =
+        render_submit(view, "submit_approve", %{
+          "approve" => %{"admin_notes" => ""},
+          "config" => %{}
+        })
+
+      assert html =~ "No library path is configured"
+      assert MediaRequests.get_request!(request.id).status == "pending"
+    end
   end
 
   describe "approving with a configuration" do

--- a/test/mydia_web/live/admin_requests_live_test.exs
+++ b/test/mydia_web/live/admin_requests_live_test.exs
@@ -1,0 +1,75 @@
+defmodule MydiaWeb.AdminRequestsLiveTest do
+  @moduledoc """
+  Covers the approve dialog's configuration controls specifically.
+
+  The end-to-end request lifecycle lives in `guest_request_flow_test.exs`.
+  This file is only about what the dialog offers and what the submitted
+  values do.
+  """
+
+  # async: false for the same reason as guest_request_flow_test:
+  # setup_metadata_stub mutates the global Provider.Registry.
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.MetadataStub
+  import Mydia.SettingsFixtures
+
+  alias Mydia.MediaRequests
+  alias Mydia.MetadataStubProvider
+
+  setup :setup_metadata_stub
+
+  setup %{conn: conn} do
+    guest = create_test_user(%{role: "guest"})
+    admin = create_admin_user()
+
+    {:ok, request} =
+      MediaRequests.create_request(%{
+        media_type: "movie",
+        title: MetadataStubProvider.movie_title(),
+        tmdb_id: MetadataStubProvider.movie_tmdb_id(),
+        requester_id: guest.id
+      })
+
+    %{conn: log_in_user(conn, admin), admin: admin, guest: guest, request: request}
+  end
+
+  defp open_approve(view, request) do
+    view
+    |> element(~s(button[phx-click="open_approve_modal"][phx-value-id="#{request.id}"]))
+    |> render_click()
+  end
+
+  describe "approve modal configuration fields" do
+    test "renders the config controls", %{conn: conn, request: request} do
+      library_path_fixture(%{type: "movies"})
+      profile = quality_profile_fixture()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/requests")
+      html = open_approve(view, request)
+
+      assert html =~ "config[library_path_id]"
+      assert html =~ "config[quality_profile_id]"
+      assert html =~ "config[monitored]"
+      assert html =~ "config[search_on_add]"
+      assert html =~ profile.name
+    end
+
+    test "omits season monitoring for a movie request", %{conn: conn, request: request} do
+      library_path_fixture(%{type: "movies"})
+
+      {:ok, view, _html} = live(conn, ~p"/admin/requests")
+
+      refute open_approve(view, request) =~ "config[season_monitoring]"
+    end
+
+    test "blocks approval when no library path exists", %{conn: conn, request: request} do
+      {:ok, view, _html} = live(conn, ~p"/admin/requests")
+      html = open_approve(view, request)
+
+      assert html =~ "No library paths configured"
+      assert has_element?(view, "#approve-form button[type=submit][disabled]")
+    end
+  end
+end

--- a/test/mydia_web/live/guest_request_flow_test.exs
+++ b/test/mydia_web/live/guest_request_flow_test.exs
@@ -22,6 +22,7 @@ defmodule MydiaWeb.GuestRequestFlowTest do
   import Phoenix.LiveViewTest
   import Mydia.MetadataStub
   import Mydia.MetadataCacheHelpers
+  import Mydia.SettingsFixtures
 
   alias Mydia.Media
   alias Mydia.Media.MediaRequest
@@ -34,6 +35,16 @@ defmodule MydiaWeb.GuestRequestFlowTest do
   setup do
     guest = create_test_user(%{role: "guest"})
     admin = create_admin_user()
+
+    # Approving a request now requires a library path (AdminRequestsLive.Index
+    # refuses the approval otherwise), so any test in this file that approves
+    # needs one seeded. Do not delete this as unused-looking noise. Both types
+    # are seeded because this file approves both a movie and a tv_show request
+    # (see "movie request lifecycle" and "tv request lifecycle" below), and
+    # AddDefaults.resolve/3 only offers a library whose type matches the
+    # media being approved.
+    library_path_fixture(%{type: "movies"})
+    library_path_fixture(%{type: "series"})
 
     %{guest: guest, admin: admin}
   end

--- a/test/mydia_web/live/guest_request_flow_test.exs
+++ b/test/mydia_web/live/guest_request_flow_test.exs
@@ -277,6 +277,11 @@ defmodule MydiaWeb.GuestRequestFlowTest do
 
       assert html =~ "Could not reach the metadata service"
 
+      # The dialog stays open: it now holds configuration (library, quality
+      # profile, monitoring) the admin picked, and a transient relay hiccup
+      # must not discard those choices and force the admin to redo them.
+      assert has_element?(admin_view, "#approve-form")
+
       untouched = Repo.get!(MediaRequest, request.id)
 
       assert untouched.status == "pending"

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -571,6 +571,36 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
     end
   end
 
+  describe "resolve_add_defaults/3" do
+    test "returns the resolved struct with the submitted values folded in" do
+      library = library_path_fixture(%{type: "movies"})
+      profile = quality_profile_fixture()
+
+      params = %{
+        "library_path_id" => library.id,
+        "quality_profile_id" => profile.id,
+        "monitored" => "false",
+        "search_on_add" => "true"
+      }
+
+      assert {:ok, defaults} = MediaAddHelpers.resolve_add_defaults(params, :movie, nil)
+
+      assert defaults.library_path_id == library.id
+      assert defaults.quality_profile_id == profile.id
+      assert defaults.monitored == false
+      assert defaults.search_on_add == true
+    end
+
+    test "rejects a library that is not a candidate for the media type" do
+      assert {:error, :unknown_library} =
+               MediaAddHelpers.resolve_add_defaults(
+                 %{"library_path_id" => Ecto.UUID.generate()},
+                 :movie,
+                 nil
+               )
+    end
+  end
+
   describe "put_add_config/4 library freshness" do
     # candidate_libraries/1 is called from inside put_add_config/4 itself, at
     # OPEN time, rather than being threaded in from an earlier assign a host


### PR DESCRIPTION
Approving a guest's media request offered the admin one optional notes textarea and decided everything else. This gives it the same five controls the Configure Before Adding dialog already has, and makes the documented behaviour true for the first time.

## The problem

`MediaRequests.approve_request/3` called `Add.resolve_attrs/4` and `Add.from_attrs/3` directly, bypassing `Mydia.Media.AddDefaults` entirely. So approving a request:

- hardcoded `monitored: true`
- passed no `quality_profile_id` and no `library_path_id`, leaving every approved item with no quality profile and on dynamic resolution
- took `season_monitoring: "all"` from `create_media_item`'s default
- **never queued a search at all**

That last point made the docs wrong. `docs/using/how-to/manage-users.md` has promised "If approved, media is added to library and download begins" since it was written. Approval created a monitored entry and stopped.

Meanwhile #676 merged the two-step add flow into a single Configure Before Adding dialog across Discover, Dashboard and the media detail rails, and #678 extracted its shared submit preamble. Approval was never in scope for either. It was the last path that created a library item without offering the settings that govern it.

## What changed

The Approve button already opened a modal, so no new interaction is added. The modal gains the five controls above its existing notes textarea, prefilled from the approving admin's own add defaults, so approving with no changes is still two clicks.

`add_config_modal/1`'s five form controls move into a shared `add_config_fields/1` that both dialogs render. The two dialogs genuinely differ in shell, preview, submit button and extra fields, so only the controls are shared, which is the part that must never drift.

`approve_request/3`'s existing `opts` keyword gains the five settings. `monitored`, `quality_profile_id` and `library_path_id` go onto the `Add.resolve_attrs/4` call it already makes; `season_monitoring` onto `Add.from_attrs/3`, which already forwards it through `@create_opt_keys`. `search_on_add` is honoured after `Repo.transaction` commits, never inside the `Ecto.Multi`, since event broadcasts are deferred until commit and a search queued against an uncommitted item is a race.

`maybe_queue_search/2` moves from private in `MydiaWeb.Live.Helpers.MediaAddHelpers` to public in `Mydia.Search`. A context calling into the web layer is the wrong direction.

Defaults come from the approving admin, not the requester. The preference in play is which disk files land on and which quality profile applies, and that is the admin's server.

The config is deliberately not stored on the request. `approve_changeset` still casts only `[:admin_notes, :approved_by_id, :media_item_id]`; the settings live on the created media item where they are visible and editable.

## Two bugs found on the way

**A failed approval discarded the admin's choices.** The metadata-failure branch closed the dialog and flashed "Please try again", which was tolerable when the dialog held one optional textarea. With five configuration controls it means redoing the work. The dialog now stays open showing what was picked, which falls out cleanly because `config.defaults` is an `%AddDefaults{}` and the resolved struct can be assigned straight back.

**Approving a title already in the library queued a search for the incumbent.** `insert_approval/4` collapses `{:error, {:already_in_library, item}}` into `{:ok, item}` so the request can link to the existing row rather than failing on a unique constraint, and the search was then queued unconditionally against a pre-existing item somebody else set up. The Add flow's `handle_add_media_to_library/5` matches that case and skips the search; approval now does too, via a `created?` tag on the Multi result.

## Behaviour change worth calling out

An install with zero library paths can no longer approve a request: the submit button disables and shows the same "No library paths configured" warning the Add dialog already shows. Previously such an install could approve and the item landed on dynamic resolution. This was deliberate, for parity with Add, and that case is already blocked there.

## Testing

`mix precommit`: Credo, `format --check-formatted`, `deps.unlock --unused` and `compile --warnings-as-errors` all clean. The full run reported 9 failures, all `(Exqlite.Error) Database busy` in `DevicesLive`, `Indexers`, `FileAnalysisUnique`, `ProfileLive` and `TargetResolver`, none of which this branch touches. Re-running all five suites in isolation gives 81 tests, 0 failures. `.github/ci-flakes.md` documents SQLite `busy_timeout` contention as a known flake class; this machine runs many parallel worktrees against one test database. CI is the real check.

New coverage: each setting reaching the created item, `monitored: false` overriding the old hardcoded `true`, season monitoring discriminating on actual episode count, search queued on the created path and not the linked one, the unknown-library flash, and a metadata failure preserving the admin's choices.

`test/mydia_web/live/admin_requests_live_test.exs` is new. There was no dedicated file for this page; all approval coverage lived in `guest_request_flow_test.exs`, which stays as the end-to-end flow.

Exactly one existing test was edited: `guest_request_flow_test.exs`'s unreachable-provider case, because the metadata-failure behaviour deliberately changed. Its assertions never checked modal state, so it passed either way; an explicit assertion was added rather than leaving the gap.

**Known limitation:** the 4 Wallaby tests in `test/mydia_web/features/add_config_flow_test.exs` could not run locally, since the worktree has no built frontend assets. CI is their first real run.

## Follow-up, not in this PR

The Configure dialog offers `season_monitoring: "future"` labelled "Monitor Future Seasons", but `Media.refresh_episodes_for_tv_show/2` handles only `"first"`, `"latest"` and `"none"`, so anything else falls through to every season. That option has silently behaved as "Monitor All Seasons" in the Add flow since it shipped. Pre-existing and inherited here; fixing it means deciding what "future" should mean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can configure library, quality profile, monitoring, season monitoring, and search-on-add settings when approving media requests.
  * Newly added media can automatically trigger a search when enabled.
  * Approval settings remain available after metadata or validation errors.

* **Bug Fixes**
  * Approval is blocked when no suitable library is available.
  * Existing media items are preserved without unnecessary search jobs.
  * Request approval correctly applies selected settings and defaults.

* **Documentation**
  * Updated request approval guidance to reflect configuration and search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->