### PR TITLE
fix(media): scope requests, library items, and provider IDs by media type

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -151,7 +151,7 @@ defmodule Mydia.Media do
   """
   @spec get_media_item_by_tmdb(String.t() | atom(), integer(), keyword()) :: MediaItem.t() | nil
   def get_media_item_by_tmdb(type, tmdb_id, opts)
-      when (is_binary(type) or is_atom(type)) and is_integer(tmdb_id) do
+      when (is_binary(type) or is_atom(type)) and not is_nil(type) and is_integer(tmdb_id) do
     type_str = to_string(type)
 
     MediaItem
@@ -168,7 +168,7 @@ defmodule Mydia.Media do
   @spec get_media_item_by_tmdb(String.t() | atom(), integer()) :: MediaItem.t() | nil
   @spec get_media_item_by_tmdb(integer(), keyword()) :: MediaItem.t() | nil
   def get_media_item_by_tmdb(type, tmdb_id)
-      when (is_binary(type) or is_atom(type)) and is_integer(tmdb_id) do
+      when (is_binary(type) or is_atom(type)) and not is_nil(type) and is_integer(tmdb_id) do
     get_media_item_by_tmdb(type, tmdb_id, [])
   end
 
@@ -211,7 +211,7 @@ defmodule Mydia.Media do
   """
   @spec get_media_item_by_tvdb(String.t() | atom(), integer(), keyword()) :: MediaItem.t() | nil
   def get_media_item_by_tvdb(type, tvdb_id, opts)
-      when (is_binary(type) or is_atom(type)) and is_integer(tvdb_id) do
+      when (is_binary(type) or is_atom(type)) and not is_nil(type) and is_integer(tvdb_id) do
     type_str = to_string(type)
 
     MediaItem
@@ -228,7 +228,7 @@ defmodule Mydia.Media do
   @spec get_media_item_by_tvdb(String.t() | atom(), integer()) :: MediaItem.t() | nil
   @spec get_media_item_by_tvdb(integer(), keyword()) :: MediaItem.t() | nil
   def get_media_item_by_tvdb(type, tvdb_id)
-      when (is_binary(type) or is_atom(type)) and is_integer(tvdb_id) do
+      when (is_binary(type) or is_atom(type)) and not is_nil(type) and is_integer(tvdb_id) do
     get_media_item_by_tvdb(type, tvdb_id, [])
   end
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -147,25 +147,102 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  Gets a single media item by TMDB ID.
+  Gets a single media item by media type and TMDB ID.
   """
-  @spec get_media_item_by_tmdb(integer(), keyword()) :: MediaItem.t() | nil
-  def get_media_item_by_tmdb(tmdb_id, opts \\ []) do
+  @spec get_media_item_by_tmdb(String.t() | atom(), integer(), keyword()) :: MediaItem.t() | nil
+  def get_media_item_by_tmdb(type, tmdb_id, opts)
+      when (is_binary(type) or is_atom(type)) and is_integer(tmdb_id) do
+    type_str = to_string(type)
+
     MediaItem
-    |> where([m], m.tmdb_id == ^tmdb_id)
+    |> where([m], m.type == ^type_str and m.tmdb_id == ^tmdb_id)
     |> maybe_preload(opts[:preload])
     |> Repo.one()
   end
 
+  def get_media_item_by_tmdb(_, _, _), do: nil
+
+  @doc """
+  Gets a single media item by media type and TMDB ID, or by TMDB ID with options.
+  """
+  @spec get_media_item_by_tmdb(String.t() | atom(), integer()) :: MediaItem.t() | nil
+  @spec get_media_item_by_tmdb(integer(), keyword()) :: MediaItem.t() | nil
+  def get_media_item_by_tmdb(type, tmdb_id)
+      when (is_binary(type) or is_atom(type)) and is_integer(tmdb_id) do
+    get_media_item_by_tmdb(type, tmdb_id, [])
+  end
+
+  def get_media_item_by_tmdb(tmdb_id, opts) when is_integer(tmdb_id) do
+    MediaItem
+    |> where([m], m.tmdb_id == ^tmdb_id)
+    |> maybe_filter_type(opts[:type])
+    |> maybe_preload(opts[:preload])
+    |> Repo.one()
+  end
+
+  def get_media_item_by_tmdb(_, _), do: nil
+
+  @doc """
+  Gets a single media item by TMDB ID.
+  """
+  @spec get_media_item_by_tmdb(integer()) :: MediaItem.t() | nil
+  def get_media_item_by_tmdb(tmdb_id) when is_integer(tmdb_id) do
+    get_media_item_by_tmdb(tmdb_id, [])
+  end
+
+  def get_media_item_by_tmdb(_), do: nil
+
+  @doc """
+  Gets a single media item by media type and TVDB ID.
+  """
+  @spec get_media_item_by_tvdb(String.t() | atom(), integer(), keyword()) :: MediaItem.t() | nil
+  def get_media_item_by_tvdb(type, tvdb_id, opts)
+      when (is_binary(type) or is_atom(type)) and is_integer(tvdb_id) do
+    type_str = to_string(type)
+
+    MediaItem
+    |> where([m], m.type == ^type_str and m.tvdb_id == ^tvdb_id)
+    |> maybe_preload(opts[:preload])
+    |> Repo.one()
+  end
+
+  def get_media_item_by_tvdb(_, _, _), do: nil
+
+  @doc """
+  Gets a single media item by TVDB ID, optionally filtered by type option.
+  """
+  @spec get_media_item_by_tvdb(String.t() | atom(), integer()) :: MediaItem.t() | nil
+  @spec get_media_item_by_tvdb(integer(), keyword()) :: MediaItem.t() | nil
+  def get_media_item_by_tvdb(type, tvdb_id)
+      when (is_binary(type) or is_atom(type)) and is_integer(tvdb_id) do
+    get_media_item_by_tvdb(type, tvdb_id, [])
+  end
+
+  def get_media_item_by_tvdb(tvdb_id, opts) when is_integer(tvdb_id) do
+    MediaItem
+    |> where([m], m.tvdb_id == ^tvdb_id)
+    |> maybe_filter_type(opts[:type])
+    |> maybe_preload(opts[:preload])
+    |> Repo.one()
+  end
+
+  def get_media_item_by_tvdb(_, _), do: nil
+
   @doc """
   Gets a single media item by TVDB ID.
   """
-  @spec get_media_item_by_tvdb(integer(), keyword()) :: MediaItem.t() | nil
-  def get_media_item_by_tvdb(tvdb_id, opts \\ []) do
-    MediaItem
-    |> where([m], m.tvdb_id == ^tvdb_id)
-    |> maybe_preload(opts[:preload])
-    |> Repo.one()
+  @spec get_media_item_by_tvdb(integer()) :: MediaItem.t() | nil
+  def get_media_item_by_tvdb(tvdb_id) when is_integer(tvdb_id) do
+    get_media_item_by_tvdb(tvdb_id, [])
+  end
+
+  def get_media_item_by_tvdb(_), do: nil
+
+  defp maybe_filter_type(query, nil), do: query
+
+  defp maybe_filter_type(query, type) do
+    type_str = to_string(type)
+    where(query, [m], m.type == ^type_str)
   end
 
   @doc """

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -173,11 +173,26 @@ defmodule Mydia.Media do
   end
 
   def get_media_item_by_tmdb(tmdb_id, opts) when is_integer(tmdb_id) do
-    MediaItem
-    |> where([m], m.tmdb_id == ^tmdb_id)
-    |> maybe_filter_type(opts[:type])
-    |> maybe_preload(opts[:preload])
-    |> Repo.one()
+    query =
+      MediaItem
+      |> where([m], m.tmdb_id == ^tmdb_id)
+      |> maybe_filter_type(opts[:type])
+      |> maybe_preload(opts[:preload])
+
+    case Repo.all(query) do
+      [item] ->
+        item
+
+      [] ->
+        nil
+
+      _items ->
+        Logger.warning(
+          "Ambiguous unscoped TMDB lookup for #{tmdb_id}: multiple media items exist across types"
+        )
+
+        nil
+    end
   end
 
   def get_media_item_by_tmdb(tmdb_id, opts) when is_binary(tmdb_id) and is_list(opts) do
@@ -233,11 +248,26 @@ defmodule Mydia.Media do
   end
 
   def get_media_item_by_tvdb(tvdb_id, opts) when is_integer(tvdb_id) do
-    MediaItem
-    |> where([m], m.tvdb_id == ^tvdb_id)
-    |> maybe_filter_type(opts[:type])
-    |> maybe_preload(opts[:preload])
-    |> Repo.one()
+    query =
+      MediaItem
+      |> where([m], m.tvdb_id == ^tvdb_id)
+      |> maybe_filter_type(opts[:type])
+      |> maybe_preload(opts[:preload])
+
+    case Repo.all(query) do
+      [item] ->
+        item
+
+      [] ->
+        nil
+
+      _items ->
+        Logger.warning(
+          "Ambiguous unscoped TVDB lookup for #{tvdb_id}: multiple media items exist across types"
+        )
+
+        nil
+    end
   end
 
   def get_media_item_by_tvdb(tvdb_id, opts) when is_binary(tvdb_id) and is_list(opts) do

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -180,14 +180,28 @@ defmodule Mydia.Media do
     |> Repo.one()
   end
 
+  def get_media_item_by_tmdb(tmdb_id, opts) when is_binary(tmdb_id) and is_list(opts) do
+    case Integer.parse(tmdb_id) do
+      {id, ""} -> get_media_item_by_tmdb(id, opts)
+      _ -> nil
+    end
+  end
+
   def get_media_item_by_tmdb(_, _), do: nil
 
   @doc """
   Gets a single media item by TMDB ID.
   """
-  @spec get_media_item_by_tmdb(integer()) :: MediaItem.t() | nil
+  @spec get_media_item_by_tmdb(integer() | String.t()) :: MediaItem.t() | nil
   def get_media_item_by_tmdb(tmdb_id) when is_integer(tmdb_id) do
     get_media_item_by_tmdb(tmdb_id, [])
+  end
+
+  def get_media_item_by_tmdb(tmdb_id) when is_binary(tmdb_id) do
+    case Integer.parse(tmdb_id) do
+      {id, ""} -> get_media_item_by_tmdb(id, [])
+      _ -> nil
+    end
   end
 
   def get_media_item_by_tmdb(_), do: nil
@@ -226,14 +240,28 @@ defmodule Mydia.Media do
     |> Repo.one()
   end
 
+  def get_media_item_by_tvdb(tvdb_id, opts) when is_binary(tvdb_id) and is_list(opts) do
+    case Integer.parse(tvdb_id) do
+      {id, ""} -> get_media_item_by_tvdb(id, opts)
+      _ -> nil
+    end
+  end
+
   def get_media_item_by_tvdb(_, _), do: nil
 
   @doc """
   Gets a single media item by TVDB ID.
   """
-  @spec get_media_item_by_tvdb(integer()) :: MediaItem.t() | nil
+  @spec get_media_item_by_tvdb(integer() | String.t()) :: MediaItem.t() | nil
   def get_media_item_by_tvdb(tvdb_id) when is_integer(tvdb_id) do
     get_media_item_by_tvdb(tvdb_id, [])
+  end
+
+  def get_media_item_by_tvdb(tvdb_id) when is_binary(tvdb_id) do
+    case Integer.parse(tvdb_id) do
+      {id, ""} -> get_media_item_by_tvdb(id, [])
+      _ -> nil
+    end
   end
 
   def get_media_item_by_tvdb(_), do: nil
@@ -1088,11 +1116,11 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  Returns a map of provider IDs to library status for efficient lookup.
+  Returns a map of `{media_type, provider, provider_id}` to library status for efficient lookup.
 
-  Returns a map where:
-  - TMDB IDs are integer keys: `12345 => %{...}`
-  - TVDB IDs are tuple keys: `{:tvdb, 67890} => %{...}`
+  Returns a map where keys are 3-tuples:
+  - `{:movie, :tmdb, 12345} => %{...}`
+  - `{:tv_show, :tvdb, 67890} => %{...}`
 
   Values are maps with:
   - `:in_library` - boolean
@@ -1104,8 +1132,8 @@ defmodule Mydia.Media do
 
       iex> get_library_status_map()
       %{
-        12345 => %{in_library: true, monitored: true, type: "movie", id: 1},
-        {:tvdb, 67890} => %{in_library: true, monitored: false, type: "tv_show", id: 2}
+        {:movie, :tmdb, 12345} => %{in_library: true, monitored: true, type: "movie", id: 1},
+        {:tv_show, :tvdb, 67890} => %{in_library: true, monitored: false, type: "tv_show", id: 2}
       }
   """
   @spec get_library_status_map() :: map()
@@ -1115,12 +1143,13 @@ defmodule Mydia.Media do
     |> select([m], {m.tmdb_id, m.tvdb_id, m.monitored, m.type, m.id})
     |> Repo.all()
     |> Enum.reduce(%{}, fn {tmdb_id, tvdb_id, monitored, type, id}, acc ->
+      type_atom = if type == "movie", do: :movie, else: :tv_show
       entry = %{in_library: true, monitored: monitored, type: type, id: id}
 
       acc =
-        if tmdb_id, do: Map.put(acc, tmdb_id, entry), else: acc
+        if tmdb_id, do: Map.put(acc, {type_atom, :tmdb, tmdb_id}, entry), else: acc
 
-      if tvdb_id, do: Map.put(acc, {:tvdb, tvdb_id}, entry), else: acc
+      if tvdb_id, do: Map.put(acc, {type_atom, :tvdb, tvdb_id}, entry), else: acc
     end)
   end
 

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -95,9 +95,36 @@ defmodule Mydia.Media.Add do
       |> Keyword.put(:config, config)
 
     case Media.create_media_item(attrs, create_opts) do
-      {:ok, media_item} -> {:ok, media_item}
-      {:error, changeset} -> {:error, {:changeset, changeset}}
+      {:ok, media_item} ->
+        {:ok, media_item}
+
+      {:error, changeset} ->
+        if provider_constraint_violation?(changeset) do
+          case existing_item(attrs) do
+            nil ->
+              {:error, {:changeset, changeset}}
+
+            incumbent ->
+              title = Map.get(attrs, :title) || Map.get(attrs, "title")
+
+              Logger.warning(
+                "[Add] Concurrent add detected for #{inspect(title)}, resolving to existing library item #{incumbent.id}"
+              )
+
+              {:error, {:already_in_library, backfill_ids(incumbent, attrs)}}
+          end
+        else
+          {:error, {:changeset, changeset}}
+        end
     end
+  end
+
+  defp provider_constraint_violation?(changeset) do
+    Enum.any?(changeset.errors, fn
+      {:tmdb_id, {_, opts}} -> opts[:constraint] == :unique
+      {:tvdb_id, {_, opts}} -> opts[:constraint] == :unique
+      _ -> false
+    end)
   end
 
   # The unique indexes on tmdb_id and tvdb_id turn "you already have this" into
@@ -123,13 +150,16 @@ defmodule Mydia.Media.Add do
   # declining the imdb leg here costs no coverage.
   defp existing_item(attrs) do
     xrefs = metadata_external_ids(attrs)
+    type = Map.get(attrs, :type) || Map.get(attrs, "type")
+    tmdb_id = Map.get(attrs, :tmdb_id) || Map.get(attrs, "tmdb_id")
+    tvdb_id = Map.get(attrs, :tvdb_id) || Map.get(attrs, "tvdb_id")
 
     Enum.find_value(
       [
-        %{tmdb: attrs[:tmdb_id], tvdb: attrs[:tvdb_id]},
+        %{tmdb: tmdb_id, tvdb: tvdb_id},
         %{tmdb: xrefs[:tmdb], tvdb: xrefs[:tvdb]}
       ],
-      &find_by_ids(&1, attrs[:type])
+      &find_by_ids(&1, type)
     )
   end
 
@@ -173,7 +203,8 @@ defmodule Mydia.Media.Add do
       %{tmdb_id: item.tmdb_id, tvdb_id: item.tvdb_id}
       |> ExternalIds.put_free_ids(%{tmdb: attrs[:tmdb_id], tvdb: xrefs[:tvdb]},
         exclude_id: item.id,
-        title: item.title
+        title: item.title,
+        type: item.type
       )
 
     changes =

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -157,7 +157,10 @@ defmodule Mydia.Media.Add do
     Enum.find_value(
       [
         %{tmdb: tmdb_id, tvdb: tvdb_id},
-        %{tmdb: xrefs[:tmdb], tvdb: xrefs[:tvdb]}
+        %{
+          tmdb: xrefs[:tmdb] || xrefs["tmdb"],
+          tvdb: xrefs[:tvdb] || xrefs["tvdb"]
+        }
       ],
       &find_by_ids(&1, type)
     )
@@ -176,8 +179,9 @@ defmodule Mydia.Media.Add do
   # the attrs. `external_ids` itself is nil on metadata written before
   # cross-provider ids were stored.
   defp metadata_external_ids(attrs) do
-    case attrs[:metadata] do
+    case Map.get(attrs, :metadata) || Map.get(attrs, "metadata") do
       %{external_ids: ids} when is_map(ids) -> ids
+      %{"external_ids" => ids} when is_map(ids) -> ids
       _ -> %{}
     end
   end
@@ -198,10 +202,12 @@ defmodule Mydia.Media.Add do
   # `Mydia.Jobs.MetadataBackfill`, which refreshes it from its own provider.
   defp backfill_ids(item, attrs) do
     xrefs = metadata_external_ids(attrs)
+    tmdb_id = Map.get(attrs, :tmdb_id) || Map.get(attrs, "tmdb_id")
+    tvdb_id = xrefs[:tvdb] || xrefs["tvdb"]
 
     merged =
       %{tmdb_id: item.tmdb_id, tvdb_id: item.tvdb_id}
-      |> ExternalIds.put_free_ids(%{tmdb: attrs[:tmdb_id], tvdb: xrefs[:tvdb]},
+      |> ExternalIds.put_free_ids(%{tmdb: tmdb_id, tvdb: tvdb_id},
         exclude_id: item.id,
         title: item.title,
         type: item.type

--- a/lib/mydia/media/external_ids.ex
+++ b/lib/mydia/media/external_ids.ex
@@ -39,6 +39,8 @@ defmodule Mydia.Media.ExternalIds do
 
     * `:exclude_id` - id of the media item being updated. A row writing its own
       id back is not a conflict.
+    * `:type` - media type used to scope provider id conflict lookups.
+      Defaults to `attrs[:type]`.
     * `:title` - title used in the warning when a conflict is reported.
       Defaults to `attrs[:title]`.
   """
@@ -55,11 +57,12 @@ defmodule Mydia.Media.ExternalIds do
 
   defp put_free_id(attrs, _provider, nil, _opts), do: attrs
 
-  defp put_free_id(attrs, provider, id, opts) do
+  defp put_free_id(attrs, provider, id, opts) when is_integer(id) do
     key = attrs_key(provider)
+    type = Map.get(attrs, :type) || Map.get(attrs, "type") || opts[:type]
 
     if is_nil(Map.get(attrs, key)) do
-      case conflicting_item(provider, id, opts[:exclude_id]) do
+      case conflicting_item(provider, id, type, opts[:exclude_id]) do
         nil -> Map.put(attrs, key, id)
         other -> report_conflict(attrs, provider, id, other, opts)
       end
@@ -68,19 +71,23 @@ defmodule Mydia.Media.ExternalIds do
     end
   end
 
+  defp put_free_id(attrs, _provider, _id, _opts), do: attrs
+
   defp attrs_key(:tmdb), do: :tmdb_id
   defp attrs_key(:tvdb), do: :tvdb_id
 
-  defp conflicting_item(provider, id, exclude_id) do
-    case lookup(provider, id) do
+  defp conflicting_item(provider, id, type, exclude_id) do
+    case lookup(provider, id, type) do
       nil -> nil
       %{id: ^exclude_id} -> nil
       item -> item
     end
   end
 
-  defp lookup(:tmdb, id), do: Media.get_media_item_by_tmdb(id)
-  defp lookup(:tvdb, id), do: Media.get_media_item_by_tvdb(id)
+  defp lookup(:tmdb, id, nil), do: Media.get_media_item_by_tmdb(id)
+  defp lookup(:tmdb, id, type), do: Media.get_media_item_by_tmdb(type, id)
+  defp lookup(:tvdb, id, nil), do: Media.get_media_item_by_tvdb(id)
+  defp lookup(:tvdb, id, type), do: Media.get_media_item_by_tvdb(type, id)
 
   defp report_conflict(attrs, provider, id, other, opts) do
     title = opts[:title] || Map.get(attrs, :title)

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -114,8 +114,13 @@ defmodule Mydia.Media.MediaItem do
     |> validate_inclusion(:type, @type_values)
     |> validate_number(:year, greater_than: 1800, less_than: 2200)
     |> validate_year_for_movies()
-    |> unique_constraint(:tmdb_id)
-    |> unique_constraint(:tvdb_id)
+    # Two names for one guarantee: Postgres reports the real index name
+    # (:media_items_type_*_unique_index). SQLite only gets column names
+    # and ecto_sqlite3 guesses :media_items_type_*_index.
+    |> unique_constraint(:tmdb_id, name: :media_items_type_tmdb_id_unique_index)
+    |> unique_constraint(:tmdb_id, name: :media_items_type_tmdb_id_index)
+    |> unique_constraint(:tvdb_id, name: :media_items_type_tvdb_id_unique_index)
+    |> unique_constraint(:tvdb_id, name: :media_items_type_tvdb_id_index)
     |> foreign_key_constraint(:quality_profile_id)
     |> foreign_key_constraint(:library_path_id)
   end

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -281,6 +281,7 @@ defmodule Mydia.MediaRequests do
     tvdb_id = Ecto.Changeset.get_field(changeset, :tvdb_id)
 
     cond do
+      is_nil(media_type) -> :ok
       tmdb_id && Media.get_media_item_by_tmdb(media_type, tmdb_id) -> {:error, :duplicate_media}
       tvdb_id && Media.get_media_item_by_tvdb(media_type, tvdb_id) -> {:error, :duplicate_media}
       true -> :ok
@@ -293,6 +294,7 @@ defmodule Mydia.MediaRequests do
     tvdb_id = Ecto.Changeset.get_field(changeset, :tvdb_id)
 
     cond do
+      is_nil(media_type) -> :ok
       tmdb_id && pending_request_exists?(media_type, tmdb_id) -> {:error, :duplicate_request}
       tvdb_id && pending_tvdb_request_exists?(media_type, tvdb_id) -> {:error, :duplicate_request}
       true -> :ok

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -250,8 +250,21 @@ defmodule Mydia.MediaRequests do
   end
 
   @doc """
-  Checks if a request with the given TMDB ID is pending.
+  Checks if a request with the given media type and TMDB ID is pending.
   """
+  def pending_request_exists?(media_type, tmdb_id)
+      when (is_binary(media_type) or is_atom(media_type)) and not is_nil(media_type) and
+             is_integer(tmdb_id) do
+    type_str = to_string(media_type)
+
+    MediaRequest
+    |> where([r], r.media_type == ^type_str and r.tmdb_id == ^tmdb_id and r.status == "pending")
+    |> Repo.exists?()
+  end
+
+  def pending_request_exists?(_, _), do: false
+
+  # Backward compatibility clause
   def pending_request_exists?(tmdb_id) when is_integer(tmdb_id) do
     MediaRequest
     |> where([r], r.tmdb_id == ^tmdb_id and r.status == "pending")
@@ -263,35 +276,40 @@ defmodule Mydia.MediaRequests do
   # Private functions
 
   defp check_duplicate_media(changeset) do
+    media_type = Ecto.Changeset.get_field(changeset, :media_type)
     tmdb_id = Ecto.Changeset.get_field(changeset, :tmdb_id)
     tvdb_id = Ecto.Changeset.get_field(changeset, :tvdb_id)
 
     cond do
-      tmdb_id && Media.get_media_item_by_tmdb(tmdb_id) -> {:error, :duplicate_media}
-      tvdb_id && Media.get_media_item_by_tvdb(tvdb_id) -> {:error, :duplicate_media}
+      tmdb_id && Media.get_media_item_by_tmdb(media_type, tmdb_id) -> {:error, :duplicate_media}
+      tvdb_id && Media.get_media_item_by_tvdb(media_type, tvdb_id) -> {:error, :duplicate_media}
       true -> :ok
     end
   end
 
   defp check_duplicate_request(changeset) do
+    media_type = Ecto.Changeset.get_field(changeset, :media_type)
     tmdb_id = Ecto.Changeset.get_field(changeset, :tmdb_id)
     tvdb_id = Ecto.Changeset.get_field(changeset, :tvdb_id)
 
     cond do
-      tmdb_id && pending_request_exists?(tmdb_id) -> {:error, :duplicate_request}
-      tvdb_id && pending_tvdb_request_exists?(tvdb_id) -> {:error, :duplicate_request}
+      tmdb_id && pending_request_exists?(media_type, tmdb_id) -> {:error, :duplicate_request}
+      tvdb_id && pending_tvdb_request_exists?(media_type, tvdb_id) -> {:error, :duplicate_request}
       true -> :ok
     end
   end
 
-  # A TVDB-sourced request has no tmdb_id, so pending_request_exists?/1 (which
-  # is documented and tested as TMDB-only) never sees it. Kept private and
-  # separate rather than widening that public function's contract.
-  defp pending_tvdb_request_exists?(tvdb_id) do
+  defp pending_tvdb_request_exists?(media_type, tvdb_id)
+       when (is_binary(media_type) or is_atom(media_type)) and not is_nil(media_type) and
+              is_integer(tvdb_id) do
+    type_str = to_string(media_type)
+
     MediaRequest
-    |> where([r], r.tvdb_id == ^tvdb_id and r.status == "pending")
+    |> where([r], r.media_type == ^type_str and r.tvdb_id == ^tvdb_id and r.status == "pending")
     |> Repo.exists?()
   end
+
+  defp pending_tvdb_request_exists?(_, _), do: false
 
   @doc """
   Automatically approves any pending requests matching the given media item.

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -90,12 +90,10 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   """
   def enrich_with_library_status(items, library_status_map) do
     Enum.map(items, fn item ->
-      provider_id_int = Add.parse_provider_id(item.provider_id)
+      key = item_library_key(item)
 
       library_status =
-        Map.get(library_status_map, provider_id_int) ||
-          Map.get(library_status_map, {:tvdb, provider_id_int}) ||
-          %{in_library: false}
+        Map.get(library_status_map, key) || fallback_library_status(item, library_status_map)
 
       Map.merge(item, %{
         in_library: library_status[:in_library] || false,
@@ -104,6 +102,61 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       })
     end)
   end
+
+  defp item_library_key(item) do
+    type = normalize_type(Map.get(item, :media_type))
+    provider = normalize_provider(Map.get(item, :provider))
+    provider_id = safe_parse_id(item)
+    {type, provider, provider_id}
+  end
+
+  defp fallback_library_status(item, library_status_map) do
+    type = normalize_type(Map.get(item, :media_type))
+    provider_id = safe_parse_id(item)
+    tmdb_id = Map.get(item, :tmdb_id)
+    tvdb_id = Map.get(item, :tvdb_id)
+
+    cond do
+      tmdb_id && Map.has_key?(library_status_map, {type, :tmdb, tmdb_id}) ->
+        Map.get(library_status_map, {type, :tmdb, tmdb_id})
+
+      tvdb_id && Map.has_key?(library_status_map, {type, :tvdb, tvdb_id}) ->
+        Map.get(library_status_map, {type, :tvdb, tvdb_id})
+
+      tmdb_id && Map.has_key?(library_status_map, tmdb_id) ->
+        Map.get(library_status_map, tmdb_id)
+
+      tvdb_id && Map.has_key?(library_status_map, {:tvdb, tvdb_id}) ->
+        Map.get(library_status_map, {:tvdb, tvdb_id})
+
+      provider_id && Map.has_key?(library_status_map, provider_id) ->
+        Map.get(library_status_map, provider_id)
+
+      provider_id && Map.has_key?(library_status_map, {:tvdb, provider_id}) ->
+        Map.get(library_status_map, {:tvdb, provider_id})
+
+      true ->
+        %{in_library: false}
+    end
+  end
+
+  defp safe_parse_id(item) do
+    case Map.get(item, :provider_id) do
+      nil -> nil
+      id -> Add.parse_provider_id(id)
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp normalize_type(:movie), do: :movie
+  defp normalize_type("movie"), do: :movie
+  defp normalize_type(:tv_show), do: :tv_show
+  defp normalize_type("tv_show"), do: :tv_show
+  defp normalize_type(_), do: :movie
+
+  defp normalize_provider(:tvdb), do: :tvdb
+  defp normalize_provider(_), do: :tmdb
 
   @doc """
   Builds media item attrs from metadata. See `Mydia.Media.Add.build_media_item_attrs/3`.
@@ -504,6 +557,8 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   # unless the add resolved a cross-reference), so a TVDB-only add no longer
   # writes anything into this slot.
   defp update_library_status_map(library_status_map, media_item) do
+    type_atom = if media_item.type == "movie", do: :movie, else: :tv_show
+
     entry = %{
       in_library: true,
       monitored: media_item.monitored,
@@ -513,13 +568,13 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
     map =
       if media_item.tmdb_id do
-        Map.put(library_status_map, media_item.tmdb_id, entry)
+        Map.put(library_status_map, {type_atom, :tmdb, media_item.tmdb_id}, entry)
       else
         library_status_map
       end
 
     if media_item.tvdb_id do
-      Map.put(map, {:tvdb, media_item.tvdb_id}, entry)
+      Map.put(map, {type_atom, :tvdb, media_item.tvdb_id}, entry)
     else
       map
     end

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -25,13 +25,12 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   @backfill_timeout 30_000
 
   @doc """
-  Maps a provider id to request status for every outstanding request.
+  Maps a `{media_type, provider, provider_id}` tuple to request status for every
+  outstanding request.
 
-  TMDB and TVDB ids are both plain integers and can collide (a movie and a
-  show sharing the same numeric id on their respective providers), so a TVDB
-  entry is keyed under a tagged `{:tvdb, id}` tuple, mirroring
-  `MediaAddHelpers.update_library_status_map/3`. A TMDB entry keeps the bare
-  integer key. `enrich_with_request_status/2` looks up the same tagged shape.
+  Canonical 3-tuple keys prevent collisions between movies and TV shows sharing
+  the same numeric ID on TMDB, and between TMDB and TVDB catalog IDs.
+  `enrich_with_request_status/2` looks up the same 3-tuple shape.
 
   Deliberately not scoped to a requester. `MediaRequests.create_request/1`
   rejects duplicates globally via `pending_request_exists?/1`, so a per-user map
@@ -59,30 +58,31 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
     end)
   end
 
-  # A request stores exactly one of tmdb_id/tvdb_id (see
-  # handle_request_media/3). TMDB keeps the plain integer key; TVDB is tagged
-  # so it cannot collide with a same-numbered TMDB id.
   defp status_map_key(request) do
+    type = MediaRequest.media_type_atom(request)
+
     case MediaRequest.external_ref(request) do
-      {:tmdb, id} -> id
-      {:tvdb, id} -> {:tvdb, id}
+      {:tmdb, id} -> {type, :tmdb, id}
+      {:tvdb, id} -> {type, :tvdb, id}
       nil -> nil
     end
   end
 
-  # Mirrors the write path in handle_request_media/3: only a TV show sourced
-  # from TVDB is stored (and therefore looked up) under the tagged key; every
-  # other case, movies always and TV shows sourced from TMDB, uses the bare
-  # provider id.
   defp item_status_key(item) do
+    type = normalize_type(Map.get(item, :media_type))
+    provider = normalize_provider(Map.get(item, :provider))
     provider_id = Add.parse_provider_id(item.provider_id)
-
-    if Map.get(item, :media_type) == :tv_show and Map.get(item, :provider) == :tvdb do
-      {:tvdb, provider_id}
-    else
-      provider_id
-    end
+    {type, provider, provider_id}
   end
+
+  defp normalize_type(:movie), do: :movie
+  defp normalize_type("movie"), do: :movie
+  defp normalize_type(:tv_show), do: :tv_show
+  defp normalize_type("tv_show"), do: :tv_show
+  defp normalize_type(_), do: :movie
+
+  defp normalize_provider(:tvdb), do: :tvdb
+  defp normalize_provider(_), do: :tmdb
 
   @doc """
   Submits a request for a trending card item.

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -71,8 +71,20 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   defp item_status_key(item) do
     type = normalize_type(Map.get(item, :media_type))
     provider = normalize_provider(Map.get(item, :provider))
-    provider_id = Add.parse_provider_id(item.provider_id)
-    {type, provider, provider_id}
+
+    case safe_parse_id(item) do
+      nil -> nil
+      provider_id -> {type, provider, provider_id}
+    end
+  end
+
+  defp safe_parse_id(item) do
+    case Map.get(item, :provider_id) do
+      nil -> nil
+      id -> Add.parse_provider_id(id)
+    end
+  rescue
+    ArgumentError -> nil
   end
 
   defp normalize_type(:movie), do: :movie

--- a/lib/mydia_web/live/media_live/show/detail_modal_events.ex
+++ b/lib/mydia_web/live/media_live/show/detail_modal_events.ex
@@ -161,8 +161,10 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalEvents do
     tmdb_ids = Enum.map(results, &RecommendationEvents.safe_provider_id/1)
 
     status = Mydia.Media.library_status_for_tmdb_ids(tmdb_ids, media_item.type)
+    media_type = if media_item.type == "tv_show", do: :tv_show, else: :movie
 
     results
+    |> Enum.map(&Map.put(&1, :media_type, media_type))
     |> MediaAddHelpers.enrich_with_library_status(status)
     |> MediaRequestHelpers.enrich_with_request_status(MediaRequestHelpers.request_status_map())
   end

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -241,11 +241,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
 
       entries =
         Enum.map(franchise.entries, fn entry ->
-          status =
-            Map.get(status_map, {:movie, :tmdb, entry.tmdb_id}) ||
-              Map.get(status_map, entry.tmdb_id)
-
-          %{entry | request_status: status}
+          %{entry | request_status: Map.get(status_map, {:movie, :tmdb, entry.tmdb_id})}
         end)
 
       %{franchise | entries: entries}

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -241,7 +241,11 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
 
       entries =
         Enum.map(franchise.entries, fn entry ->
-          %{entry | request_status: Map.get(status_map, entry.tmdb_id)}
+          status =
+            Map.get(status_map, {:movie, :tmdb, entry.tmdb_id}) ||
+              Map.get(status_map, entry.tmdb_id)
+
+          %{entry | request_status: status}
         end)
 
       %{franchise | entries: entries}

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -319,8 +319,10 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     tmdb_ids = Enum.map(results, &safe_provider_id/1)
 
     status = Media.library_status_for_tmdb_ids(tmdb_ids, media_item.type)
+    media_type = if media_item.type == "tv_show", do: :tv_show, else: :movie
 
     results
+    |> Enum.map(&Map.put(&1, :media_type, media_type))
     |> MediaAddHelpers.enrich_with_library_status(status)
     |> maybe_enrich_with_request_status(current_user)
     |> Enum.map(fn item ->

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -198,16 +198,20 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
           |> assign(:requesting_recommendation_id, nil)
           |> assign(
             :recommendations,
-            MediaRequestHelpers.enrich_with_request_status(
+            mark_requested(
               socket.assigns.recommendations,
-              status_updates
+              status_updates,
+              tmdb_id,
+              request.status
             )
           )
           |> assign(
             :selected_recommendations,
-            MediaRequestHelpers.enrich_with_request_status(
+            mark_requested(
               socket.assigns[:selected_recommendations] || [],
-              status_updates
+              status_updates,
+              tmdb_id,
+              request.status
             )
           )
 
@@ -357,6 +361,25 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     Add.parse_provider_id(result.provider_id)
   rescue
     ArgumentError -> nil
+  end
+
+  defp mark_requested(items, status_updates, tmdb_id, status) do
+    Enum.map(items, fn item ->
+      type = if Map.get(item, :media_type) in [:tv_show, "tv_show"], do: :tv_show, else: :movie
+      provider = if Map.get(item, :provider) == :tvdb, do: :tvdb, else: :tmdb
+      id = safe_provider_id(item)
+
+      cond do
+        Map.has_key?(status_updates, {type, provider, id}) ->
+          Map.put(item, :request_status, Map.get(status_updates, {type, provider, id}))
+
+        to_string(Map.get(item, :provider_id)) == to_string(tmdb_id) ->
+          Map.put(item, :request_status, status)
+
+        true ->
+          item
+      end
+    end)
   end
 
   defp mark_in_flight(socket, tmdb_id) do

--- a/priv/repo/migrations/20260905120000_scope_provider_ids_by_media_type.exs
+++ b/priv/repo/migrations/20260905120000_scope_provider_ids_by_media_type.exs
@@ -1,7 +1,7 @@
 defmodule Mydia.Repo.Migrations.ScopeProviderIdsByMediaType do
   use Ecto.Migration
 
-  def change do
+  def up do
     # Drop legacy single-column unique indexes on media_items
     drop_if_exists index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
     drop_if_exists index(:media_items, [:tvdb_id], name: :media_items_tvdb_id_index)
@@ -25,6 +25,31 @@ defmodule Mydia.Repo.Migrations.ScopeProviderIdsByMediaType do
 
     create index(:media_requests, [:media_type, :tvdb_id, :status],
              name: :media_requests_type_tvdb_id_status_index
+           )
+  end
+
+  def down do
+    drop_if_exists index(:media_requests, [:media_type, :tvdb_id, :status],
+                     name: :media_requests_type_tvdb_id_status_index
+                   )
+
+    drop_if_exists index(:media_requests, [:media_type, :tmdb_id, :status],
+                     name: :media_requests_type_tmdb_id_status_index
+                   )
+
+    drop_if_exists index(:media_items, [:type, :tvdb_id],
+                     name: :media_items_type_tvdb_id_unique_index
+                   )
+
+    drop_if_exists index(:media_items, [:type, :tmdb_id],
+                     name: :media_items_type_tmdb_id_unique_index
+                   )
+
+    create unique_index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
+
+    create unique_index(:media_items, [:tvdb_id],
+             where: "tvdb_id IS NOT NULL",
+             name: :media_items_tvdb_id_index
            )
   end
 end

--- a/priv/repo/migrations/20260905120000_scope_provider_ids_by_media_type.exs
+++ b/priv/repo/migrations/20260905120000_scope_provider_ids_by_media_type.exs
@@ -1,0 +1,30 @@
+defmodule Mydia.Repo.Migrations.ScopeProviderIdsByMediaType do
+  use Ecto.Migration
+
+  def change do
+    # Drop legacy single-column unique indexes on media_items
+    drop_if_exists index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
+    drop_if_exists index(:media_items, [:tvdb_id], name: :media_items_tvdb_id_index)
+    drop_if_exists index(:media_items, [:tvdb_id], name: :media_items_tvdb_id_unique_index)
+
+    # Add composite partial unique indexes on media_items
+    create unique_index(:media_items, [:type, :tmdb_id],
+             where: "tmdb_id IS NOT NULL",
+             name: :media_items_type_tmdb_id_unique_index
+           )
+
+    create unique_index(:media_items, [:type, :tvdb_id],
+             where: "tvdb_id IS NOT NULL",
+             name: :media_items_type_tvdb_id_unique_index
+           )
+
+    # Add query indexes on media_requests
+    create index(:media_requests, [:media_type, :tmdb_id, :status],
+             name: :media_requests_type_tmdb_id_status_index
+           )
+
+    create index(:media_requests, [:media_type, :tvdb_id, :status],
+             name: :media_requests_type_tvdb_id_status_index
+           )
+  end
+end

--- a/test/mydia/media/add_test.exs
+++ b/test/mydia/media/add_test.exs
@@ -477,6 +477,58 @@ defmodule Mydia.Media.AddTest do
       assert found.tvdb_id == exact_tvdb_id
     end
 
+    test "backfills ids when attrs contain string keys" do
+      tmdb_id = System.unique_integer([:positive])
+      exact_tvdb_id = System.unique_integer([:positive])
+
+      existing_series =
+        Mydia.MediaFixtures.media_item_fixture(%{
+          type: "tv_show",
+          title: "String Key Series",
+          tmdb_id: tmdb_id,
+          tvdb_id: nil
+        })
+
+      attrs = %{
+        "type" => "tv_show",
+        "title" => "String Key Series",
+        "tmdb_id" => tmdb_id,
+        "metadata" => %{
+          external_ids: %{tvdb: exact_tvdb_id}
+        }
+      }
+
+      assert {:error, {:already_in_library, found}} = Add.from_attrs(attrs)
+      assert found.id == existing_series.id
+      assert found.tvdb_id == exact_tvdb_id
+      assert Mydia.Media.get_media_item!(existing_series.id).tvdb_id == exact_tvdb_id
+
+      other_tmdb_id = System.unique_integer([:positive])
+      other_tvdb_id = System.unique_integer([:positive])
+
+      existing_with_tvdb =
+        Mydia.MediaFixtures.media_item_fixture(%{
+          type: "tv_show",
+          title: "Another String Key Series",
+          tmdb_id: nil,
+          tvdb_id: other_tvdb_id
+        })
+
+      attrs_tvdb = %{
+        "type" => "tv_show",
+        "title" => "Another String Key Series",
+        "tmdb_id" => other_tmdb_id,
+        "metadata" => %{
+          external_ids: %{"tvdb" => other_tvdb_id}
+        }
+      }
+
+      assert {:error, {:already_in_library, found_tvdb}} = Add.from_attrs(attrs_tvdb)
+      assert found_tvdb.id == existing_with_tvdb.id
+      assert found_tvdb.tmdb_id == other_tmdb_id
+      assert Mydia.Media.get_media_item!(existing_with_tvdb.id).tmdb_id == other_tmdb_id
+    end
+
     test "from_attrs/3 resolves unique constraint collision to already_in_library" do
       shared_id = System.unique_integer([:positive])
 

--- a/test/mydia/media/add_test.exs
+++ b/test/mydia/media/add_test.exs
@@ -4,6 +4,7 @@ defmodule Mydia.Media.AddTest do
   import ExUnit.CaptureLog
   import Mydia.SettingsFixtures
 
+  alias Mydia.Media
   alias Mydia.Media.Add
   alias Mydia.Media.MediaItem
 
@@ -474,6 +475,52 @@ defmodule Mydia.Media.AddTest do
 
       assert found.id == existing.id
       assert found.tvdb_id == exact_tvdb_id
+    end
+
+    test "from_attrs/3 resolves unique constraint collision to already_in_library" do
+      shared_id = System.unique_integer([:positive])
+
+      attrs = %{
+        type: "movie",
+        title: "Concurrent Movie",
+        year: 2024,
+        tmdb_id: shared_id
+      }
+
+      # Insert incumbent directly to simulate race after pre-flight check
+      {:ok, incumbent} = Media.create_media_item(attrs)
+
+      # Attempting from_attrs with same attrs returns {:error, {:already_in_library, ...}}
+      assert {:error, {:already_in_library, found}} = Add.from_attrs(attrs)
+      assert found.id == incumbent.id
+    end
+
+    test "from_attrs/3 handles concurrent inserts gracefully" do
+      shared_id = System.unique_integer([:positive])
+
+      attrs = %{
+        type: "movie",
+        title: "Concurrent Race Movie",
+        year: 2024,
+        tmdb_id: shared_id
+      }
+
+      tasks =
+        for _ <- 1..2 do
+          Task.async(fn -> Add.from_attrs(attrs) end)
+        end
+
+      results = Task.await_many(tasks)
+
+      assert Enum.count(results, &match?({:ok, _}, &1)) == 1
+      assert Enum.count(results, &match?({:error, {:already_in_library, _}}, &1)) == 1
+
+      {:ok, item} = Enum.find(results, &match?({:ok, _}, &1))
+
+      {:error, {:already_in_library, found}} =
+        Enum.find(results, &match?({:error, {:already_in_library, _}}, &1))
+
+      assert found.id == item.id
     end
   end
 end

--- a/test/mydia/media/external_ids_test.exs
+++ b/test/mydia/media/external_ids_test.exs
@@ -5,7 +5,26 @@ defmodule Mydia.Media.ExternalIdsTest do
   import Mydia.MediaFixtures
 
   alias Mydia.Events
+  alias Mydia.Media
   alias Mydia.Media.ExternalIds
+
+  test "does not conflict with an existing item of a different media type" do
+    shared_id = System.unique_integer([:positive])
+
+    {:ok, _movie} =
+      Media.create_media_item(%{
+        type: "movie",
+        title: "Existing Movie",
+        year: 2024,
+        tmdb_id: shared_id
+      })
+
+    attrs = %{type: "tv_show", title: "Incoming Series"}
+    external_ids = %{tmdb: shared_id}
+
+    result = ExternalIds.put_free_ids(attrs, external_ids)
+    assert result[:tmdb_id] == shared_id
+  end
 
   test "adds ids that no other row owns" do
     attrs = %{type: "tv_show", title: "New Show", tmdb_id: 1399}

--- a/test/mydia/media/library_status_test.exs
+++ b/test/mydia/media/library_status_test.exs
@@ -50,4 +50,56 @@ defmodule Mydia.Media.LibraryStatusTest do
 
     assert id == unmonitored.id
   end
+
+  describe "get_library_status_map/0" do
+    test "keys movie entries by {:movie, :tmdb, tmdb_id}" do
+      movie = media_item_fixture(%{type: "movie", title: "Movie Status", tmdb_id: 12345})
+
+      status = Media.get_library_status_map()
+
+      assert %{in_library: true, monitored: true, type: "movie", id: id} =
+               status[{:movie, :tmdb, 12345}]
+
+      assert id == movie.id
+    end
+
+    test "keys tv show entries with tmdb_id and tvdb_id" do
+      series =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Series Status",
+          tmdb_id: 67890,
+          tvdb_id: 54321
+        })
+
+      status = Media.get_library_status_map()
+
+      assert %{in_library: true, type: "tv_show", id: id} = status[{:tv_show, :tmdb, 67890}]
+      assert id == series.id
+      assert %{in_library: true, type: "tv_show", id: ^id} = status[{:tv_show, :tvdb, 54321}]
+    end
+
+    test "differentiates movie and tv show with identical numeric tmdb_id" do
+      shared_id = System.unique_integer([:positive])
+
+      movie =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Shared Movie",
+          tmdb_id: shared_id
+        })
+
+      show =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Shared Show",
+          tmdb_id: shared_id
+        })
+
+      status = Media.get_library_status_map()
+
+      assert status[{:movie, :tmdb, shared_id}].id == movie.id
+      assert status[{:tv_show, :tmdb, shared_id}].id == show.id
+    end
+  end
 end

--- a/test/mydia/media/media_item_test.exs
+++ b/test/mydia/media/media_item_test.exs
@@ -1,7 +1,109 @@
 defmodule Mydia.Media.MediaItemTest do
-  use ExUnit.Case, async: true
+  use Mydia.DataCase, async: true
 
   alias Mydia.Media.MediaItem
+
+  describe "provider-id uniqueness scoped by media type" do
+    test "allows movie and tv_show to share the same tmdb_id" do
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _movie} =
+        %MediaItem{}
+        |> MediaItem.changeset(%{
+          type: "movie",
+          title: "Movie Shared",
+          year: 2024,
+          tmdb_id: shared_id
+        })
+        |> Repo.insert()
+
+      assert {:ok, _series} =
+               %MediaItem{}
+               |> MediaItem.changeset(%{
+                 type: "tv_show",
+                 title: "Series Shared",
+                 year: 2024,
+                 tmdb_id: shared_id
+               })
+               |> Repo.insert()
+    end
+
+    test "rejects two movies sharing the same tmdb_id" do
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _movie1} =
+        %MediaItem{}
+        |> MediaItem.changeset(%{
+          type: "movie",
+          title: "Movie 1",
+          year: 2024,
+          tmdb_id: shared_id
+        })
+        |> Repo.insert()
+
+      assert {:error, changeset} =
+               %MediaItem{}
+               |> MediaItem.changeset(%{
+                 type: "movie",
+                 title: "Movie 2",
+                 year: 2024,
+                 tmdb_id: shared_id
+               })
+               |> Repo.insert()
+
+      assert %{tmdb_id: ["has already been taken"]} = errors_on(changeset)
+    end
+
+    test "allows movie and tv_show to share the same tvdb_id" do
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _movie} =
+        %MediaItem{}
+        |> MediaItem.changeset(%{
+          type: "movie",
+          title: "Movie Shared TVDB",
+          year: 2024,
+          tvdb_id: shared_id
+        })
+        |> Repo.insert()
+
+      assert {:ok, _series} =
+               %MediaItem{}
+               |> MediaItem.changeset(%{
+                 type: "tv_show",
+                 title: "Series Shared TVDB",
+                 year: 2024,
+                 tvdb_id: shared_id
+               })
+               |> Repo.insert()
+    end
+
+    test "rejects two tv_shows sharing the same tvdb_id" do
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _series1} =
+        %MediaItem{}
+        |> MediaItem.changeset(%{
+          type: "tv_show",
+          title: "Series 1",
+          year: 2024,
+          tvdb_id: shared_id
+        })
+        |> Repo.insert()
+
+      assert {:error, changeset} =
+               %MediaItem{}
+               |> MediaItem.changeset(%{
+                 type: "tv_show",
+                 title: "Series 2",
+                 year: 2024,
+                 tvdb_id: shared_id
+               })
+               |> Repo.insert()
+
+      assert %{tvdb_id: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
 
   describe "changeset/2 metadata_source" do
     test "casts :tvdb" do

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -2,7 +2,6 @@ defmodule Mydia.MediaRequestsTest do
   use Mydia.DataCase, async: false
   use Oban.Testing, repo: Mydia.Repo
 
-  import ExUnit.CaptureLog
   import Mydia.SettingsFixtures
 
   alias Mydia.MediaRequests
@@ -194,6 +193,111 @@ defmodule Mydia.MediaRequestsTest do
 
       assert {:error, :duplicate_media} = MediaRequests.create_request(attrs)
     end
+
+    test "allows requesting a movie when a TV show with the same tmdb_id is in the library" do
+      user = create_user()
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _show} =
+        Media.create_media_item(
+          %{
+            type: "tv_show",
+            title: "Existing Show",
+            year: 2024,
+            tmdb_id: shared_id
+          },
+          skip_episode_refresh: true
+        )
+
+      assert {:ok, request} =
+               MediaRequests.create_request(%{
+                 media_type: "movie",
+                 title: "Fight Club",
+                 year: 1999,
+                 tmdb_id: shared_id,
+                 requester_id: user.id
+               })
+
+      assert request.media_type == "movie"
+      assert request.tmdb_id == shared_id
+    end
+
+    test "allows requesting a movie when a TV show request with the same tmdb_id is pending" do
+      user = create_user()
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _req} =
+        MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "Existing TV Show Request",
+          tmdb_id: shared_id,
+          requester_id: user.id
+        })
+
+      assert {:ok, request} =
+               MediaRequests.create_request(%{
+                 media_type: "movie",
+                 title: "Fight Club",
+                 year: 1999,
+                 tmdb_id: shared_id,
+                 requester_id: user.id
+               })
+
+      assert request.media_type == "movie"
+      assert request.tmdb_id == shared_id
+    end
+
+    test "allows requesting a movie when a TV show with the same tvdb_id is in the library" do
+      user = create_user()
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _show} =
+        Media.create_media_item(
+          %{
+            type: "tv_show",
+            title: "Existing Show",
+            tvdb_id: shared_id
+          },
+          skip_episode_refresh: true
+        )
+
+      assert {:ok, request} =
+               MediaRequests.create_request(%{
+                 media_type: "movie",
+                 title: "Fight Club",
+                 year: 1999,
+                 tvdb_id: shared_id,
+                 requester_id: user.id
+               })
+
+      assert request.media_type == "movie"
+      assert request.tvdb_id == shared_id
+    end
+
+    test "allows requesting a movie when a TV show with the same tvdb_id is pending" do
+      user = create_user()
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _req} =
+        MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "Existing TV Show Request",
+          tvdb_id: shared_id,
+          requester_id: user.id
+        })
+
+      assert {:ok, request} =
+               MediaRequests.create_request(%{
+                 media_type: "movie",
+                 title: "Fight Club",
+                 year: 1999,
+                 tvdb_id: shared_id,
+                 requester_id: user.id
+               })
+
+      assert request.media_type == "movie"
+      assert request.tvdb_id == shared_id
+    end
   end
 
   describe "approve_request/2" do
@@ -260,53 +364,39 @@ defmodule Mydia.MediaRequestsTest do
       assert %{approved_by_id: ["can't be blank"]} = errors_on(changeset)
     end
 
-    # `Add.from_attrs/3`'s pre-flight is scoped to the request's own media type,
-    # while the unique index on tmdb_id is global. A movie holding the id is
-    # therefore invisible to the lookup and only the index catches it, which is
-    # the one path left that reaches insert_approval/4's media_item rollback.
-    # Pinning the behaviour here: closing the cross-type gap needs a composite
-    # (type, tmdb_id) index and so a migration.
-    test "rolls back and leaves the request pending when the other media type owns the tmdb_id",
-         %{user: user, admin: admin} do
+    test "approving a request for a TV show succeeds when a movie with same tmdb_id exists in library",
+         %{admin: admin, user: user} do
       bypass = Bypass.open()
-      tmdb_id = System.unique_integer([:positive])
+      shared_id = System.unique_integer([:positive])
 
-      request =
-        create_request(user, %{media_type: "tv_show", title: "Crossed Type", tmdb_id: tmdb_id})
-
-      # Filed first, so create_request/1's own duplicate check does not fire:
-      # the movie lands in the library while the request sits pending.
-      {:ok, movie} =
+      {:ok, _movie} =
         Media.create_media_item(%{
           type: "movie",
-          title: "Crossed Type",
-          year: 2023,
-          tmdb_id: tmdb_id
+          title: "Existing Movie",
+          year: 2024,
+          tmdb_id: shared_id
         })
 
-      stub_tmdb_tv_show(bypass, tmdb_id, "Crossed Type")
+      request =
+        create_request(user, %{
+          media_type: "tv_show",
+          title: "Crossed Type Show",
+          tmdb_id: shared_id
+        })
+
+      stub_tmdb_tv_show(bypass, shared_id, "Crossed Type Show")
       stub_tvdb_search_empty(bypass)
 
-      before_count = Repo.aggregate(MediaItem, :count)
+      assert {:ok, %{request: approved, media_item: created_item}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: relay_config(bypass)
+               )
 
-      log =
-        capture_log(fn ->
-          assert {:error, %Ecto.Changeset{} = changeset} =
-                   MediaRequests.approve_request(request, %{approved_by_id: admin.id},
-                     config: relay_config(bypass)
-                   )
-
-          assert %{tmdb_id: ["has already been taken"]} = errors_on(changeset)
-        end)
-
-      assert log =~ "Failed to create media item for request #{request.id}"
-
-      reloaded = Repo.get!(MediaRequest, request.id)
-      assert reloaded.status == "pending"
-      assert is_nil(reloaded.media_item_id)
-
-      assert Repo.aggregate(MediaItem, :count) == before_count
-      assert Media.get_media_item_by_tmdb(tmdb_id).id == movie.id
+      assert approved.status == "approved"
+      assert approved.media_item_id != nil
+      assert created_item.id == approved.media_item_id
+      assert created_item.type == "tv_show"
+      assert created_item.tmdb_id == shared_id
     end
   end
 
@@ -655,7 +745,7 @@ defmodule Mydia.MediaRequestsTest do
     end
   end
 
-  describe "pending_request_exists?/1" do
+  describe "pending_request_exists?" do
     setup do
       user = create_user()
       %{user: user}
@@ -666,6 +756,26 @@ defmodule Mydia.MediaRequestsTest do
 
       assert MediaRequests.pending_request_exists?(12345) == true
       assert MediaRequests.pending_request_exists?(99999) == false
+    end
+
+    test "pending_request_exists?/2 differentiates by media_type" do
+      user = create_user()
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _req} =
+        MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "Wheel of Fortune",
+          tmdb_id: shared_id,
+          requester_id: user.id
+        })
+
+      assert MediaRequests.pending_request_exists?(:tv_show, shared_id) == true
+      assert MediaRequests.pending_request_exists?("tv_show", shared_id) == true
+      assert MediaRequests.pending_request_exists?(:movie, shared_id) == false
+      assert MediaRequests.pending_request_exists?("movie", shared_id) == false
+      assert MediaRequests.pending_request_exists?(nil, shared_id) == false
+      assert MediaRequests.pending_request_exists?(:tv_show, nil) == false
     end
 
     test "returns false for nil or invalid input" do

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -298,6 +298,28 @@ defmodule Mydia.MediaRequestsTest do
       assert request.media_type == "movie"
       assert request.tvdb_id == shared_id
     end
+
+    test "returns changeset error when media_type is omitted with tmdb_id or tvdb_id" do
+      user = create_user()
+
+      assert {:error, changeset} =
+               MediaRequests.create_request(%{
+                 title: "Missing Type TMDB",
+                 tmdb_id: 12345,
+                 requester_id: user.id
+               })
+
+      assert "can't be blank" in errors_on(changeset).media_type
+
+      assert {:error, changeset} =
+               MediaRequests.create_request(%{
+                 title: "Missing Type TVDB",
+                 tvdb_id: 67890,
+                 requester_id: user.id
+               })
+
+      assert "can't be blank" in errors_on(changeset).media_type
+    end
   end
 
   describe "approve_request/2" do

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -52,6 +52,70 @@ defmodule Mydia.MediaTest do
       assert Media.get_media_item!(media_item.id) == media_item
     end
 
+    test "get_media_item_by_tmdb/2 and /3 filters by type" do
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, movie} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "Movie Title",
+          year: 2024,
+          tmdb_id: shared_id
+        })
+
+      {:ok, series} =
+        Media.create_media_item(
+          %{
+            type: "tv_show",
+            title: "Series Title",
+            year: 2024,
+            tmdb_id: shared_id
+          },
+          skip_episode_refresh: true
+        )
+
+      assert Media.get_media_item_by_tmdb("movie", shared_id).id == movie.id
+      assert Media.get_media_item_by_tmdb(:movie, shared_id).id == movie.id
+      assert Media.get_media_item_by_tmdb("tv_show", shared_id).id == series.id
+      assert Media.get_media_item_by_tmdb(:tv_show, shared_id).id == series.id
+      assert Media.get_media_item_by_tmdb(shared_id, type: "movie").id == movie.id
+      assert Media.get_media_item_by_tmdb(shared_id, type: :tv_show).id == series.id
+      assert Media.get_media_item_by_tmdb("movie", System.unique_integer([:positive])) == nil
+      assert Media.get_media_item_by_tmdb(nil) == nil
+    end
+
+    test "get_media_item_by_tvdb/2 and /3 filters by type" do
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, movie} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "Movie Title",
+          year: 2024,
+          tvdb_id: shared_id
+        })
+
+      {:ok, series} =
+        Media.create_media_item(
+          %{
+            type: "tv_show",
+            title: "Series Title",
+            year: 2024,
+            tvdb_id: shared_id
+          },
+          skip_episode_refresh: true
+        )
+
+      assert Media.get_media_item_by_tvdb("movie", shared_id).id == movie.id
+      assert Media.get_media_item_by_tvdb(:movie, shared_id).id == movie.id
+      assert Media.get_media_item_by_tvdb("tv_show", shared_id).id == series.id
+      assert Media.get_media_item_by_tvdb(:tv_show, shared_id).id == series.id
+      assert Media.get_media_item_by_tvdb(shared_id, type: "movie").id == movie.id
+      assert Media.get_media_item_by_tvdb(shared_id, type: :tv_show).id == series.id
+      assert Media.get_media_item_by_tvdb("movie", System.unique_integer([:positive])) == nil
+      assert Media.get_media_item_by_tvdb(nil) == nil
+    end
+
     test "create_media_item/1 with valid data creates a media item" do
       valid_attrs = %{
         type: "movie",

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -83,6 +83,7 @@ defmodule Mydia.MediaTest do
       assert Media.get_media_item_by_tmdb("movie", System.unique_integer([:positive])) == nil
       assert Media.get_media_item_by_tmdb(nil) == nil
       assert Media.get_media_item_by_tmdb(nil, 550) == nil
+      assert Media.get_media_item_by_tmdb(shared_id) == nil
     end
 
     test "get_media_item_by_tvdb/2 and /3 filters by type" do
@@ -116,6 +117,7 @@ defmodule Mydia.MediaTest do
       assert Media.get_media_item_by_tvdb("movie", System.unique_integer([:positive])) == nil
       assert Media.get_media_item_by_tvdb(nil) == nil
       assert Media.get_media_item_by_tvdb(nil, 550) == nil
+      assert Media.get_media_item_by_tvdb(shared_id) == nil
     end
 
     test "get_media_item_by_tmdb and get_media_item_by_tvdb return nil immediately when type is nil" do

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -82,6 +82,7 @@ defmodule Mydia.MediaTest do
       assert Media.get_media_item_by_tmdb(shared_id, type: :tv_show).id == series.id
       assert Media.get_media_item_by_tmdb("movie", System.unique_integer([:positive])) == nil
       assert Media.get_media_item_by_tmdb(nil) == nil
+      assert Media.get_media_item_by_tmdb(nil, 550) == nil
     end
 
     test "get_media_item_by_tvdb/2 and /3 filters by type" do
@@ -114,6 +115,14 @@ defmodule Mydia.MediaTest do
       assert Media.get_media_item_by_tvdb(shared_id, type: :tv_show).id == series.id
       assert Media.get_media_item_by_tvdb("movie", System.unique_integer([:positive])) == nil
       assert Media.get_media_item_by_tvdb(nil) == nil
+      assert Media.get_media_item_by_tvdb(nil, 550) == nil
+    end
+
+    test "get_media_item_by_tmdb and get_media_item_by_tvdb return nil immediately when type is nil" do
+      assert Media.get_media_item_by_tmdb(nil, 550) == nil
+      assert Media.get_media_item_by_tmdb(nil, 550, []) == nil
+      assert Media.get_media_item_by_tvdb(nil, 550) == nil
+      assert Media.get_media_item_by_tvdb(nil, 550, []) == nil
     end
 
     test "create_media_item/1 with valid data creates a media item" do

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -225,8 +225,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
 
       assert item.tvdb_id == tvdb_id
       assert item.tmdb_id == nil
-      assert updated_map[{:tvdb, tvdb_id}][:in_library] == true
+      assert updated_map[{:tv_show, :tvdb, tvdb_id}][:in_library] == true
       refute Map.has_key?(updated_map, tvdb_id)
+      refute Map.has_key?(updated_map, {:movie, :tmdb, tvdb_id})
     end
   end
 
@@ -264,7 +265,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
                MediaAddHelpers.handle_add_media_to_library({:tmdb, id}, :movie, %{}, config)
 
       assert item.id == existing.id
-      assert updated_map[id][:in_library] == true
+      assert updated_map[{:movie, :tmdb, id}][:in_library] == true
     end
   end
 
@@ -754,6 +755,113 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
 
       refute_received {:add, "551"}
       assert MapSet.to_list(socket.assigns.adding_item_ids) == ["551"]
+    end
+  end
+
+  describe "enrich_with_library_status/2" do
+    test "enriches items matching canonical 3-tuple keys" do
+      movie_id = System.unique_integer([:positive])
+      series_id = System.unique_integer([:positive])
+
+      library_status_map = %{
+        {:movie, :tmdb, movie_id} => %{in_library: true, monitored: true, type: "movie", id: 101},
+        {:tv_show, :tvdb, series_id} => %{
+          in_library: true,
+          monitored: false,
+          type: "tv_show",
+          id: 102
+        }
+      }
+
+      movie_item = %{
+        provider_id: to_string(movie_id),
+        provider: :tmdb,
+        media_type: :movie,
+        title: "Movie"
+      }
+
+      series_item = %{
+        provider_id: to_string(series_id),
+        provider: :tvdb,
+        media_type: :tv_show,
+        title: "Series"
+      }
+
+      unowned_item = %{
+        provider_id: "999999",
+        provider: :tmdb,
+        media_type: :movie,
+        title: "Unowned"
+      }
+
+      [enriched_movie, enriched_series, enriched_unowned] =
+        MediaAddHelpers.enrich_with_library_status(
+          [movie_item, series_item, unowned_item],
+          library_status_map
+        )
+
+      assert enriched_movie.in_library == true
+      assert enriched_movie.monitored == true
+      assert enriched_movie.id == 101
+
+      assert enriched_series.in_library == true
+      assert enriched_series.monitored == false
+      assert enriched_series.id == 102
+
+      assert enriched_unowned.in_library == false
+      assert enriched_unowned.monitored == false
+      assert is_nil(enriched_unowned.id)
+    end
+
+    test "differentiates TMDB TV show from TMDB movie with identical numeric id" do
+      shared_id = System.unique_integer([:positive])
+
+      library_status_map = %{
+        {:tv_show, :tmdb, shared_id} => %{
+          in_library: true,
+          monitored: true,
+          type: "tv_show",
+          id: 201
+        }
+      }
+
+      movie_item = %{
+        provider_id: to_string(shared_id),
+        provider: :tmdb,
+        media_type: :movie,
+        title: "Shared Movie"
+      }
+
+      series_item = %{
+        provider_id: to_string(shared_id),
+        provider: :tmdb,
+        media_type: :tv_show,
+        title: "Shared Show"
+      }
+
+      [enriched_movie, enriched_series] =
+        MediaAddHelpers.enrich_with_library_status(
+          [movie_item, series_item],
+          library_status_map
+        )
+
+      assert enriched_movie.in_library == false
+      assert is_nil(enriched_movie.id)
+
+      assert enriched_series.in_library == true
+      assert enriched_series.id == 201
+    end
+
+    test "falls back to bare integer keys in library_status_map" do
+      id = System.unique_integer([:positive])
+      library_status_map = %{id => %{in_library: true, monitored: true, type: "movie", id: 301}}
+
+      item = %{provider_id: to_string(id), provider: :tmdb, media_type: :movie}
+
+      [enriched] = MediaAddHelpers.enrich_with_library_status([item], library_status_map)
+
+      assert enriched.in_library == true
+      assert enriched.id == 301
     end
   end
 end

--- a/test/mydia_web/live/helpers/media_request_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_request_helpers_test.exs
@@ -247,5 +247,19 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
       assert is_nil(enriched_movie.request_status)
       assert enriched_series.request_status == "pending"
     end
+
+    test "handles items with missing, nil, or invalid provider_id without crashing" do
+      items = [
+        %{title: "Missing Provider ID"},
+        %{title: "Nil Provider ID", provider_id: nil},
+        %{title: "Invalid Provider ID", provider_id: "not-an-integer"}
+      ]
+
+      map = %{{:movie, :tmdb, 123} => "pending"}
+
+      enriched = MediaRequestHelpers.enrich_with_request_status(items, map)
+      assert length(enriched) == 3
+      assert Enum.all?(enriched, &is_nil(&1.request_status))
+    end
   end
 end

--- a/test/mydia_web/live/helpers/media_request_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_request_helpers_test.exs
@@ -57,7 +57,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
       assert request.tmdb_id == tmdb_id
       assert request.status == "pending"
       assert request.requester_id == user.id
-      assert map[tmdb_id] == "pending"
+      assert map[{:movie, :tmdb, tmdb_id}] == "pending"
     end
 
     test "reports a duplicate when a pending request already exists" do
@@ -102,9 +102,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
       assert request.tvdb_id == tvdb_id
       assert is_nil(request.tmdb_id)
       assert MediaRequest.external_ref(request) == {:tvdb, tvdb_id}
-      # Tagged, not bare: a bare key would collide with a TMDB movie or show
-      # that happens to share this same numeric id.
-      assert map[{:tvdb, tvdb_id}] == "pending"
+      assert map[{:tv_show, :tvdb, tvdb_id}] == "pending"
     end
 
     # There is no TVDB movie catalog, so a movie card tagged provider: :tvdb
@@ -144,7 +142,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
 
       # The second guest must see it as already requested: create_request/1
       # rejects duplicates globally, so an enabled button would only error.
-      assert MediaRequestHelpers.request_status_map()[tmdb_id] == "pending"
+      assert MediaRequestHelpers.request_status_map()[{:movie, :tmdb, tmdb_id}] == "pending"
       assert second.id != first.id
     end
 
@@ -160,9 +158,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
           requester_id: guest_user.id
         })
 
-      # Tagged, not bare: a bare key would collide with a TMDB movie or show
-      # that happens to share this same numeric id.
-      assert MediaRequestHelpers.request_status_map()[{:tvdb, tvdb_id}] == "pending"
+      assert MediaRequestHelpers.request_status_map()[{:tv_show, :tvdb, tvdb_id}] == "pending"
     end
   end
 
@@ -170,7 +166,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
     test "stamps the status onto matching items and nil onto the rest" do
       requested = System.unique_integer([:positive])
       untouched = System.unique_integer([:positive])
-      map = %{requested => "pending"}
+      map = %{{:movie, :tmdb, requested} => "pending"}
 
       [a, b] =
         MediaRequestHelpers.enrich_with_request_status(
@@ -193,9 +189,9 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
         tvdb_item(shared_id, "Shared Id Series")
         |> Map.put(:media_type, :tv_show)
 
-      # Only the TMDB movie has an outstanding request, keyed bare as
-      # request_status_map/0 would store it.
-      map = %{shared_id => "pending"}
+      # Only the TMDB movie has an outstanding request, keyed with canonical
+      # 3-tuple as request_status_map/0 stores it.
+      map = %{{:movie, :tmdb, shared_id} => "pending"}
 
       [enriched_movie, enriched_series] =
         MediaRequestHelpers.enrich_with_request_status([movie, series], map)
@@ -215,9 +211,35 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
         tvdb_item(shared_id, "Other Shared Id Series")
         |> Map.put(:media_type, :tv_show)
 
-      # No TMDB movie request exists; only the TVDB show does, keyed tagged
-      # as request_status_map/0 would store it.
-      map = %{{:tvdb, shared_id} => "pending"}
+      # No TMDB movie request exists; only the TVDB show does, keyed with canonical
+      # 3-tuple as request_status_map/0 stores it.
+      map = %{{:tv_show, :tvdb, shared_id} => "pending"}
+
+      [enriched_movie, enriched_series] =
+        MediaRequestHelpers.enrich_with_request_status([movie, series], map)
+
+      assert is_nil(enriched_movie.request_status)
+      assert enriched_series.request_status == "pending"
+    end
+
+    test "differentiates TMDB TV show from TMDB movie with identical numeric id" do
+      user = guest()
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _req} =
+        MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "Shared Show",
+          tmdb_id: shared_id,
+          requester_id: user.id
+        })
+
+      map = MediaRequestHelpers.request_status_map()
+      assert map[{:tv_show, :tmdb, shared_id}] == "pending"
+      assert is_nil(map[{:movie, :tmdb, shared_id}])
+
+      movie = item(shared_id, "Shared Movie") |> Map.put(:media_type, :movie)
+      series = item(shared_id, "Shared Series") |> Map.put(:media_type, :tv_show)
 
       [enriched_movie, enriched_series] =
         MediaRequestHelpers.enrich_with_request_status([movie, series], map)

--- a/test/mydia_web/live/media_live/show/detail_modal_test.exs
+++ b/test/mydia_web/live/media_live/show/detail_modal_test.exs
@@ -428,4 +428,43 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalTest do
     refute has_element?(view, ~s(#media-detail-modal button[phx-click="add_selected_item"]))
     assert has_element?(view, "#trending-detail-modal-actions a", "Go to Movie")
   end
+
+  describe "DetailModalEvents.handle_recommendations_result/2" do
+    test "stamps media_type matching media_item.type on modal recommendations" do
+      current =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Current TV",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      rec_id = System.unique_integer([:positive])
+
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{
+          __changed__: %{},
+          media_item: current,
+          selected_recommendations: []
+        }
+      }
+
+      raw_results = [
+        %Mydia.Metadata.Structs.SearchResult{
+          provider_id: to_string(rec_id),
+          provider: :tmdb,
+          media_type: nil,
+          title: "Modal TV Rec"
+        }
+      ]
+
+      {:noreply, updated} =
+        MydiaWeb.MediaLive.Show.DetailModalEvents.handle_recommendations_result(
+          {:ok, {:ok, raw_results}},
+          socket
+        )
+
+      [rec] = updated.assigns.selected_recommendations
+      assert rec.media_type == :tv_show
+    end
+  end
 end

--- a/test/mydia_web/live/media_live/show/franchise_events_test.exs
+++ b/test/mydia_web/live/media_live/show/franchise_events_test.exs
@@ -542,6 +542,45 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEventsTest do
       assert untouched.request_status == nil
     end
 
+    test "does not stamp request_status when an outstanding request for another media type shares tmdb_id",
+         %{config: config} do
+      requester = user_fixture(%{role: "guest"})
+
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "First",
+          year: 2001,
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      shared_tmdb_id = System.unique_integer([:positive])
+      franchise = franchise_with_missing(current, shared_tmdb_id)
+      [_current_entry, _missing_entry] = franchise.entries
+
+      {:ok, _request} =
+        Mydia.MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "TV Show with same ID",
+          tmdb_id: shared_tmdb_id,
+          requester_id: requester.id
+        })
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          metadata_config: config,
+          current_user: user_fixture(%{role: "guest"})
+        })
+
+      {:noreply, socket} = FranchiseEvents.handle_load_result({:ok, {:ok, franchise}}, socket)
+
+      entries = socket.assigns.franchise.entries
+      entry = Enum.find(entries, &(&1.tmdb_id == shared_tmdb_id))
+
+      assert entry.request_status == nil
+    end
+
     # Regression: request_status_map/0 issued two unfiltered list_requests/1
     # queries and PR #461 ran them on every franchise load, though the value
     # only ever affects the Request button that only a guest sees. A non-guest

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -134,6 +134,89 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
 
       assert Map.get(requested, :request_status) == nil
     end
+
+    test "stamps request_status for TV show recommendations and ensures media_type is :tv_show" do
+      requester = user_fixture(%{role: "guest"})
+
+      current =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Current TV Show",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      requested_tmdb_id = System.unique_integer([:positive])
+      untouched_tmdb_id = System.unique_integer([:positive])
+
+      {:ok, _request} =
+        MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "Requested TV Rec",
+          tmdb_id: requested_tmdb_id,
+          requester_id: requester.id
+        })
+
+      results = [
+        result(%{provider_id: to_string(requested_tmdb_id), title: "Requested TV Rec"}),
+        result(%{provider_id: to_string(untouched_tmdb_id), title: "Untouched TV Rec"})
+      ]
+
+      socket = stub_socket(%{media_item: current, current_user: user_fixture(%{role: "guest"})})
+
+      {:noreply, socket} = RecommendationEvents.handle_load_result({:ok, {:ok, results}}, socket)
+
+      requested =
+        Enum.find(
+          socket.assigns.recommendations,
+          &(&1.provider_id == to_string(requested_tmdb_id))
+        )
+
+      untouched =
+        Enum.find(
+          socket.assigns.recommendations,
+          &(&1.provider_id == to_string(untouched_tmdb_id))
+        )
+
+      assert requested.media_type == :tv_show
+      assert requested.request_status == "pending"
+      assert untouched.media_type == :tv_show
+      assert untouched.request_status == nil
+    end
+
+    test "does not stamp request_status when a request of a different media type shares tmdb_id" do
+      requester = user_fixture(%{role: "guest"})
+      shared_id = System.unique_integer([:positive])
+
+      current =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Current TV Show",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      {:ok, _request} =
+        MediaRequests.create_request(%{
+          media_type: "movie",
+          title: "Movie Request",
+          tmdb_id: shared_id,
+          requester_id: requester.id
+        })
+
+      results = [result(%{provider_id: to_string(shared_id), title: "TV Recommendation"})]
+
+      socket = stub_socket(%{media_item: current, current_user: user_fixture(%{role: "guest"})})
+
+      {:noreply, socket} = RecommendationEvents.handle_load_result({:ok, {:ok, results}}, socket)
+
+      item =
+        Enum.find(
+          socket.assigns.recommendations,
+          &(&1.provider_id == to_string(shared_id))
+        )
+
+      assert item.media_type == :tv_show
+      assert item.request_status == nil
+    end
   end
 
   describe "request_recommendation/2" do
@@ -201,6 +284,43 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       assert request.title == "Dialog Only Title"
       assert request.tmdb_id == tmdb_id
 
+      refute updated.assigns.flash["error"]
+    end
+
+    test "a guest requesting a TV show recommendation creates a tv_show request and updates status" do
+      current =
+        media_item_fixture(%{
+          type: "tv_show",
+          title: "Current Series",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      tmdb_id = System.unique_integer([:positive])
+
+      item =
+        result(%{
+          provider_id: to_string(tmdb_id),
+          title: "Recommended Series",
+          media_type: :tv_show
+        })
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          recommendations: [item],
+          current_user: user_fixture(%{role: "guest"})
+        })
+
+      {:noreply, updated} =
+        RecommendationEvents.request_recommendation(%{"ref" => "tmdb:#{tmdb_id}"}, socket)
+
+      assert [request] = MediaRequests.list_requests(status: "pending")
+      assert request.title == "Recommended Series"
+      assert request.media_type == "tv_show"
+      assert request.tmdb_id == tmdb_id
+
+      [updated_rec] = updated.assigns.recommendations
+      assert updated_rec.request_status == "pending"
       refute updated.assigns.flash["error"]
     end
   end

--- a/test/mydia_web/live/media_live/show/recommendation_events_test.exs
+++ b/test/mydia_web/live/media_live/show/recommendation_events_test.exs
@@ -323,6 +323,59 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEventsTest do
       assert updated_rec.request_status == "pending"
       refute updated.assigns.flash["error"]
     end
+
+    test "requesting a recommendation preserves request_status on previously requested recommendations" do
+      current =
+        media_item_fixture(%{
+          type: "movie",
+          title: "Current Movie",
+          tmdb_id: System.unique_integer([:positive])
+        })
+
+      already_requested_id = System.unique_integer([:positive])
+      newly_requested_id = System.unique_integer([:positive])
+
+      item1 =
+        result(%{
+          provider_id: to_string(already_requested_id),
+          title: "Already Requested"
+        })
+        |> Map.put(:request_status, "pending")
+
+      item2 =
+        result(%{
+          provider_id: to_string(newly_requested_id),
+          title: "Newly Requested"
+        })
+
+      socket =
+        stub_socket(%{
+          media_item: current,
+          recommendations: [item1, item2],
+          current_user: user_fixture(%{role: "guest"})
+        })
+
+      {:noreply, updated} =
+        RecommendationEvents.request_recommendation(
+          %{"ref" => "tmdb:#{newly_requested_id}"},
+          socket
+        )
+
+      rec1 =
+        Enum.find(
+          updated.assigns.recommendations,
+          &(&1.provider_id == to_string(already_requested_id))
+        )
+
+      rec2 =
+        Enum.find(
+          updated.assigns.recommendations,
+          &(&1.provider_id == to_string(newly_requested_id))
+        )
+
+      assert rec1.request_status == "pending"
+      assert rec2.request_status == "pending"
+    end
   end
 
   describe "handle_add_result/3" do


### PR DESCRIPTION
## Summary

Fixes #463 and #473.

Ensures media requests, library items, and provider lookups are properly scoped by media type (`:movie` vs `:tv_show`), preventing cross-type ID collisions where a movie and TV show sharing the same TMDB ID blocked each other.

### Changes

1. **Database Schema & Indexes**:
   - Migration `20260905120000_scope_provider_ids_by_media_type.exs` replaces single-column unique indexes with composite partial unique indexes on `(type, tmdb_id)` and `(type, tvdb_id)` across both SQLite and PostgreSQL.
   - Updated `MediaItem.changeset/2` to pair both SQLite and PostgreSQL index names for accurate `:tmdb_id` and `:tvdb_id` field error attribution.

2. **Context Provider Lookups**:
   - Added type-scoped `Mydia.Media.get_media_item_by_tmdb(type, id, opts)` and `get_media_item_by_tvdb(type, id, opts)` clauses, normalizing atom and string media types and returning `nil` immediately if type is `nil`.
   - Preserved backward-compatible `(id, opts)` clauses.

3. **Concurrency & Safe ID Assignment**:
   - Scoped `ExternalIds.put_free_ids/3` by media type so an existing movie does not block ID assignment on a TV show (and vice versa).
   - In `Add.from_attrs/3`, caught unique constraint collisions on insert/update and resolved them to `{:error, {:already_in_library, backfill_ids(incumbent, attrs)}}` handling both string and atom keys.

4. **Media Request Scoping**:
   - Scoped `MediaRequests.pending_request_exists?/2` by media type.
   - Updated `check_duplicate_media/1` and `check_duplicate_request/1` to pass `media_type` from changesets.

5. **Canonical Status Map Keys**:
   - Standardized on canonical `{media_type, provider, provider_id}` 3-tuple keys across `MediaRequestHelpers.request_status_map/0`, `Media.get_library_status_map/0`, enrichment functions, `FranchiseEvents`, `RecommendationEvents`, and `DetailModalEvents`.
   - Added `safe_parse_id/1` in `MediaRequestHelpers` to prevent crashes from unparseable provider IDs.

### Verification

- Comprehensive test coverage added across schema, context lookups, concurrency recovery, media requests, and live view helpers.
- Full test suite passed (10,768 tests, 0 failures).
- `./dev mix precommit` passed cleanly with 0 errors across formatting, Credo, Dialyzer, and migrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media lookups now support movie/TV type filtering, string IDs, and optional preloading.
  * Movies and TV shows can share provider IDs without being confused with one another.
* **Bug Fixes**
  * Library and request statuses remain accurate when IDs overlap across media types or providers.
  * Concurrent additions are handled gracefully, preventing duplicate-library errors.
  * Invalid provider IDs no longer cause status or enrichment failures.
  * Recommendations and franchise entries preserve the correct media type and request status.
  * Ambiguous untyped provider-ID lookups now return safely instead of raising errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->