### PR TITLE
perf(ci): stop running bcrypt and Argon2 at production cost in tests

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -272,6 +272,26 @@ Four gotchas around it:
   when a local dev-env compile is clean. Reproduce with
   `MIX_ENV=test mix compile --warnings-as-errors --force`.
 
+### Watching test-suite speed
+
+The regression signal is already free on every run: ExUnit's
+`Finished in Xs (Ys async, Zs sync)` line. Sync time is the number that matters
+here, because `test/test_helper.exs` pins `max_cases: 1` on SQLite and
+`Mydia.DataCase` forces database tests to `async: false`, so the suite is
+overwhelmingly serial and a slowdown shows up as sync time climbing. Measured on
+master 2026-09-03: `876.4 seconds (59.1s async, 817.3s sync)`.
+
+To find *which* tests are slow, profile on demand rather than in CI:
+
+    devenv shell -- bash -c 'MIX_ENV=test mix test --slowest-modules 20'
+
+Do not add `--slowest` or `--slowest-modules` to the CI invocations. Both
+automatically set `--trace`, and `--trace` forces `--max-cases 1` and sets the
+test timeout to `:infinity` (`mix help test`; ExUnit's `max_cases/1` checks
+`opts[:trace]` before any explicit `--max-cases`). On the PostgreSQL job that
+silently serializes the whole suite, and on both jobs it means a hung test runs
+until the GitHub job timeout instead of failing fast.
+
 ## Docker tags
 
 `ci-docker.yml` pushes `:master` and `:master-pg` on every master push, which is

--- a/.github/README.md
+++ b/.github/README.md
@@ -250,11 +250,18 @@ opts-arity of a live `count_books/0` and cannot be deleted. Ignores are
 rule-shaped, as regexes or predicates, in `mix.exs`'s `unused_ignore/0`, including
 a behaviour-callback predicate `MydiaQuality.behaviour_callback?/1`.
 
-Three gotchas around it:
+Four gotchas around it:
 
 - The mix_unused `:unused` compiler must be prepended (`[:unused | base]`).
   Appending (`base ++ [:unused]`) produces no report in this version. It is gated
   to `Mix.env() in [:dev, :test]` and `UNUSED_CHECK=true`.
+- The report runs on master pushes only, not on pull requests. It recompiles all
+  765 files a second time and cost 199s of every run, measured 2026-09-03, for
+  output nothing is gated on. `ci.yml` gates it on `GITHUB_EVENT_NAME` inside the
+  `devenv shell` heredoc rather than with a step-level `if:`, because splitting
+  the heredoc evaluates the devenv environment twice and costs more than it
+  saves. Run it yourself with
+  `UNUSED_CHECK=true ./dev mix compile --force`.
 - Build-time helper modules referenced by `mix.exs` must be inlined in `mix.exs`
   rather than kept in a separate root file. The Docker build's
   `mix deps.get --only prod` layer copies only `mix.exs` and `mix.lock`, so a

--- a/.github/README.md
+++ b/.github/README.md
@@ -283,7 +283,9 @@ master 2026-09-03: `876.4 seconds (59.1s async, 817.3s sync)`.
 
 To find *which* tests are slow, profile on demand rather than in CI:
 
-    devenv shell -- bash -c 'MIX_ENV=test mix test --slowest-modules 20'
+```bash
+devenv shell -- bash -c 'MIX_ENV=test mix test --slowest-modules 20'
+```
 
 Do not add `--slowest` or `--slowest-modules` to the CI invocations. Both
 automatically set `--trace`, and `--trace` forces `--max-cases 1` and sets the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,13 +283,7 @@ jobs:
           fi
           mix ecto.create
           mix ecto.migrate
-          # --slowest-modules is the load-bearing one: `mix help test` notes it
-          # "Includes time spent in ExUnit.Callbacks.setup/1", which is where
-          # per-test fixture cost hides. Both flags exist on the pinned Elixir
-          # 1.19.5 (--slowest-modules since 1.17.0) and cost nothing to run.
-          # This is what makes the next slowdown visible before the suite
-          # doubles again.
-          mix test --cover --slowest 30 --slowest-modules 10
+          mix test --cover
           DEVENV
 
   rust:
@@ -441,8 +435,7 @@ jobs:
           mix ecto.create
           mix ecto.migrate
           mix ecto.migrations
-          # See the `test` job for why the slowest-test flags are on.
-          mix test --cover --slowest 30 --slowest-modules 10
+          mix test --cover
           DEVENV
 
   test-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,10 +268,28 @@ jobs:
           fi
           mix credo --strict
           # Advisory dead-code report (non-blocking; see CONTRIBUTING.md "Quality gates").
-          UNUSED_CHECK=true mix compile --force || true
+          #
+          # This recompiles all 765 files a second time and cost 199s of every
+          # run, measured 2026-09-03. Nothing is ever gated on its output --
+          # .github/README.md records that mix_unused is advisory by design and
+          # must not be promoted to blocking -- so pull requests skip it and
+          # master pushes still produce the report.
+          #
+          # The gate is here rather than a step-level `if:` because splitting
+          # this heredoc would evaluate the devenv environment a second time and
+          # cost more than the 199s it saves.
+          if [ "${GITHUB_EVENT_NAME:-}" = "push" ]; then
+            UNUSED_CHECK=true mix compile --force || true
+          fi
           mix ecto.create
           mix ecto.migrate
-          mix test --cover
+          # --slowest-modules is the load-bearing one: `mix help test` notes it
+          # "Includes time spent in ExUnit.Callbacks.setup/1", which is where
+          # per-test fixture cost hides. Both flags exist on the pinned Elixir
+          # 1.19.5 (--slowest-modules since 1.17.0) and cost nothing to run.
+          # This is what makes the next slowdown visible before the suite
+          # doubles again.
+          mix test --cover --slowest 30 --slowest-modules 10
           DEVENV
 
   rust:
@@ -423,7 +441,8 @@ jobs:
           mix ecto.create
           mix ecto.migrate
           mix ecto.migrations
-          mix test --cover
+          # See the `test` job for why the slowest-test flags are on.
+          mix test --cover --slowest 30 --slowest-modules 10
           DEVENV
 
   test-e2e:

--- a/config/test.exs
+++ b/config/test.exs
@@ -198,3 +198,17 @@ config :mydia, Mydia.MigrationTestRepo,
   pool_size: 1,
   foreign_keys: :on,
   priv: "priv/repo"
+
+# bcrypt and Argon2 default to production cost: ~170ms and ~64ms per hash on a
+# development machine, closer to 300ms and 120ms on a CI runner. 135 test files
+# create users, 122 of them inside a per-test `setup`, so the suite pays this
+# thousands of times over and it dominated the ~876s ExUnit run measured on
+# 2026-09-03. Both libraries read these from application env
+# (deps/bcrypt_elixir/lib/bcrypt.ex:94), so this block reaches every call site
+# with no change under lib/. log_rounds: 4 is the value bcrypt_elixir's own
+# documentation gives for tests.
+#
+# These values must not appear in any other config file.
+# test/mydia/accounts/hash_cost_config_test.exs enforces that.
+config :bcrypt_elixir, log_rounds: 4
+config :argon2_elixir, t_cost: 1, m_cost: 8

--- a/lib/mydia/downloads/client/debrid/fetcher.ex
+++ b/lib/mydia/downloads/client/debrid/fetcher.ex
@@ -57,6 +57,11 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
   # Retry budget for the whole fetch lifecycle (URL re-resolve + stream).
   @max_retries 3
 
+  # Base unit of the linear retry backoff: attempt N waits N * this. Injectable
+  # so tests exercising the failure path do not spend 30 real seconds asleep.
+  # Mirrors Mydia.Downloads.Seedbox.Fetcher, which already does this.
+  @retry_delay_base_ms 5_000
+
   ## ── Public API ───────────────────────────────────────────────────────
 
   @doc false
@@ -131,7 +136,9 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
       download_dir: Keyword.get(opts, :download_dir),
       req_options: Keyword.get(opts, :req_options, []),
       jitter_ms: Keyword.get(opts, :jitter_ms, :rand.uniform(@startup_jitter_max_ms)),
+      max_retries: Keyword.get(opts, :max_retries, @max_retries),
       retries_left: Keyword.get(opts, :max_retries, @max_retries),
+      retry_delay_base_ms: Keyword.get(opts, :retry_delay_base_ms, @retry_delay_base_ms),
       # Pre-resolved URLs passed from the dispatch adapter on the first
       # claim. On process restart these are nil and `resolve_urls/2` falls
       # back to calling the provider, since IP-bound URLs expire.
@@ -169,7 +176,7 @@ defmodule Mydia.Downloads.Client.Debrid.Fetcher do
             "(#{state.retries_left} retries left): #{inspect(reason)}"
         )
 
-        retry_ms = (@max_retries - state.retries_left + 1) * 5_000
+        retry_ms = (state.max_retries - state.retries_left + 1) * state.retry_delay_base_ms
         Process.send_after(self(), :begin, retry_ms)
         {:noreply, %{state | retries_left: state.retries_left - 1}}
 

--- a/test/mydia/accounts/hash_cost_config_test.exs
+++ b/test/mydia/accounts/hash_cost_config_test.exs
@@ -1,0 +1,78 @@
+defmodule Mydia.Accounts.HashCostConfigTest do
+  @moduledoc """
+  Password hashing cost may be lowered in `config/test.exs` and nowhere else.
+
+  bcrypt and Argon2 default to production cost, which is ~170ms and ~64ms per
+  hash on a development machine and closer to 300ms and 120ms on a CI runner.
+  135 test files create users, 122 of them inside a per-test `setup`, so at
+  production cost the suite spends several minutes doing nothing but hashing.
+  `config/test.exs` therefore sets `log_rounds: 4` and `t_cost: 1, m_cost: 8`.
+
+  Those values are catastrophic in production: bcrypt at 4 rounds is roughly
+  200x cheaper to attack than at 12. The failure mode this guard closes is
+  someone hitting a slow `mix mydia.user add` or a slow release task, moving the
+  block up into `config/config.exs` to "fix" it, and shipping 4-round password
+  hashes with CI green.
+
+  Same shape as `Mydia.Repo.Migrations.NoVarcharColumnsTest`: read the source,
+  fail with the reason and the fix.
+  """
+
+  use ExUnit.Case, async: true
+
+  # `config/runtime.exs` is evaluated in every environment including :prod, so it
+  # is checked alongside the compile-time files.
+  @cost_keys ~w(log_rounds t_cost m_cost)
+
+  describe "hashing cost configuration" do
+    test "no config file outside config/test.exs sets a hashing cost" do
+      offenders =
+        config_files()
+        |> Enum.reject(&(Path.basename(&1) == "test.exs"))
+        |> Enum.flat_map(&cost_key_lines/1)
+        |> Enum.sort()
+
+      assert offenders == [],
+             """
+             These config files set a password hashing cost:
+
+               #{Enum.join(offenders, "\n  ")}
+
+             bcrypt and Argon2 cost may only be lowered in config/test.exs.
+             `config/config.exs` and `config/runtime.exs` are evaluated in
+             production, so a cost set there weakens real password and API-key
+             hashing while every test stays green.
+
+             If a dev-only task is too slow, lower the cost in config/dev.exs
+             ONLY if you accept that dev-created credentials are weakly hashed,
+             and never in config.exs, prod.exs or runtime.exs.
+             """
+    end
+
+    test "config/test.exs still sets both costs" do
+      source = File.read!("config/test.exs")
+
+      assert source =~ "config :bcrypt_elixir, log_rounds:",
+             "config/test.exs no longer lowers bcrypt cost; the suite will spend minutes hashing"
+
+      assert source =~ "config :argon2_elixir,",
+             "config/test.exs no longer lowers Argon2 cost; the suite will spend minutes hashing"
+    end
+
+    test "the config glob actually matches files" do
+      assert config_files() != [], "no config files found; the wildcard or CWD is wrong"
+    end
+  end
+
+  defp config_files, do: Path.wildcard("config/*.exs")
+
+  defp cost_key_lines(path) do
+    path
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.reject(fn {line, _n} -> String.starts_with?(String.trim(line), "#") end)
+    |> Enum.filter(fn {line, _n} -> Enum.any?(@cost_keys, &String.contains?(line, "#{&1}:")) end)
+    |> Enum.map(fn {line, n} -> "#{Path.basename(path)}:#{n}: #{String.trim(line)}" end)
+  end
+end

--- a/test/mydia/accounts/hash_cost_config_test.exs
+++ b/test/mydia/accounts/hash_cost_config_test.exs
@@ -58,11 +58,33 @@ defmodule Mydia.Accounts.HashCostConfigTest do
     test "config/test.exs still sets both costs" do
       source = File.read!("config/test.exs")
 
-      assert source =~ "config :bcrypt_elixir, log_rounds:",
-             "config/test.exs no longer lowers bcrypt cost; the suite will spend minutes hashing"
+      # Presence checks alone pass if someone lowers the numbers back toward
+      # production cost (log_rounds: 12) or drops t_cost/m_cost entirely, so
+      # pin the exact values this suite relies on.
+      assert source =~ "config :bcrypt_elixir, log_rounds: 4",
+             "config/test.exs no longer pins bcrypt to log_rounds: 4; the suite will spend " <>
+               "minutes hashing at production cost"
 
-      assert source =~ "config :argon2_elixir,",
-             "config/test.exs no longer lowers Argon2 cost; the suite will spend minutes hashing"
+      assert source =~ "config :argon2_elixir, t_cost: 1, m_cost: 8",
+             "config/test.exs no longer pins Argon2 to t_cost: 1, m_cost: 8; the suite will " <>
+               "spend minutes hashing at production cost"
+
+      # The source-text asserts above only catch an edit to this file. They
+      # cannot catch an override applied from somewhere else (loaded after
+      # this file, or set at runtime) that changes the *effective* cost
+      # without ever touching config/test.exs, so assert what's actually
+      # loaded into application env for the running test suite too.
+      assert Application.get_env(:bcrypt_elixir, :log_rounds) == 4,
+             "bcrypt_elixir's effective log_rounds is not 4; something outside " <>
+               "config/test.exs is overriding it and the suite will spend minutes hashing"
+
+      assert Application.get_env(:argon2_elixir, :t_cost) == 1,
+             "argon2_elixir's effective t_cost is not 1; something outside " <>
+               "config/test.exs is overriding it and the suite will spend minutes hashing"
+
+      assert Application.get_env(:argon2_elixir, :m_cost) == 8,
+             "argon2_elixir's effective m_cost is not 8; something outside " <>
+               "config/test.exs is overriding it and the suite will spend minutes hashing"
     end
 
     test "the config glob actually matches files" do

--- a/test/mydia/accounts/hash_cost_config_test.exs
+++ b/test/mydia/accounts/hash_cost_config_test.exs
@@ -24,6 +24,12 @@ defmodule Mydia.Accounts.HashCostConfigTest do
   # is checked alongside the compile-time files.
   @cost_keys ~w(log_rounds t_cost m_cost)
 
+  # Anchored like `Mydia.Repo.Migrations.NoVarcharColumnsTest`'s @declarations:
+  # the key must open a keyword pair (line start, or after a comma as in
+  # `config :bcrypt_elixir, log_rounds: 4`), so an unrelated `log_rounds:`
+  # inside a string literal or heredoc doesn't trip the guard.
+  @cost_key_patterns Enum.map(@cost_keys, &Regex.compile!("(?:^|,)\\s*#{Regex.escape(&1)}:"))
+
   describe "hashing cost configuration" do
     test "no config file outside config/test.exs sets a hashing cost" do
       offenders =
@@ -72,7 +78,7 @@ defmodule Mydia.Accounts.HashCostConfigTest do
     |> String.split("\n")
     |> Enum.with_index(1)
     |> Enum.reject(fn {line, _n} -> String.starts_with?(String.trim(line), "#") end)
-    |> Enum.filter(fn {line, _n} -> Enum.any?(@cost_keys, &String.contains?(line, "#{&1}:")) end)
+    |> Enum.filter(fn {line, _n} -> Enum.any?(@cost_key_patterns, &Regex.match?(&1, line)) end)
     |> Enum.map(fn {line, n} -> "#{Path.basename(path)}:#{n}: #{String.trim(line)}" end)
   end
 end

--- a/test/mydia/downloads/client/debrid/fetcher_test.exs
+++ b/test/mydia/downloads/client/debrid/fetcher_test.exs
@@ -247,12 +247,23 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
          %{staging: staging} do
       download = insert_download()
 
-      budget = {1, 60}
-      Mydia.Downloads.Client.Debrid.RateLimiter.clear(:unknown, "backoff-key")
-      Mydia.Downloads.Client.Debrid.RateLimiter.acquire(:unknown, "backoff-key", budget)
+      # A key unique to this test, not the literal "backoff-key" the sibling
+      # test above uses: the assertion below counts RateLimiter slots for
+      # this key, and a shared key would pick up that test's acquire too.
+      api_key = "backoff-key-#{System.unique_integer([:positive])}"
 
+      # An ample budget (unlike the sibling test's saturated one) so every
+      # RateLimiter.acquire call the fetcher makes succeeds and records a
+      # slot. That gives us a direct, non-timing-based count of how many
+      # times run/1 actually attempted the fetch: each attempt calls
+      # resolve_urls/2, which acquires exactly one slot before failing.
+      budget = {100, 60}
       StubProvider.set(:rate_limit_budget, budget)
-      StubProvider.set(:get_download_urls, {:ok, ["https://example.com/x"]})
+
+      StubProvider.set(
+        :get_download_urls,
+        {:error, Mydia.Downloads.Client.Error.unknown("stub: forced failure to drive retries")}
+      )
 
       started = System.monotonic_time(:millisecond)
 
@@ -261,7 +272,7 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
           download_id: download.id,
           config: %{
             type: :debrid,
-            api_key: "backoff-key",
+            api_key: api_key,
             connection_settings: %{"provider" => "real_debrid"},
             download_directory: staging
           },
@@ -274,13 +285,24 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
         )
 
       # Two retries at a 10ms base means 10ms + 20ms of backoff. At the
-      # production 5_000ms base the same path would take 15 seconds, and at the
-      # pre-fix behaviour (which read @max_retries = 3 instead of the injected
-      # 2) it would take longer still. A 2s ceiling distinguishes all three.
+      # production 5_000ms base the same path would take 15 seconds. This
+      # ceiling proves the injected backoff base is used, but on its own
+      # can't distinguish 2 injected retries from the default 3 -- both
+      # finish well under 2s at a 10ms base. The attempt count below is
+      # what actually pins max_retries.
       :ok = wait_for_fetcher_exit(download.id, 20)
 
       elapsed = System.monotonic_time(:millisecond) - started
       assert elapsed < 2_000, "fetcher took #{elapsed}ms; the injected backoff was ignored"
+
+      # One RateLimiter slot per attempt: the initial try plus each retry.
+      # max_retries: 2 means 3 total attempts; a regression that fell back
+      # to the default max_retries (3) would run 4.
+      attempts = Mydia.Downloads.Client.Debrid.RateLimiter.usage(:unknown, api_key, 60)
+
+      assert attempts == 3,
+             "expected 3 total attempts (1 initial + max_retries: 2) but observed #{attempts}; " <>
+               "the fetcher is not honouring the injected max_retries option"
 
       reloaded = Repo.get!(Download, download.id)
       assert reloaded.import_failed_at != nil

--- a/test/mydia/downloads/client/debrid/fetcher_test.exs
+++ b/test/mydia/downloads/client/debrid/fetcher_test.exs
@@ -192,7 +192,8 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
           provider_job: fake_provider_job(download.download_client_id),
           provider_module: StubProvider,
           jitter_ms: 0,
-          download_dir: staging
+          download_dir: staging,
+          retry_delay_base_ms: 10
         )
 
       :ok = wait_for_fetcher_exit(download.id)
@@ -229,7 +230,8 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
           provider_job: fake_provider_job(download.download_client_id),
           provider_module: StubProvider,
           jitter_ms: 0,
-          download_dir: staging
+          download_dir: staging,
+          retry_delay_base_ms: 10
         )
 
       :ok = wait_for_fetcher_exit(download.id)
@@ -239,6 +241,49 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
 
       assert reloaded.import_last_error =~ "rate-limited" or
                reloaded.import_last_error =~ "rate_limited"
+    end
+
+    test "honours an injected retry_delay_base_ms and the max_retries option",
+         %{staging: staging} do
+      download = insert_download()
+
+      budget = {1, 60}
+      Mydia.Downloads.Client.Debrid.RateLimiter.clear(:unknown, "backoff-key")
+      Mydia.Downloads.Client.Debrid.RateLimiter.acquire(:unknown, "backoff-key", budget)
+
+      StubProvider.set(:rate_limit_budget, budget)
+      StubProvider.set(:get_download_urls, {:ok, ["https://example.com/x"]})
+
+      started = System.monotonic_time(:millisecond)
+
+      :ok =
+        Fetcher.claim(
+          download_id: download.id,
+          config: %{
+            type: :debrid,
+            api_key: "backoff-key",
+            connection_settings: %{"provider" => "real_debrid"},
+            download_directory: staging
+          },
+          provider_job: fake_provider_job(download.download_client_id),
+          provider_module: StubProvider,
+          jitter_ms: 0,
+          download_dir: staging,
+          max_retries: 2,
+          retry_delay_base_ms: 10
+        )
+
+      # Two retries at a 10ms base means 10ms + 20ms of backoff. At the
+      # production 5_000ms base the same path would take 15 seconds, and at the
+      # pre-fix behaviour (which read @max_retries = 3 instead of the injected
+      # 2) it would take longer still. A 2s ceiling distinguishes all three.
+      :ok = wait_for_fetcher_exit(download.id, 20)
+
+      elapsed = System.monotonic_time(:millisecond) - started
+      assert elapsed < 2_000, "fetcher took #{elapsed}ms; the injected backoff was ignored"
+
+      reloaded = Repo.get!(Download, download.id)
+      assert reloaded.import_failed_at != nil
     end
   end
 
@@ -304,11 +349,12 @@ defmodule Mydia.Downloads.Client.Debrid.FetcherTest do
     end
   end
 
-  # Polls the Fetcher's Registry entry until it's gone (or times out.)
-  # Default budget is 30s — the Fetcher's retry-with-exponential-backoff
-  # path (max_retries=3 with growing waits) needs more than the original
-  # 3s budget. Polling stays at 100ms so successful tests still exit fast.
-  defp wait_for_fetcher_exit(download_id, attempts \\ 300) do
+  # Polls the Fetcher's Registry entry until it's gone (or times out).
+  # Polling stays at 100ms so successful tests still exit fast. The retry paths
+  # inject `retry_delay_base_ms: 10` rather than sleeping the production 5s
+  # base, so a 3s budget covers a full exhausted retry budget with room to
+  # spare. Raising this back to 30s hides a regression rather than fixing one.
+  defp wait_for_fetcher_exit(download_id, attempts \\ 30) do
     if attempts == 0 do
       flunk("fetcher for #{download_id} did not exit in time")
     else


### PR DESCRIPTION
The SQLite `Test` job takes 24-26 minutes. The obvious suspect was `max_cases: 1`
in `test/test_helper.exs`, but the numbers rule it out, and the real cause is a
line `config/test.exs` never had.

## What the job actually spends its time on

Phase boundaries from run 33710806501, the last green master before this branch:

| Phase | Time |
| --- | --- |
| `mix deps.get` + deps compile | 125s |
| `mix compile --warnings-as-errors` (765 files) | 218s |
| format check + inline guards | 41s |
| `mix credo --strict` | 32s |
| `UNUSED_CHECK=true mix compile --force`, recompiling all 765 files again for non-blocking output | 199s |
| `mix ecto.create` + `mix ecto.migrate` | 43s |
| **ExUnit** | **876s** |
| cover report | 4s |

## `max_cases` was not the problem

The two database jobs run the same ~10,700 tests. SQLite caps concurrency at
one case; PostgreSQL uses `System.schedulers_online()`.

| Job | ExUnit total | async | sync |
| --- | --- | --- | --- |
| `Test` (SQLite, `max_cases: 1`) | 876.4s | 59.1s | 817.3s |
| `Test / PostgreSQL` (`schedulers_online`) | 868.1s | 80.1s | 788.0s |

Full parallelism buys eight seconds. ExUnit runs `async: false` cases one at a
time regardless of `max_cases`, and 93% of this suite is sync. So parallelism
is not the lever, and this PR does not touch it.

## The actual cause: hashing at production cost

`config/test.exs` never lowered the password hashing work factor. Phoenix ships
`config :bcrypt_elixir, log_rounds: 1` in generated test config; this project
never had the line, so `bcrypt_elixir` fell back to its built-in default of 12
rounds and Argon2 to `t_cost: 3` / `m_cost: 16` (64 MiB).

Measured on a development machine, which is faster per-core than a CI runner:

```
bcrypt log_rounds=12 (default): 168.5 ms
bcrypt log_rounds=4:              0.8 ms
argon2 defaults (t=3,m=16):      63.6 ms
argon2 t=1,m=8:                   0.5 ms
```

135 test files create users, 1,343 tests between them, and 122 of those files do
it inside a per-test `setup` rather than `setup_all`. The path is
`AuthHelpers.create_test_user/1` -> `Accounts.create_user/1` ->
`Bcrypt.hash_pwd_salt/1`; API keys and remote-device tokens add Argon2 on top.

That is the "170-340ms per authenticated database test" this started from. Not
the database. One bcrypt.

## Changes

**1. `config/test.exs` sets `log_rounds: 4` and `t_cost: 1, m_cost: 8`.** Both
libraries read these from application env, so no change under `lib/` is needed.
`log_rounds: 4` is the value `bcrypt_elixir`'s own docs give for tests.

**2. A guard test** (`test/mydia/accounts/hash_cost_config_test.exs`) fails if
those keys appear in any config file other than `config/test.exs`. These values
are catastrophic in production, and the plausible failure mode is someone hitting
a slow `mix mydia.user add` and moving the block into `config/config.exs`, which
would ship 4-round password hashes with CI green. Same shape as
`no_varchar_columns_test.exs`. The guard was verified to actually fail by
planting the offence and observing it caught, then reverting.

**3. The dead-code report runs on master pushes only.** `mix_unused` recompiles
all 765 files a second time (199s) for output that is advisory by design and
never gated on, as `.github/README.md` already records. The gate is a bash
conditional inside the existing `devenv shell` heredoc rather than a step-level
`if:`, because that heredoc exists so the environment evaluates once and
`_build` stays warm across steps; splitting it would cost more than the 199s.

**4. The debrid fetcher's retry backoff is injectable.** It hardcoded
`5_000`, so two tests that exhaust the retry budget each slept 5+10+15 = 30 real
seconds. `Mydia.Downloads.Seedbox.Fetcher` had already solved this correctly;
this mirrors it. A latent bug goes with it: the retry clause read the module
attribute `@max_retries` while `init/1` already accepted `max_retries` as an
option, so a caller passing `max_retries: 1` got a delay computed from 3.

## Measurements

Same machine, before and after:

| | before | after |
| --- | --- | --- |
| `test/mydia_web/live/devices_live_test.exs` (27 tests) | 5.8s | 0.8s |
| `test/mydia/downloads/client/debrid/fetcher_test.exs` | 63.1s | 3.0s |

Full suite green on both adapters after the change:

```
SQLite      Finished in 291.0 seconds (37.8s async, 253.1s sync)
            13 doctests, 10720 tests, 0 failures, 44 skipped
PostgreSQL  Finished in 297.6 seconds (62.8s async, 234.8s sync)
            13 doctests, 10721 tests, 0 failures, 47 skipped
```

Those totals are local hardware and post-change only, so they are not comparable
to the 876.4s CI figure above. This PR's own CI run is the real before/after.

## One trap worth recording

An earlier revision of this branch added `--slowest 30 --slowest-modules 10` to
both test jobs to make future slowdowns visible. That was wrong and is reverted.
Both flags automatically set `--trace`, and `--trace` forces `--max-cases 1` and
sets the test timeout to `:infinity` (`mix help test`; ExUnit's `max_cases/1`
checks `opts[:trace]` before any explicit `--max-cases`, so it cannot be won
back). On the PostgreSQL job that silently serializes the suite, and on both jobs
a hung test would run to the GitHub job timeout instead of failing fast.

`.github/README.md` now documents the trap, the free regression signal
(ExUnit's `Finished in Xs (Ys async, Zs sync)` line, where rising sync time is
what to watch), and the on-demand profiling command.

## Scope

No test is deleted, skipped, retagged, or moved between adapters. No `async:`
flag changes, `max_cases` is untouched, and `--cover` stays on both database
jobs. Coverage is unchanged: the hashing change is a work-factor reduction, not
a stub, and real hash/verify round-trips still execute
(`default_admin_test.exs`, `api_key_test.exs`).

Deliberately left out, each worth its own change:

- **The `_build` cache misses entirely.** On the measured run neither the exact
  key nor the `restore-keys` prefix hit, which is why `mix compile` rebuilt all
  765 files for 218s; the job then ended with `Failed to save: Unable to reserve
  cache with key ..., another job may be creating this cache`. Worth roughly
  another 200s.
- **Parallelizing the suite.** 397 of 809 test files run sync. Flipping the safe
  ones to `async: true`, and revisiting `DataCase`'s blanket `async: false` for
  SQLite, is a much larger diff with a real flake shakeout.
- **Sharding** with `mix test --partitions N`, which needs `MIX_TEST_PARTITION`
  folded into the SQLite database path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable retry limits and backoff timing for debrid downloads.

* **Documentation**
  * Expanded guidance on monitoring test-suite performance and profiling slow tests.
  * Documented that advisory unused-code checks run on master pushes, while pull requests skip them.

* **Tests**
  * Reduced password-hashing costs in test environments to speed up the test suite.
  * Added safeguards to ensure reduced hashing costs remain limited to test configuration.
  * Improved coverage for download retry behavior and rate-limit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->