### PR TITLE
feat(ci): separate stable and pre-release TestFlight tracks for iOS

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -112,6 +112,13 @@ jobs:
       - name: Assert the store release notes hold their contract
         run: ./scripts/check-testflight-notes.sh
 
+      # The refresh workflow it feeds cannot be dispatched or scheduled until it
+      # is on the default branch, so this is the only place its decision is
+      # exercised before merge. Needs the same fetch-depth: 0 checkout, because
+      # it reads the tag list.
+      - name: Assert the TestFlight refresh decision holds its contract
+        run: ./scripts/check-ios-refresh-due.sh
+
   generated-freshness:
     name: Check / Generated Freshness
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -119,6 +119,12 @@ jobs:
       - name: Assert the TestFlight refresh decision holds its contract
         run: ./scripts/check-ios-refresh-due.sh
 
+      # ci-fastlane.yml proves the Fastfile parses and that release_metadata.rb
+      # is reachable through require_relative. This proves what the helpers in
+      # it actually return, which a lane listing cannot see.
+      - name: Assert the iOS fastlane metadata helpers behave
+        run: ./scripts/check-ios-fastlane-metadata.sh
+
   generated-freshness:
     name: Check / Generated Freshness
     runs-on: ubuntu-latest

--- a/.github/workflows/player-ios-refresh.yml
+++ b/.github/workflows/player-ios-refresh.yml
@@ -143,8 +143,24 @@ jobs:
     permissions:
       contents: write
     steps:
+      # fetch-depth: 0 because this job tags the stable release's commit, and
+      # the workflow only fires 60 or more days after that release, by which
+      # time the default branch has moved well past it. checkout's default
+      # depth-1 clone of the branch tip does not contain that commit, and
+      # `git tag <name> <sha>` then dies with "trying to write ref ... with
+      # nonexistent object", exit 128.
+      #
+      # The failure is nastier than a plain red run: the upload has already
+      # succeeded by this point, so the build reaches TestFlight while the
+      # marker recording it never lands. The baseline never advances, and every
+      # following week re-refreshes and fails again.
+      #
+      # Verified in a scratch clone: depth-1 fails exactly as above, full
+      # history succeeds.
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       # scripts/ios-refresh-due.sh reads this tag back as the baseline. It uses
       # a tag rather than this workflow's run history because a run that decides

--- a/.github/workflows/player-ios-refresh.yml
+++ b/.github/workflows/player-ios-refresh.yml
@@ -1,0 +1,171 @@
+name: Player / iOS TestFlight Refresh
+
+# TestFlight deletes a build 90 days after upload, and the installed app then
+# refuses to launch. Both external groups are topped up only when a release
+# uploads one, and the gaps between stable releases have reached 73 days
+# (v0.9.0 to v0.10.0). This re-uploads the current stable release before that
+# happens.
+#
+# Weekly rather than monthly so a failed refresh retries in seven days instead
+# of thirty, with 60 days as the threshold: that leaves 30 days of margin.
+#
+# This file cannot be tested before it is merged. workflow_dispatch only
+# triggers for a file on the default branch, and schedules only run there. The
+# decision is therefore in scripts/ios-refresh-due.sh, covered by
+# scripts/check-ios-refresh-due.sh in ci-nix.yml, and the two inputs below exist
+# so the first runs on master can be staged.
+
+on:
+  schedule:
+    # Mondays, off the hour to avoid the top-of-hour scheduling crush.
+    - cron: '17 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Refresh even when the newest build is younger than the threshold
+        type: boolean
+        default: false
+      dry_run:
+        description: Build and sign without uploading, and without pushing the marker tag
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  decide:
+    name: Decide
+    runs-on: ubuntu-latest
+    outputs:
+      due: ${{ steps.due.outputs.due }}
+      tag: ${{ steps.due.outputs.tag }}
+      version: ${{ steps.due.outputs.version }}
+      sha: ${{ steps.due.outputs.sha }}
+      version_code: ${{ steps.build_number.outputs.version_code }}
+      notes: ${{ steps.notes.outputs.notes }}
+    steps:
+      # fetch-depth: 0 because the decision reads the tag list and the notes
+      # fall back to walking a commit range.
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether a refresh is due
+        id: due
+        run: ./scripts/ios-refresh-due.sh >> "$GITHUB_OUTPUT"
+
+      # release.yml derives its build number from `github.run_number + 10000`.
+      # This workflow has its own independent run_number, so reusing that
+      # formula would eventually mint a CFBundleVersion Apple already holds for
+      # the same marketing version and reject the upload. 900000 is disjoint by
+      # 890,000 release runs.
+      #
+      # Arithmetic is done here rather than in the `with:` block below because
+      # GitHub expressions have no arithmetic operators.
+      - name: Compute a build number that cannot collide with a release
+        id: build_number
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: echo "version_code=$(( RUN_NUMBER + 900000 ))" >> "$GITHUB_OUTPUT"
+
+      # The same notes testers already saw for this release. Computed here
+      # rather than in the build, for the same reason release.yml computes them
+      # in `prepare`: the iOS checkout is shallow and pinned to one commit.
+      - name: Compute store release notes
+        id: notes
+        if: steps.due.outputs.due == 'true' || inputs.force
+        env:
+          VERSION: ${{ steps.due.outputs.version }}
+          NOTES_SHA: ${{ steps.due.outputs.sha }}
+          TAG: ${{ steps.due.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          NOTES=$(./scripts/testflight-notes.sh "$VERSION" "$NOTES_SHA" "$TAG")
+
+          # A random delimiter: a fixed one appearing in the notes would
+          # terminate the value early.
+          DELIM="notes-$(openssl rand -hex 16)"
+          {
+            echo "notes<<${DELIM}"
+            echo "$NOTES"
+            echo "${DELIM}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Summarise the decision
+        env:
+          DUE: ${{ steps.due.outputs.due }}
+          AGE: ${{ steps.due.outputs.age_days }}
+          TAG: ${{ steps.due.outputs.tag }}
+          FORCED: ${{ inputs.force }}
+        run: |
+          {
+            echo "### iOS TestFlight refresh"
+            echo
+            echo "- Newest stable release: \`${TAG}\`"
+            echo "- Days since the groups were last topped up: ${AGE}"
+            echo "- Due: ${DUE}"
+            echo "- Forced: ${FORCED:-false}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  refresh:
+    name: Refresh
+    needs: decide
+    if: needs.decide.outputs.due == 'true' || inputs.force
+    uses: ./.github/workflows/player-ios.yml
+    with:
+      sha: ${{ needs.decide.outputs.sha }}
+      version: ${{ needs.decide.outputs.version }}
+      version_code: ${{ needs.decide.outputs.version_code }}
+      # Both groups. Refreshing only the stable group would leave the
+      # pre-release group's own 90-day clock running through the same drought.
+      groups: 'Beta,Pre-release'
+      notes: ${{ needs.decide.outputs.notes }}
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets:
+      IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+      IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+      IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+
+  mark:
+    name: Mark refreshed
+    needs: [decide, refresh]
+    # Only after a real upload. A dry run must not move the baseline, or the
+    # next real refresh is deferred by 60 days on the strength of a build that
+    # never reached Apple.
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # scripts/ios-refresh-due.sh reads this tag back as the baseline. It uses
+      # a tag rather than this workflow's run history because a run that decides
+      # "not due" also succeeds, so run history would reset the baseline every
+      # week and the refresh would never fire.
+      #
+      # scripts/testflight-notes.sh excludes the ios-refresh/ prefix from its
+      # previous_tag() lookup. It is the only other code that walks the tag list.
+      - name: Push the marker tag
+        env:
+          SHA: ${{ needs.decide.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          TAG="ios-refresh/$(date -u +%Y-%m-%d)"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "${TAG} already exists, so today's refresh is already recorded."
+            exit 0
+          fi
+
+          git tag "$TAG" "$SHA"
+          git push origin "$TAG"
+          echo "Recorded this refresh as ${TAG}."

--- a/.github/workflows/player-ios.yml
+++ b/.github/workflows/player-ios.yml
@@ -71,10 +71,14 @@ jobs:
   build:
     name: Build and upload
     runs-on: macos-26
-    # Serialises a refresh against a release so a stale refresh cannot land
-    # after a fresh release. Distinct build numbers mean both uploads would
-    # succeed, but the resulting order in App Store Connect reads as a
-    # regression.
+    # Serialises the iOS build so a release and a refresh never upload at once.
+    #
+    # This prevents overlap, not staleness. A refresh queued behind a release
+    # still uploads the version it resolved before it queued, so a slightly
+    # older build can briefly become the newest one in App Store Connect. That
+    # window needs a release dispatched during the refresh's queue wait, and the
+    # next release corrects it, so the version is deliberately not re-resolved
+    # after the lock is acquired.
     concurrency:
       group: player-ios-testflight
       cancel-in-progress: false

--- a/.github/workflows/player-ios.yml
+++ b/.github/workflows/player-ios.yml
@@ -1,0 +1,225 @@
+name: Player / iOS
+
+# The iOS build, extracted from release.yml so player-ios-refresh.yml can run
+# exactly the same one. release.yml calls it on every release; the refresh cron
+# calls it when a stable build is approaching TestFlight's 90-day expiry.
+#
+# PLAYER_PATH is declared on the job below rather than inherited. A caller's
+# workflow-level `env` is NOT propagated into a called workflow, and `env:` is
+# not permitted alongside `uses:`, so leaning on release.yml's copy resolves
+# every path to `/ios` and fails immediately.
+
+on:
+  workflow_call:
+    inputs:
+      sha:
+        description: Commit SHA to build. Every release job checks out the same one.
+        type: string
+        required: true
+      version:
+        description: Version with the leading `v` already stripped. A prerelease suffix is removed below.
+        type: string
+        required: true
+      version_code:
+        description: CFBundleVersion. Apple rejects a reused one for the same marketing version.
+        type: string
+        required: true
+      groups:
+        description: >-
+          Comma-separated App Store Connect external group names, matched
+          exactly. "Beta,Pre-release" for a stable release, "Pre-release" for a
+          prerelease.
+        type: string
+        required: true
+      notes:
+        description: TestFlight "What to Test". At most 4000 characters, never empty.
+        type: string
+        required: true
+      dry_run:
+        description: >-
+          Build and sign without uploading. MUST stay `boolean`: as a string,
+          "false" is truthy and the dry-run condition inverts.
+        type: boolean
+        required: false
+        default: false
+    # Named one by one rather than left to `secrets: inherit` at the call site,
+    # for the reason already written down in deploy-web-player.yml: inherit
+    # would hand an iOS workflow the Android keystore, the Flatpak GPG key and
+    # the R2 credentials. These same names resolve to the repository secrets on
+    # a bare dispatch, so the steps below read `secrets.*` either way.
+    #
+    # The signing secrets are optional because the unsigned path below is what
+    # runs when they are absent.
+    secrets:
+      IOS_CERTIFICATE_BASE64:
+        required: false
+      IOS_CERTIFICATE_PASSWORD:
+        required: false
+      IOS_PROVISIONING_PROFILE_BASE64:
+        required: false
+      APP_STORE_CONNECT_API_KEY_ID:
+        required: false
+      APP_STORE_CONNECT_ISSUER_ID:
+        required: false
+      APP_STORE_CONNECT_API_KEY_CONTENT:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and upload
+    runs-on: macos-26
+    # Serialises a refresh against a release so a stale refresh cannot land
+    # after a fresh release. Distinct build numbers mean both uploads would
+    # succeed, but the resulting order in App Store Connect reads as a
+    # regression.
+    concurrency:
+      group: player-ios-testflight
+      cancel-in-progress: false
+    # `upload_to_testflight` uses `distribute_external: true`, which cannot skip
+    # waiting for Apple to finish processing the build, so a slow processing
+    # queue parks this job in a poll loop with no upper bound of its own. On
+    # v0.13.0 that ran 5h49m before the 6h default killed it, on a runner billed
+    # at 10x. The job normally finishes in 17-20 minutes; this bounds the wait
+    # while leaving generous headroom. Hitting it fails the publish gate, which
+    # is the correct outcome: re-dispatch with `allow_missing=ios` to ship
+    # without it, since the IPA reaches TestFlight whenever Apple is done
+    # regardless of what this job reports.
+    timeout-minutes: 45
+    env:
+      PLAYER_PATH: 'player'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version-file: player/.fvmrc
+          channel: 'stable'
+          cache: true
+
+      - name: Update version
+        working-directory: ${{ env.PLAYER_PATH }}
+        env:
+          VERSION: ${{ inputs.version }}
+          VERSION_CODE: ${{ inputs.version_code }}
+        run: |
+          # Apple's CFBundleShortVersionString must be at most three
+          # period-separated integers, so strip any prerelease suffix
+          # (e.g. 0.12.0-beta.2 -> 0.12.0). The unique build number is
+          # carried by VERSION_CODE (CFBundleVersion).
+          MARKETING_VERSION="${VERSION%%-*}"
+          sed -i '' "s/^version: .*/version: ${MARKETING_VERSION}+${VERSION_CODE}/" pubspec.yaml
+
+      - name: Install dependencies
+        working-directory: ${{ env.PLAYER_PATH }}
+        run: flutter pub get
+
+      - name: Run code generation
+        working-directory: ${{ env.PLAYER_PATH }}
+        run: flutter pub run build_runner build
+
+      - name: Install certificate and provisioning profile
+        if: env.IOS_CERTIFICATE_BASE64 != ''
+        env:
+          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          echo -n "$IOS_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          security import $CERTIFICATE_PATH -P "$IOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+      - name: Configure manual signing for CI
+        if: env.IOS_CERTIFICATE_BASE64 != ''
+        env:
+          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+        working-directory: ${{ env.PLAYER_PATH }}/ios
+        run: |
+          # Extract provisioning profile name
+          PP_PATH=$(ls ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision | head -1)
+          security cms -D -i "$PP_PATH" > $RUNNER_TEMP/pp.plist
+          PP_NAME=$(/usr/libexec/PlistBuddy -c "Print Name" $RUNNER_TEMP/pp.plist)
+          echo "Using provisioning profile: $PP_NAME"
+
+          # Remove CODE_SIGN_STYLE from project so xcconfig takes over
+          sed -i '' '/CODE_SIGN_STYLE = Automatic;/d' Runner.xcodeproj/project.pbxproj
+
+          # Inject signing overrides into Release.xcconfig
+          cat >> Flutter/Release.xcconfig << EOF
+          // CI Signing Overrides
+          CODE_SIGN_STYLE=Manual
+          CODE_SIGN_IDENTITY=Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER=$PP_NAME
+          EOF
+
+      - name: Build iOS (unsigned)
+        if: env.IOS_CERTIFICATE_BASE64 == ''
+        env:
+          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+        working-directory: ${{ env.PLAYER_PATH }}
+        run: flutter build ios --release --no-codesign
+
+      - name: Build iOS (signed)
+        if: env.IOS_CERTIFICATE_BASE64 != ''
+        env:
+          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+        working-directory: ${{ env.PLAYER_PATH }}
+        run: flutter build ios --release
+
+      - name: Setup Ruby for Fastlane
+        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ${{ env.PLAYER_PATH }}/ios
+
+      # The notes reach the shell through env, never through ${{ }} substitution
+      # into this body: changelog text contains backticks and $, which would be
+      # both an injection risk and a corruption bug.
+      - name: Write TestFlight notes
+        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          NOTES: ${{ inputs.notes }}
+        run: printf '%s' "$NOTES" > "$RUNNER_TEMP/testflight-notes.txt"
+
+      - name: Upload to TestFlight
+        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          TESTFLIGHT_CHANGELOG_PATH: ${{ runner.temp }}/testflight-notes.txt
+          # Group names, matched exactly by App Store Connect.
+          TESTFLIGHT_GROUPS: ${{ inputs.groups }}
+        working-directory: ${{ env.PLAYER_PATH }}/ios
+        run: bundle exec fastlane testflight
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,147 +528,28 @@ jobs:
   player-ios:
     name: Player / iOS
     needs: prepare
-    runs-on: macos-26
-    # `upload_to_testflight` uses `distribute_external: true`, which cannot skip
-    # waiting for Apple to finish processing the build, so a slow processing
-    # queue parks this job in a poll loop with no upper bound of its own. On
-    # v0.13.0 that ran 5h49m before the 6h default killed it, on a runner billed
-    # at 10x. The job normally finishes in 17-20 minutes; this bounds the wait
-    # while leaving generous headroom. Hitting it fails the publish gate, which
-    # is the correct outcome: re-dispatch with `allow_missing=ios` to ship
-    # without it, since the IPA reaches TestFlight whenever Apple is done
-    # regardless of what this job reports.
-    timeout-minutes: 45
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.prepare.outputs.sha }}
-
-      - name: Setup Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version-file: player/.fvmrc
-          channel: 'stable'
-          cache: true
-
-      - name: Update version
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: |
-          VERSION="${{ needs.prepare.outputs.version }}"
-          VERSION_CODE="${{ needs.prepare.outputs.version_code }}"
-          # Apple's CFBundleShortVersionString must be at most three
-          # period-separated integers, so strip any prerelease suffix
-          # (e.g. 0.12.0-beta.2 -> 0.12.0). The unique build number is
-          # carried by VERSION_CODE (CFBundleVersion).
-          MARKETING_VERSION="${VERSION%%-*}"
-          sed -i '' "s/^version: .*/version: ${MARKETING_VERSION}+${VERSION_CODE}/" pubspec.yaml
-
-      - name: Install dependencies
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
-
-      - name: Run code generation
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub run build_runner build
-
-      - name: Install certificate and provisioning profile
-        if: env.IOS_CERTIFICATE_BASE64 != ''
-        env:
-          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
-          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
-          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-          PP_PATH=$RUNNER_TEMP/build_pp.mobileprovision
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
-          echo -n "$IOS_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
-          echo -n "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode -o $PP_PATH
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-
-          security import $CERTIFICATE_PATH -P "$IOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychain -d user -s $KEYCHAIN_PATH
-
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
-
-      - name: Configure manual signing for CI
-        if: env.IOS_CERTIFICATE_BASE64 != ''
-        env:
-          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
-        working-directory: ${{ env.PLAYER_PATH }}/ios
-        run: |
-          # Extract provisioning profile name
-          PP_PATH=$(ls ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision | head -1)
-          security cms -D -i "$PP_PATH" > $RUNNER_TEMP/pp.plist
-          PP_NAME=$(/usr/libexec/PlistBuddy -c "Print Name" $RUNNER_TEMP/pp.plist)
-          echo "Using provisioning profile: $PP_NAME"
-
-          # Remove CODE_SIGN_STYLE from project so xcconfig takes over
-          sed -i '' '/CODE_SIGN_STYLE = Automatic;/d' Runner.xcodeproj/project.pbxproj
-
-          # Inject signing overrides into Release.xcconfig
-          cat >> Flutter/Release.xcconfig << EOF
-          // CI Signing Overrides
-          CODE_SIGN_STYLE=Manual
-          CODE_SIGN_IDENTITY=Apple Distribution
-          PROVISIONING_PROFILE_SPECIFIER=$PP_NAME
-          EOF
-
-      - name: Build iOS (unsigned)
-        if: env.IOS_CERTIFICATE_BASE64 == ''
-        env:
-          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter build ios --release --no-codesign
-
-      - name: Build iOS (signed)
-        if: env.IOS_CERTIFICATE_BASE64 != ''
-        env:
-          IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
-        working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter build ios --release
-
-      - name: Setup Ruby for Fastlane
-        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
-        env:
-          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-          bundler-cache: true
-          working-directory: ${{ env.PLAYER_PATH }}/ios
-
-      # The notes reach the shell through env, never through ${{ }} substitution
-      # into this body: changelog text contains backticks and $, which would be
-      # both an injection risk and a corruption bug.
-      - name: Write TestFlight notes
-        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
-        env:
-          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          NOTES: ${{ needs.prepare.outputs.testflight_notes }}
-        run: printf '%s' "$NOTES" > "$RUNNER_TEMP/testflight-notes.txt"
-
-      - name: Upload to TestFlight
-        if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
-        env:
-          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
-          TESTFLIGHT_CHANGELOG_PATH: ${{ runner.temp }}/testflight-notes.txt
-        working-directory: ${{ env.PLAYER_PATH }}/ios
-        run: bundle exec fastlane beta
-
-      - name: Cleanup keychain
-        if: always()
-        run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
+    # The build itself lives in its own workflow so player-ios-refresh.yml can
+    # run the same one. The job id stays `player-ios` because the publish gate
+    # below reads `needs.player-ios.result`.
+    uses: ./.github/workflows/player-ios.yml
+    with:
+      sha: ${{ needs.prepare.outputs.sha }}
+      version: ${{ needs.prepare.outputs.version }}
+      version_code: ${{ needs.prepare.outputs.version_code }}
+      # A prerelease reaches only the pre-release group. A stable release
+      # reaches both, so a pre-release tester receives it as an ordinary update
+      # instead of sitting on a beta until the next cycle opens. The names are
+      # matched exactly: "Pre-release" carries a hyphen and a capital P.
+      groups: ${{ needs.prepare.outputs.is_prerelease == 'true' && 'Pre-release' || 'Beta,Pre-release' }}
+      notes: ${{ needs.prepare.outputs.testflight_notes }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      IOS_CERTIFICATE_BASE64: ${{ secrets.IOS_CERTIFICATE_BASE64 }}
+      IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}
+      IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
 
   player-macos:
     name: Player / macOS

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/getmydia/mydia/actions/workflows/ci.yml/badge.svg)](https://github.com/getmydia/mydia/actions/workflows/ci.yml)
 [![Documentation](https://github.com/getmydia/mydia/actions/workflows/ci-docs.yml/badge.svg)](https://docs.mydia.dev)
-[![TestFlight](https://img.shields.io/badge/TestFlight-Join%20iOS%20Beta-0D96F6?logo=apple&logoColor=white)](https://testflight.apple.com/join/KFSYxaQP)
+[![TestFlight](https://img.shields.io/badge/TestFlight-Install%20on%20iOS-0D96F6?logo=apple&logoColor=white)](https://testflight.apple.com/join/KFSYxaQP)
 
 **Your personal media companion, built with Phoenix LiveView**
 
@@ -85,7 +85,7 @@ peer-to-peer connection. No port forwarding, no VPN.
 | Platform | Get it | Notes |
 |---|---|---|
 | Android | [Download APK](https://mydia.dev/download/android) | Allow installs from unknown sources |
-| iOS | [Join the TestFlight beta](https://testflight.apple.com/join/KFSYxaQP) | Needs the TestFlight app |
+| iOS | [Install via TestFlight](https://testflight.apple.com/join/KFSYxaQP) | Needs the TestFlight app |
 | macOS | [Download .dmg](https://mydia.dev/download/macos) | Notarized, updates itself |
 | Windows | [Download installer](https://mydia.dev/download/windows) | Per-user install, unsigned build |
 | Linux | [Flatpak](https://mydia.dev/download/flatpak) or [.tar.gz](https://mydia.dev/download/linux) | Flatpak recommended |

--- a/docs/contributing/releasing.md
+++ b/docs/contributing/releasing.md
@@ -302,6 +302,47 @@ private key breaks updates for every existing install. Recovery means shipping
 new repo files and asking users to re-add the remote. Keep a backup outside
 GitHub Actions.
 
+## iOS TestFlight tracks
+
+iOS ships through two App Store Connect external groups. The names are matched
+exactly by App Store Connect, and `Pre-release` carries a hyphen and a capital
+P:
+
+| Group | Public link | Receives |
+| --- | --- | --- |
+| `Beta` | `https://testflight.apple.com/join/KFSYxaQP` | stable releases, refresh builds |
+| `Pre-release` | `https://testflight.apple.com/join/XTvarNBK` | everything |
+
+The `Beta` group holds the link published in the README, on the site and in the
+user documentation, which is why it carries stable despite the name. The
+`Pre-release` group is a superset rather than prereleases alone, so a tester
+there receives a stable release as an ordinary update instead of sitting on a
+beta until the next cycle opens.
+
+`release.yml` picks the groups from `is_prerelease` and passes them to
+`player-ios.yml`, which both it and the refresh cron call.
+
+### The refresh cron
+
+TestFlight deletes a build 90 days after upload, and the installed app then
+refuses to launch. The `Beta` group is topped up only by stable releases, and
+the gap between v0.9.0 and v0.10.0 was 73 days.
+
+`player-ios-refresh.yml` runs weekly. When the newest build passes 60 days it
+rebuilds the current stable tag and uploads it to both groups, then records the
+refresh as an `ios-refresh/YYYY-MM-DD` tag. `scripts/ios-refresh-due.sh` makes
+that decision and `scripts/check-ios-refresh-due.sh` tests it, which is the only
+way it can be tested: a `workflow_dispatch` workflow only triggers for a file on
+the default branch, and schedules only run there, so nothing about this workflow
+is exercisable from a pull request.
+
+Refresh build numbers are `run_number + 900000`, disjoint from release.yml's
+`run_number + 10000`. Apple rejects a reused build number for a marketing
+version it already holds, and the two workflows have independent run counters.
+
+To force one: `gh workflow run player-ios-refresh.yml -f force=true`. Add
+`-f dry_run=true` to build without uploading or moving the marker tag.
+
 ## Release notes
 
 Notes are authored into `priv/changelog/<version>.md` and tracked in the

--- a/docs/using/how-to/remote-access.md
+++ b/docs/using/how-to/remote-access.md
@@ -2,11 +2,23 @@
 
 Remote access allows the Mydia mobile app to connect to your Mydia instance from anywhere, even when your server is behind NAT or a firewall.
 
-## Get the Mobile App (iOS Beta)
+## Get the Mobile App
 
-The Mydia player is in open beta on TestFlight. Install the [TestFlight app](https://apps.apple.com/app/testflight/id899247664) on your iPhone or iPad, then join the beta. New builds reach you automatically as they ship.
+The Mydia player is distributed through TestFlight. Install the [TestFlight app](https://apps.apple.com/app/testflight/id899247664) on your iPhone or iPad, then use the link below. Each new release reaches you automatically.
 
-[Join the iOS Beta](https://testflight.apple.com/join/KFSYxaQP){ .md-button .md-button--primary }
+[Install on iOS](https://testflight.apple.com/join/KFSYxaQP){ .md-button .md-button--primary }
+
+### Pre-release builds
+
+There is a second TestFlight track carrying release candidates and betas
+alongside every stable release, for anyone who wants to try changes early and
+report problems before they ship. It is the same opt-in as the Docker `:beta`
+tag and the Flatpak beta channel, and it moves faster and breaks more often.
+
+[Install pre-release builds](https://testflight.apple.com/join/XTvarNBK){ .md-button }
+
+Use one or the other, not both: a device can hold only one copy of the app, and
+whichever link you install from last is the track you are on.
 
 ## Configuration
 

--- a/docs/using/how-to/remote-access.md
+++ b/docs/using/how-to/remote-access.md
@@ -18,8 +18,8 @@ tag and the Flatpak beta channel, and it moves faster and breaks more often.
 [Install pre-release builds](https://testflight.apple.com/join/XTvarNBK){ .md-button }
 
 Pick one. Joining the pre-release track does not remove you from the stable one,
-so if you use both links you will keep getting pre-release builds until you
-leave that group from inside the TestFlight app.
+so opening both links leaves you a member of both. Leaving a track again is done
+from inside the TestFlight app, not from these links.
 
 ## Configuration
 

--- a/docs/using/how-to/remote-access.md
+++ b/docs/using/how-to/remote-access.md
@@ -17,8 +17,9 @@ tag and the Flatpak beta channel, and it moves faster and breaks more often.
 
 [Install pre-release builds](https://testflight.apple.com/join/XTvarNBK){ .md-button }
 
-Use one or the other, not both: a device can hold only one copy of the app, and
-whichever link you install from last is the track you are on.
+Pick one. Joining the pre-release track does not remove you from the stable one,
+so if you use both links you will keep getting pre-release builds until you
+leave that group from inside the TestFlight app.
 
 ## Configuration
 

--- a/docs/using/how-to/update-mydia.md
+++ b/docs/using/how-to/update-mydia.md
@@ -63,7 +63,7 @@ The `:master` tag:
 If you want pre-release builds on arm64, use `:beta` (or `:beta-pg`), which is
 published from tagged pre-releases and is multi-arch.
 
-Looking for the mobile app's beta programme instead? See [Remote Access](remote-access.md) for the iOS TestFlight beta.
+Looking for the mobile app instead? See [Remote Access](remote-access.md) for the iOS TestFlight links, stable and pre-release.
 
 ## Version Pinning
 

--- a/player/ios/fastlane/Fastfile
+++ b/player/ios/fastlane/Fastfile
@@ -1,21 +1,10 @@
+require_relative "release_metadata"
+
 default_platform(:ios)
-
-# What testers read in TestFlight. The release workflow writes the release's
-# `## Player` notes to a file and names it here. The literal fallback keeps a
-# local `fastlane beta` working with nothing set up, and degrades a failed write
-# to the old behaviour rather than to a rejected upload: Apple refuses an empty
-# "What to Test" for external distribution.
-def testflight_changelog
-  path = ENV["TESTFLIGHT_CHANGELOG_PATH"]
-  return "Automated beta build." if path.nil? || path.empty? || !File.readable?(path)
-
-  notes = File.read(path).strip
-  notes.empty? ? "Automated beta build." : notes
-end
 
 platform :ios do
   desc "Build and upload to TestFlight"
-  lane :beta do
+  lane :testflight do
     setup_ci if ENV['CI']
 
     # Install the App Store Connect API key
@@ -35,13 +24,14 @@ platform :ios do
       output_name: "Mydia Player.ipa"
     )
 
-    # Upload to TestFlight and distribute to the public "Beta" external group.
-    # External distribution requires the build to finish processing, so we can't
-    # skip waiting here. The first build of each new version goes through Apple's
-    # Beta App Review before public-link testers can install it.
+    # Upload to TestFlight and distribute to the external groups the workflow
+    # named. External distribution requires the build to finish processing, so
+    # we can't skip waiting here. The first build of each new version goes
+    # through Apple's Beta App Review; that is per version, not per group, so
+    # routing a stable release to a second group does not trigger another one.
     upload_to_testflight(
       distribute_external: true,
-      groups: ["Beta"],
+      groups: testflight_groups,
       changelog: testflight_changelog,
       notify_external_testers: false
     )

--- a/player/ios/fastlane/release_metadata.rb
+++ b/player/ios/fastlane/release_metadata.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+#
+# Metadata the TestFlight upload needs, derived from the environment that
+# release.yml and player-ios-refresh.yml set.
+#
+# Extracted from the Fastfile so it can be tested with plain ruby: a Fastfile
+# only loads under fastlane, which needs bundler and the full gem set.
+# scripts/check-ios-fastlane-metadata.sh covers everything here.
+
+# What testers read in TestFlight. The workflow writes the release's `## Player`
+# notes to a file and names it here. The literal fallback keeps a local run
+# working with nothing set up, and degrades a failed write to the old behaviour
+# rather than to a rejected upload: Apple refuses an empty "What to Test" for
+# external distribution.
+def testflight_changelog
+  path = ENV["TESTFLIGHT_CHANGELOG_PATH"]
+  return "Automated beta build." if path.nil? || path.empty? || !File.readable?(path)
+
+  notes = File.read(path).strip
+  notes.empty? ? "Automated beta build." : notes
+end
+
+# Which App Store Connect external groups this build reaches. The workflow sets
+# TESTFLIGHT_GROUPS from `is_prerelease`: a prerelease reaches only the
+# pre-release group, a stable release reaches both, so a pre-release tester
+# receives a stable release as an ordinary update rather than sitting on a beta
+# until the next cycle opens.
+#
+# App Store Connect matches a group by exact name. "Pre-release" carries a
+# hyphen and a capital P because that is how the group is named in the account.
+# "Prerelease" is a different, non-existent group, and naming it fails the
+# upload.
+#
+# The fallback is the behaviour from before the split, so a bare local run still
+# works with nothing set up.
+def testflight_groups
+  groups = ENV["TESTFLIGHT_GROUPS"].to_s.split(",").map(&:strip).reject(&:empty?)
+  groups.empty? ? ["Beta"] : groups
+end

--- a/scripts/check-ios-fastlane-metadata.sh
+++ b/scripts/check-ios-fastlane-metadata.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Assert the iOS fastlane metadata helpers behave, using the system ruby.
+#
+# A Fastfile only loads under fastlane, so these two functions live in their own
+# plain-Ruby file to be testable here. ci-fastlane.yml separately proves the
+# Fastfile still parses and that the file is reachable via require_relative;
+# this proves the logic inside it.
+set -euo pipefail
+export LC_ALL=C.UTF-8
+
+cd "$(dirname "$0")/.."
+
+ruby - "player/ios/fastlane/release_metadata.rb" <<'RUBY'
+require File.expand_path(ARGV[0])
+require "tempfile"
+
+failures = []
+check = lambda do |desc, got, want|
+  failures << "#{desc}: got #{got.inspect}, wanted #{want.inspect}" unless got == want
+end
+
+# Group names are matched exactly by App Store Connect, so the hyphen and the
+# capital P in "Pre-release" are load-bearing.
+ENV.delete("TESTFLIGHT_GROUPS")
+check.call("unset falls back to the pre-split group", testflight_groups, ["Beta"])
+
+ENV["TESTFLIGHT_GROUPS"] = ""
+check.call("empty falls back", testflight_groups, ["Beta"])
+
+ENV["TESTFLIGHT_GROUPS"] = "Pre-release"
+check.call("a prerelease reaches one group", testflight_groups, ["Pre-release"])
+
+ENV["TESTFLIGHT_GROUPS"] = "Beta,Pre-release"
+check.call("a stable release reaches both", testflight_groups, ["Beta", "Pre-release"])
+
+ENV["TESTFLIGHT_GROUPS"] = " Beta , Pre-release "
+check.call("whitespace is trimmed", testflight_groups, ["Beta", "Pre-release"])
+
+ENV["TESTFLIGHT_GROUPS"] = "Beta,,Pre-release"
+check.call("empty entries are dropped", testflight_groups, ["Beta", "Pre-release"])
+
+# Apple refuses an empty "What to Test" for external distribution, so every
+# failure mode here has to land on the literal rather than on "".
+ENV.delete("TESTFLIGHT_CHANGELOG_PATH")
+check.call("no notes path", testflight_changelog, "Automated beta build.")
+
+ENV["TESTFLIGHT_CHANGELOG_PATH"] = ""
+check.call("empty notes path", testflight_changelog, "Automated beta build.")
+
+ENV["TESTFLIGHT_CHANGELOG_PATH"] = "/nonexistent/notes.txt"
+check.call("unreadable notes path", testflight_changelog, "Automated beta build.")
+
+blank = Tempfile.new("notes")
+blank.write("   \n\n")
+blank.flush
+ENV["TESTFLIGHT_CHANGELOG_PATH"] = blank.path
+check.call("blank notes file", testflight_changelog, "Automated beta build.")
+
+real = Tempfile.new("notes")
+real.write("\nWhat changed.\n\n")
+real.flush
+ENV["TESTFLIGHT_CHANGELOG_PATH"] = real.path
+check.call("real notes are read and stripped", testflight_changelog, "What changed.")
+
+if failures.empty?
+  puts "ios fastlane metadata: all cases pass"
+else
+  failures.each { |f| warn "FAIL: #{f}" }
+  exit 1
+end
+RUBY

--- a/scripts/check-ios-refresh-due.sh
+++ b/scripts/check-ios-refresh-due.sh
@@ -97,9 +97,17 @@ git tag -d "$MARKER_PROBE" >/dev/null 2>&1 || true
 # An ANNOTATED tag carries its tagger date as creatordate, unlike a lightweight
 # one, so a pinned future date puts this probe above every real tag forever. A
 # broken exclusion regex returns the probe; a working one skips it.
+#
+# The tagger identity is supplied inline because an annotated tag needs one and
+# a CI runner has no git identity configured: `git tag -a` there dies with
+# "Committer identity unknown", exit 128, which is a green suite locally and a
+# red one in CI. The marker probe above uses a lightweight tag and needs none.
+# `-f` so a run killed before its EXIT trap fires cannot wedge the next one.
 readonly PRERELEASE_PROBE="v9.9.9-beta.1"
 GIT_COMMITTER_DATE="2099-01-01T00:00:00Z" \
-  git tag -a -m "check-ios-refresh-due probe" "$PRERELEASE_PROBE" HEAD >/dev/null 2>&1
+GIT_COMMITTER_NAME="mydia-ci" \
+GIT_COMMITTER_EMAIL="ci@mydia.invalid" \
+  git tag -af -m "check-ios-refresh-due probe" "$PRERELEASE_PROBE" HEAD >/dev/null 2>&1
 
 probe_result="$(IOS_REFRESH_TODAY=2026-09-04 "$SCRIPT" 2>/dev/null | sed -n 's/^tag=//p')"
 case "$probe_result" in

--- a/scripts/check-ios-refresh-due.sh
+++ b/scripts/check-ios-refresh-due.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Assert scripts/ios-refresh-due.sh holds its contract.
+#
+# The refresh workflow this feeds cannot be dispatched, scheduled or exercised
+# in any way until it is on the default branch, because workflow_dispatch only
+# triggers for a file that exists there and schedules only run there. So the
+# decision it makes is tested here instead, where a pull request can see it.
+set -euo pipefail
+export LC_ALL=C.UTF-8
+
+cd "$(dirname "$0")/.."
+
+readonly SCRIPT="scripts/ios-refresh-due.sh"
+
+# The marker-path case below creates a real tag, so cleanup has to cover it even
+# when an assertion fails partway through.
+#
+# The date is far in the future because newest_marker() returns the greatest
+# dated marker across ALL ios-refresh/* refs, not just this probe. Once the
+# refresh workflow ships, real markers accumulate permanently, and a probe dated
+# in the past would lose to the first real one and fail this suite on every run
+# from then on. 9999-12-31 wins forever.
+readonly MARKER_PROBE="ios-refresh/9999-12-31"
+trap 'git tag -d "$MARKER_PROBE" >/dev/null 2>&1 || true' EXIT
+
+fail=0
+note_failure() { echo "FAIL: $*" >&2; fail=1; }
+
+# A synthetic world: today, the newest stable release as "tag date", and the
+# newest refresh marker as "tag date" or empty for none. Echoes one output key.
+run_case() {
+  IOS_REFRESH_TODAY="$1" IOS_REFRESH_STABLE="$2" IOS_REFRESH_MARKER="$3" \
+    "$SCRIPT" 2>/dev/null | sed -n "s/^$4=//p"
+}
+
+expect() {
+  [ "$3" = "$2" ] || note_failure "$1: got '$3', wanted '$2'"
+}
+
+# v0.13.2 is a real tag, so sha resolution is exercised rather than stubbed.
+readonly REAL_TAG=v0.13.2
+
+expect "a release yesterday is not due" false \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-09-03" "" due)"
+
+# Strictly greater, so the threshold does not fire a day early.
+expect "exactly 60 days is not due" false \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-07-06" "" due)"
+expect "61 days is due" true \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-07-05" "" due)"
+
+# The case a "last successful workflow run" baseline gets wrong.
+expect "a recent refresh holds off a build" false \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-01-01" "ios-refresh/2026-08-20 2026-08-20" due)"
+expect "an ancient refresh does not" true \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-01-01" "ios-refresh/2026-02-01 2026-02-01" due)"
+expect "a release newer than the marker wins" false \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-09-01" "ios-refresh/2026-02-01 2026-02-01" due)"
+
+expect "age is measured" 61 \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-07-05" "" age_days)"
+
+# pubspec.yaml and CFBundleShortVersionString both want a bare number.
+expect "version drops the leading v" 0.13.2 \
+  "$(run_case 2026-09-04 "$REAL_TAG 2026-07-05" "" version)"
+
+# A real marker tag, reaching newest_marker() for real. Every case above
+# overrides IOS_REFRESH_MARKER and so never executes that function at all, which
+# is how a real bug survived a full green suite once already.
+#
+# Asserted on baseline_date, not on due. The probe names 9999-12-31 but points
+# at HEAD, whose commit date is recent, so the two implementations disagree on
+# exactly one observable: reading the date from the tag's NAME gives a baseline
+# of 9999-12-31, while reading any git date field gives HEAD's committer date.
+# Both make `due` false, so asserting on `due` here would pass under the bug and
+# test nothing. That is not hypothetical: it is the shape of the defect this
+# case exists to catch.
+git tag -f "$MARKER_PROBE" HEAD >/dev/null 2>&1
+
+marker_baseline="$(IOS_REFRESH_TODAY=2026-09-04 IOS_REFRESH_STABLE="$REAL_TAG 2026-01-01" \
+  "$SCRIPT" 2>/dev/null | sed -n 's/^baseline_date=//p')"
+expect "the marker date is read from the tag name, not a git date" \
+  9999-12-31 "$marker_baseline"
+
+git tag -d "$MARKER_PROBE" >/dev/null 2>&1 || true
+
+# The real repository, with only today pinned. Proves the git queries work
+# against real refs rather than only against synthetic strings, and that the
+# prerelease exclusion holds: there are v0.14.0-beta.* tags newer than the
+# newest stable one, so a broken filter fails here.
+out="$(IOS_REFRESH_TODAY=2026-09-04 "$SCRIPT" 2>/dev/null)"
+real_tag="$(sed -n 's/^tag=//p' <<<"$out")"
+real_sha="$(sed -n 's/^sha=//p' <<<"$out")"
+
+case "$real_tag" in
+  v*) : ;;
+  *) note_failure "real repo: tag '${real_tag}' does not look like a release tag" ;;
+esac
+case "$real_tag" in
+  *-beta*|*-rc*|*-alpha*) note_failure "real repo: picked prerelease tag ${real_tag}" ;;
+esac
+[ "${#real_sha}" -eq 40 ] || note_failure "real repo: sha '${real_sha}' is not a full SHA"
+
+[ "$fail" -eq 0 ] || exit 1
+echo "ios refresh decision: all cases pass"

--- a/scripts/check-ios-refresh-due.sh
+++ b/scripts/check-ios-refresh-due.sh
@@ -22,7 +22,7 @@ readonly SCRIPT="scripts/ios-refresh-due.sh"
 # in the past would lose to the first real one and fail this suite on every run
 # from then on. 9999-12-31 wins forever.
 readonly MARKER_PROBE="ios-refresh/9999-12-31"
-trap 'git tag -d "$MARKER_PROBE" >/dev/null 2>&1 || true' EXIT
+trap 'git tag -d "$MARKER_PROBE" "v9.9.9-beta.1" >/dev/null 2>&1 || true' EXIT
 
 fail=0
 note_failure() { echo "FAIL: $*" >&2; fail=1; }
@@ -85,10 +85,32 @@ expect "the marker date is read from the tag name, not a git date" \
 
 git tag -d "$MARKER_PROBE" >/dev/null 2>&1 || true
 
+# newest_stable()'s prerelease exclusion, with a probe that cannot go stale.
+#
+# Every synthetic case above overrides IOS_REFRESH_STABLE and so never calls
+# newest_stable() at all. The real-repository case below cannot cover the
+# exclusion either: it only discriminates while some prerelease tag happens to
+# be newer than the newest stable one. That was true when this suite was
+# written and stopped being true the day v0.14.0 shipped, which is how long a
+# timing-dependent assertion survives.
+#
+# An ANNOTATED tag carries its tagger date as creatordate, unlike a lightweight
+# one, so a pinned future date puts this probe above every real tag forever. A
+# broken exclusion regex returns the probe; a working one skips it.
+readonly PRERELEASE_PROBE="v9.9.9-beta.1"
+GIT_COMMITTER_DATE="2099-01-01T00:00:00Z" \
+  git tag -a -m "check-ios-refresh-due probe" "$PRERELEASE_PROBE" HEAD >/dev/null 2>&1
+
+probe_result="$(IOS_REFRESH_TODAY=2026-09-04 "$SCRIPT" 2>/dev/null | sed -n 's/^tag=//p')"
+case "$probe_result" in
+  *-beta*|*-rc*|*-alpha*)
+    note_failure "prerelease exclusion: newest_stable() returned '${probe_result}', a prerelease" ;;
+esac
+
+git tag -d "$PRERELEASE_PROBE" >/dev/null 2>&1 || true
+
 # The real repository, with only today pinned. Proves the git queries work
-# against real refs rather than only against synthetic strings, and that the
-# prerelease exclusion holds: there are v0.14.0-beta.* tags newer than the
-# newest stable one, so a broken filter fails here.
+# against real refs rather than only against synthetic strings.
 out="$(IOS_REFRESH_TODAY=2026-09-04 "$SCRIPT" 2>/dev/null)"
 real_tag="$(sed -n 's/^tag=//p' <<<"$out")"
 real_sha="$(sed -n 's/^sha=//p' <<<"$out")"

--- a/scripts/check-testflight-notes.sh
+++ b/scripts/check-testflight-notes.sh
@@ -14,7 +14,10 @@ readonly MAX_CHARS=4000
 
 fail=0
 err="$(mktemp)"
-trap 'rm -f "$err"' EXIT
+# The marker-tag case below creates a real tag, so cleanup has to cover it even
+# when an assertion fails partway through.
+readonly PROBE_TAG="ios-refresh/9999-12-31"
+trap 'git tag -d "$PROBE_TAG" >/dev/null 2>&1 || true; rm -f "$err"' EXIT
 
 note_failure() { echo "FAIL: $*" >&2; fail=1; }
 
@@ -133,6 +136,32 @@ if out="$(TESTFLIGHT_PREV_TAG=v0.13.2 "$SCRIPT" 9.9.9 7f080ff3714f91b186eaa052cf
 else
   note_failure "fallback markup: script exited non-zero"
 fi
+
+# player-ios-refresh.yml pushes `ios-refresh/<date>` tags to record a TestFlight
+# refresh. previous_tag() must never return one: it is not a release, and the
+# commit range it implies has nothing to do with what changed since one.
+#
+# This passes today even without the grep guard in previous_tag(), because
+# `-version:refname` orders a non-version name lexicographically against the
+# version tags and `ios-` sorts below `v0-`: a marker lands at the bottom of the
+# list, where head -n1 never reaches it. That is a property of the prefix, not of
+# the code. A prefix sorting after `v` goes straight to position 1. This case
+# exists to catch that, so it asserts the invariant that matters rather than
+# pretending to exercise the guard.
+git tag -f "$PROBE_TAG" HEAD >/dev/null 2>&1
+
+if "$SCRIPT" 9.9.9 HEAD v9.9.9 >/dev/null 2>"$err"; then
+  prev="$(sed -n 's/^testflight-notes: prev=//p' "$err")"
+  case "$prev" in
+    "")   note_failure "marker tag: no previous tag was reported, so this assertion proves nothing" ;;
+    v*)   : ;;
+    *)    note_failure "marker tag: previous_tag() returned '${prev}', which is not a release tag" ;;
+  esac
+else
+  note_failure "marker tag: script exited non-zero: $(cat "$err")"
+fi
+
+git tag -d "$PROBE_TAG" >/dev/null 2>&1 || true
 
 [ "$fail" -eq 0 ] || exit 1
 echo "testflight notes: all $(find priv/changelog -name '*.md' | wc -l | tr -d ' ') bundled changelogs pass"

--- a/scripts/ios-refresh-due.sh
+++ b/scripts/ios-refresh-due.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Decide whether the iOS TestFlight groups need a refresh build, and emit the
+# coordinates for one.
+#
+#   scripts/ios-refresh-due.sh >> "$GITHUB_OUTPUT"
+#
+# TestFlight deletes a build 90 days after upload, and the installed app then
+# refuses to launch. Both external groups are topped up only when a build is
+# uploaded, so a long quiet stretch between stable releases is what strands
+# testers. This script is the decision; player-ios-refresh.yml is the trigger.
+#
+# stdout: GITHUB_OUTPUT-shaped `key=value` lines.
+# stderr: one line explaining the decision.
+#
+# The baseline is the newer of the last stable release and the last refresh.
+# The refresh records itself as an `ios-refresh/YYYY-MM-DD` tag rather than as
+# a successful workflow run, because a weekly run that decides *not due* also
+# succeeds: run history would reset the baseline every week and the refresh
+# would never fire at all.
+#
+# The overrides exist for check-ios-refresh-due.sh. Production sets none of
+# them. IOS_REFRESH_MARKER uses `${VAR-default}` rather than `${VAR:-default}`
+# so a deliberately empty value means "no marker exists" instead of falling
+# through to the git lookup, which is how the no-marker cases are tested in a
+# repository that has markers.
+set -euo pipefail
+export LC_ALL=C.UTF-8
+
+readonly DEFAULT_THRESHOLD_DAYS=60
+readonly MARKER_PREFIX="ios-refresh/"
+
+die() { echo "ios-refresh-due: $*" >&2; exit 1; }
+
+epoch() { date -u -d "$1" +%s 2>/dev/null || die "cannot parse date '$1'"; }
+
+# `creatordate` here resolves to the tagged commit's committer date, because
+# GitHub creates release tags as lightweight refs: `git cat-file -t v0.13.2`
+# reports `commit`, not `tag`. That is the best signal available locally, and it
+# errs old, because a draft can target a commit from days before it ships. An
+# older baseline makes the refresh fire sooner, which is the safe direction
+# against a 90-day expiry.
+#
+# `refs/tags/v*` excludes the metadata-relay tags for free: they are named
+# metadata-relay-v*, which does not start with v.
+newest_stable() {
+  git for-each-ref --sort=-creatordate \
+      --format='%(refname:short) %(creatordate:short)' 'refs/tags/v*' \
+    | grep -vE -- '-(beta|rc|alpha)' \
+    | head -n1
+}
+
+# A marker's date comes from its own name, never from a git date field.
+#
+# These are lightweight tags too, and `creatordate` on a lightweight tag is the
+# tagged commit's committer date, not the moment the tag was created. The
+# refresh tags the stable release's commit, so reading a git date here would
+# report the release's own date: the marker could never advance the baseline
+# past the release, and the refresh would re-fire every week for the length of a
+# drought. That is the exact failure this marker exists to prevent.
+#
+# Verified: a lightweight tag created today against a 2020 commit reports
+# `creatordate` 2020-01-01, while an annotated tag on the same commit reports
+# today.
+#
+# The `case` both extracts and validates: a marker whose suffix is not a date is
+# skipped rather than silently sorting as garbage.
+newest_marker() {
+  git for-each-ref --format='%(refname:short)' "refs/tags/${MARKER_PREFIX}*" \
+    | while IFS= read -r ref; do
+        marker_date="${ref#"${MARKER_PREFIX}"}"
+        case "$marker_date" in
+          [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) echo "${ref} ${marker_date}" ;;
+        esac
+      done \
+    | sort -k2 \
+    | tail -n1
+}
+
+threshold="${IOS_REFRESH_THRESHOLD_DAYS:-$DEFAULT_THRESHOLD_DAYS}"
+today="${IOS_REFRESH_TODAY:-$(date -u +%Y-%m-%d)}"
+
+stable="${IOS_REFRESH_STABLE:-$(newest_stable)}"
+[ -n "$stable" ] || die "no stable release tag found"
+
+tag="${stable%% *}"
+baseline_date="${stable##* }"
+baseline_why="stable release ${tag} (${baseline_date})"
+
+marker="${IOS_REFRESH_MARKER-$(newest_marker)}"
+if [ -n "$marker" ]; then
+  marker_date="${marker##* }"
+  if [ "$(epoch "$marker_date")" -gt "$(epoch "$baseline_date")" ]; then
+    baseline_date="$marker_date"
+    baseline_why="refresh ${marker%% *} (${marker_date})"
+  fi
+fi
+
+age_days=$(( ( $(epoch "$today") - $(epoch "$baseline_date") ) / 86400 ))
+
+if [ "$age_days" -gt "$threshold" ]; then due=true; else due=false; fi
+
+sha="$(git rev-list -n1 "$tag")"
+
+{
+  echo "due=${due}"
+  echo "age_days=${age_days}"
+  # The date the age was measured from, and which of the two sources won. Emitted
+  # because it is the only way to assert that a marker's date came from its name
+  # rather than from a git date field: both readings can yield the same `due`.
+  echo "baseline_date=${baseline_date}"
+  echo "tag=${tag}"
+  echo "version=${tag#v}"
+  echo "sha=${sha}"
+}
+
+echo "ios-refresh-due: ${age_days}d since ${baseline_why}, threshold ${threshold}d, due=${due}" >&2

--- a/scripts/testflight-notes.sh
+++ b/scripts/testflight-notes.sh
@@ -98,6 +98,17 @@ fit_to_budget() {
 # publishes the draft. So the newest existing tag is the previous release. The
 # grep -vFx is defensive against a re-dispatch where it somehow already does.
 #
+# player-ios-refresh.yml pushes `ios-refresh/<date>` tags to record a TestFlight
+# refresh. They are not releases and must never be selected here: the range one
+# implies has nothing to do with what changed since a release.
+#
+# The current prefix is already safe by accident. `-version:refname` orders a
+# non-version name lexicographically against the version tags, so `ios-` sorts
+# below `v0-` and a marker lands at the bottom of the list, out of head -n1's
+# reach. A prefix sorting after `v`, `zzz-refresh` for instance, lands at
+# position 1 instead. This grep is what stops the prefix choice from being
+# load-bearing on release notes.
+#
 # TESTFLIGHT_PREV_TAG exists for check-testflight-notes.sh, which needs a
 # deterministic commit range. Production never sets it.
 previous_tag() {
@@ -112,7 +123,11 @@ previous_tag() {
   # before Source 3's placeholder fallback is ever reached. The trailing
   # `|| true` keeps this a clean empty result so the `if [ -n "$prev" ]` guard
   # at the call site can handle it. Do not remove this as dead code.
-  git tag --sort=-version:refname | grep -v metadata-relay | grep -vFx "$TAG" | head -n1 || true
+  git tag --sort=-version:refname \
+    | grep -v metadata-relay \
+    | grep -v '^ios-refresh/' \
+    | grep -vFx "$TAG" \
+    | head -n1 || true
 }
 
 notes=""
@@ -133,6 +148,10 @@ fi
 # a normal subject here, and backticks in a subject are not unusual either.
 if [ -z "$notes" ]; then
   prev="$(previous_tag)"
+  # Reported so check-testflight-notes.sh can assert which tag was chosen. The
+  # commit range is often empty even when the choice is correct, so the notes
+  # themselves cannot distinguish a good previous tag from a bad one.
+  echo "testflight-notes: prev=${prev}" >&2
   if [ -n "$prev" ]; then
     notes="$(git log --format='- %s' "${prev}..${SHA}" -- player/ | to_plain_text || true)"
     [ -n "$notes" ] && source_label="gitlog"

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -32,10 +32,10 @@ const platforms: Platform[] = [
   {
     id: 'ios',
     name: 'iOS',
-    tagline: 'iPhone and iPad, open beta',
+    tagline: 'iPhone and iPad',
     icon: 'M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z',
-    options: [{ label: 'Join the TestFlight beta', href: '/download/ios', primary: true }],
-    note: 'Needs the free TestFlight app from the App Store. New builds reach testers automatically as they ship.',
+    options: [{ label: 'Install via TestFlight', href: '/download/ios', primary: true }],
+    note: 'Needs the free TestFlight app from the App Store. Each new release reaches you automatically. Pre-release builds are a separate opt-in, documented in the remote access guide.',
   },
   {
     id: 'macos',
@@ -192,7 +192,7 @@ flatpak install mydia dev.mydia.player`,
   // Flatpak, and that needs two commands rather than a file.
   const TARGETS: Record<string, Target> = {
     android: { href: '/download/android', label: 'Download for Android' },
-    ios: { href: '/download/ios', label: 'Get the iOS beta' },
+    ios: { href: '/download/ios', label: 'Install via TestFlight' },
     macos: { href: '/download/macos', label: 'Download for macOS' },
     windows: { href: '/download/windows', label: 'Download for Windows' },
     linux: { href: '#linux', label: 'Get it for Linux' },


### PR DESCRIPTION
Splits iOS TestFlight distribution into a stable track and a pre-release track, fed from one build.

## The problem

Every release, prerelease or stable, ran `fastlane beta` and distributed to a single App Store Connect group. That group holds `https://testflight.apple.com/join/KFSYxaQP`, the only advertised way to install the player on iOS, published in the README, on the download site and in the user docs. Anyone who used it received `0.14.0-beta.5` and `0.14.0` alike with no way to opt out.

`release.yml` already computes `is_prerelease` and Docker and Flatpak both branch on it. iOS was the one platform ignoring it.

## The two tracks

| Group | Public link | Receives |
| --- | --- | --- |
| `Beta` | `https://testflight.apple.com/join/KFSYxaQP` (unchanged) | stable releases, refresh builds |
| `Pre-release` | `https://testflight.apple.com/join/XTvarNBK` (new, docs only) | everything |

The already-published link becomes the stable track, so nothing anyone has bookmarked or installed from breaks. `Pre-release` is a superset rather than prereleases alone, so a tester there receives a stable release as an ordinary update instead of sitting on a beta until the next cycle opens.

Group names are matched exactly by App Store Connect. `Pre-release` carries a hyphen and a capital P.

## The refresh cron

TestFlight deletes a build 90 days after upload, and the installed app then refuses to launch. The public group is now topped up only by stable releases, and the gap between v0.9.0 and v0.10.0 was 73 days.

`player-ios-refresh.yml` runs weekly and re-uploads the current stable release to both groups when the newest build passes 60 days, recording each refresh as an `ios-refresh/YYYY-MM-DD` tag. `scripts/ios-refresh-due.sh` makes the decision and `scripts/check-ios-refresh-due.sh` tests it, which is the only way it can be tested: `workflow_dispatch` only triggers for a file on the default branch and schedules only run there, so nothing about that workflow is exercisable from a pull request.

Refresh build numbers are `run_number + 900000`, disjoint from `release.yml`'s `run_number + 10000`. The two workflows have independent run counters and Apple rejects a reused build number for a marketing version it already holds.

## Structure

The iOS build moves out of `release.yml` into `player-ios.yml` as a reusable `workflow_call` workflow, so the refresh cron runs the identical build rather than a second copy that would drift. The job id stays `player-ios`, so the publish gate's `needs.player-ios.result` and the `allow_missing=ios` waiver keep working untouched.

## Worth a reviewer's attention

Three GitHub Actions behaviours shaped this and are easy to regress:

- A caller's workflow-level `env` is not propagated into a called workflow, and `env:` is not permitted beside `uses:`. `player-ios.yml` declares its own `PLAYER_PATH`; inheriting `release.yml`'s would resolve every path to `/ios`.
- `dry_run` must stay `type: boolean`. As a string, `"false"` is truthy, so `!inputs.dry_run` inverts and real releases would skip the upload while dry runs uploaded for real.
- The `if: env.X != ''` plus same-step `env:` pattern on the signing steps is deliberate, because secrets cannot be referenced in an `if:`. It moved verbatim.

Also load-bearing: the refresh marker's date comes from its own tag name, never from a git date field. These are lightweight tags, and `creatordate` on one is the tagged commit's committer date rather than when the tag was made. The `mark` job tags the release commit, which is old, so reading a git date there would report the release's own date and the baseline could never advance.

## Prerequisite

Already done. The `Pre-release` group exists in App Store Connect with its public link enabled.

## Post-merge verification, before the cron is trusted

Run in order:

1. `gh workflow run player-ios-refresh.yml -f force=true -f dry_run=true`
   Expect: `decide` runs, `refresh` builds and signs, all three upload steps skipped, `mark` skipped, no `ios-refresh` tag created.
2. `gh workflow run player-ios-refresh.yml -f force=true`
   Expect: a build in both TestFlight groups, and `git fetch --tags && git tag --list 'ios-refresh/*'` shows today's tag.
3. `gh workflow run player-ios-refresh.yml`
   Expect: `decide` reports `due=false` because the tag from step 2 is today, and both `refresh` and `mark` are skipped.

Step 1 alone is not sufficient: the dry-run path skips `mark` entirely, so it cannot exercise the marker push.

## Optional pre-merge rehearsal

`gh workflow run release.yml --ref feat-ios-testflight-tracks -f dry_run=true` builds and signs iOS without uploading and is the only end-to-end exercise of the reusable-workflow call graph available before merge. Roughly 20 minutes on a macOS runner.

## Known and deliberately carried

- `scripts/ios-refresh-due.sh` validates a marker's date suffix syntactically rather than as a real calendar date. Markers are only ever created by the workflow from `date -u +%Y-%m-%d`, and the failure mode is a red run rather than a wrong decision.
- `check-ios-refresh-due.sh` and `check-testflight-notes.sh` share the probe literal `ios-refresh/9999-12-31`. Harmless while those steps run sequentially in one job, worth revisiting if that job is ever parallelised.
- No top-level `concurrency:` on the refresh workflow, no `timeout-minutes` on its `decide` and `mark` jobs, and its `build_number` step runs ungated.
- `player/ios-setup-templates/Fastfile.template` still carries a `lane :beta`. It is tracked but referenced by nothing and is not on the release path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added weekly iOS TestFlight refreshes to keep stable builds available before expiration.
  - Added separate Beta and Pre-release TestFlight distribution tracks.
  - Added support for manual refreshes and dry runs.

- **Documentation**
  - Updated installation guidance and release documentation for iOS TestFlight access and track membership.

- **Bug Fixes**
  - Prevented refresh tags from affecting release-note comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->