### PR TITLE
fix(ci): only record an iOS TestFlight refresh when a build actually uploaded

### DIFF
--- a/.github/workflows/player-ios-refresh.yml
+++ b/.github/workflows/player-ios-refresh.yml
@@ -135,10 +135,16 @@ jobs:
   mark:
     name: Mark refreshed
     needs: [decide, refresh]
-    # Only after a real upload. A dry run must not move the baseline, or the
-    # next real refresh is deferred by 60 days on the strength of a build that
-    # never reached Apple.
-    if: ${{ !inputs.dry_run }}
+    # Only after a real upload, proven by the called workflow's own output
+    # rather than inferred from its success.
+    #
+    # `!inputs.dry_run` alone is not enough. The upload steps in player-ios.yml
+    # also skip when the App Store Connect credentials are absent, and the job
+    # still succeeds, so a credentials outage would have written a marker for a
+    # build that never reached Apple and deferred the next real refresh by 60
+    # days. That is the failure this whole workflow exists to prevent, arriving
+    # silently through the mechanism meant to prevent it.
+    if: ${{ !inputs.dry_run && needs.refresh.outputs.uploaded == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/player-ios.yml
+++ b/.github/workflows/player-ios.yml
@@ -63,6 +63,15 @@ on:
         required: false
       APP_STORE_CONNECT_API_KEY_CONTENT:
         required: false
+    outputs:
+      uploaded:
+        description: >-
+          "true" only when a build actually reached TestFlight. Empty on a dry
+          run, and empty when the App Store Connect credentials are absent,
+          because the upload steps below skip on either and the job still
+          succeeds. A caller that records the upload as having happened must
+          gate on this rather than on the job's own success.
+        value: ${{ jobs.build.outputs.uploaded }}
 
 permissions:
   contents: read
@@ -71,6 +80,8 @@ jobs:
   build:
     name: Build and upload
     runs-on: macos-26
+    outputs:
+      uploaded: ${{ steps.upload.outputs.uploaded }}
     # Serialises the iOS build so a release and a refresh never upload at once.
     #
     # This prevents overlap, not staleness. A refresh queued behind a release
@@ -211,7 +222,12 @@ jobs:
           NOTES: ${{ inputs.notes }}
         run: printf '%s' "$NOTES" > "$RUNNER_TEMP/testflight-notes.txt"
 
+      # `uploaded` is written only after fastlane returns successfully, and the
+      # step is skipped entirely when this condition is false, so an empty value
+      # means "no build reached TestFlight" for either reason. player-ios-refresh
+      # gates its marker tag on it.
       - name: Upload to TestFlight
+        id: upload
         if: ${{ !inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != '' }}
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -221,7 +237,9 @@ jobs:
           # Group names, matched exactly by App Store Connect.
           TESTFLIGHT_GROUPS: ${{ inputs.groups }}
         working-directory: ${{ env.PLAYER_PATH }}/ios
-        run: bundle exec fastlane testflight
+        run: |
+          bundle exec fastlane testflight
+          echo "uploaded=true" >> "$GITHUB_OUTPUT"
 
       - name: Cleanup keychain
         if: always()


### PR DESCRIPTION
Follow-up to #703, addressing the CodeRabbit finding on that PR. Valid, and worth fixing properly rather than papering over.

## The bug

`player-ios.yml` gates its three upload steps on `!inputs.dry_run && env.APP_STORE_CONNECT_API_KEY_ID != ''`. When those credentials are absent the steps skip and the job still succeeds.

`player-ios-refresh.yml`'s `mark` job gated its marker tag on `!inputs.dry_run` alone, and it runs whenever `refresh` succeeds. So with the credentials missing, the sequence was:

1. `decide` finds a refresh is due
2. `refresh` builds, signs, and silently skips the upload
3. `refresh` succeeds
4. `mark` pushes `ios-refresh/<today>`
5. `scripts/ios-refresh-due.sh` reads that marker next week and reports `due=false` for another 60 days

The marker means "a build reached TestFlight and the 90-day clock restarted". Written on a build that never reached Apple, it says the opposite of the truth, and the refresh stops refreshing. That is the stranded-tester failure this workflow exists to prevent, arriving silently through the mechanism meant to prevent it.

It is not hypothetical: the credentials are optional secrets, precisely so the build can run without them.

## The fix

`player-ios.yml` now reports whether a build actually reached TestFlight, and `mark` gates on that evidence rather than inferring it from the job's success:

- the `Upload to TestFlight` step gains an id and writes `uploaded=true`, **after** `bundle exec fastlane testflight` returns successfully
- the `build` job exposes it, and `workflow_call` exposes it to callers
- `mark`'s condition becomes `!inputs.dry_run && needs.refresh.outputs.uploaded == 'true'`

A skipped step produces no output, so an empty value covers both reasons a build might not have shipped: a dry run, and missing credentials. It also covers any future reason, which is the point of asserting the outcome instead of a proxy for it.

## Why not require the credentials instead

CodeRabbit offered that as the alternative. It would break the deliberate unsigned-build path: `player-ios.yml` keeps `Build iOS (unsigned)` for the case where signing secrets are absent, and hard-failing on missing App Store Connect credentials would take that with it. Gating the marker is the narrower change, and it fixes the actual defect, which is a marker asserting something that did not happen.

## Verification

The plumbing was checked end to end by parsing both workflows: `workflow_call.outputs.uploaded` resolves to `jobs.build.outputs.uploaded`, which resolves to `steps.upload.outputs.uploaded`; the upload step carries `id: upload` and writes the value only after fastlane succeeds; `mark` reads `needs.refresh.outputs.uploaded`.

Adding an output is additive, so `release.yml`'s call site is unaffected and needs no change.

Runtime behaviour still cannot be exercised before merge: `workflow_dispatch` only triggers for a workflow file on the default branch and schedules only run there. The post-merge steps in #703 remain the way to prove it, and step 2 there (`-f force=true`, no dry run) now also exercises this guard, since it is the only path that both uploads and marks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TestFlight marker tags are now created only when a build is successfully uploaded to TestFlight.
  * Dry runs and builds without App Store Connect credentials no longer produce misleading marker tags.

* **Workflow Improvements**
  * Added a reliable upload status signal for workflows that trigger or depend on the iOS build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->