### PR TITLE
fix(test): close the log-in navigation race behind the backdrop flake

### DIFF
--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -622,6 +622,24 @@ Three confirmations now, so treat this signature as flake-first. It and the
 `Mydia.MediaTest` tie-break can fire in the same run, so two reds on a PR are not
 evidence of a real break until you have read both signatures.
 
+**`MydiaWeb.Features.MediaBackdropTest`**, "below the lg breakpoint the backdrop
+spans the full width", failing alone (1 of 34) with `(MatchError) no match of
+right hand side value: "no backdrop rendered"`. Fixed, not flaky any more, but
+the signature is worth recognising because it generalises.
+
+Confirmed on CI run 33868003647, a PR that only renamed a documentation file, so
+it was already latent on master. The tell is in the log rather than the message:
+the failing test produced one server render and one LiveView mount, where every
+passing test in the same job produced two. The media page was never requested.
+`login/3` had returned with the browser still on `/auth/local/login`, the
+`visit/2` that followed was discarded by the log-in redirect still in flight, and
+`wait_for_liveview()` was then satisfied by the dashboard's connected root.
+
+Any E2E failure where a probe reports a missing element on a page you can see
+renders it is worth checking this way first: count the server renders for that
+test. Fixed by making `login/3` wait for its redirect and by moving the suite
+onto `visit_liveview/3`, which fails naming the page the browser is actually on.
+
 ## Getting the real output
 
 `gh run view --job <id> --log-failed` returns Postgres server log noise, where

--- a/test/README.md
+++ b/test/README.md
@@ -177,6 +177,35 @@ other LiveView test in the repo is already non-async for this reason.
 First hit was PR #172, the downloads sort feature, with 5 failures on
 `#downloads-sort` not rendering.
 
+## Navigating straight after login/3 used to lose the navigation
+
+`login/3` submits a real form. `POST /auth/local/login` answers 302 to `/`, and
+ChromeDriver's click command returns before that navigation commits: measured,
+the browser was still on `/auth/local/login` with `document.readyState` already
+`"complete"` in roughly 3 of 20 log-ins, so there was no pending-load signal for
+anyone to wait on. A `visit/2` issued into that window was discarded outright,
+and the test ran against `/` while every wait it performed was satisfied by that
+page's connected root. The symptom was a probe reporting a missing element on a
+page that renders it perfectly, three lines below the navigation that never
+happened.
+
+`login/3` now blocks until the pathname has left `/auth/local/login`, so this
+particular race is closed. Two habits keep the class of bug closed:
+
+- Navigate with `visit_liveview/3`, not `visit/2` plus `wait_for_liveview/2`.
+  It supplies `:at` from the same argument it navigates with, so a lost or
+  redirected navigation fails naming both paths instead of surfacing later as a
+  missing element. Use a bare `visit/2` only where a redirect is the thing under
+  test.
+- Do not wait on `[data-phx-main].phx-connected` alone to prove a page arrived.
+  It is true of the previous page too. That is why the older convention of
+  following `login/3` with a bare `wait_for_liveview()` worked on a first log-in,
+  where the log-in page is a controller view with no root at all, and did nothing
+  on a second log-in in the same session.
+
+Seen on CI run 33868003647, as `MydiaWeb.Features.MediaBackdropTest` raising
+`MatchError` on `"no backdrop rendered"`.
+
 ## Tests must not mutate global env
 
 Never `System.put_env("METADATA_RELAY_URL", ...)`, or write any other global env

--- a/test/mydia_web/feature_case_message_test.exs
+++ b/test/mydia_web/feature_case_message_test.exs
@@ -28,4 +28,18 @@ defmodule MydiaWeb.FeatureCaseMessageTest do
       refute message =~ "mix assets.build"
     end
   end
+
+  describe "login_redirect_failure_message/1" do
+    test "names the path the browser is stuck on and the budget" do
+      message = FeatureCase.login_redirect_failure_message(5_000)
+
+      assert message =~ "/auth/local/login"
+      assert message =~ "5000ms"
+      # The only way a real test reaches this message is credentials the form
+      # rejected, so the message has to say that rather than leave it to be
+      # rediscovered.
+      assert message =~ "credentials"
+      assert message =~ "session_controller_test.exs"
+    end
+  end
 end

--- a/test/mydia_web/feature_case_message_test.exs
+++ b/test/mydia_web/feature_case_message_test.exs
@@ -42,4 +42,31 @@ defmodule MydiaWeb.FeatureCaseMessageTest do
       assert message =~ "session_controller_test.exs"
     end
   end
+
+  describe "expected_pathname/1" do
+    test "is nil when no path was requested" do
+      assert FeatureCase.expected_pathname(nil) == nil
+    end
+
+    test "keeps a plain path unchanged" do
+      assert FeatureCase.expected_pathname("/media/abc-123") == "/media/abc-123"
+    end
+
+    test "drops a query string, which window.location.pathname never carries" do
+      assert FeatureCase.expected_pathname("/discover?type=movie&q=stub") == "/discover"
+    end
+  end
+
+  describe "wrong_page_message/3" do
+    test "names both the expected path and the one the browser is on" do
+      message = FeatureCase.wrong_page_message("/media/abc-123", "/", 15_000)
+
+      assert message =~ "/media/abc-123"
+      assert message =~ "15000ms"
+      # The whole point is that the reader learns where the browser actually
+      # went, not just that something was missing.
+      assert message =~ "is on /"
+      assert message =~ "redirect"
+    end
+  end
 end

--- a/test/mydia_web/features/add_config_flow_test.exs
+++ b/test/mydia_web/features/add_config_flow_test.exs
@@ -190,8 +190,7 @@ defmodule MydiaWeb.Features.AddConfigFlowTest do
   # off the edge of the viewport.
   defp open_first_config(session) do
     session
-    |> visit("/discover")
-    |> wait_for_liveview()
+    |> visit_liveview("/discover")
     |> assert_has(Query.css(~s([data-test="add-config-caret"]), minimum: 1))
     # Tried a real click(Query.css(..., at: 0)) here first: it reaches the
     # caret and opens the dialog at the 1400x1000 desktop viewport, but at

--- a/test/mydia_web/features/discover_skeleton_height_parity_test.exs
+++ b/test/mydia_web/features/discover_skeleton_height_parity_test.exs
@@ -79,8 +79,7 @@ defmodule MydiaWeb.Features.DiscoverSkeletonHeightParityTest do
        %{session: session} do
     session
     |> login_as_admin()
-    |> visit("/discover")
-    |> wait_for_liveview()
+    |> visit_liveview("/discover")
 
     wait_for_real_card(session)
 
@@ -93,8 +92,7 @@ defmodule MydiaWeb.Features.DiscoverSkeletonHeightParityTest do
   test "the guard actually fails when the skeleton card falls short", %{session: session} do
     session
     |> login_as_admin()
-    |> visit("/discover")
-    |> wait_for_liveview()
+    |> visit_liveview("/discover")
 
     wait_for_real_card(session)
 

--- a/test/mydia_web/features/dock_nav_test.exs
+++ b/test/mydia_web/features/dock_nav_test.exs
@@ -26,8 +26,7 @@ defmodule MydiaWeb.Features.DockNavTest do
 
       session
       |> resize_window(390, 844)
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       assert Wallaby.Browser.has_css?(session, ~s([phx-hook="DockNav"]))
 
@@ -43,8 +42,7 @@ defmodule MydiaWeb.Features.DockNavTest do
 
       session
       |> resize_window(390, 844)
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       # The dock item is `<.link navigate="/movies" data-dock-link>`
       # (layouts.ex), and `<.link navigate>` compiles to a real
@@ -84,8 +82,7 @@ defmodule MydiaWeb.Features.DockNavTest do
 
       session
       |> resize_window(390, 844)
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       # The hamburger is `<label for="main-drawer">` (layouts.ex). A real click
       # on a label toggles its associated checkbox, which is the only thing

--- a/test/mydia_web/features/geometry_self_test.exs
+++ b/test/mydia_web/features/geometry_self_test.exs
@@ -14,8 +14,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var el = document.createElement('div');
@@ -33,8 +32,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var under = document.createElement('div');
@@ -66,8 +64,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var on = document.createElement('div');
@@ -98,8 +95,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var box = document.createElement('div');
@@ -138,8 +134,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var a = document.createElement('div');
@@ -163,8 +158,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var a = document.createElement('div');
@@ -189,8 +183,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var a = document.createElement('div');
@@ -229,8 +222,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var a = document.createElement('div');
@@ -266,8 +258,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var b = document.createElement('div');
@@ -291,8 +282,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var a = document.createElement('div');
@@ -316,8 +306,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var a = document.createElement('div');
@@ -347,8 +336,7 @@ defmodule MydiaWeb.Features.GeometrySelfTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       inject(session, """
         var a = document.createElement('div');

--- a/test/mydia_web/features/guest_test.exs
+++ b/test/mydia_web/features/guest_test.exs
@@ -54,11 +54,9 @@ defmodule MydiaWeb.Features.GuestTest do
 
       # --- Guest submits through Discover's one-click Request button ---
       login(session, guest.username, "password123")
-      session |> wait_for_liveview()
 
       session
-      |> visit("/discover?type=movie&q=stub")
-      |> wait_for_liveview()
+      |> visit_liveview("/discover?type=movie&q=stub")
       |> assert_has_text(MetadataStubProvider.movie_title())
 
       session
@@ -75,11 +73,9 @@ defmodule MydiaWeb.Features.GuestTest do
 
       # --- Admin approves through the modal ---
       login(session, admin.username, "password123")
-      session |> wait_for_liveview()
 
       session
-      |> visit("/admin/requests")
-      |> wait_for_liveview()
+      |> visit_liveview("/admin/requests")
       |> assert_has_text(MetadataStubProvider.movie_title())
 
       session

--- a/test/mydia_web/features/history_rail_test.exs
+++ b/test/mydia_web/features/history_rail_test.exs
@@ -122,8 +122,7 @@ defmodule MydiaWeb.Features.HistoryRailTest do
     session
     |> login_as_admin()
     |> resize_window(1700, 1000)
-    |> visit("/media/#{show.id}")
-    |> wait_for_liveview()
+    |> visit_liveview("/media/#{show.id}")
 
     assert probe(session, @track_count) == 3
 
@@ -162,8 +161,7 @@ defmodule MydiaWeb.Features.HistoryRailTest do
     session
     |> login_as_admin()
     |> resize_window(1300, 1000)
-    |> visit("/media/#{show.id}")
-    |> wait_for_liveview()
+    |> visit_liveview("/media/#{show.id}")
 
     assert probe(session, @track_count) == 2
 

--- a/test/mydia_web/features/media_backdrop_test.exs
+++ b/test/mydia_web/features/media_backdrop_test.exs
@@ -99,8 +99,7 @@ defmodule MydiaWeb.Features.MediaBackdropTest do
     session
     |> login_as_admin()
     |> resize_window(1700, 800)
-    |> visit("/media/#{show.id}")
-    |> wait_for_liveview()
+    |> visit_liveview("/media/#{show.id}")
 
     assert eval_js(session, @backdrop_position) == "fixed"
 
@@ -145,8 +144,7 @@ defmodule MydiaWeb.Features.MediaBackdropTest do
     session
     |> login_as_admin()
     |> resize_window(1000, 800)
-    |> visit("/media/#{show.id}")
-    |> wait_for_liveview()
+    |> visit_liveview("/media/#{show.id}")
 
     [top, left, _height, _viewport, _page] = eval_js(session, @backdrop_metrics)
 

--- a/test/mydia_web/features/media_file_row_width_test.exs
+++ b/test/mydia_web/features/media_file_row_width_test.exs
@@ -96,8 +96,7 @@ defmodule MydiaWeb.Features.MediaFileRowWidthTest do
           ] do
         session
         |> resize_window(w, h)
-        |> visit("/media/#{show.id}")
-        |> wait_for_liveview()
+        |> visit_liveview("/media/#{show.id}")
 
         js_click(session, ~s([aria-controls="episode-#{episode.id}-detail"]))
 
@@ -131,8 +130,7 @@ defmodule MydiaWeb.Features.MediaFileRowWidthTest do
           ] do
         session
         |> resize_window(w, h)
-        |> visit("/media/#{show.id}")
-        |> wait_for_liveview()
+        |> visit_liveview("/media/#{show.id}")
 
         assert Wallaby.Browser.has_css?(session, "#version-#{show_file.id}")
 
@@ -154,8 +152,7 @@ defmodule MydiaWeb.Features.MediaFileRowWidthTest do
 
       session
       |> resize_window(1024, 768)
-      |> visit("/media/#{show.id}")
-      |> wait_for_liveview()
+      |> visit_liveview("/media/#{show.id}")
 
       assert Wallaby.Browser.has_css?(session, "[id^='episode-'][id$='-row']")
 

--- a/test/mydia_web/features/smoke_test.exs
+++ b/test/mydia_web/features/smoke_test.exs
@@ -19,8 +19,7 @@ defmodule MydiaWeb.Features.SmokeTest do
       login_as_admin(session)
 
       session
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       assert Wallaby.Browser.has_css?(session, "[data-phx-main].phx-connected")
     end

--- a/test/mydia_web/features/ui_hooks_test.exs
+++ b/test/mydia_web/features/ui_hooks_test.exs
@@ -40,8 +40,7 @@ defmodule MydiaWeb.Features.UiHooksTest do
 
       session
       |> resize_window(1400, 1000)
-      |> visit("/")
-      |> wait_for_liveview()
+      |> visit_liveview("/")
 
       before = document_theme(session)
 
@@ -72,8 +71,7 @@ defmodule MydiaWeb.Features.UiHooksTest do
       # `visit/2` is a full browser navigation (not a `<.link navigate>`
       # pushState), so there is no race to poll out here.
       session
-      |> visit("/movies")
-      |> wait_for_liveview()
+      |> visit_liveview("/movies")
 
       assert document_theme(session) == after_toggle
     end
@@ -107,8 +105,7 @@ defmodule MydiaWeb.Features.UiHooksTest do
       login_as_admin(session)
 
       session
-      |> visit("/import")
-      |> wait_for_liveview()
+      |> visit_liveview("/import")
 
       selector = "#auto-import-toggle"
 
@@ -130,10 +127,8 @@ defmodule MydiaWeb.Features.UiHooksTest do
       # `mounted()` re-reads localStorage on the way back rather than being
       # skipped as an already-mounted, `phx-update="ignore"`d node.
       session
-      |> visit("/movies")
-      |> wait_for_liveview()
-      |> visit("/import")
-      |> wait_for_liveview()
+      |> visit_liveview("/movies")
+      |> visit_liveview("/import")
 
       assert checkbox_checked?(session, selector) == toggled
     end

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -154,15 +154,91 @@ defmodule MydiaWeb.FeatureCase do
     {:ok, session: session}
   end
 
+  @login_path "/auth/local/login"
+
+  # One redirect is one round trip. A longer budget would only slow a genuine
+  # breakage, and the only way to reach it is a log-in the form rejected.
+  @login_redirect_timeout 5_000
+
   @doc """
-  Visits the login page and fills in the login form with the given credentials.
+  Visits the login page, submits the credentials, and blocks until the
+  resulting redirect has landed.
+
+  The wait is the point. `POST #{@login_path}` answers 302 to `/`, a real
+  full-page navigation, and ChromeDriver's click command returns before that
+  navigation commits: measured, the browser is still on `#{@login_path}` with
+  `document.readyState` already `"complete"` in roughly 3 of 20 log-ins, so
+  there is no pending-load signal for Wallaby to wait on. Anything the test
+  does next races it, and a `visit/2` that loses is discarded outright. The
+  test then runs against `/` while every wait it performs is satisfied by that
+  page's connected root. That is CI run 33868003647.
+
+  Waiting on the pathname rather than on `[data-phx-main]` is deliberate.
+  `#{@login_path}` is a plain controller page, so a bare `wait_for_liveview/2`
+  after a first log-in does block until the redirect lands, by accident. It
+  does nothing at all on a second log-in in the same session, which runs from
+  an already-connected LiveView page whose root satisfies that poll instantly.
   """
   def login(session, username, password) do
     session
-    |> Wallaby.Browser.visit("/auth/local/login")
+    |> Wallaby.Browser.visit(@login_path)
     |> Wallaby.Browser.fill_in(Wallaby.Query.text_field("user[username]"), with: username)
     |> Wallaby.Browser.fill_in(Wallaby.Query.text_field("user[password]"), with: password)
     |> Wallaby.Browser.click(Wallaby.Query.button("Log In"))
+    |> wait_for_login_redirect()
+  end
+
+  defp wait_for_login_redirect(session) do
+    try do
+      eventually(
+        fn ->
+          [path, ready_state] =
+            session
+            |> eval_js("return window.location.pathname + '|' + document.readyState;")
+            |> String.split("|", parts: 2)
+
+          if path != @login_path and ready_state == "complete" do
+            {:ok, session}
+          else
+            :error
+          end
+        end,
+        timeout: @login_redirect_timeout,
+        interval: 50,
+        description: "the log-in redirect to land"
+      )
+    rescue
+      e in RuntimeError ->
+        if String.starts_with?(e.message, "eventually/2 timed out") do
+          reraise login_redirect_failure_message(@login_redirect_timeout), __STACKTRACE__
+        else
+          reraise e, __STACKTRACE__
+        end
+    end
+
+    session
+  end
+
+  @doc """
+  The message `login/3` raises when the log-in redirect never lands.
+
+  Public so it can be tested without a browser, like `liveview_failure_message/2`.
+  """
+  def login_redirect_failure_message(timeout_ms) do
+    """
+    The log-in form was submitted but the browser was still on #{@login_path}
+    after #{timeout_ms}ms.
+
+    `login/3` blocks until the POST's redirect has landed, because ChromeDriver's
+    click returns before that navigation commits and anything the test does next
+    races it. A `visit/2` that loses that race is discarded, and the test then
+    asserts against whatever page the redirect produced.
+
+    The usual cause is credentials the form rejected, which re-renders the form
+    at the same path. A browser test is not the place to assert a failed log-in;
+    those assertions live in
+    test/mydia_web/controllers/session_controller_test.exs.
+    """
   end
 
   @doc """

--- a/test/support/feature_case.ex
+++ b/test/support/feature_case.ex
@@ -368,27 +368,33 @@ defmodule MydiaWeb.FeatureCase do
   turned into the diagnostic below; anything else is re-raised unchanged so a
   dead session is never reported as an ordinary unconnected socket.
 
-  Options: `:timeout` (ms, default 15_000).
+  Options: `:timeout` (ms, default 15_000), `:at` (the path the browser is
+  expected to be on, compared against `window.location.pathname`; a query
+  string is ignored). Prefer `visit_liveview/3`, which supplies `:at` from the
+  same argument it navigates with so the two cannot drift apart.
   """
   def wait_for_liveview(session, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, 15_000)
+    expected = opts |> Keyword.get(:at) |> expected_pathname()
 
     try do
       eventually(
         fn ->
-          if root_connected?(session) do
+          [state, path] = session |> page_state() |> String.split("|", parts: 2)
+
+          if state == "connected" and (is_nil(expected) or path == expected) do
             {:ok, session}
           else
             :error
           end
         end,
         timeout: timeout,
-        description: "the root LiveView to connect its socket"
+        description: wait_description(expected)
       )
     rescue
       e in RuntimeError ->
         if String.starts_with?(e.message, "eventually/2 timed out") do
-          reraise liveview_failure_message(root_present?(session), timeout), __STACKTRACE__
+          reraise timeout_message(session, expected, timeout), __STACKTRACE__
         else
           reraise e, __STACKTRACE__
         end
@@ -397,8 +403,75 @@ defmodule MydiaWeb.FeatureCase do
     session
   end
 
-  defp root_connected?(session) do
-    eval_js(session, "return document.querySelector('[data-phx-main].phx-connected') !== null;")
+  @doc """
+  Navigates to `path` and blocks until that page's root LiveView has connected.
+
+  The path is given once, to the call that navigates, so the `:at` check cannot
+  drift from the navigation or be forgotten on a new test. Use a bare
+  `Wallaby.Browser.visit/2` only where the browser is expected to end up
+  somewhere else, as when asserting a redirect.
+
+  Options are passed through to `wait_for_liveview/2`.
+  """
+  def visit_liveview(session, path, opts \\ []) do
+    session
+    |> Wallaby.Browser.visit(path)
+    |> wait_for_liveview(Keyword.put(opts, :at, path))
+  end
+
+  # Both conditions in one WebDriver call, so `eventually/2`'s budget stays the
+  # thing that governs the wait. See the note in the doc above about `has?/2`.
+  defp page_state(session) do
+    eval_js(session, """
+    const root = document.querySelector('[data-phx-main].phx-connected');
+    return (root ? 'connected' : 'pending') + '|' + window.location.pathname;
+    """)
+  end
+
+  defp wait_description(nil), do: "the root LiveView to connect its socket"
+
+  defp wait_description(expected),
+    do: "the root LiveView at #{expected} to connect its socket"
+
+  defp timeout_message(session, nil, timeout),
+    do: liveview_failure_message(root_present?(session), timeout)
+
+  defp timeout_message(session, expected, timeout) do
+    [_state, actual] = session |> page_state() |> String.split("|", parts: 2)
+
+    if actual == expected do
+      liveview_failure_message(root_present?(session), timeout)
+    else
+      wrong_page_message(expected, actual, timeout)
+    end
+  end
+
+  @doc """
+  Normalises an `:at` path to what `window.location.pathname` will report.
+
+  Public so it is testable without a browser.
+  """
+  def expected_pathname(nil), do: nil
+  def expected_pathname(path), do: URI.parse(path).path
+
+  @doc """
+  The message `wait_for_liveview/2` raises when the browser is on the wrong page.
+
+  Public so it can be tested without a browser, like `liveview_failure_message/2`.
+  """
+  def wrong_page_message(expected_path, actual_path, timeout_ms) do
+    """
+    Expected the browser on #{expected_path}.
+    After #{timeout_ms}ms it is on #{actual_path}.
+
+    The navigation did not land. The usual causes are a redirect, from an auth
+    guard or from a LiveView that redirects on mount, and a navigation discarded
+    by another still in flight from the command before it.
+
+    Every assertion that follows would have run against the wrong page, so this
+    fails here rather than letting a later probe report a missing element and
+    send the reader looking at the wrong component.
+    """
   end
 
   defp root_present?(session) do


### PR DESCRIPTION
## The flake

`MydiaWeb.Features.MediaBackdropTest` "below the lg breakpoint the backdrop spans
the full width" failed on CI run 33868003647 with:

```
** (MatchError) no match of right hand side value:
    "no backdrop rendered"
code: [top, left, _height, _viewport, _page] = eval_js(session, @backdrop_metrics)
```

That run was a PR that only renamed a documentation file, so the cause was
already latent on master. Nothing was wrong with the backdrop.

## Root cause

`FeatureCase.login/3` ended at `click("Log In")` and returned. That click submits
a real form (`POST /auth/local/login` answers 302 to `/`), and ChromeDriver's
click command returns before the navigation commits. Anything the test does next
races it.

Measured with a 20-iteration probe reading `window.location` immediately after
`login_as_admin/1`:

- 3 of 20 runs: still on `/auth/local/login`, with `document.readyState` already
  `"complete"`, so there was no pending-load signal for Wallaby to wait on.
- 2 of those 3: the following `visit/2` was discarded outright. The in-flight
  log-in redirect won and the browser ended up on `/`.

The CI log matches exactly. The failing test produced one server render and one
LiveView mount, where every passing test in that job produced two: the media page
was never requested. `wait_for_liveview()` was then satisfied by the dashboard's
connected root, and `#page-backdrop` genuinely did not exist. Retrying the probe
would not have helped, because the browser stays on `/`.

`history_rail_test.exs` used the identical sequence and carried the same exposure.

## The fix

1. **`login/3` blocks until its redirect lands** (5s budget), polling the pathname
   rather than `[data-phx-main]`. The log-in page is a plain controller view, so
   the older convention of following `login/3` with a bare `wait_for_liveview()`
   blocked on a *first* log-in by accident and did nothing at all on a second one
   from an already-connected page.
2. **`wait_for_liveview/2` gains `:at`**, folding a pathname check into the same
   single-round-trip poll. Its timeout message now names both the expected path
   and the one the browser is actually on.
3. **`visit_liveview/3`** pairs the two so the path is written once, to the call
   that navigates. All 33 `visit |> wait_for_liveview` pairs across ten files
   migrate onto it. The two exceptions are in `auth_test.exs`: the log-in form
   itself, and `/auth/logout`, which the test follows with an assertion that it
   was redirected away.

## Verification

- The 50-iteration probe harness, re-run after the fix: **50/50 landed on the
  requested page**, against the 3-in-20 stranded / 2-in-20 wrong-page baseline.
  The harness was scratch and is not committed.
- Full feature suite: 34 tests, 0 failures. No route rewrote its path on mount,
  so the `:at` check held at every migrated call site.
- `mix precommit`: 10,725 tests, 0 failures, format and Credo clean.
- Both new failure messages are unit-tested without a browser in
  `feature_case_message_test.exs`, so they run in the fast suite rather than only
  in the E2E job.

## Docs

`test/README.md` gains the trap. `.github/ci-flakes.md` gets the entry, keyed on
the log signature rather than the assertion: one server render where passing tests
produce two means the navigation never happened.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated browser-test navigation to ensure pages finish loading and the expected destination is reached.
  - Added clearer timeout diagnostics for failed redirects, unexpected pages, and LiveView loading issues.
  - Resolved a race condition that could cause media page tests to run against the wrong page.

- **Documentation**
  - Documented the redirect race, recommended navigation practices, and the resolved CI failure in the testing guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->