### PR TITLE
Auto-approve pending media requests when added to library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,7 @@ done | cut -d_ -f1 | sort | uniq -d
 - Push the branch to origin (`git push -u origin <branch>`) and create the PR (`gh pr create`).
 - Enable auto-merge immediately (`gh pr merge <pr-number> --auto --merge`).
 - Poll checks and review comments (`gh pr checks <pr-number>`, `gh pr view <pr-number> --comments`).
-- Actively review and resolve CodeRabbit comments or reviewer feedback: evaluate technical validity, apply changes, run tests, commit inside devenv shell, and push to update the PR.
+- Actively review and resolve CodeRabbit comments or reviewer feedback: evaluate technical validity, apply changes, run `./dev mix precommit`, commit inside devenv shell, and push to update the PR.
 - Monitor until CI checks complete and the PR is successfully merged into `master`.
 - Only clean up or delete the worktree after the merge is verified.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,14 @@ done | cut -d_ -f1 | sort | uniq -d
 `some_command; code=$?` dies before the assignment runs. Use
 `exit_code=0; some_command || exit_code=$?`.
 
+**Babysitting PRs.** When asked to create a PR and babysit it until merged:
+- Push the branch to origin (`git push -u origin <branch>`) and create the PR (`gh pr create`).
+- Enable auto-merge immediately (`gh pr merge <pr-number> --auto --merge`).
+- Poll checks and review comments (`gh pr checks <pr-number>`, `gh pr view <pr-number> --comments`).
+- Actively review and resolve CodeRabbit comments or reviewer feedback: evaluate technical validity, apply changes, run tests, commit inside devenv shell, and push to update the PR.
+- Monitor until CI checks complete and the PR is successfully merged into `master`.
+- Only clean up or delete the worktree after the merge is verified.
+
 ### Where the deeper notes live
 
 Hard-won specifics live next to the code they describe rather than in this file.

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -350,33 +350,43 @@ defmodule Mydia.Media do
       Events.media_item_added(media_item, actor_type, actor_id)
 
       # Auto-approve any pending media requests matching this item
-      MediaRequests.auto_approve_matching_requests(
-        media_item,
-        actor_type: actor_type,
-        actor_id: actor_id,
-        exclude_request_id: Keyword.get(opts, :exclude_request_id)
-      )
+      case MediaRequests.auto_approve_matching_requests(
+             media_item,
+             actor_type: actor_type,
+             actor_id: actor_id,
+             exclude_request_id: Keyword.get(opts, :exclude_request_id)
+           ) do
+        {:ok, _approved_requests} ->
+          # For TV shows, automatically fetch episodes unless explicitly skipped
+          if media_item.type == "tv_show" and not Keyword.get(opts, :skip_episode_refresh, false) do
+            season_monitoring = Keyword.get(opts, :season_monitoring, "all")
 
-      # For TV shows, automatically fetch episodes unless explicitly skipped
-      if media_item.type == "tv_show" and not Keyword.get(opts, :skip_episode_refresh, false) do
-        season_monitoring = Keyword.get(opts, :season_monitoring, "all")
+            refresh_opts =
+              [season_monitoring: season_monitoring]
+              |> maybe_put_refresh_config(Keyword.get(opts, :config))
 
-        refresh_opts =
-          [season_monitoring: season_monitoring]
-          |> maybe_put_refresh_config(Keyword.get(opts, :config))
+            case refresh_episodes_for_tv_show(media_item, refresh_opts) do
+              {:ok, count} ->
+                Logger.info("Created #{count} episodes for #{media_item.title}")
 
-        case refresh_episodes_for_tv_show(media_item, refresh_opts) do
-          {:ok, count} ->
-            Logger.info("Created #{count} episodes for #{media_item.title}")
+              {:error, reason} ->
+                # Log the error but don't fail the media item creation
+                # The show is still usable and episodes can be refreshed later
+                Logger.warning(
+                  "Failed to fetch episodes for #{media_item.title}: #{inspect(reason)}"
+                )
+            end
+          end
 
-          {:error, reason} ->
-            # Log the error but don't fail the media item creation
-            # The show is still usable and episodes can be refreshed later
-            Logger.warning("Failed to fetch episodes for #{media_item.title}: #{inspect(reason)}")
-        end
+          {:ok, media_item}
+
+        {:error, changeset} ->
+          Logger.error(
+            "Failed to auto-approve requests for media #{media_item.id}: #{inspect(changeset)}"
+          )
+
+          {:error, changeset}
       end
-
-      {:ok, media_item}
     end
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -11,6 +11,7 @@ defmodule Mydia.Media do
   alias Mydia.Media.Structs.CalendarEntry
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Events
+  alias Mydia.MediaRequests
 
   ## Media Items
 
@@ -347,6 +348,14 @@ defmodule Mydia.Media do
       # (Mydia.Plugins.Dispatcher), which replaced the Luerl after_media_added
       # hook (U11). No explicit hook call is needed here.
       Events.media_item_added(media_item, actor_type, actor_id)
+
+      # Auto-approve any pending media requests matching this item
+      MediaRequests.auto_approve_matching_requests(
+        media_item,
+        actor_type: actor_type,
+        actor_id: actor_id,
+        exclude_request_id: Keyword.get(opts, :exclude_request_id)
+      )
 
       # For TV shows, automatically fetch episodes unless explicitly skipped
       if media_item.type == "tv_show" and not Keyword.get(opts, :skip_episode_refresh, false) do

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -22,7 +22,13 @@ defmodule Mydia.Media.Add do
   alias Mydia.Settings
 
   # Options consumed by `Media.create_media_item/2` rather than by attrs building.
-  @create_opt_keys [:actor_type, :actor_id, :skip_episode_refresh, :season_monitoring]
+  @create_opt_keys [
+    :actor_type,
+    :actor_id,
+    :skip_episode_refresh,
+    :season_monitoring,
+    :exclude_request_id
+  ]
 
   @type error ::
           {:metadata, term()}

--- a/lib/mydia/media/media_request.ex
+++ b/lib/mydia/media/media_request.ex
@@ -95,6 +95,20 @@ defmodule Mydia.Media.MediaRequest do
   end
 
   @doc """
+  Changeset for automatically approving a media request when its media is added.
+  Requires `:media_item_id`, while `:approved_by_id` remains optional (nil for system additions).
+  """
+  def auto_approve_changeset(media_request, attrs) do
+    media_request
+    |> cast(attrs, [:admin_notes, :approved_by_id, :media_item_id])
+    |> validate_required([:media_item_id])
+    |> put_change(:status, "approved")
+    |> put_change(:approved_at, DateTime.utc_now() |> DateTime.truncate(:second))
+    |> foreign_key_constraint(:approved_by_id)
+    |> foreign_key_constraint(:media_item_id)
+  end
+
+  @doc """
   Changeset for rejecting a media request.
   """
   def reject_changeset(media_request, attrs) do

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -19,6 +19,7 @@ defmodule Mydia.MediaRequests do
   alias Mydia.Media.Add
   alias Mydia.Media.MediaItem
   alias Mydia.Media.MediaRequest
+  alias Mydia.DB
   alias Mydia.Search
   alias Ecto.Multi
 
@@ -317,9 +318,12 @@ defmodule Mydia.MediaRequests do
     default_notes =
       Keyword.get(opts, :admin_notes, "Automatically approved: title added to library")
 
-    approved_list =
-      Enum.reduce(requests, [], fn request, acc ->
-        case Repo.get(MediaRequest, request.id) do
+    Repo.transaction(fn ->
+      Enum.reduce_while(requests, [], fn request, acc ->
+        query = where(MediaRequest, [r], r.id == ^request.id)
+        query = if DB.postgres?(), do: lock(query, "FOR UPDATE"), else: query
+
+        case Repo.one(query) do
           %MediaRequest{status: "pending"} = fresh_request ->
             attrs = %{
               media_item_id: media_item.id,
@@ -335,22 +339,25 @@ defmodule Mydia.MediaRequests do
                   "Auto-approved request #{fresh_request.id} for media #{media_item.id} (#{media_item.title})"
                 )
 
-                [updated | acc]
+                {:cont, [updated | acc]}
 
               {:error, changeset} ->
                 Logger.error(
                   "Failed to auto-approve request #{fresh_request.id}: #{inspect(changeset.errors)}"
                 )
 
-                acc
+                Repo.rollback(changeset)
             end
 
           _other ->
-            acc
+            {:cont, acc}
         end
       end)
-
-    {:ok, Enum.reverse(approved_list)}
+    end)
+    |> case do
+      {:ok, approved_list} -> {:ok, Enum.reverse(approved_list)}
+      {:error, changeset} -> {:error, changeset}
+    end
   end
 
   @doc """

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -17,6 +17,7 @@ defmodule Mydia.MediaRequests do
   alias Mydia.Repo
   alias Mydia.Media
   alias Mydia.Media.Add
+  alias Mydia.Media.MediaItem
   alias Mydia.Media.MediaRequest
   alias Mydia.Search
   alias Ecto.Multi
@@ -160,8 +161,11 @@ defmodule Mydia.MediaRequests do
       case Add.from_attrs(
              media_attrs,
              opts[:config],
-             [actor_type: :user, actor_id: attrs[:approved_by_id]] ++
-               Keyword.take(opts, [:season_monitoring])
+             [
+               actor_type: :user,
+               actor_id: attrs[:approved_by_id],
+               exclude_request_id: request.id
+             ] ++ Keyword.take(opts, [:season_monitoring])
            ) do
         {:ok, media_item} ->
           {:ok, %{item: media_item, created?: true}}
@@ -276,6 +280,120 @@ defmodule Mydia.MediaRequests do
   defp pending_tvdb_request_exists?(tvdb_id) do
     MediaRequest
     |> where([r], r.tvdb_id == ^tvdb_id and r.status == "pending")
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Automatically approves any pending requests matching the given media item.
+
+  Finds pending requests matching the media item's type (`movie` or `tv_show`)
+  and any matching external IDs (`tmdb_id`, `tvdb_id`, or `imdb_id`).
+  Links each request to the media item, stamps approval time, and records
+  the approver if an actor user ID was provided.
+
+  ## Options
+    - `:actor_type` - `:user` or `:system`
+    - `:actor_id` - ID of the actor (if a valid user UUID, recorded as approved_by_id)
+    - `:approved_by_id` - Explicit user ID to attribute approval to
+    - `:exclude_request_id` - Optional request ID to skip (used during manual approval)
+    - `:admin_notes` - Optional admin notes (defaults to "Automatically approved: title added to library")
+  """
+  @spec auto_approve_matching_requests(MediaItem.t(), keyword()) ::
+          {:ok, [MediaRequest.t()]} | {:error, term()}
+  def auto_approve_matching_requests(%MediaItem{} = media_item, opts \\ []) do
+    requests = list_pending_matching_requests(media_item, opts)
+
+    approved_by_id = resolve_approved_by_id(opts)
+
+    default_notes =
+      Keyword.get(opts, :admin_notes, "Automatically approved: title added to library")
+
+    results =
+      Enum.reduce_while(requests, {:ok, []}, fn request, {:ok, acc} ->
+        attrs = %{
+          media_item_id: media_item.id,
+          approved_by_id: approved_by_id,
+          admin_notes: request.admin_notes || default_notes
+        }
+
+        case request
+             |> MediaRequest.auto_approve_changeset(attrs)
+             |> Repo.update() do
+          {:ok, updated} ->
+            Logger.info(
+              "Auto-approved request #{request.id} for media #{media_item.id} (#{media_item.title})"
+            )
+
+            {:cont, {:ok, [updated | acc]}}
+
+          {:error, changeset} ->
+            Logger.error(
+              "Failed to auto-approve request #{request.id}: #{inspect(changeset.errors)}"
+            )
+
+            {:halt, {:error, changeset}}
+        end
+      end)
+
+    case results do
+      {:ok, approved_list} -> {:ok, Enum.reverse(approved_list)}
+      error -> error
+    end
+  end
+
+  @doc """
+  Lists pending requests matching a media item's type and external IDs.
+  """
+  @spec list_pending_matching_requests(MediaItem.t(), keyword()) :: [MediaRequest.t()]
+  def list_pending_matching_requests(%MediaItem{} = media_item, opts \\ []) do
+    dynamic_cond =
+      false
+      |> maybe_or_match_id(:tmdb_id, media_item.tmdb_id)
+      |> maybe_or_match_id(:tvdb_id, media_item.tvdb_id)
+      |> maybe_or_match_id(:imdb_id, media_item.imdb_id)
+
+    if dynamic_cond == false do
+      []
+    else
+      query =
+        from r in MediaRequest,
+          where: r.status == "pending" and r.media_type == ^media_item.type,
+          where: ^dynamic_cond
+
+      query =
+        case opts[:exclude_request_id] do
+          nil -> query
+          exclude_id -> where(query, [r], r.id != ^exclude_id)
+        end
+
+      Repo.all(query)
+    end
+  end
+
+  defp maybe_or_match_id(dynamic, _field, nil), do: dynamic
+  defp maybe_or_match_id(false, :tmdb_id, val), do: dynamic([r], r.tmdb_id == ^val)
+  defp maybe_or_match_id(dynamic, :tmdb_id, val), do: dynamic([r], ^dynamic or r.tmdb_id == ^val)
+  defp maybe_or_match_id(false, :tvdb_id, val), do: dynamic([r], r.tvdb_id == ^val)
+  defp maybe_or_match_id(dynamic, :tvdb_id, val), do: dynamic([r], ^dynamic or r.tvdb_id == ^val)
+  defp maybe_or_match_id(false, :imdb_id, val), do: dynamic([r], r.imdb_id == ^val)
+  defp maybe_or_match_id(dynamic, :imdb_id, val), do: dynamic([r], ^dynamic or r.imdb_id == ^val)
+
+  defp resolve_approved_by_id(opts) do
+    cond do
+      is_binary(opts[:approved_by_id]) and user_exists?(opts[:approved_by_id]) ->
+        opts[:approved_by_id]
+
+      opts[:actor_type] == :user and is_binary(opts[:actor_id]) and user_exists?(opts[:actor_id]) ->
+        opts[:actor_id]
+
+      true ->
+        nil
+    end
+  end
+
+  defp user_exists?(user_id) do
+    Mydia.Accounts.User
+    |> where([u], u.id == ^user_id)
     |> Repo.exists?()
   end
 end

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -194,6 +194,15 @@ defmodule Mydia.MediaRequests do
           "Request #{request.id} approved by user #{attrs[:approved_by_id]}, linked to media #{media_item.id}"
         )
 
+        if not created? do
+          auto_approve_matching_requests(
+            media_item,
+            actor_type: :user,
+            actor_id: attrs[:approved_by_id],
+            exclude_request_id: request.id
+          )
+        end
+
         {:ok, %{request: updated_request, media_item: media_item}, created?}
 
       {:error, :media_item, changeset, _changes} ->
@@ -308,37 +317,40 @@ defmodule Mydia.MediaRequests do
     default_notes =
       Keyword.get(opts, :admin_notes, "Automatically approved: title added to library")
 
-    results =
-      Enum.reduce_while(requests, {:ok, []}, fn request, {:ok, acc} ->
-        attrs = %{
-          media_item_id: media_item.id,
-          approved_by_id: approved_by_id,
-          admin_notes: request.admin_notes || default_notes
-        }
+    approved_list =
+      Enum.reduce(requests, [], fn request, acc ->
+        case Repo.get(MediaRequest, request.id) do
+          %MediaRequest{status: "pending"} = fresh_request ->
+            attrs = %{
+              media_item_id: media_item.id,
+              approved_by_id: approved_by_id,
+              admin_notes: fresh_request.admin_notes || default_notes
+            }
 
-        case request
-             |> MediaRequest.auto_approve_changeset(attrs)
-             |> Repo.update() do
-          {:ok, updated} ->
-            Logger.info(
-              "Auto-approved request #{request.id} for media #{media_item.id} (#{media_item.title})"
-            )
+            case fresh_request
+                 |> MediaRequest.auto_approve_changeset(attrs)
+                 |> Repo.update() do
+              {:ok, updated} ->
+                Logger.info(
+                  "Auto-approved request #{fresh_request.id} for media #{media_item.id} (#{media_item.title})"
+                )
 
-            {:cont, {:ok, [updated | acc]}}
+                [updated | acc]
 
-          {:error, changeset} ->
-            Logger.error(
-              "Failed to auto-approve request #{request.id}: #{inspect(changeset.errors)}"
-            )
+              {:error, changeset} ->
+                Logger.error(
+                  "Failed to auto-approve request #{fresh_request.id}: #{inspect(changeset.errors)}"
+                )
 
-            {:halt, {:error, changeset}}
+                acc
+            end
+
+          _other ->
+            acc
         end
       end)
 
-    case results do
-      {:ok, approved_list} -> {:ok, Enum.reverse(approved_list)}
-      error -> error
-    end
+    {:ok, Enum.reverse(approved_list)}
   end
 
   @doc """
@@ -346,11 +358,13 @@ defmodule Mydia.MediaRequests do
   """
   @spec list_pending_matching_requests(MediaItem.t(), keyword()) :: [MediaRequest.t()]
   def list_pending_matching_requests(%MediaItem{} = media_item, opts \\ []) do
+    # As documented in lib/mydia/media/add.ex:116-123, IMDb IDs carry no unique
+    # index and TVDB's remoteIds can hand split and spin-off series a shared
+    # IMDb ID. We match only across stable primary provider IDs (TMDB and TVDB).
     dynamic_cond =
       false
       |> maybe_or_match_id(:tmdb_id, media_item.tmdb_id)
       |> maybe_or_match_id(:tvdb_id, media_item.tvdb_id)
-      |> maybe_or_match_id(:imdb_id, media_item.imdb_id)
 
     if dynamic_cond == false do
       []
@@ -375,8 +389,6 @@ defmodule Mydia.MediaRequests do
   defp maybe_or_match_id(dynamic, :tmdb_id, val), do: dynamic([r], ^dynamic or r.tmdb_id == ^val)
   defp maybe_or_match_id(false, :tvdb_id, val), do: dynamic([r], r.tvdb_id == ^val)
   defp maybe_or_match_id(dynamic, :tvdb_id, val), do: dynamic([r], ^dynamic or r.tvdb_id == ^val)
-  defp maybe_or_match_id(false, :imdb_id, val), do: dynamic([r], r.imdb_id == ^val)
-  defp maybe_or_match_id(dynamic, :imdb_id, val), do: dynamic([r], ^dynamic or r.imdb_id == ^val)
 
   defp resolve_approved_by_id(opts) do
     cond do

--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -488,7 +488,7 @@ defmodule MydiaWeb.CoreComponents do
 
   def poster_figure(assigns) do
     ~H"""
-    <div class="hover-3d w-full">
+    <div class="hover-3d w-full align-top">
       <figure class={["relative aspect-[2/3] overflow-hidden bg-base-300", @class]}>
         <img
           :if={@src}

--- a/lib/mydia_web/live/admin_requests_live/index.html.heex
+++ b/lib/mydia_web/live/admin_requests_live/index.html.heex
@@ -84,7 +84,11 @@
                 <.icon name="hero-check-circle" class="w-4 h-4 mt-0.5" />
                 <div>
                   <div>
-                    Approved by {request.approved_by.email} on {format_date(request.approved_at)}
+                    <%= if request.approved_by do %>
+                      Approved by {request.approved_by.email} on {format_date(request.approved_at)}
+                    <% else %>
+                      Approved automatically on {format_date(request.approved_at)}
+                    <% end %>
                   </div>
                   <div :if={request.admin_notes} class="text-xs mt-1">
                     Admin notes: {request.admin_notes}

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -388,20 +388,23 @@ defmodule MydiaWeb.DashboardLive.Index do
          |> put_flash(:info, "#{media_item.title} has been added to your library")}
 
       {:already_in_library, media_item, updated_map} ->
+        request_status_map = MediaRequestHelpers.request_status_map()
+
         trending_movies =
           socket.assigns.trending_movies
           |> MediaAddHelpers.enrich_with_library_status(updated_map)
-          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
+          |> MediaRequestHelpers.enrich_with_request_status(request_status_map)
 
         trending_tv =
           socket.assigns.trending_tv
           |> MediaAddHelpers.enrich_with_library_status(updated_map)
-          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
+          |> MediaRequestHelpers.enrich_with_request_status(request_status_map)
 
         {:noreply,
          socket
          |> clear_adding(ref)
          |> assign(:library_status_map, updated_map)
+         |> assign(:request_status_map, request_status_map)
          |> assign(:trending_movies, trending_movies)
          |> assign(:trending_tv, trending_tv)
          |> DetailModal.refresh_selected([trending_movies, trending_tv])

--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -354,6 +354,11 @@ defmodule MydiaWeb.DashboardLive.Index do
   ## Private Helpers
 
   defp add_with_opts(ref, media_type, opts, socket) do
+    opts =
+      opts
+      |> Keyword.put_new(:actor_type, :user)
+      |> Keyword.put_new(:actor_id, socket.assigns.current_user.id)
+
     case MediaAddHelpers.handle_add_media_to_library(
            ref,
            media_type,

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -575,10 +575,12 @@ defmodule MydiaWeb.DiscoverLive.Index do
          |> put_flash(:info, "#{media_item.title} has been added to your library")}
 
       {:already_in_library, media_item, updated_map} ->
+        request_status_map = MediaRequestHelpers.request_status_map()
+
         items =
           socket.assigns.items
           |> MediaAddHelpers.enrich_with_library_status(updated_map)
-          |> MediaRequestHelpers.enrich_with_request_status(socket.assigns.request_status_map)
+          |> MediaRequestHelpers.enrich_with_request_status(request_status_map)
 
         recommendations =
           MediaAddHelpers.enrich_with_library_status(
@@ -590,6 +592,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
          socket
          |> clear_adding(ref)
          |> assign(:library_status_map, updated_map)
+         |> assign(:request_status_map, request_status_map)
          |> assign(:items, items)
          |> assign_visible_items()
          |> assign(:selected_recommendations, recommendations)

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -537,6 +537,11 @@ defmodule MydiaWeb.DiscoverLive.Index do
   defp presence(value), do: value
 
   defp add_with_opts(ref, media_type, opts, socket) do
+    opts =
+      opts
+      |> Keyword.put_new(:actor_type, :user)
+      |> Keyword.put_new(:actor_id, socket.assigns.current_user.id)
+
     case MediaAddHelpers.handle_add_media_to_library(
            ref,
            media_type,

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -158,6 +158,8 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
                MediaRequests.auto_approve_matching_requests(media_item, add_opts) do
           {:already_in_library, media_item,
            update_library_status_map(library_status_map, media_item)}
+        else
+          {:error, changeset} -> {:error, {:changeset, changeset}}
         end
 
       {:error, _} = error ->

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -9,6 +9,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   alias Mydia.Media.Add
   alias Mydia.Media.AddDefaults
+  alias Mydia.MediaRequests
   alias Mydia.Media.FranchiseEntry
   alias Mydia.Metadata
   alias Mydia.Metadata.Ref
@@ -153,6 +154,8 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       # Not an error from here up: the show the user asked for is in the
       # library. Callers flash it as info and flip the card.
       {:error, {:already_in_library, media_item}} ->
+        MediaRequests.auto_approve_matching_requests(media_item, add_opts)
+
         {:already_in_library, media_item,
          update_library_status_map(library_status_map, media_item)}
 

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -154,10 +154,11 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       # Not an error from here up: the show the user asked for is in the
       # library. Callers flash it as info and flip the card.
       {:error, {:already_in_library, media_item}} ->
-        MediaRequests.auto_approve_matching_requests(media_item, add_opts)
-
-        {:already_in_library, media_item,
-         update_library_status_map(library_status_map, media_item)}
+        with {:ok, _approved} <-
+               MediaRequests.auto_approve_matching_requests(media_item, add_opts) do
+          {:already_in_library, media_item,
+           update_library_status_map(library_status_map, media_item)}
+        end
 
       {:error, _} = error ->
         error

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -112,6 +112,15 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
       media_item = socket.assigns.media_item
       config = socket.assigns.metadata_config
 
+      opts =
+        if socket.assigns[:current_user] do
+          opts
+          |> Keyword.put_new(:actor_type, :user)
+          |> Keyword.put_new(:actor_id, socket.assigns.current_user.id)
+        else
+          opts
+        end
+
       socket =
         socket
         |> mark_in_flight(tmdb_id)

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -133,6 +133,15 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
       media_item = socket.assigns.media_item
       config = socket.assigns.metadata_config
 
+      opts =
+        if socket.assigns[:current_user] do
+          opts
+          |> Keyword.put_new(:actor_type, :user)
+          |> Keyword.put_new(:actor_id, socket.assigns.current_user.id)
+        else
+          opts
+        end
+
       socket =
         socket
         |> mark_in_flight(tmdb_id)

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -851,6 +851,26 @@ defmodule Mydia.MediaRequestsTest do
       assert reloaded.status == "pending"
     end
 
+    test "rolls back earlier approvals when a later approval fails", %{user: user} do
+      first = create_request(user, %{tmdb_id: 77888, media_type: "movie"})
+
+      second =
+        create_request(user, %{tmdb_id: nil, tvdb_id: 77888, media_type: "movie"})
+
+      invalid_media_item = %Media.MediaItem{
+        id: Ecto.UUID.generate(),
+        type: "movie",
+        tmdb_id: 77888,
+        title: "Unavailable Media Item"
+      }
+
+      assert {:error, %Ecto.Changeset{}} =
+               MediaRequests.auto_approve_matching_requests(invalid_media_item)
+
+      assert MediaRequests.get_request!(first.id).status == "pending"
+      assert MediaRequests.get_request!(second.id).status == "pending"
+    end
+
     test "Media.create_media_item/2 triggers auto-approval of matching pending requests", %{
       user: user,
       admin: admin

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -753,6 +753,126 @@ defmodule Mydia.MediaRequestsTest do
     end)
   end
 
+  describe "auto_approve_matching_requests/2" do
+    setup do
+      user = create_user()
+      admin = create_user(%{role: "admin"})
+      %{user: user, admin: admin}
+    end
+
+    test "auto-approves pending request matching TMDB ID", %{user: user, admin: admin} do
+      request = create_request(user, %{tmdb_id: 12345, media_type: "movie", title: "Test Movie"})
+      media_item = create_media_item(%{type: "movie", tmdb_id: 12345, title: "Test Movie"})
+
+      assert {:ok, [approved]} =
+               MediaRequests.auto_approve_matching_requests(media_item,
+                 actor_type: :user,
+                 actor_id: admin.id
+               )
+
+      assert approved.id == request.id
+      assert approved.status == "approved"
+      assert approved.media_item_id == media_item.id
+      assert approved.approved_by_id == admin.id
+      assert approved.approved_at != nil
+      assert approved.admin_notes =~ "Automatically approved"
+
+      # Verify persisted in database
+      reloaded = MediaRequests.get_request!(request.id)
+      assert reloaded.status == "approved"
+      assert reloaded.media_item_id == media_item.id
+    end
+
+    test "auto-approves pending request matching TVDB ID", %{user: user} do
+      request =
+        create_request(user, %{
+          tvdb_id: 99999,
+          tmdb_id: nil,
+          media_type: "tv_show",
+          title: "Test Series"
+        })
+
+      media_item = create_media_item(%{type: "tv_show", tvdb_id: 99999, title: "Test Series"})
+
+      assert {:ok, [approved]} = MediaRequests.auto_approve_matching_requests(media_item)
+
+      assert approved.id == request.id
+      assert approved.status == "approved"
+      assert approved.media_item_id == media_item.id
+      assert approved.approved_by_id == nil
+      assert approved.approved_at != nil
+    end
+
+    test "auto-approves pending request matching IMDB ID", %{user: user} do
+      request =
+        create_request(user, %{
+          imdb_id: "tt1234567",
+          tmdb_id: nil,
+          media_type: "movie",
+          title: "IMDB Movie"
+        })
+
+      media_item = create_media_item(%{type: "movie", imdb_id: "tt1234567", title: "IMDB Movie"})
+
+      assert {:ok, [approved]} = MediaRequests.auto_approve_matching_requests(media_item)
+
+      assert approved.id == request.id
+      assert approved.status == "approved"
+      assert approved.media_item_id == media_item.id
+    end
+
+    test "honors exclude_request_id option", %{user: user} do
+      request1 = create_request(user, %{tmdb_id: 55555, media_type: "movie"})
+      media_item = create_media_item(%{type: "movie", tmdb_id: 55555, title: "Movie"})
+
+      assert {:ok, []} =
+               MediaRequests.auto_approve_matching_requests(media_item,
+                 exclude_request_id: request1.id
+               )
+
+      reloaded = MediaRequests.get_request!(request1.id)
+      assert reloaded.status == "pending"
+    end
+
+    test "ignores requests of different media type or already non-pending", %{user: user} do
+      # TV show request with same tmdb_id as a movie media item
+      request1 = create_request(user, %{tmdb_id: 77777, media_type: "tv_show"})
+      media_item = create_media_item(%{type: "movie", tmdb_id: 77777, title: "Movie"})
+
+      assert {:ok, []} = MediaRequests.auto_approve_matching_requests(media_item)
+
+      reloaded = MediaRequests.get_request!(request1.id)
+      assert reloaded.status == "pending"
+    end
+
+    test "Media.create_media_item/2 triggers auto-approval of matching pending requests", %{
+      user: user,
+      admin: admin
+    } do
+      request = create_request(user, %{tmdb_id: 88888, media_type: "movie", title: "Auto Movie"})
+      library = library_path_fixture(%{type: "movies"})
+
+      {:ok, media_item} =
+        Media.create_media_item(
+          %{
+            type: "movie",
+            title: "Auto Movie",
+            year: 2024,
+            tmdb_id: 88888,
+            library_path_id: library.id
+          },
+          actor_type: :user,
+          actor_id: admin.id,
+          skip_episode_refresh: true
+        )
+
+      reloaded = MediaRequests.get_request!(request.id)
+      assert reloaded.status == "approved"
+      assert reloaded.media_item_id == media_item.id
+      assert reloaded.approved_by_id == admin.id
+    end
+  end
+
   defp create_user(attrs \\ %{}) do
     unique_id = System.unique_integer([:positive])
 
@@ -786,5 +906,23 @@ defmodule Mydia.MediaRequestsTest do
       |> MediaRequests.create_request()
 
     request
+  end
+
+  defp create_media_item(attrs) do
+    type = Map.get(attrs, :type, "movie")
+    lib_type = if type == "movie", do: "movies", else: "series"
+    library = library_path_fixture(%{type: lib_type})
+
+    default_attrs = %{
+      type: type,
+      title: "Test Media Item",
+      year: 2023,
+      library_path_id: library.id,
+      monitored: true
+    }
+
+    %Media.MediaItem{}
+    |> Media.MediaItem.changeset(Map.merge(default_attrs, attrs))
+    |> Repo.insert!()
   end
 end

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -803,22 +803,28 @@ defmodule Mydia.MediaRequestsTest do
       assert approved.approved_at != nil
     end
 
-    test "auto-approves pending request matching IMDB ID", %{user: user} do
+    test "does not auto-approve based on IMDB ID alone without TMDB or TVDB match", %{user: user} do
       request =
         create_request(user, %{
           imdb_id: "tt1234567",
-          tmdb_id: nil,
+          tmdb_id: 11111,
           media_type: "movie",
           title: "IMDB Movie"
         })
 
-      media_item = create_media_item(%{type: "movie", imdb_id: "tt1234567", title: "IMDB Movie"})
+      # Item with same IMDB ID but different TMDB ID (e.g. shared remoteIds across spin-offs)
+      media_item =
+        create_media_item(%{
+          type: "movie",
+          tmdb_id: 22222,
+          imdb_id: "tt1234567",
+          title: "Other Movie"
+        })
 
-      assert {:ok, [approved]} = MediaRequests.auto_approve_matching_requests(media_item)
+      assert {:ok, []} = MediaRequests.auto_approve_matching_requests(media_item)
 
-      assert approved.id == request.id
-      assert approved.status == "approved"
-      assert approved.media_item_id == media_item.id
+      reloaded = MediaRequests.get_request!(request.id)
+      assert reloaded.status == "pending"
     end
 
     test "honors exclude_request_id option", %{user: user} do

--- a/test/mydia_web/live/admin_requests_live_test.exs
+++ b/test/mydia_web/live/admin_requests_live_test.exs
@@ -192,4 +192,42 @@ defmodule MydiaWeb.AdminRequestsLiveTest do
       assert has_element?(view, ~s(option[value="#{profile.id}"][selected]))
     end
   end
+
+  describe "rendering auto-approved requests" do
+    test "renders approved request without approved_by user safely", %{
+      conn: conn,
+      guest: guest
+    } do
+      {:ok, req} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "Auto-Approved Movie",
+          tmdb_id: 112_233,
+          requester_id: guest.id
+        })
+
+      library = library_path_fixture(%{type: "movies"})
+
+      media_item =
+        %Mydia.Media.MediaItem{}
+        |> Mydia.Media.MediaItem.changeset(%{
+          type: "movie",
+          title: "Auto-Approved Movie",
+          year: 2024,
+          tmdb_id: 112_233,
+          library_path_id: library.id,
+          monitored: true
+        })
+        |> Mydia.Repo.insert!()
+
+      {:ok, [approved]} = MediaRequests.auto_approve_matching_requests(media_item)
+      assert approved.id == req.id
+      assert approved.approved_by_id == nil
+
+      {:ok, view, _html} = live(conn, ~p"/admin/requests?status=approved")
+      rendered = render(view)
+      assert rendered =~ "Auto-Approved Movie"
+      assert rendered =~ "Approved automatically on"
+    end
+  end
 end

--- a/test/mydia_web/live/guest_request_flow_test.exs
+++ b/test/mydia_web/live/guest_request_flow_test.exs
@@ -180,7 +180,7 @@ defmodule MydiaWeb.GuestRequestFlowTest do
         )
 
       # Request should now be auto-approved and linked
-      approved = Repo.get!(MediaRequest, request.id)
+      approved = wait_until_request(id: request.id, status: "approved")
       assert approved.status == "approved"
       assert approved.approved_by_id == admin.id
       assert approved.media_item_id == media_item.id

--- a/test/mydia_web/live/guest_request_flow_test.exs
+++ b/test/mydia_web/live/guest_request_flow_test.exs
@@ -73,6 +73,23 @@ defmodule MydiaWeb.GuestRequestFlowTest do
     end
   end
 
+  defp wait_until_media_item(clause, retries \\ 200)
+
+  defp wait_until_media_item(clause, 0) do
+    flunk("no MediaItem matching #{inspect(clause)} was created in time")
+  end
+
+  defp wait_until_media_item(clause, retries) do
+    case Repo.get_by(Media.MediaItem, clause) do
+      nil ->
+        Process.sleep(10)
+        wait_until_media_item(clause, retries - 1)
+
+      media_item ->
+        media_item
+    end
+  end
+
   describe "movie request lifecycle" do
     test "guest submits a movie request and an admin approves it into the library",
          %{conn: conn, guest: guest, admin: admin} do
@@ -128,6 +145,57 @@ defmodule MydiaWeb.GuestRequestFlowTest do
       assert media_item.type == "movie"
       assert media_item.title == MetadataStubProvider.movie_title()
       assert media_item.tmdb_id == MetadataStubProvider.movie_tmdb_id()
+    end
+
+    test "guest submits a movie request and an admin adding it via Discover auto-approves it",
+         %{conn: conn, guest: guest, admin: admin} do
+      # --- Guest submits request ---
+      warm_genre_cache(:movie, [])
+      {:ok, view, _html} = live(guest_conn(conn, guest), ~p"/discover?type=movie&q=stub")
+
+      view
+      |> element(
+        ~s(button[phx-click="request_media"][phx-value-ref="tmdb:#{MetadataStubProvider.movie_tmdb_id()}"])
+      )
+      |> render_click()
+
+      request = wait_until_request(tmdb_id: MetadataStubProvider.movie_tmdb_id())
+      assert request.status == "pending"
+
+      # --- Admin adds movie via Discover ---
+      {:ok, admin_discover, _html} =
+        live(admin_conn(conn, admin), ~p"/discover?type=movie&q=stub")
+
+      admin_discover
+      |> element(
+        ~s(button[phx-click="add_to_library"][phx-value-ref="tmdb:#{MetadataStubProvider.movie_tmdb_id()}"])
+      )
+      |> render_click()
+
+      # Wait for media item creation
+      media_item =
+        wait_until_media_item(
+          type: "movie",
+          tmdb_id: MetadataStubProvider.movie_tmdb_id()
+        )
+
+      # Request should now be auto-approved and linked
+      approved = Repo.get!(MediaRequest, request.id)
+      assert approved.status == "approved"
+      assert approved.approved_by_id == admin.id
+      assert approved.media_item_id == media_item.id
+      refute is_nil(approved.approved_at)
+
+      # --- Admin requests page shows it under approved, not pending ---
+      {:ok, admin_requests, _html} = live(admin_conn(conn, admin), ~p"/admin/requests")
+      refute render(admin_requests) =~ "request-#{request.id}"
+
+      {:ok, approved_view, _html} =
+        live(admin_conn(conn, admin), ~p"/admin/requests?status=approved")
+
+      html = render(approved_view)
+      assert html =~ "request-#{request.id}"
+      assert html =~ admin.email
     end
   end
 


### PR DESCRIPTION
## Summary
When a movie or TV show is awaiting approval and is subsequently added through other means (Discover, Dashboard, "More Like This", Recommendations, Franchise list, Library Scanner, etc.), pending requests for that media item remained in the pending queue in Manage Media Requests.

This change:
1. Automatically marks any matching pending requests as approved and links them to the `MediaItem` (`media_item_id`) when media is created or already found in the library.
2. Attributes approval to the user performing the add when done through interactive UI flows (Discover, Dashboard, Recommendations, Franchise).
3. Safely handles automatic/scanner additions by permitting `approved_by_id` to be nil, and updates `admin_requests_live/index.html.heex` to display "Approved automatically on <date>" when `approved_by` is nil.
4. Preserves request history so the requester sees their request approved in "My Requests" (`/requests`), and the request moves from "Pending" to "Approved" in Manage Media Requests (`/admin/requests`).

## Changes
- `lib/mydia/media/media_request.ex`: Added `auto_approve_changeset/2` which requires `media_item_id` and leaves `approved_by_id` optional.
- `lib/mydia/media_requests.ex`: Added `auto_approve_matching_requests/2` and `list_pending_matching_requests/2` querying by `media_type` and matching `tmdb_id`, `tvdb_id`, or `imdb_id`.
- `lib/mydia/media.ex`: Hooked `MediaRequests.auto_approve_matching_requests/2` into `create_media_item/2`.
- `lib/mydia/media/add.ex`: Added `:exclude_request_id` to `@create_opt_keys` to avoid conflict with manual approval transactions.
- `lib/mydia_web/live/helpers/media_add_helpers.ex`: Added auto-approval call when title is already in library.
- `lib/mydia_web/live/`: Forwarded `actor_type: :user, actor_id: current_user.id` from `DiscoverLive`, `DashboardLive`, `RecommendationEvents`, and `FranchiseEvents`.
- `lib/mydia_web/live/admin_requests_live/index.html.heex`: Nil-guarded `request.approved_by`.
- Tests: Added unit tests in `test/mydia/media_requests_test.exs` and LiveView tests in `test/mydia_web/live/guest_request_flow_test.exs` and `test/mydia_web/live/admin_requests_live_test.exs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending media requests are automatically approved when matching media is added to the library.
  * Matching requests are linked to the media item and retain available approval details.
* **Improvements**
  * Admin request listings distinguish user-approved and automatically approved requests.
  * Media additions retain the responsible actor’s information.
  * Matching uses TMDB and TVDB identifiers.
  * Request approvals remain consistent if an approval fails.
  * Request statuses refresh correctly when media is already in the library.
* **Style**
  * Improved poster alignment in media displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->