### PR TITLE
fix: media-server link seeding crashes on SSO accounts

### DIFF
--- a/lib/mydia/accounts/user.ex
+++ b/lib/mydia/accounts/user.ex
@@ -122,6 +122,34 @@ defmodule Mydia.Accounts.User do
   end
 
   @doc """
+  The name to show for a user.
+
+  Username comes first because it is what media-server account matching keys
+  on, so a local account reads exactly as it always has and the fallbacks
+  engage only where the label would otherwise be blank. An OIDC-provisioned
+  account has no username at all: `oidc_changeset/2` never casts the field.
+
+  Email and display name are optional too, since OIDC requires only
+  `oidc_sub`, so the last resort is an id prefix. It is ugly, but two
+  otherwise-identical accounts have to be distinguishable in the
+  account-mapping picker.
+  """
+  @spec label(t()) :: String.t()
+  def label(%__MODULE__{} = user) do
+    [user.username, user.display_name, user.email]
+    |> Enum.find(&present?/1)
+    |> case do
+      nil -> id_label(user)
+      value -> String.trim(value)
+    end
+  end
+
+  defp present?(value), do: is_binary(value) and String.trim(value) != ""
+
+  defp id_label(%__MODULE__{id: id}) when is_binary(id), do: "user " <> String.slice(id, 0, 8)
+  defp id_label(%__MODULE__{}), do: "unknown user"
+
+  @doc """
   Returns the list of valid role values.
   """
   def valid_roles, do: @role_values

--- a/lib/mydia/accounts/username_index.ex
+++ b/lib/mydia/accounts/username_index.ex
@@ -1,0 +1,58 @@
+defmodule Mydia.Accounts.UsernameIndex do
+  @moduledoc """
+  A case-insensitive index of Mydia users by username, for matching them
+  against a media server's account names.
+
+  Both halves of the match live here on purpose. `build/1` decides what a key
+  looks like and `get/2` decides how a remote name is turned into one, so the
+  two sides cannot drift apart. They did drift: the seeds guarded the remote
+  name with `name || ""` and then looked that up in an index that had been
+  built without any guard at all, which crashed on the first
+  OIDC-provisioned user and, had it not crashed, would have matched a nameless
+  remote profile against a blank Mydia username.
+
+  Users with no usable username are absent from the index rather than keyed
+  under `""`. An OIDC account has `username: nil` because
+  `Mydia.Accounts.User.oidc_changeset/2` never casts the field and the column
+  is nullable, so such an account can never be name-matched. The operator maps
+  it by hand in the account-mapping modal instead.
+  """
+
+  alias Mydia.Accounts.User
+
+  @type t :: %{String.t() => User.t()}
+
+  @doc """
+  Indexes users by their normalised username, skipping those without one.
+  """
+  @spec build([User.t()]) :: t()
+  def build(users) do
+    users
+    |> Enum.map(fn %User{} = user -> {normalize(user.username), user} end)
+    |> Enum.reject(fn {key, _user} -> is_nil(key) end)
+    |> Map.new()
+  end
+
+  @doc """
+  Returns the user a remote account name matches, or `nil`.
+
+  A name that normalises to nothing matches nobody, which is the whole point:
+  a lookup of `""` could otherwise succeed.
+  """
+  @spec get(t(), String.t() | nil) :: User.t() | nil
+  def get(index, name) do
+    case normalize(name) do
+      nil -> nil
+      key -> Map.get(index, key)
+    end
+  end
+
+  defp normalize(name) when is_binary(name) do
+    case String.trim(name) do
+      "" -> nil
+      trimmed -> String.downcase(trimmed)
+    end
+  end
+
+  defp normalize(_name), do: nil
+end

--- a/lib/mydia/media_server/jellyfin/users.ex
+++ b/lib/mydia/media_server/jellyfin/users.ex
@@ -14,6 +14,7 @@ defmodule Mydia.MediaServer.Jellyfin.Users do
   """
 
   alias Mydia.Accounts
+  alias Mydia.Accounts.UsernameIndex
   alias Mydia.MediaServer.Client.Jellyfin, as: JellyfinClient
   alias Mydia.MediaServer.SeedResult
   alias Mydia.Settings
@@ -37,14 +38,11 @@ defmodule Mydia.MediaServer.Jellyfin.Users do
   end
 
   defp seed_matched_links(config, remote_users, opts) do
-    by_username =
-      Map.new(Accounts.list_users(), fn user -> {String.downcase(user.username), user} end)
+    by_username = UsernameIndex.build(Accounts.list_users())
 
     remote_users
     |> Enum.reduce_while({:ok, %SeedResult{}}, fn remote_user, {:ok, result} ->
-      name = remote_user.name || ""
-
-      case Map.get(by_username, String.downcase(name)) do
+      case UsernameIndex.get(by_username, remote_user.name) do
         nil -> {:cont, {:ok, result}}
         user -> link_account(config, user, remote_user, result, opts)
       end

--- a/lib/mydia/media_server/plex/home.ex
+++ b/lib/mydia/media_server/plex/home.ex
@@ -18,6 +18,7 @@ defmodule Mydia.MediaServer.Plex.Home do
   require Logger
 
   alias Mydia.Accounts
+  alias Mydia.Accounts.UsernameIndex
   alias Mydia.MediaServer.Error
   alias Mydia.MediaServer.PlexOAuth
   alias Mydia.MediaServer.SeedResult
@@ -141,16 +142,11 @@ defmodule Mydia.MediaServer.Plex.Home do
   end
 
   defp seed_matched_links(config, home_users, opts) do
-    by_username =
-      Map.new(Accounts.list_users(), fn user ->
-        {String.downcase(user.username), user}
-      end)
+    by_username = UsernameIndex.build(Accounts.list_users())
 
     home_users
     |> Enum.reduce_while({:ok, %SeedResult{}}, fn home_user, {:ok, result} ->
-      username = home_user.username || ""
-
-      case Map.get(by_username, String.downcase(username)) do
+      case UsernameIndex.get(by_username, home_user.username) do
         nil -> {:cont, {:ok, result}}
         user -> link_home_user(config, user, home_user, result, opts)
       end

--- a/lib/mydia_web/live/admin_media_servers_live/components.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/components.ex
@@ -2,6 +2,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   @moduledoc false
   use MydiaWeb, :html
 
+  alias Mydia.Accounts.User
   alias Mydia.MediaServer.RemoteAccount
   alias Mydia.Settings
   alias Mydia.Settings.MediaServerConfig
@@ -928,7 +929,11 @@ defmodule MydiaWeb.AdminMediaServersLive.Components do
   # a present-but-blank param rather than vanishing from the form payload, which
   # is what lets the save path tell "unlink this" apart from "never asked".
   defp user_options(users) do
-    [{"Don't sync", ""} | Enum.map(users, &{&1.username, &1.id})]
+    # `User.label/1` rather than the raw username: an OIDC-provisioned account
+    # has none, and rendered as a blank option the operator could not tell
+    # which account they were selecting. SSO accounts cannot be name-matched,
+    # so hand-mapping here is the only way they are ever linked at all.
+    [{"Don't sync", ""} | Enum.map(users, &{User.label(&1), &1.id})]
   end
 
   # Each server calls these something different, and a modal that says "Plex

--- a/lib/mydia_web/live/admin_media_servers_live/index.ex
+++ b/lib/mydia_web/live/admin_media_servers_live/index.ex
@@ -2,6 +2,8 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
   use MydiaWeb, :live_view
 
   alias Mydia.Accounts
+  alias Mydia.Accounts.User
+  alias Mydia.Accounts.UsernameIndex
   alias Mydia.Settings
   alias Mydia.Settings.MediaServerConfig
   alias Mydia.MediaServer.Client, as: MediaServerClient
@@ -689,7 +691,7 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
   # a form that cannot be submitted without them working out why.
   defp initial_mapping(accounts, links, users) do
     by_account = Map.new(links, &{&1.remote_user_id, &1.user_id})
-    by_username = Map.new(users, &{String.downcase(&1.username), &1.id})
+    by_username = UsernameIndex.build(users)
 
     {mapping, _taken} =
       Enum.reduce(accounts, {%{}, MapSet.new(Map.values(by_account))}, fn account, {acc, taken} ->
@@ -707,12 +709,9 @@ defmodule MydiaWeb.AdminMediaServersLive.Index do
   end
 
   defp suggestion_for(by_username, account, taken) do
-    case Map.get(by_username, String.downcase(account.name || "")) do
-      suggestion when is_binary(suggestion) ->
-        if MapSet.member?(taken, suggestion), do: nil, else: suggestion
-
-      _ ->
-        nil
+    case UsernameIndex.get(by_username, account.name) do
+      %User{id: id} -> if MapSet.member?(taken, id), do: nil, else: id
+      nil -> nil
     end
   end
 

--- a/test/mydia/accounts/user_label_test.exs
+++ b/test/mydia/accounts/user_label_test.exs
@@ -1,0 +1,43 @@
+defmodule Mydia.Accounts.UserLabelTest do
+  # No database: label/1 reads struct fields only.
+  use ExUnit.Case, async: true
+
+  alias Mydia.Accounts.User
+
+  defp user(attrs), do: struct!(%User{id: "9f4c2a10-1111-2222-3333-444455556666"}, attrs)
+
+  test "prefers the username" do
+    # Username first, so a local account keeps reading exactly as it does
+    # today and the fallbacks only engage for accounts that render blank.
+    label = User.label(user(username: "tonix", display_name: "Tonix R", email: "t@example.test"))
+
+    assert label == "tonix"
+  end
+
+  test "falls back to the display name when there is no username" do
+    assert User.label(user(username: nil, display_name: "Tonix R")) == "Tonix R"
+  end
+
+  test "falls back to the email when there is no username or display name" do
+    assert User.label(user(username: nil, display_name: nil, email: "t@example.test")) ==
+             "t@example.test"
+  end
+
+  test "falls back to an id prefix when the account has nothing else" do
+    # OIDC only requires oidc_sub, so display_name and email are both
+    # optional. Two such accounts must still be distinguishable in the
+    # picker.
+    assert User.label(user(username: nil, display_name: nil, email: nil)) == "user 9f4c2a10"
+  end
+
+  test "treats a blank field as absent" do
+    assert User.label(user(username: "  ", display_name: "Tonix R")) == "Tonix R"
+
+    assert User.label(user(username: nil, display_name: "", email: "t@example.test")) ==
+             "t@example.test"
+  end
+
+  test "labels an unsaved struct without an id" do
+    assert User.label(%User{}) == "unknown user"
+  end
+end

--- a/test/mydia/accounts/username_index_test.exs
+++ b/test/mydia/accounts/username_index_test.exs
@@ -1,0 +1,72 @@
+defmodule Mydia.Accounts.UsernameIndexTest do
+  # No database: build/1 takes a list and get/2 reads a map.
+  use ExUnit.Case, async: true
+
+  alias Mydia.Accounts.User
+  alias Mydia.Accounts.UsernameIndex
+
+  defp user(attrs), do: struct!(%User{id: Ecto.UUID.generate()}, attrs)
+
+  describe "build/1" do
+    test "keys each user by their downcased username" do
+      tonix = user(username: "Tonix")
+
+      assert UsernameIndex.build([tonix]) == %{"tonix" => tonix}
+    end
+
+    test "skips a user with no username" do
+      # Every OIDC-provisioned account is this shape: oidc_changeset/2 never
+      # casts :username and the column is nullable. One such account used to
+      # take the whole seed job down with String.downcase(nil).
+      sso = user(username: nil, email: "sso@example.test")
+      tonix = user(username: "tonix")
+
+      assert UsernameIndex.build([sso, tonix]) == %{"tonix" => tonix}
+    end
+
+    test "skips a user whose username is blank or only whitespace" do
+      # A blank key is reachable from the lookup side: a nameless remote
+      # profile would find it and be linked to a real person's account.
+      assert UsernameIndex.build([user(username: "")]) == %{}
+      assert UsernameIndex.build([user(username: "   ")]) == %{}
+    end
+
+    test "trims surrounding whitespace from the key" do
+      tonix = user(username: " tonix ")
+
+      assert UsernameIndex.build([tonix]) == %{"tonix" => tonix}
+    end
+
+    test "is empty for an empty list" do
+      assert UsernameIndex.build([]) == %{}
+    end
+  end
+
+  describe "get/2" do
+    setup do
+      tonix = user(username: "Tonix")
+      {:ok, index: UsernameIndex.build([tonix]), tonix: tonix}
+    end
+
+    test "matches a remote name case-insensitively", %{index: index, tonix: tonix} do
+      assert UsernameIndex.get(index, "TONIX") == tonix
+      assert UsernameIndex.get(index, "tonix") == tonix
+    end
+
+    test "matches a remote name with surrounding whitespace", %{index: index, tonix: tonix} do
+      assert UsernameIndex.get(index, "  Tonix  ") == tonix
+    end
+
+    test "returns nil for a name nobody has", %{index: index} do
+      assert UsernameIndex.get(index, "nobody") == nil
+    end
+
+    test "returns nil for a nameless remote profile", %{index: index} do
+      # Plex managed profiles and guest profiles carry a null username. They
+      # match nobody rather than falling through to a "" lookup.
+      assert UsernameIndex.get(index, nil) == nil
+      assert UsernameIndex.get(index, "") == nil
+      assert UsernameIndex.get(index, "   ") == nil
+    end
+  end
+end

--- a/test/mydia/media_server/jellyfin/users_test.exs
+++ b/test/mydia/media_server/jellyfin/users_test.exs
@@ -78,10 +78,14 @@ defmodule Mydia.MediaServer.Jellyfin.UsersTest do
     assert link.user_id == user.id
   end
 
-  test "a nameless Jellyfin account is not linked to a blank Mydia username", %{
+  test "a nameless Jellyfin account is skipped rather than matched", %{
     bypass: bypass,
     config: config
   } do
+    # UsernameIndex.get/2 normalizes a nil-or-blank name to `nil` instead of
+    # looking up `""`, so an account with no name matches nobody and no link
+    # is created. Blank-username-side coverage (a Mydia user keyed under a
+    # blank username) lives in test/mydia/accounts/username_index_test.exs.
     Bypass.expect_once(bypass, "GET", "/Users", fn conn ->
       conn
       |> Plug.Conn.put_resp_content_type("application/json")

--- a/test/mydia/media_server/jellyfin/users_test.exs
+++ b/test/mydia/media_server/jellyfin/users_test.exs
@@ -59,6 +59,39 @@ defmodule Mydia.MediaServer.Jellyfin.UsersTest do
     assert Settings.list_media_server_user_links(config.id) == []
   end
 
+  test "links the local account instead of crashing on a user with no username", %{
+    bypass: bypass,
+    config: config
+  } do
+    # Same defect as #705 on the Plex side, in code copied from it. Unreported
+    # only because fewer operators pair Jellyfin with SSO.
+    user = admin_user_fixture(%{username: "tonix"})
+    _sso = oidc_user_fixture(%{})
+
+    Bypass.expect_once(bypass, "GET", "/Users", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, ~s([{"Id":"jf1","Name":"Tonix"}]))
+    end)
+
+    assert {:ok, %SeedResult{linked: [link]}} = Users.seed_links(config)
+    assert link.user_id == user.id
+  end
+
+  test "a nameless Jellyfin account is not linked to a blank Mydia username", %{
+    bypass: bypass,
+    config: config
+  } do
+    Bypass.expect_once(bypass, "GET", "/Users", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, ~s([{"Id":"jf1","Name":null}]))
+    end)
+
+    assert {:ok, %SeedResult{linked: []}} = Users.seed_links(config)
+    assert Settings.list_media_server_user_links(config.id) == []
+  end
+
   test "does not create a link that carries an access token", %{
     bypass: bypass,
     config: config

--- a/test/mydia/media_server/plex/home_test.exs
+++ b/test/mydia/media_server/plex/home_test.exs
@@ -180,11 +180,12 @@ defmodule Mydia.MediaServer.Plex.HomeTest do
       assert link.user_id == user.id
     end
 
-    test "a nameless Plex profile is not linked to a blank Mydia username",
+    test "a nameless Plex profile is skipped rather than matched",
          %{bypass: bypass, config: config, base: base} do
-      # The read side used to look up `""` for a profile with no name. A Mydia
-      # user keyed under `""` would have matched it, binding two strangers'
-      # watch history together.
+      # UsernameIndex.get/2 normalizes a nil-or-blank name to `nil` instead of
+      # looking up `""`, so a profile with no name matches nobody and no link
+      # is created. Blank-username-side coverage (a Mydia user keyed under a
+      # blank username) lives in test/mydia/accounts/username_index_test.exs.
       Bypass.stub(bypass, "GET", "/api/v2/home/users", fn conn ->
         conn
         |> Plug.Conn.put_resp_content_type("application/json")

--- a/test/mydia/media_server/plex/home_test.exs
+++ b/test/mydia/media_server/plex/home_test.exs
@@ -145,6 +145,65 @@ defmodule Mydia.MediaServer.Plex.HomeTest do
     end
   end
 
+  describe "seed_links/2 with an SSO account present" do
+    test "links the local account instead of crashing on a user with no username",
+         %{bypass: bypass, config: config, base: base} do
+      # Regression for #705. Every OIDC-provisioned account has username: nil,
+      # and the index was built with an unguarded String.downcase/1, so a
+      # single SSO user took the whole seed job down on every scheduled run.
+      Bypass.stub(bypass, "GET", "/api/v2/home/users", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "users" => [
+              %{"id" => 2, "uuid" => "uuid-kid", "username" => "kid", "admin" => false}
+            ]
+          })
+        )
+      end)
+
+      Bypass.stub(bypass, "POST", "/api/v2/home/users/uuid-kid/switch", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"authToken" => "kid-token"}))
+      end)
+
+      # Created first so an admin exists and the OIDC upsert does not
+      # auto-promote the SSO account.
+      user = Mydia.AccountsFixtures.admin_user_fixture(%{username: "kid"})
+      _sso = Mydia.AccountsFixtures.oidc_user_fixture(%{})
+      {:ok, saved} = Mydia.Settings.create_media_server_config(persistable(config))
+
+      assert {:ok, %SeedResult{linked: [link]}} = Home.seed_links(saved, plex_tv_base: base)
+      assert link.user_id == user.id
+    end
+
+    test "a nameless Plex profile is not linked to a blank Mydia username",
+         %{bypass: bypass, config: config, base: base} do
+      # The read side used to look up `""` for a profile with no name. A Mydia
+      # user keyed under `""` would have matched it, binding two strangers'
+      # watch history together.
+      Bypass.stub(bypass, "GET", "/api/v2/home/users", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{
+            "users" => [
+              %{"id" => 3, "uuid" => "uuid-ghost", "username" => nil, "title" => nil}
+            ]
+          })
+        )
+      end)
+
+      {:ok, saved} = Mydia.Settings.create_media_server_config(persistable(config))
+
+      assert {:ok, %SeedResult{linked: []}} = Home.seed_links(saved, plex_tv_base: base)
+    end
+  end
+
   describe "seed_links/2 owner fallback" do
     test "leaves an existing mapping alone instead of reverting it to the owner",
          %{bypass: bypass, config: config, base: base} do

--- a/test/mydia_web/live/admin_media_servers_live/components_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live/components_test.exs
@@ -6,6 +6,7 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
   import Phoenix.LiveViewTest, except: [render: 1]
   import Phoenix.Component, only: [to_form: 1]
 
+  alias Mydia.Accounts.User
   alias Mydia.Settings.MediaServerConfig
   alias MydiaWeb.AdminMediaServersLive.Components
 
@@ -315,7 +316,12 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
       %Mydia.MediaServer.RemoteAccount{id: id, name: name, admin?: admin?}
     end
 
-    defp users, do: [%{id: "u-admin", username: "admin"}, %{id: "u-alex", username: "alex"}]
+    defp users do
+      [
+        %User{id: "u-admin", username: "admin"},
+        %User{id: "u-alex", username: "alex"}
+      ]
+    end
 
     defp jellyfin, do: %MediaServerConfig{name: "Jellyfin", type: :jellyfin}
 
@@ -426,6 +432,18 @@ defmodule MydiaWeb.AdminMediaServersLive.ComponentsTest do
       empty = render_mapping(config: jellyfin(), state: :ready, accounts: [])
       assert empty =~ ~s(id="account-mapping-empty")
       refute empty =~ "Plex"
+    end
+
+    test "labels an SSO account by its display name rather than a blank option" do
+      # An OIDC-provisioned account has no username, so the option used to
+      # render with an empty label and the operator could not tell which
+      # account they were picking.
+      sso = %User{id: "u-sso", username: nil, display_name: "Robin Vega", email: "r@example.test"}
+
+      html = render_mapping(accounts: [account("1", "Camille")], users: users() ++ [sso])
+
+      assert html =~ "Robin Vega"
+      assert html =~ ~s(value="u-sso")
     end
   end
 end

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -373,6 +373,22 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
       assert Mydia.Settings.list_media_server_user_links(server.id) == []
     end
 
+    test "the modal still opens and suggests a match when an SSO account exists",
+         %{conn: conn, bypass: bypass} do
+      # initial_mapping/3 built its own unguarded username index, so opening
+      # the modal on an install with SSO crashed the LiveView outright.
+      user = Mydia.AccountsFixtures.user_fixture(%{username: "tonix"})
+      _sso = Mydia.AccountsFixtures.oidc_user_fixture(%{display_name: "Robin Vega"})
+      server = sync_enabled_server(bypass)
+
+      stub_jellyfin_users(bypass, [%{"Id" => "guid-1", "Name" => "Tonix"}])
+
+      view = open_account_mapping(conn, server)
+
+      assert has_element?(view, ~s{#account-select-guid-1 option[value="#{user.id}"][selected]})
+      assert render(view) =~ "Robin Vega"
+    end
+
     test "saving a Jellyfin mapping stores the account GUID and no token",
          %{conn: conn, bypass: bypass} do
       user = Mydia.AccountsFixtures.user_fixture(%{username: "tonix"})

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -30,4 +30,26 @@ defmodule Mydia.AccountsFixtures do
   def admin_user_fixture(attrs \\ %{}) do
     user_fixture(Map.merge(%{role: "admin"}, attrs))
   end
+
+  @doc """
+  Generate an OIDC-provisioned user, which has no username.
+
+  `Accounts.upsert_user_from_oidc/3` is the only path that creates one:
+  `create_user/1` runs `User.changeset/2`, which requires a username, so it
+  cannot build the account shape that SSO installs actually have.
+  """
+  def oidc_user_fixture(attrs \\ %{}) do
+    n = System.unique_integer([:positive])
+
+    attrs =
+      Map.merge(
+        %{email: "sso#{n}@example.test", display_name: "SSO User #{n}", role: "user"},
+        attrs
+      )
+
+    {:ok, user} =
+      Accounts.upsert_user_from_oidc("oidc-sub-#{n}", "https://issuer.example.test", attrs)
+
+    user
+  end
 end


### PR DESCRIPTION
Closes #705.

Every OIDC-provisioned account has `username: nil` — `User.oidc_changeset/2` never casts the field and the column is nullable — and four sites built a username index over `Accounts.list_users()` with an unguarded `String.downcase/1`.

| Site | Effect on an install pairing a media server with SSO |
| --- | --- |
| `plex/home.ex` | The reported crash. 9205 occurrences across 3 instances in relay telemetry, the highest-volume crash by a wide margin, on release builds as well as dev. `MediaServerLinkSeed` failed on every scheduled run, so no Plex Home user was ever linked and the job retried forever. |
| `jellyfin/users.ex` | The same code, copied. Unreported only because fewer operators pair Jellyfin with SSO. |
| `admin_media_servers_live/index.ex` | Crashed the LiveView outright when the account-mapping modal was opened. |
| `admin_media_servers_live/components.ex` | Not a crash: the SSO account rendered as a blank `<option>`, so the operator could not tell which account they were picking. |

All four now go through `Mydia.Accounts.UsernameIndex`, which owns both how a key is built and how a remote name is looked up, so the two sides share one normalisation and cannot drift apart again.

That drift was itself the deeper defect. The read side guarded a nameless remote profile with `name || ""` and then looked `""` up in an index built with no guard at all. The crash fired first, but the shape of the bug was two halves of one match disagreeing about what a missing name means.

SSO accounts stay selectable in the mapping dropdown, now labelled by `User.label/1` (`username || display_name || email || "user " <> id-prefix`). They cannot be name-matched — they have no name to match on — so hand-mapping is the only way such an account is ever linked at all, and removing them would leave an SSO-only install with no path to per-user watched sync.

`username` stays nullable. Deriving one for SSO accounts is a data migration with collision handling and belongs in its own issue.

## Testing

`./dev mix precommit` green: 10759 tests, 0 failures, format and Credo clean.

Both seed fixes are TDD regressions that first reproduced the real production `FunctionClauseError` in `String.downcase/2` before the fix went in. `AccountsFixtures.oidc_user_fixture/1` is new and necessary: `user_fixture/1` goes through `User.changeset/2`, which *requires* a username, so it cannot construct the account shape that crashes.

## Known gap, deliberately not fixed here

`admin_users_live` renders a blank name for SSO users in the Admin Users table and in the Edit Role and Delete confirmation modals — the same defect class, pre-existing, non-crashing. It is outside this PR's scope, which is the crash and its immediate surface. Worth a follow-up. (The Reset Password modal is already safe: it refuses to open for OIDC users.)

Case-colliding usernames (`Tonix` vs `tonix`, which the case-sensitive unique constraint permits) resolve last-write-wins, unchanged by this PR and out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added meaningful account labels using username, display name, email, or a fallback identifier.
  * Improved media server account matching with case-insensitive, whitespace-tolerant username lookup.
  * Account-mapping options now display useful names for accounts without usernames.

* **Bug Fixes**
  * Prevented crashes and incorrect matches for SSO accounts and media server profiles without names.
  * Ensured nameless remote profiles are skipped during account linking.

* **Tests**
  * Added coverage for account labels, username matching, SSO accounts, and nameless media profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->