### PR TITLE
fix(p2p): retire the unauthenticated read_media request

### DIFF
--- a/lib/mydia/p2p.ex
+++ b/lib/mydia/p2p.ex
@@ -59,13 +59,6 @@ defmodule Mydia.P2p do
   def send_response(_resource, _request_id, _response), do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """
-  Read a file chunk and send it as a response.
-  This is optimized to read and send directly from Rust.
-  """
-  def respond_with_file_chunk(_resource, _request_id, _file_path, _offset, _length),
-    do: :erlang.nif_error(:nif_not_loaded)
-
-  @doc """
   Get network statistics including connected peers and relay status.
   """
   def get_network_stats(_resource), do: :erlang.nif_error(:nif_not_loaded)
@@ -124,19 +117,6 @@ defmodule Mydia.P2p.PairingResponse do
           device_token: String.t() | nil,
           error: String.t() | nil,
           direct_urls: [String.t()]
-        }
-end
-
-defmodule Mydia.P2p.ReadMediaRequest do
-  @moduledoc """
-  A request to read a media file chunk.
-  """
-  defstruct [:file_path, :offset, :length]
-
-  @type t :: %__MODULE__{
-          file_path: String.t(),
-          offset: non_neg_integer(),
-          length: non_neg_integer()
         }
 end
 

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -290,39 +290,6 @@ defmodule Mydia.P2p.Server do
     {:noreply, state}
   end
 
-  def handle_info({:ok, "request_received", "read_media", request_id, req}, state) do
-    resource = state.resource
-
-    serve_request(resource, request_id, "read_media", fn ->
-      cond do
-        not RemoteAccess.enabled?() ->
-          {:error, "Remote access is disabled"}
-
-        # Validate file path exists
-        # SECURITY: In production, verify path is within allowed directories!
-        File.exists?(req.file_path) ->
-          # Use the optimized NIF to read chunk and respond. It answers the
-          # peer itself, so there is no response left for `serve_request`
-          # to send.
-          P2p.respond_with_file_chunk(
-            resource,
-            request_id,
-            req.file_path,
-            req.offset,
-            req.length
-          )
-
-          :responded
-
-        true ->
-          Logger.warning("Requested file not found: #{req.file_path}")
-          {:error, "File not found"}
-      end
-    end)
-
-    {:noreply, state}
-  end
-
   def handle_info({:ok, "request_received", "graphql", request_id, req}, state) do
     # Read what the request needs out of the GenServer's state here; the task
     # below must not close over `state`.

--- a/native/mydia_p2p/src/lib.rs
+++ b/native/mydia_p2p/src/lib.rs
@@ -9,8 +9,6 @@ use mydia_p2p_core::{
 use rustler::{
     Binary, Encoder, Env, LocalPid, NifStruct, NifTaggedEnum, OwnedEnv, ResourceArc, Term,
 };
-use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
 use std::thread;
 
 mod atoms {
@@ -114,14 +112,6 @@ struct ElixirPairingResponse {
 }
 
 #[derive(NifStruct)]
-#[module = "Mydia.P2p.ReadMediaRequest"]
-struct ElixirReadMediaRequest {
-    pub file_path: String,
-    pub offset: u64,
-    pub length: u32,
-}
-
-#[derive(NifStruct)]
 #[module = "Mydia.P2p.GraphQLRequest"]
 struct ElixirGraphQLRequest {
     pub query: String,
@@ -194,43 +184,6 @@ fn send_response(
         Ok(_) => Ok("ok".to_string()),
         Err(e) => Err(rustler::Error::Term(Box::new(e))),
     }
-}
-
-/// Read a file chunk and send it as a response.
-/// This is done in a separate thread to avoid blocking the NIF.
-#[rustler::nif]
-fn respond_with_file_chunk(
-    resource: ResourceArc<HostResource>,
-    request_id: String,
-    file_path: String,
-    offset: u64,
-    length: u32,
-) -> Result<String, rustler::Error> {
-    let resource_clone = resource.clone();
-
-    thread::spawn(move || {
-        let response = match File::open(&file_path) {
-            Ok(mut file) => {
-                if file.seek(SeekFrom::Start(offset)).is_ok() {
-                    let mut buffer = vec![0; length as usize];
-                    match file.read(&mut buffer) {
-                        Ok(n) => {
-                            buffer.truncate(n);
-                            MydiaResponse::MediaChunk(buffer)
-                        }
-                        Err(e) => MydiaResponse::Error(format!("Read error: {}", e)),
-                    }
-                } else {
-                    MydiaResponse::Error("Seek error".to_string())
-                }
-            }
-            Err(e) => MydiaResponse::Error(format!("File open error: {}", e)),
-        };
-
-        let _ = blocking::send_response(&resource_clone.host, request_id, response);
-    });
-
-    Ok("ok".to_string())
 }
 
 /// Send an HLS response header for a streaming request.
@@ -403,21 +356,6 @@ fn start_listening(
                             )
                                 .encode(env)
                         }
-                        MydiaRequest::ReadMedia(req) => {
-                            let elixir_req = ElixirReadMediaRequest {
-                                file_path: req.file_path,
-                                offset: req.offset,
-                                length: req.length,
-                            };
-                            (
-                                atoms::ok(),
-                                "request_received",
-                                "read_media",
-                                request_id,
-                                elixir_req,
-                            )
-                                .encode(env)
-                        }
                         MydiaRequest::GraphQL(req) => {
                             let elixir_req = ElixirGraphQLRequest {
                                 query: req.query,
@@ -439,12 +377,13 @@ fn start_listening(
                             (atoms::ok(), "request_received", "ping", request_id).encode(env)
                         }
                         // `RemoteControl` and `Custom` are intercepted and rejected before
-                        // this match (see above), so in practice this only ever matches
-                        // `HlsStream` -- which never reaches `Event::RequestReceived` at
-                        // all, since the core routes it to `Event::HlsStreamRequest`
-                        // instead. Kept for exhaustiveness against future variants; a
-                        // message reaching here still carries no `request_id` for Elixir
-                        // to answer with.
+                        // this match (see above), and `ReadMedia` is refused by the core
+                        // before it ever becomes a `RequestReceived` event, so in practice
+                        // this only ever matches `HlsStream` -- which never reaches
+                        // `Event::RequestReceived` at all, since the core routes it to
+                        // `Event::HlsStreamRequest` instead. Kept for exhaustiveness
+                        // against future variants; a message reaching here still carries
+                        // no `request_id` for Elixir to answer with.
                         _ => (atoms::ok(), "unknown_request").encode(env),
                     },
                     Event::HlsStreamRequest {

--- a/native/mydia_p2p_core/src/lib.rs
+++ b/native/mydia_p2p_core/src/lib.rs
@@ -1738,6 +1738,25 @@ async fn handle_connection(
                     continue;
                 }
 
+                // `ReadMedia` is legacy dead surface. No client has ever
+                // constructed one: mydia-rs answers it with an error of its
+                // own, and the Flutter player has never referenced it. The
+                // Phoenix handler behind it read whatever path the peer named,
+                // with no auth token at all, so refuse it here before it can
+                // reach a host. The variant deliberately stays in
+                // `MydiaRequest` so this answers with an error rather than
+                // failing to decode, which would drop the stream and leave the
+                // caller waiting out a timeout. See getmydia/mydia#687.
+                if matches!(request, MydiaRequest::ReadMedia(_)) {
+                    let mut send = send;
+                    let response = MydiaResponse::Error("unsupported_request_type".to_string());
+                    if let Ok(response_data) = serde_cbor::to_vec(&response) {
+                        let _ = send.write_all(&response_data).await;
+                        let _ = send.finish();
+                    }
+                    continue;
+                }
+
                 // For HLS streaming requests, store the send stream and emit
                 // event. Host role only: answering an HLS request means
                 // holding the send half open until the four HLS commands

--- a/native/mydia_p2p_core/tests/read_media_refused.rs
+++ b/native/mydia_p2p_core/tests/read_media_refused.rs
@@ -1,0 +1,72 @@
+//! `ReadMedia` is refused by the core before it can reach a host.
+//!
+//! The Phoenix handler behind this request read whatever absolute path the
+//! peer named, with no auth token anywhere on the path (getmydia/mydia#687).
+//! Nothing has ever sent one: the Flutter player has never referenced the
+//! request in any commit, and mydia-rs already answers it with an error of
+//! its own. The variant stays on the wire so a peer that does send one gets a
+//! clean refusal rather than a dropped stream, and this pins that refusal.
+
+use mydia_p2p_core::{blocking, Host, HostConfig, MydiaRequest, MydiaResponse, ReadMediaRequest};
+use std::time::Duration;
+
+/// The endpoint binds and publishes its address asynchronously, so poll
+/// rather than sleeping a fixed amount. Same helper as `host_loopback.rs`;
+/// integration tests are separate binaries and cannot share it.
+fn wait_for_addr(host: &Host) -> String {
+    for _ in 0..100 {
+        let addr = blocking::get_node_addr(host);
+        if !addr.is_empty() && addr != "null" {
+            return addr;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!("host never published an endpoint address");
+}
+
+#[test]
+fn read_media_is_refused_without_reading_the_file() {
+    let rt = tokio::runtime::Runtime::new().expect("test runtime");
+
+    // A file the server process can certainly read. Asking for a path that
+    // does not exist would pass even if the refusal were reordered behind a
+    // filesystem check, which is exactly the regression this guards against.
+    let probe = std::env::temp_dir().join(format!("mydia_read_media_probe_{}", std::process::id()));
+    let secret = b"this content must never reach a peer";
+    std::fs::write(&probe, secret).expect("write probe file");
+
+    let (server, server_id) = Host::new(HostConfig::default());
+    let (client, _client_id) = Host::new(HostConfig::default());
+
+    let server_addr = wait_for_addr(&server);
+    blocking::dial(&client, server_addr).expect("dial should succeed");
+
+    let request = MydiaRequest::ReadMedia(ReadMediaRequest {
+        file_path: probe.to_string_lossy().into_owned(),
+        offset: 0,
+        length: secret.len() as u32,
+    });
+
+    let response = rt
+        .block_on(async {
+            tokio::time::timeout(
+                Duration::from_secs(10),
+                client.send_request(server_id.clone(), request),
+            )
+            .await
+        })
+        .expect("read_media timed out; the core never answered it")
+        .expect("read_media returned a transport error");
+
+    let _ = std::fs::remove_file(&probe);
+
+    match response {
+        MydiaResponse::Error(message) => {
+            assert_eq!(message, "unsupported_request_type");
+        }
+        MydiaResponse::MediaChunk(bytes) => {
+            panic!("the core served {} bytes of a peer-named file", bytes.len());
+        }
+        other => panic!("expected a refusal, got {other:?}"),
+    }
+}

--- a/native/mydia_p2p_core/tests/wire_format.rs
+++ b/native/mydia_p2p_core/tests/wire_format.rs
@@ -39,6 +39,11 @@ fn pong_encoding_is_stable() {
 fn every_request_variant_name_is_frozen() {
     // Decoding a hand-written encoding proves the name, not just that our own
     // round trip agrees with itself.
+    // `ReadMedia` is in this set on purpose even though the core now refuses
+    // it (see tests/read_media_refused.rs). Removing the variant would make
+    // the request fail to decode, and the decode-failure path drops the
+    // stream without a response, so a peer would hang instead of being told
+    // no. Keep it.
     let get_state =
         serde_cbor::to_vec(&MydiaRequest::RemoteControl(RemoteControlRequest::GetState)).unwrap();
 

--- a/native/mydia_p2p_core/tests/wire_format.rs
+++ b/native/mydia_p2p_core/tests/wire_format.rs
@@ -43,10 +43,9 @@ fn every_request_variant_name_is_frozen() {
     // but don't remove either as dead code. The core now refuses ReadMedia
     // (see tests/read_media_refused.rs, which covers the refusal end to end),
     // and it does that by decoding the request and rejecting it. Delete the
-    // variant and the request fails to decode instead; the decode-failure
-    // path in handle_connection hits `continue` and drops the stream with no
-    // response, so the peer sits out a 30-second timeout instead of getting
-    // a clean refusal.
+    // variant and the request fails to decode instead: the server drops the
+    // stream with no response at all, and the peer gets an opaque decode
+    // error off an empty read instead of a named refusal it can act on.
     let get_state =
         serde_cbor::to_vec(&MydiaRequest::RemoteControl(RemoteControlRequest::GetState)).unwrap();
 

--- a/native/mydia_p2p_core/tests/wire_format.rs
+++ b/native/mydia_p2p_core/tests/wire_format.rs
@@ -39,11 +39,14 @@ fn pong_encoding_is_stable() {
 fn every_request_variant_name_is_frozen() {
     // Decoding a hand-written encoding proves the name, not just that our own
     // round trip agrees with itself.
-    // `ReadMedia` is in this set on purpose even though the core now refuses
-    // it (see tests/read_media_refused.rs). Removing the variant would make
-    // the request fail to decode, and the decode-failure path drops the
-    // stream without a response, so a peer would hang instead of being told
-    // no. Keep it.
+    // This test doesn't touch `MydiaRequest::ReadMedia` or `ReadMediaRequest`,
+    // but don't remove either as dead code. The core now refuses ReadMedia
+    // (see tests/read_media_refused.rs, which covers the refusal end to end),
+    // and it does that by decoding the request and rejecting it. Delete the
+    // variant and the request fails to decode instead; the decode-failure
+    // path in handle_connection hits `continue` and drops the stream with no
+    // response, so the peer sits out a 30-second timeout instead of getting
+    // a clean refusal.
     let get_state =
         serde_cbor::to_vec(&MydiaRequest::RemoteControl(RemoteControlRequest::GetState)).unwrap();
 

--- a/priv/changelog/0.14.0.md
+++ b/priv/changelog/0.14.0.md
@@ -25,7 +25,7 @@
 - The p2p keypair path defaults to a file under `MYDIA_DATA_DIR` instead of being required. An install that never set `P2P_KEYPAIR_PATH` would otherwise have failed to boot once remote access defaulted on (#510)
 - Server and player each declare the oldest counterpart version they work with, published over a public `serverCompatibility` GraphQL field, with a banner in the app shell on a mismatch. Fails open to silence (#470)
 - Pre-iroh leftovers removed from remote access, and iroh-relay held at v1.0.0 with image verification against real UDP traffic (#509, #498)
-- The legacy `read_media` p2p request is gone. It read whatever file path a peer asked for and checked no auth token, unlike the GraphQL and HLS requests beside it, so with remote access on, anyone who could reach the node and knew its ID could read any file the server could. Nothing ever sent one: the player has never used it and media has always arrived over HLS. Peers that ask now get a refusal (#695)
+- The legacy `read_media` p2p request no longer serves files, and a peer that sends one is refused. It used to read whatever file path the peer asked for and checked no auth token, unlike the GraphQL and HLS requests beside it, so with remote access on, anyone who could reach the node and knew its ID could read any file the server could. Nothing ever sent one: the player has never used it and media has always arrived over HLS (#695)
 
 ### TV and metadata
 

--- a/priv/changelog/0.14.0.md
+++ b/priv/changelog/0.14.0.md
@@ -25,6 +25,7 @@
 - The p2p keypair path defaults to a file under `MYDIA_DATA_DIR` instead of being required. An install that never set `P2P_KEYPAIR_PATH` would otherwise have failed to boot once remote access defaulted on (#510)
 - Server and player each declare the oldest counterpart version they work with, published over a public `serverCompatibility` GraphQL field, with a banner in the app shell on a mismatch. Fails open to silence (#470)
 - Pre-iroh leftovers removed from remote access, and iroh-relay held at v1.0.0 with image verification against real UDP traffic (#509, #498)
+- The legacy `read_media` p2p request is gone. It read whatever file path a peer asked for and checked no auth token, unlike the GraphQL and HLS requests beside it, so with remote access on, anyone who could reach the node and knew its ID could read any file the server could. Nothing ever sent one: the player has never used it and media has always arrived over HLS. Peers that ask now get a refusal (#695)
 
 ### TV and metadata
 


### PR DESCRIPTION
Closes #687.

`Mydia.P2p.Server`'s `read_media` handler read whatever absolute path a peer named, and checked no auth token. The `graphql` and `hls` handlers beside it both verify one through Guardian; `accept_inbound` admits a connection on matching ALPN alone, so an unpaired peer reached the handler on any install with remote access switched on.

No client is affected. `git log --all -S'read_media'` scoped to `player/` returns zero commits, and mydia-rs already answers the request with `"ReadMedia not implemented in mydia-rs; use HlsStream"`, calling it a legacy direct read path. This makes Phoenix agree with that.

The `MydiaRequest::ReadMedia` wire variant is kept on purpose. Deleting it would make the request fail to decode, and the decode-failure path at `native/mydia_p2p_core/src/lib.rs:1718` hits `continue`, dropping the stream with no response at all. The peer would then get an opaque decode error off an empty read rather than a named refusal it can act on. The refusal lives in the core rather than beside the `RemoteControl`/`Custom` rejection in the NIF crate so that a loopback test can actually reach it.

Supersedes #325, which deletes a pre-`serve_request/5` version of the handler and no longer rebases.

## Verification

- New `native/mydia_p2p_core/tests/read_media_refused.rs` stands up two real hosts and asserts a `ReadMedia` request is refused. It writes a real, readable probe file first, so an implementation that refused only after a filesystem-existence check would still fail it.
- `mix precommit`: 10733 tests, 0 failures.
- `cargo test --manifest-path native/mydia_p2p_core/Cargo.toml`: 39 tests, 0 failures.
- `cargo clippy --manifest-path native/mydia_p2p/Cargo.toml -- -D warnings`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for the legacy peer-to-peer media file request.
  * Requests through this pathway are refused with an `unsupported_request_type` error.

* **Security**
  * Peer-requested file paths are no longer served directly, preventing unauthorized remote file access.

* **Documentation**
  * Updated the changelog to reflect the removal and refusal behavior.
  * Added coverage confirming these requests are rejected before any file is read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->