### PR TITLE
docs: rename .github/README.md so it stops hijacking the repo front page

### DIFF
--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -115,7 +115,7 @@ loudly and nothing was listening. When triaging a merged-but-broken commit, chec
 the PR's full check list rather than whether it merged green.
 
 `--auto` is no longer used for dependabot. See the merge gate in
-`.github/README.md`.
+`.github/ci.md`.
 
 ## CI / Docker used to cancel its own master runs
 

--- a/.github/ci.md
+++ b/.github/ci.md
@@ -4,6 +4,12 @@ How the workflows in this directory actually behave, including the parts that le
 breakage sit unnoticed. For the catalogue of known flakes and how to read a red
 check, see `ci-flakes.md` next to this file.
 
+This file is deliberately **not** called `README.md`. GitHub picks the repository
+landing page from `.github/README.md` before the root `README.md`, so a README
+here silently replaces the project's front page with this document. It did, from
+46cbdfdb0 until it was noticed. Any new doc in this directory needs a name other
+than `README.md`.
+
 ## The Nix jobs never run on pull requests
 
 Both jobs in `ci-nix.yml` carry `if: github.event_name != 'pull_request'`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
           #
           # This recompiles all 765 files a second time and cost 199s of every
           # run, measured 2026-09-03. Nothing is ever gated on its output --
-          # .github/README.md records that mix_unused is advisory by design and
+          # .github/ci.md records that mix_unused is advisory by design and
           # must not be promoted to blocking -- so pull requests skip it and
           # master pushes still produce the report.
           #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,7 +365,7 @@ Read the relevant one before working in that area:
 | `lib/mydia/config/README.md` | layered config lifecycle |
 | `lib/mydia/downloads/README.md`, `lib/mydia/indexers/README.md` | trackerless releases, Torznab categories |
 | `native/README.md`, `plugins/README.md` | NIF crates, p2p, wasip2 guests |
-| `.github/README.md`, `.github/ci-flakes.md` | CI mechanics, releases, the flake catalogue |
+| `.github/ci.md`, `.github/ci-flakes.md` | CI mechanics, releases, the flake catalogue |
 | `player/docs/` | player workflow, testing, Riverpod, packaging |
 
 ### Phoenix v1.8 guidelines


### PR DESCRIPTION
The repo front page at https://github.com/getmydia/mydia has been showing
"CI mechanics" instead of the project README.

GitHub resolves the repository landing page from `.github/README.md` before the
root `README.md`. Commit 46cbdfdb0 ("docs: move agent-memory knowledge into
code-adjacent docs") added a CI-mechanics document at exactly that path, so it
quietly took over the front page. The root `README.md` was never touched and is
fine.

Fix: rename it to `.github/ci.md`, update the three references to it (the doc
table in `AGENTS.md`, a cross-link in `.github/ci-flakes.md`, and a comment in
`ci.yml`), and note the trap at the top of the file so the next doc added to
`.github/` does not pick the same name.

Docs and one comment only. No workflow behaviour changes; `ci.yml` still parses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references to the CI documentation to use `.github/ci.md`.
  * Added guidance explaining why the CI documentation is not named `README.md`.
  * Clarified that the `mix_unused` report is advisory and should not block builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->