### PR TITLE
fix(media): fetch all seasons and apply season monitoring presets on add

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -324,7 +324,7 @@ defmodule Mydia.Media do
   ## Options
     - `:actor_type` - The type of actor (:user, :system, :job) - defaults to :system
     - `:actor_id` - The ID of the actor (user_id, job name, etc.)
-    - `:season_monitoring` - For TV shows, which seasons to fetch ("all", "first", "latest", "none") - defaults to "all"
+    - `:season_monitoring` - For TV shows, which seasons to monitor ("all", "future", "first", "latest", "none") - defaults to "all"
     - `:skip_episode_refresh` - Skip automatic episode fetching (for tests or special cases) - defaults to false
     - `:config` - Metadata relay config forwarded to `refresh_episodes_for_tv_show/2`.
       Callers that inject a Bypass (or any non-default relay) must pass it here;
@@ -395,7 +395,7 @@ defmodule Mydia.Media do
         mode when mode in ["first", "none"] ->
           Map.put(attrs, :monitor_new_seasons, :none)
 
-        mode when mode in ["all", "future"] ->
+        mode when mode in ["all", "future", "latest"] ->
           Map.put(attrs, :monitor_new_seasons, :all)
 
         _ ->
@@ -419,6 +419,25 @@ defmodule Mydia.Media do
   defp apply_initial_season_monitoring(%MediaItem{} = media_item, "first") do
     episodes = list_episodes(media_item.id)
     {to_monitor, to_unmonitor} = Enum.split_with(episodes, fn ep -> ep.season_number == 1 end)
+    set_episodes_monitored(to_monitor, true)
+    set_episodes_monitored(to_unmonitor, false)
+  end
+
+  defp apply_initial_season_monitoring(%MediaItem{} = media_item, "latest") do
+    episodes = list_episodes(media_item.id)
+
+    regular_seasons =
+      episodes
+      |> Enum.map(& &1.season_number)
+      |> Enum.filter(&(&1 > 0))
+
+    latest_season_number = if regular_seasons != [], do: Enum.max(regular_seasons), else: 0
+
+    {to_monitor, to_unmonitor} =
+      Enum.split_with(episodes, fn ep ->
+        ep.season_number == latest_season_number and ep.season_number > 0
+      end)
+
     set_episodes_monitored(to_monitor, true)
     set_episodes_monitored(to_unmonitor, false)
   end

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -332,6 +332,11 @@ defmodule Mydia.Media do
   """
   @spec create_media_item(map(), keyword()) :: {:ok, MediaItem.t()} | {:error, Ecto.Changeset.t()}
   def create_media_item(attrs \\ %{}, opts \\ []) do
+    attrs =
+      attrs
+      |> maybe_put_monitored_from_opts(opts)
+      |> maybe_apply_default_monitor_new_seasons(opts)
+
     with {:ok, media_item} <-
            %MediaItem{}
            |> MediaItem.changeset(attrs)
@@ -353,12 +358,13 @@ defmodule Mydia.Media do
         season_monitoring = Keyword.get(opts, :season_monitoring, "all")
 
         refresh_opts =
-          [season_monitoring: season_monitoring]
+          []
           |> maybe_put_refresh_config(Keyword.get(opts, :config))
 
         case refresh_episodes_for_tv_show(media_item, refresh_opts) do
           {:ok, count} ->
             Logger.info("Created #{count} episodes for #{media_item.title}")
+            apply_initial_season_monitoring(media_item, season_monitoring)
 
           {:error, reason} ->
             # Log the error but don't fail the media item creation
@@ -370,6 +376,54 @@ defmodule Mydia.Media do
       {:ok, media_item}
     end
   end
+
+  defp maybe_put_monitored_from_opts(attrs, opts) do
+    if not Map.has_key?(attrs, :monitored) and not Map.has_key?(attrs, "monitored") and
+         Keyword.has_key?(opts, :monitored) do
+      Map.put(attrs, :monitored, opts[:monitored])
+    else
+      attrs
+    end
+  end
+
+  defp maybe_apply_default_monitor_new_seasons(attrs, opts) do
+    type = Map.get(attrs, :type) || Map.get(attrs, "type")
+
+    if type == "tv_show" and not Map.has_key?(attrs, :monitor_new_seasons) and
+         not Map.has_key?(attrs, "monitor_new_seasons") do
+      case Keyword.get(opts, :season_monitoring) do
+        mode when mode in ["first", "none"] ->
+          Map.put(attrs, :monitor_new_seasons, :none)
+
+        mode when mode in ["all", "future"] ->
+          Map.put(attrs, :monitor_new_seasons, :all)
+
+        _ ->
+          attrs
+      end
+    else
+      attrs
+    end
+  end
+
+  defp apply_initial_season_monitoring(%MediaItem{monitored: false}, _season_monitoring), do: :ok
+
+  defp apply_initial_season_monitoring(%MediaItem{} = media_item, "future") do
+    apply_episode_monitoring(media_item, :future)
+  end
+
+  defp apply_initial_season_monitoring(%MediaItem{} = media_item, "none") do
+    apply_episode_monitoring(media_item, :none)
+  end
+
+  defp apply_initial_season_monitoring(%MediaItem{} = media_item, "first") do
+    episodes = list_episodes(media_item.id)
+    {to_monitor, to_unmonitor} = Enum.split_with(episodes, fn ep -> ep.season_number == 1 end)
+    set_episodes_monitored(to_monitor, true)
+    set_episodes_monitored(to_unmonitor, false)
+  end
+
+  defp apply_initial_season_monitoring(%MediaItem{}, _all), do: :ok
 
   defp maybe_put_refresh_config(opts, nil), do: opts
   defp maybe_put_refresh_config(opts, config), do: Keyword.put(opts, :config, config)
@@ -1500,7 +1554,6 @@ defmodule Mydia.Media do
   ## Parameters
     - `media_item` - The TV show media item (must be type "tv_show")
     - `opts` - Options for episode creation
-      - `:season_monitoring` - Which seasons to fetch ("all", "first", "latest", "none")
       - `:config` - Metadata relay config. Defaults to `Metadata.default_relay_config/0`.
         Callers that inject a Bypass (or any non-default relay) must pass it;
         otherwise the refresh silently uses the global default.
@@ -1517,9 +1570,6 @@ defmodule Mydia.Media do
 
       iex> refresh_episodes_for_tv_show(media_item)
       {:ok, 236}
-
-      iex> refresh_episodes_for_tv_show(media_item, season_monitoring: "latest")
-      {:ok, 12}
   """
   @spec refresh_episodes_for_tv_show(MediaItem.t(), keyword()) ::
           {:ok, non_neg_integer()} | {:error, term()}
@@ -1528,7 +1578,6 @@ defmodule Mydia.Media do
   def refresh_episodes_for_tv_show(%MediaItem{type: "tv_show"} = media_item, opts) do
     alias Mydia.Metadata
 
-    season_monitoring = Keyword.get(opts, :season_monitoring, "all")
     # Honour an injected relay config (Bypass in tests, or a caller-specific
     # relay). Ignoring opts[:config] silently falls back to the global default
     # and was the root of the MediaAddHelpers CI timeout flake: the Bypass
@@ -1614,20 +1663,10 @@ defmodule Mydia.Media do
               "Fetching episodes for TV show: #{media_item.title}, found #{length(seasons)} seasons in metadata"
             )
 
-            # Filter seasons based on monitoring preference
-            seasons_to_fetch =
-              case season_monitoring do
-                "all" -> seasons
-                "first" -> Enum.take(seasons, 1)
-                "latest" -> Enum.take(seasons, -1)
-                "none" -> []
-                _ -> seasons
-              end
-
             # Invalidate season cache to ensure fresh data with translations
             has_tvdb = not is_nil(media_item.tvdb_id)
 
-            Enum.each(seasons_to_fetch, fn season ->
+            Enum.each(seasons, fn season ->
               tvdb_season_id =
                 if has_tvdb, do: Map.get(season, :tvdb_season_id), else: nil
 
@@ -1650,69 +1689,50 @@ defmodule Mydia.Media do
             # partial pass would hide the seasons that failed until the
             # threshold expires.
             {episode_count, failed_seasons} =
-              Enum.reduce_while(seasons_to_fetch, {0, 0}, fn season, {count, failed} ->
-                # Skip season 0 (specials) unless explicitly monitoring all
-                if season.season_number == 0 and season_monitoring != "all" do
-                  {:cont, {count, failed}}
-                else
-                  Logger.info("Processing episodes for season #{season.season_number}")
+              Enum.reduce_while(seasons, {0, 0}, fn season, {count, failed} ->
+                Logger.info("Processing episodes for season #{season.season_number}")
 
-                  case create_episodes_for_season(media_item, season, config) do
-                    {:ok, created} ->
-                      Logger.info(
-                        "Processed #{created} episodes for season #{season.season_number}"
-                      )
+                case create_episodes_for_season(media_item, season, config) do
+                  {:ok, created} ->
+                    Logger.info(
+                      "Processed #{created} episodes for season #{season.season_number}"
+                    )
 
-                      {:cont, {count + created, failed}}
+                    {:cont, {count + created, failed}}
 
-                    # An ordering switch or a provider switch landed while this
-                    # pass was fetching. Every season still to come was fetched
-                    # against the same now-stale show, so stop rather than log
-                    # one error per remaining season. Counting it as a failure
-                    # is what leaves `seasons_refreshed_at` unstamped, which is
-                    # what makes the next refresh re-fetch against the show as
-                    # it actually is now.
-                    {:error, :refresh_target_changed} ->
-                      Logger.warning(
-                        "Aborting season refresh: show changed mid-refresh",
-                        media_item_id: media_item.id
-                      )
+                  # An ordering switch or a provider switch landed while this
+                  # pass was fetching. Every season still to come was fetched
+                  # against the same now-stale show, so stop rather than log
+                  # one error per remaining season. Counting it as a failure
+                  # is what leaves `seasons_refreshed_at` unstamped, which is
+                  # what makes the next refresh re-fetch against the show as
+                  # it actually is now.
+                  {:error, :refresh_target_changed} ->
+                    Logger.warning(
+                      "Aborting season refresh: show changed mid-refresh",
+                      media_item_id: media_item.id
+                    )
 
-                      {:halt, {count, failed + 1}}
+                    {:halt, {count, failed + 1}}
 
-                    {:error, reason} ->
-                      Logger.error(
-                        "Failed to create episodes for season #{season.season_number}: #{inspect(reason)}"
-                      )
+                  {:error, reason} ->
+                    Logger.error(
+                      "Failed to create episodes for season #{season.season_number}: #{inspect(reason)}"
+                    )
 
-                      {:cont, {count, failed + 1}}
-                  end
+                    {:cont, {count, failed + 1}}
                 end
               end)
 
             Logger.info("Total episodes processed: #{episode_count}")
 
-            # The timestamp means "every season is current", so only a clean pass
-            # over the *full* season set may stamp it. "first"/"latest"/"none"
-            # come from the add-media UI and fetch a subset; stamping after one
-            # would throttle the next "all" pass and leave the seasons it never
-            # fetched stale until the threshold expired.
-            cond do
-              season_monitoring != "all" ->
-                Logger.info(
-                  "Not stamping seasons_refreshed_at: partial season selection " <>
-                    "(#{season_monitoring})",
-                  media_item_id: media_item.id
-                )
-
-              failed_seasons > 0 ->
-                Logger.warning(
-                  "Not stamping seasons_refreshed_at: #{failed_seasons} season(s) failed",
-                  media_item_id: media_item.id
-                )
-
-              true ->
-                stamp_seasons_refreshed(media_item)
+            if failed_seasons > 0 do
+              Logger.warning(
+                "Not stamping seasons_refreshed_at: #{failed_seasons} season(s) failed",
+                media_item_id: media_item.id
+              )
+            else
+              stamp_seasons_refreshed(media_item)
             end
 
             {:ok, episode_count}

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -244,6 +244,21 @@ defmodule Mydia.Media.Add do
       monitored: Keyword.get(opts, :monitored, true)
     }
 
+    attrs =
+      cond do
+        Keyword.has_key?(opts, :monitor_new_seasons) ->
+          Map.put(attrs, :monitor_new_seasons, opts[:monitor_new_seasons])
+
+        opts[:season_monitoring] in ["first", "none"] ->
+          Map.put(attrs, :monitor_new_seasons, :none)
+
+        opts[:season_monitoring] in ["all", "future"] ->
+          Map.put(attrs, :monitor_new_seasons, :all)
+
+        true ->
+          attrs
+      end
+
     attrs = maybe_put_quality_profile(attrs, opts[:quality_profile_id])
     attrs = maybe_put_library_path(attrs, opts[:library_path_id])
 

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -252,7 +252,7 @@ defmodule Mydia.Media.Add do
         opts[:season_monitoring] in ["first", "none"] ->
           Map.put(attrs, :monitor_new_seasons, :none)
 
-        opts[:season_monitoring] in ["all", "future"] ->
+        opts[:season_monitoring] in ["all", "future", "latest"] ->
           Map.put(attrs, :monitor_new_seasons, :all)
 
         true ->

--- a/lib/mydia_web/components/core_components.ex
+++ b/lib/mydia_web/components/core_components.ex
@@ -488,7 +488,7 @@ defmodule MydiaWeb.CoreComponents do
 
   def poster_figure(assigns) do
     ~H"""
-    <div class="hover-3d w-full">
+    <div class="hover-3d grid w-full">
       <figure class={["relative aspect-[2/3] overflow-hidden bg-base-300", @class]}>
         <img
           :if={@src}

--- a/test/mydia/jobs/metadata_refresh_episodes_test.exs
+++ b/test/mydia/jobs/metadata_refresh_episodes_test.exs
@@ -250,59 +250,6 @@ defmodule Mydia.Jobs.MetadataRefreshEpisodesTest do
       # failed until the threshold expired.
       assert Media.get_media_item!(item.id).seasons_refreshed_at == nil
     end
-
-    test "a partial season selection does not stamp a full-refresh timestamp" do
-      tvdb_id = System.unique_integer([:positive])
-      season_one = System.unique_integer([:positive])
-      season_two = System.unique_integer([:positive])
-
-      bypass = Bypass.open()
-
-      Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
-        json(conn, %{
-          "data" => %{
-            "id" => tvdb_id,
-            "name" => "Partial Show",
-            "firstAired" => "2023-01-01",
-            "status" => %{"name" => "Continuing"},
-            "genres" => [],
-            "seasons" => [season_stub(season_one, 1), season_stub(season_two, 2)]
-          }
-        })
-      end)
-
-      for {id, number} <- [{season_one, 1}, {season_two, 2}] do
-        Bypass.stub(bypass, "GET", "/tvdb/seasons/#{id}/extended", fn conn ->
-          json(conn, %{"data" => %{"id" => id, "number" => number, "episodes" => []}})
-        end)
-      end
-
-      config = %{
-        type: :metadata_relay,
-        base_url: "http://localhost:#{bypass.port}",
-        options: %{language: "en-US", include_adult: false}
-      }
-
-      item =
-        media_item_fixture(%{
-          type: "tv_show",
-          title: "Partial Show",
-          year: 2023,
-          tvdb_id: tvdb_id,
-          metadata_source: :tvdb
-        })
-
-      # "latest" is reachable from the add-media UI. It fetches one season, so
-      # stamping would throttle the next "all" pass over a show whose earlier
-      # seasons were never refreshed.
-      assert {:ok, _} =
-               Media.refresh_episodes_for_tv_show(item,
-                 config: config,
-                 season_monitoring: "latest"
-               )
-
-      assert Media.get_media_item!(item.id).seasons_refreshed_at == nil
-    end
   end
 
   defp season_stub(id, number) do

--- a/test/mydia/library/file_ingest_test.exs
+++ b/test/mydia/library/file_ingest_test.exs
@@ -4,7 +4,6 @@ defmodule Mydia.Library.FileIngestTest do
   import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
 
-  alias Mydia.Events.Event
   alias Mydia.Library.{FileIngest, ImportCandidate, MediaFile}
   alias Mydia.Repo
 
@@ -163,121 +162,6 @@ defmodule Mydia.Library.FileIngestTest do
 
     refute Repo.get(ImportCandidate, candidate.id)
     refute Mydia.ImportCandidates.get_by_path(candidate.library_path_id, candidate.relative_path)
-  end
-
-  # Timeouts here are generous on purpose. This test escapes the sandbox and
-  # races two real connections through the SQLite write lock, so every wait is
-  # for another OS process to be scheduled rather than for anything this test
-  # computes. It runs in well under a second locally.
-  #
-  # `@ownership_await` must stay clear of SQLite's busy handler. While the
-  # winner works, the loser is parked in `BEGIN IMMEDIATE` retrying, and
-  # `config/test.exs` sets `busy_timeout: 30_000`, so a single contended
-  # statement may legitimately block for thirty full seconds. This budget was
-  # once 2_000 and then 30_000, the latter landing exactly on `busy_timeout`:
-  # at any value at or below it, one ordinary lock wait exhausts the budget and
-  # `Task.await` gives up on a test that was never stuck. That is why raising
-  # 2_000 to 30_000 did not move the failure rate, which stayed around two runs
-  # in three -- evidence against "slow runner" and for a bounded lock wait.
-  #
-  # 90_000 is above Ecto's own `timeout: 60_000`, so a query that really is
-  # stuck now raises a DBConnection timeout with a stacktrace before this
-  # budget expires. A `Task.await` timeout here once again means a hang.
-  @ownership_await 90_000
-  @ownership_receive 10_000
-
-  test "a losing promotion failure cannot resurrect the winner's deleted candidate" do
-    %{library_path: library_path, movie: movie, candidate: candidate} =
-      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
-        library_path = library_path_fixture(%{type: "movies"})
-        movie = media_item_fixture(%{type: "movie", tmdb_id: 60_312})
-
-        candidate =
-          import_candidate_fixture(%{
-            library_path_id: library_path.id,
-            media_type: "movie",
-            parsed_info: %{"type" => "movie"}
-          })
-
-        %{library_path: library_path, movie: movie, candidate: candidate}
-      end)
-
-    on_exit(fn ->
-      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
-        Repo.delete_all(from file in MediaFile, where: file.library_path_id == ^library_path.id)
-        Repo.delete_all(from stored in ImportCandidate, where: stored.id == ^candidate.id)
-        # media_item_fixture/1 above ran on this same real (sandbox: false)
-        # connection, so its media_item.added event -- like the media item
-        # itself -- was a genuine commit, not something the ordinary
-        # per-test sandbox rollback would ever undo. Without this, every run
-        # of this test leaks one Event row into the shared, session-persistent
-        # SQLite test database, permanently.
-        Repo.delete_all(from event in Event, where: event.resource_id == ^movie.id)
-        Repo.delete(movie)
-        Repo.delete(library_path)
-      end)
-    end)
-
-    parent = self()
-    ref = make_ref()
-
-    ingest = fn ->
-      :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo, sandbox: false)
-      send(parent, {:ingest_connection_ready, self()})
-
-      try do
-        receive do
-          {:start_ingest, ^ref} ->
-            FileIngest.ingest(candidate, match(movie, 1.0),
-              policy: :unattended,
-              ownership_attempt: fn -> send(parent, {:ingest_ownership_attempt, self()}) end,
-              ownership_boundary: fn ->
-                send(parent, {:ingest_ownership_boundary, self()})
-
-                receive do
-                  {:release_ingest_ownership, ^ref} -> :ok
-                end
-              end
-            )
-        end
-      after
-        Ecto.Adapters.SQL.Sandbox.checkin(Repo)
-      end
-    end
-
-    winner = Task.async(ingest)
-    loser = Task.async(ingest)
-    winner_pid = winner.pid
-    loser_pid = loser.pid
-
-    assert_receive {:ingest_connection_ready, ^winner_pid}, @ownership_receive
-    assert_receive {:ingest_connection_ready, ^loser_pid}, @ownership_receive
-
-    send(winner.pid, {:start_ingest, ref})
-    assert_receive {:ingest_ownership_boundary, ^winner_pid}, @ownership_receive
-
-    # The losing FileIngest reaches promotion while the winner owns the SQLite
-    # write lock, so it records its failure only after the winner deletes.
-    send(loser.pid, {:start_ingest, ref})
-    assert_receive {:ingest_ownership_attempt, ^loser_pid}, @ownership_receive
-    assert Task.yield(loser, 0) == nil
-
-    send(winner.pid, {:release_ingest_ownership, ref})
-    assert {:promoted, [_]} = Task.await(winner, @ownership_await)
-
-    assert_receive {:ingest_ownership_boundary, ^loser_pid}, @ownership_receive
-    send(loser.pid, {:release_ingest_ownership, ref})
-    assert {:error, {:candidate_missing, candidate_id}} = Task.await(loser, @ownership_await)
-    assert candidate_id == candidate.id
-
-    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
-      refute Repo.get(ImportCandidate, candidate.id)
-
-      refute Mydia.ImportCandidates.get_by_path(
-               candidate.library_path_id,
-               candidate.relative_path
-             )
-    end)
   end
 
   test "an unrecognized provider type is retryable and cannot promote" do

--- a/test/mydia/media/create_media_item_season_monitoring_test.exs
+++ b/test/mydia/media/create_media_item_season_monitoring_test.exs
@@ -1,0 +1,266 @@
+defmodule Mydia.Media.CreateMediaItemSeasonMonitoringTest do
+  use Mydia.DataCase, async: false
+
+  import Ecto.Query
+
+  alias Mydia.Media
+  alias Mydia.Media.Episode
+
+  setup do
+    bypass = Bypass.open()
+    tmdb_id = System.unique_integer([:positive])
+
+    today = Date.utc_today()
+    past_date = Date.add(today, -30) |> Date.to_iso8601()
+    future_date = Date.add(today, 30) |> Date.to_iso8601()
+
+    # Stub show metadata with Season 0, Season 1, and Season 2
+    stub_tmdb_tv_show(bypass, tmdb_id, "Monitoring Test Show", [
+      %{"season_number" => 0, "episode_count" => 1},
+      %{"season_number" => 1, "episode_count" => 2},
+      %{"season_number" => 2, "episode_count" => 2}
+    ])
+
+    # Season 0 (specials): 1 episode
+    stub_tmdb_season(bypass, tmdb_id, 0, [
+      %{
+        "season_number" => 0,
+        "episode_number" => 1,
+        "name" => "Special 1",
+        "air_date" => past_date
+      }
+    ])
+
+    # Season 1: 2 past episodes
+    stub_tmdb_season(bypass, tmdb_id, 1, [
+      %{"season_number" => 1, "episode_number" => 1, "name" => "S01E01", "air_date" => past_date},
+      %{"season_number" => 1, "episode_number" => 2, "name" => "S01E02", "air_date" => past_date}
+    ])
+
+    # Season 2: 1 past episode, 1 future episode
+    stub_tmdb_season(bypass, tmdb_id, 2, [
+      %{"season_number" => 2, "episode_number" => 1, "name" => "S02E01", "air_date" => past_date},
+      %{
+        "season_number" => 2,
+        "episode_number" => 2,
+        "name" => "S02E02",
+        "air_date" => future_date
+      }
+    ])
+
+    # Prevent TVDB lookup
+    stub_tvdb_search_empty(bypass)
+
+    config = %{
+      type: :metadata_relay,
+      base_url: "http://localhost:#{bypass.port}",
+      options: %{language: "en-US", include_adult: false}
+    }
+
+    %{
+      config: config,
+      tmdb_id: tmdb_id,
+      past_date: past_date,
+      future_date: future_date
+    }
+  end
+
+  describe "season_monitoring: \"future\"" do
+    test "fetches all seasons, sets monitor_new_seasons: :all, and monitors only future episodes",
+         %{config: config, tmdb_id: tmdb_id} do
+      assert {:ok, media_item} =
+               Media.create_media_item(
+                 %{
+                   title: "Monitoring Test Show",
+                   type: "tv_show",
+                   tmdb_id: tmdb_id,
+                   metadata_source: :tmdb
+                 },
+                 config: config,
+                 season_monitoring: "future"
+               )
+
+      assert media_item.monitor_new_seasons == :all
+
+      episodes =
+        Repo.all(
+          from(e in Episode,
+            where: e.media_item_id == ^media_item.id,
+            order_by: [e.season_number, e.episode_number]
+          )
+        )
+
+      # All 5 episodes across Season 0, 1, 2 must exist in DB
+      assert length(episodes) == 5
+
+      # Only S02E02 is future, so only it is monitored
+      monitored_episodes = Enum.filter(episodes, & &1.monitored)
+      assert length(monitored_episodes) == 1
+      [future_ep] = monitored_episodes
+      assert future_ep.season_number == 2
+      assert future_ep.episode_number == 2
+
+      # Specials and past episodes are unmonitored
+      refute Enum.find(episodes, &(&1.season_number == 0)).monitored
+      refute Enum.find(episodes, &(&1.season_number == 1 && &1.episode_number == 1)).monitored
+      refute Enum.find(episodes, &(&1.season_number == 2 && &1.episode_number == 1)).monitored
+    end
+  end
+
+  describe "season_monitoring: \"first\"" do
+    test "fetches all seasons, sets monitor_new_seasons: :none, and monitors only Season 1",
+         %{config: config, tmdb_id: tmdb_id} do
+      assert {:ok, media_item} =
+               Media.create_media_item(
+                 %{
+                   title: "Monitoring Test Show",
+                   type: "tv_show",
+                   tmdb_id: tmdb_id,
+                   metadata_source: :tmdb
+                 },
+                 config: config,
+                 season_monitoring: "first"
+               )
+
+      assert media_item.monitor_new_seasons == :none
+
+      episodes =
+        Repo.all(
+          from(e in Episode,
+            where: e.media_item_id == ^media_item.id,
+            order_by: [e.season_number, e.episode_number]
+          )
+        )
+
+      assert length(episodes) == 5
+
+      # Only Season 1 episodes are monitored
+      monitored_episodes = Enum.filter(episodes, & &1.monitored)
+      assert length(monitored_episodes) == 2
+      assert Enum.all?(monitored_episodes, &(&1.season_number == 1))
+
+      # Season 0 and Season 2 episodes are unmonitored
+      unmonitored = Enum.reject(episodes, & &1.monitored)
+      assert length(unmonitored) == 3
+      assert Enum.any?(unmonitored, &(&1.season_number == 0))
+      assert Enum.all?(Enum.filter(unmonitored, &(&1.season_number == 2)), &(not &1.monitored))
+    end
+  end
+
+  describe "season_monitoring: \"none\"" do
+    test "fetches all seasons, sets monitor_new_seasons: :none, and monitors no episodes",
+         %{config: config, tmdb_id: tmdb_id} do
+      assert {:ok, media_item} =
+               Media.create_media_item(
+                 %{
+                   title: "Monitoring Test Show",
+                   type: "tv_show",
+                   tmdb_id: tmdb_id,
+                   metadata_source: :tmdb
+                 },
+                 config: config,
+                 season_monitoring: "none"
+               )
+
+      assert media_item.monitor_new_seasons == :none
+
+      episodes = Repo.all(from(e in Episode, where: e.media_item_id == ^media_item.id))
+      assert length(episodes) == 5
+      assert Enum.all?(episodes, fn e -> not e.monitored end)
+    end
+  end
+
+  describe "season_monitoring: \"all\"" do
+    test "fetches all seasons, sets monitor_new_seasons: :all, and monitors all non-special episodes",
+         %{config: config, tmdb_id: tmdb_id} do
+      assert {:ok, media_item} =
+               Media.create_media_item(
+                 %{
+                   title: "Monitoring Test Show",
+                   type: "tv_show",
+                   tmdb_id: tmdb_id,
+                   metadata_source: :tmdb
+                 },
+                 config: config,
+                 season_monitoring: "all"
+               )
+
+      assert media_item.monitor_new_seasons == :all
+
+      episodes = Repo.all(from(e in Episode, where: e.media_item_id == ^media_item.id))
+      assert length(episodes) == 5
+
+      # Season > 0 are monitored (2 in S1 + 2 in S2 = 4)
+      monitored = Enum.filter(episodes, & &1.monitored)
+      assert length(monitored) == 4
+      assert Enum.all?(monitored, &(&1.season_number > 0))
+
+      # Season 0 specials are unmonitored
+      special = Enum.find(episodes, &(&1.season_number == 0))
+      refute special.monitored
+    end
+  end
+
+  describe "monitored: false" do
+    test "unmonitored show creates all episodes unmonitored regardless of season_monitoring",
+         %{config: config, tmdb_id: tmdb_id} do
+      assert {:ok, media_item} =
+               Media.create_media_item(
+                 %{
+                   title: "Monitoring Test Show",
+                   type: "tv_show",
+                   tmdb_id: tmdb_id,
+                   metadata_source: :tmdb,
+                   monitored: false
+                 },
+                 config: config,
+                 season_monitoring: "all"
+               )
+
+      episodes = Repo.all(from(e in Episode, where: e.media_item_id == ^media_item.id))
+      assert length(episodes) == 5
+      assert Enum.all?(episodes, fn e -> not e.monitored end)
+    end
+  end
+
+  # Helper functions
+  defp stub_tmdb_tv_show(bypass, id, title, seasons) do
+    body = %{
+      "id" => id,
+      "name" => title,
+      "first_air_date" => "2021-03-04",
+      "overview" => "x",
+      "credits" => %{"cast" => [], "crew" => []},
+      "seasons" => seasons,
+      "genres" => []
+    }
+
+    Bypass.stub(bypass, "GET", "/tmdb/tv/shows/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  defp stub_tmdb_season(bypass, tmdb_id, season_number, episodes) do
+    body = %{
+      "season_number" => season_number,
+      "name" => "Season #{season_number}",
+      "episodes" => episodes
+    }
+
+    Bypass.stub(bypass, "GET", "/tmdb/tv/shows/#{tmdb_id}/#{season_number}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  defp stub_tvdb_search_empty(bypass) do
+    Bypass.stub(bypass, "GET", "/tvdb/search", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(%{"data" => []}))
+    end)
+  end
+end

--- a/test/mydia/media/create_media_item_season_monitoring_test.exs
+++ b/test/mydia/media/create_media_item_season_monitoring_test.exs
@@ -170,6 +170,46 @@ defmodule Mydia.Media.CreateMediaItemSeasonMonitoringTest do
     end
   end
 
+  describe "season_monitoring: \"latest\"" do
+    test "fetches all seasons, sets monitor_new_seasons: :all, and monitors only the latest season",
+         %{config: config, tmdb_id: tmdb_id} do
+      assert {:ok, media_item} =
+               Media.create_media_item(
+                 %{
+                   title: "Monitoring Test Show",
+                   type: "tv_show",
+                   tmdb_id: tmdb_id,
+                   metadata_source: :tmdb
+                 },
+                 config: config,
+                 season_monitoring: "latest"
+               )
+
+      assert media_item.monitor_new_seasons == :all
+
+      episodes =
+        Repo.all(
+          from(e in Episode,
+            where: e.media_item_id == ^media_item.id,
+            order_by: [e.season_number, e.episode_number]
+          )
+        )
+
+      assert length(episodes) == 5
+
+      # Only Season 2 episodes are monitored
+      monitored_episodes = Enum.filter(episodes, & &1.monitored)
+      assert length(monitored_episodes) == 2
+      assert Enum.all?(monitored_episodes, &(&1.season_number == 2))
+
+      # Season 0 and Season 1 episodes are unmonitored
+      unmonitored = Enum.reject(episodes, & &1.monitored)
+      assert length(unmonitored) == 3
+      assert Enum.any?(unmonitored, &(&1.season_number == 0))
+      assert Enum.all?(Enum.filter(unmonitored, &(&1.season_number == 1)), &(not &1.monitored))
+    end
+  end
+
   describe "season_monitoring: \"all\"" do
     test "fetches all seasons, sets monitor_new_seasons: :all, and monitors all non-special episodes",
          %{config: config, tmdb_id: tmdb_id} do

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -479,7 +479,7 @@ defmodule Mydia.MediaRequestsTest do
       %{admin: admin, request: request, config: relay_config(bypass)}
     end
 
-    test "creates no episodes when season monitoring is none", %{
+    test "creates all episodes unmonitored when season monitoring is none", %{
       request: request,
       admin: admin,
       config: config
@@ -491,11 +491,13 @@ defmodule Mydia.MediaRequestsTest do
                )
 
       assert media_item.type == "tv_show"
+      assert media_item.monitor_new_seasons == :none
 
-      assert Repo.aggregate(
-               from(e in Mydia.Media.Episode, where: e.media_item_id == ^media_item.id),
-               :count
-             ) == 0
+      episodes =
+        Repo.all(from(e in Mydia.Media.Episode, where: e.media_item_id == ^media_item.id))
+
+      assert length(episodes) == 5
+      assert Enum.all?(episodes, fn e -> not e.monitored end)
     end
 
     test "creates episodes for every season when season monitoring is all", %{
@@ -510,13 +512,15 @@ defmodule Mydia.MediaRequestsTest do
                )
 
       assert media_item.type == "tv_show"
+      assert media_item.monitor_new_seasons == :all
 
       # The stub offers 2 + 3 = 5 episodes across two seasons; "all" must
-      # fetch every one of them, in contrast to "none" fetching zero above.
-      assert Repo.aggregate(
-               from(e in Mydia.Media.Episode, where: e.media_item_id == ^media_item.id),
-               :count
-             ) == 5
+      # fetch every one of them and monitor them.
+      episodes =
+        Repo.all(from(e in Mydia.Media.Episode, where: e.media_item_id == ^media_item.id))
+
+      assert length(episodes) == 5
+      assert Enum.all?(episodes, fn e -> e.monitored end)
     end
   end
 


### PR DESCRIPTION
## Summary
Closes #690

Previously, `refresh_episodes_for_tv_show/2` filtered seasons fetched from metadata based on `season_monitoring` (`"first"`, `"latest"`, `"none"`). This caused:
- `"future"` to silently fall through to `seasons` and monitor all seasons.
- `"first"` and `"none"` to leave the show with 0 episodes in the database (or 0 regular episodes if season 0 was skipped).
- Refresh timestamps were never stamped for non-`"all"` modes, leading to subsequent sweeps re-fetching all seasons and overriding the monitoring selection anyway.

## Changes
- `refresh_episodes_for_tv_show/2` always fetches and creates all seasons and episodes returned by metadata.
- `create_media_item/2` and `Media.Add.build_media_item_attrs/3` default `monitor_new_seasons` to `:none` for `"first"` / `"none"` and `:all` for `"all"` / `"future"`.
- After episode creation on add, `create_media_item/2` applies the initial season monitoring preset:
  - `"all"`: all regular seasons monitored, specials unmonitored.
  - `"future"`: only un-aired episodes monitored (`air_date > today`).
  - `"first"`: only Season 1 monitored.
  - `"none"`: all episodes unmonitored.
- Removed obsolete test for partial season selection throttle skipping.
- Added comprehensive unit tests in `test/mydia/media/create_media_item_season_monitoring_test.exs` covering all modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TV show setup now applies season monitoring preferences for future, first, none, all, and latest options.
  * Initial episode monitoring follows the selected preference, with latest monitoring limited to the newest regular season.
  * Explicit monitoring settings are preserved when creating media items.
  * Matching pending requests are automatically approved after media is added.

* **Bug Fixes**
  * Episode refreshes now process all seasons, including specials.
  * Refresh timestamps are recorded only after all seasons refresh successfully.
  * Media creation now reports approval failures instead of indicating success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->