### PR TITLE
feat(skills): add issue-loop for autonomous batch issue fixing

### DIFF
--- a/.claude/skills/issue-loop/SKILL.md
+++ b/.claude/skills/issue-loop/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: issue-loop
+description: Fan Claude Code out over open GitHub issues, one background agent per issue, taking only straightforward bugs and crashes and carrying each to a merged PR. Use when asked to work through the issue backlog in bulk, batch-fix issues, or run agents on many issues at once.
+---
+
+# Issue loop
+
+Runs three phases over the open issue list. Every phase is resumable and keeps
+its state in the main checkout, so an interrupted run continues rather than
+restarts, and deleting a worktree loses nothing.
+
+```
+triage  ->  [human gate]  ->  fix  ->  babysit
+read-only     you approve     1 agent    poll PRs, wake
+~10 at once   the worklist    per issue  an agent when red
+```
+
+## Running it
+
+```bash
+.claude/skills/issue-loop/scripts/run.sh              # the whole loop
+.claude/skills/issue-loop/scripts/run.sh 706 707 708  # only these issues
+.claude/skills/issue-loop/scripts/run.sh --yolo       # no human gate
+.claude/skills/issue-loop/scripts/status.sh           # where everything stands
+.claude/skills/issue-loop/scripts/stop-all.sh         # kill switch
+```
+
+Phases can also be run on their own: `triage.sh`, `fix.sh`, `harvest.sh`,
+`babysit.sh`. `babysit.sh` is the one worth re-running later on its own, since
+PRs keep moving after the loop exits.
+
+`run.sh` blocks on a `read` prompt at the human gate, so run it in a terminal
+the user can see, not as a background job. If you are driving this from a Claude
+session, run the phases separately and present the triage table yourself instead
+of using `run.sh`.
+
+## What each phase does
+
+**Triage** fetches open issues labelled `bug` or `crash` and gives each one a
+read-only agent (`--restricted --tools Read,Grep,Glob`, so it has no Bash and no
+Edit and structurally cannot change anything). Each returns a schema-validated
+verdict: take or skip, a confidence, a located root cause, the files a fix would
+touch, and a test plan.
+
+An issue is auto-approved only if **all** of these hold:
+
+| gate | default | override |
+| --- | --- | --- |
+| verdict is `take` | | |
+| confidence | `>= 0.7` | `ISSUE_LOOP_MIN_CONFIDENCE` |
+| risk | `low` | |
+| files to change | `<= 3` | `ISSUE_LOOP_MAX_FILES` |
+| labelled `bug` or `crash` | | |
+
+Everything else lands in the table as `skipped` with a one-line reason. That is
+the design: a wrong `skip` costs a human one line of reading, a wrong `take`
+costs them a bad PR review.
+
+**Fix** gives each approved issue its own worktree and background agent via
+`claude --bg -w issue-<N>`, with a pre-generated `--session-id` so phase 3 can
+resume that exact session later. The agent gets the issue, the triage findings,
+and `prompts/guardrails.md` as an appended system prompt. It writes a failing
+regression test first, fixes, runs only the touched tests, commits through
+`devenv shell --`, and opens a PR ready for review. If it cannot write a failing
+test, or the fix exceeds five files, it bails out and commits nothing.
+
+`harvest.sh` waits for the agents. An agent that goes idle without writing a
+result file is marked `needs_human` rather than waited on forever.
+
+**Babysit** polls `gh pr checks` itself, which costs no tokens, and only wakes
+an agent when CI goes red or someone comments. It wakes it with
+`claude --bg --resume <uuid>`, so the agent still has the whole change in
+context. Three rounds, then `needs_human`.
+
+## Tuning
+
+| variable | default | notes |
+| --- | --- | --- |
+| `ISSUE_LOOP_FIX_CONCURRENCY` | `4` | a fresh worktree pays a full Elixir recompile plus a Rust NIF build before its first test |
+| `ISSUE_LOOP_TRIAGE_CONCURRENCY` | `10` | read-only and cheap, can go higher |
+| `ISSUE_LOOP_MODEL` | `sonnet` | do not put Opus on fan-out |
+| `ISSUE_LOOP_FIX_BUDGET` | `8` | dollars per fix agent |
+| `ISSUE_LOOP_MAX_ROUNDS` | `3` | babysit rounds before giving up |
+| `ISSUE_LOOP_REPO` | current repo | the local remote may be a fork |
+
+## When something goes wrong
+
+`status.sh` prints every issue's phase, agent id, PR and note. From there:
+
+- `claude attach <agent>` drops you into a stuck agent's session interactively.
+- `claude logs <agent>` tails its output without attaching.
+- `$STATE_DIR/logs/` holds every rendered prompt and launch log.
+- `stop-all.sh` stops every agent but keeps the conversations; `--rm` also
+  deletes the sessions and their worktrees.
+
+State lives in `.claude/issue-loop/` in the main checkout. Delete an issue's
+JSON file to make the loop forget it entirely.
+
+## Phases and their meanings
+
+| phase | meaning |
+| --- | --- |
+| `new` | fetched, not yet triaged |
+| `approved` | cleared the gate, waiting for a fix agent |
+| `skipped` | triage said no, or the agent bailed out |
+| `fixing` | an agent is working in its worktree |
+| `pr_open` | PR is open, auto-merge enabled |
+| `babysitting` | an agent is handling CI or review feedback |
+| `merged` | done |
+| `needs_human` | stuck; read the note |
+| `failed` | the agent reported an error |

--- a/.claude/skills/issue-loop/prompts/babysit.md
+++ b/.claude/skills/issue-loop/prompts/babysit.md
@@ -1,0 +1,46 @@
+Your pull request needs attention. You opened it earlier in this same session,
+so you already know the change; do not re-derive it.
+
+Handle whatever is listed below, then stop. Specifically:
+
+**If CI is red:** read the actual failure. Fetch the logs
+(`gh run view <id> --log-failed`) rather than guessing from the check name.
+Decide whether it is your bug or a known flake. If it is yours, fix it, run the
+affected test locally, commit and push. If you are confident it is a flake,
+re-run the job once (`gh run rerun --failed`) and say so; do not paper over a
+real failure by retrying it.
+
+**If there are review comments:** judge each on its merits. CodeRabbit is often
+right and sometimes confidently wrong. Verify every claim against the actual
+code before acting. Apply the ones that are correct, and reply to the ones that
+are not with the evidence that shows why. Do not fix reflexively to make a
+comment go away, and do not agree with something you have checked and found
+wrong.
+
+**If a comment asks for a change you think is out of scope:** say so in a reply
+and leave the code alone.
+
+## Rules
+
+All of your original operating rules still apply. In particular: never push to
+`master`, never force-push, never merge by hand, never `--no-verify`, and commit
+through `devenv shell -- git commit -F <file>` with `git show --stat` to confirm
+it landed.
+
+Keep the diff focused. You are responding to specific feedback, not taking
+another pass at the design.
+
+## When you are done
+
+Overwrite your result file (the same path as before) with one JSON object, so
+the driver knows this round is handled:
+
+```
+{"outcome": "round_done", "note": "fixed the failing credo check; replied to 2 of 3 review comments"}
+```
+
+If you conclude that this PR cannot be finished autonomously, write instead:
+
+```
+{"outcome": "needs_human", "reason": "the failing test depends on a live indexer"}
+```

--- a/.claude/skills/issue-loop/prompts/fix.md
+++ b/.claude/skills/issue-loop/prompts/fix.md
@@ -1,0 +1,39 @@
+Fix the GitHub issue described below, then open a pull request.
+
+A triage pass has already located the defect. Its findings are attached. Treat
+them as a strong starting point, not as gospel: verify the root cause against
+the code before you act on it. If triage was wrong, say so in your bailout or
+your PR body rather than fixing the wrong thing.
+
+## Steps
+
+1. Read the issue and the triage findings.
+2. Read the code around the named root cause, plus the README nearest to it
+   (`lib/mydia/media/README.md`, `test/README.md`, `priv/repo/README.md` and
+   siblings are listed in the table at the end of `CLAUDE.md`).
+3. Write a regression test that fails for the reason in the issue. Run it.
+   Watch it fail. If it passes, you have the wrong cause: go back to step 2.
+4. Fix the code. Run the test again and watch it pass.
+5. Run `./dev mix test` on the files you touched, then `./dev mix format` and
+   `./dev mix credo --strict`.
+6. Stage everything, commit through `devenv shell -- git commit -F <file>`, and
+   confirm with `git show --stat`.
+7. Push the branch and open the PR with `gh pr create` (never `--draft`).
+8. Write the result file described below.
+
+## Result file
+
+The driver reads this file to learn what happened. Write it exactly once, as
+your last action, whatever the outcome. It is JSON:
+
+```
+{"outcome": "pr_opened", "pr": 712, "branch": "fix/issue-708", "note": "one line"}
+{"outcome": "bailout", "reason": "could not write a failing test; the crash needs a live Plex server"}
+{"outcome": "failed", "reason": "what went wrong"}
+```
+
+Write it with a heredoc to the exact path given in your task data below. Create
+the parent directory first if it does not exist.
+
+A `bailout` is a legitimate, expected outcome. Choose it whenever the operating
+rules tell you to. Do not open a PR you would not defend in review.

--- a/.claude/skills/issue-loop/prompts/guardrails.md
+++ b/.claude/skills/issue-loop/prompts/guardrails.md
@@ -1,0 +1,85 @@
+# Autonomous fix agent: operating rules
+
+You are running unattended. Nobody will answer a question, approve a plan, or
+rescue a half-finished change. Everything below is a hard rule.
+
+## Scope
+
+You are fixing exactly one GitHub issue in one git worktree that belongs to you
+alone. Do not touch other worktrees, other branches, or unrelated files. Other
+agents are working in this repository right now; uncommitted changes elsewhere
+are theirs, not yours.
+
+## Git
+
+- Your worktree was created on a generated branch name. Rename it once, as your
+  very first action, to the name given in your task data: `git branch -m fix/issue-<N>`.
+  Work on that one branch and no other.
+- **Never** push to `master`, force-push, merge, rebase onto a shared branch, or
+  delete a branch you did not create.
+- **Never** use bare `git stash` or `git stash pop`. The stash stack is shared
+  with every other worktree on this machine and you would pop someone else's
+  work. If you must set something aside, make a WIP commit.
+- **Never** pass `--no-verify`. The pre-commit hooks are the point.
+- Commit through devenv so the hooks find their toolchains:
+  `devenv shell -- git commit -F <message-file>`.
+  Note that `./dev shell -- <cmd>` and `./dev bash -c "<cmd>"` silently discard
+  the command you give them and exit 0 having done nothing. Use `devenv shell --`
+  directly. `./dev mix <args>` does forward correctly.
+- Stage everything you mean to commit *before* invoking commit. The hook stashes
+  unstaged changes, so anything left unstaged is silently excluded and the commit
+  still exits 0.
+- **Verify every commit with `git show --stat`.** A lone ` M` in
+  `git status --porcelain` right afterwards means the hook dropped a file; fix it
+  with `git add <path>` and `git commit --amend --no-edit` while it is unpushed.
+- Run commits one per step. Back-to-back commits race the previous hook's
+  `.git/index.lock` and fail. The lock is the hook's; do not delete it.
+- Author email is `arsfeld@gmail.com`.
+
+## The change itself
+
+- **Write the failing test first.** Add a regression test that fails against the
+  current code for the reason described in the issue. Run it and see it fail. If
+  you cannot make it fail, you have not understood the bug: bail out.
+- Then fix the code, and see the test pass.
+- Run only the tests you touched plus the module's own file:
+  `./dev mix test <paths>`. Do not run the full suite; CI does that, and running
+  it locally competes with the other agents on this machine.
+- Run `./dev mix format` and `./dev mix credo --strict` scoped to your diff.
+- Keep the diff minimal. Fix the reported defect and nothing else. If you spot
+  an adjacent bug, mention it in the PR body; do not fix it.
+
+## Repository rules you must not violate
+
+- Migrations use `:text`, never `:string`. A bare `:string` is `varchar(255)` on
+  PostgreSQL and unconstrained `TEXT` on SQLite, which ships the bug to
+  production only. The project supports both adapters; keep SQL portable.
+- Migration filenames must not collide with any branch. Use a real timestamp,
+  not a round number.
+- Never put real movie or TV titles in code, tests or fixtures. Invent them.
+- No em dashes in prose you write.
+- No AI attribution, co-author trailers, or generated-by badges in commit
+  messages or PR descriptions.
+- Never embed TVDB or TMDB API keys; metadata goes through metadata-relay.
+- Use `Req` for HTTP, never httpoison/tesla/httpc.
+
+## Bail out rather than guess
+
+Stop, write the bailout file described in your task prompt, commit nothing, and
+exit if any of these become true:
+
+- You cannot write a test that fails before your change.
+- The fix would touch more than five files.
+- The real fix needs a product decision, a schema change shared across contexts,
+  a GraphQL contract change, or a Rust rebuild.
+- You cannot reproduce the defect at all.
+- You have tried three substantially different approaches and none worked.
+
+Bailing out is a success. A clean skip costs a human one line of reading. A
+speculative PR costs them a review, a revert, and their trust in this loop.
+
+## Finishing
+
+Open the PR ready for review, never as a draft. Body must contain `Fixes #<N>`,
+a short description of the mechanism, and a note of what you tested. CI green is
+the bar; do not wait for a bot review before reporting.

--- a/.claude/skills/issue-loop/prompts/triage.md
+++ b/.claude/skills/issue-loop/prompts/triage.md
@@ -1,0 +1,61 @@
+You are triaging a single GitHub issue for the Mydia repository. You are
+read-only: you have Read, Grep and Glob and nothing else. You cannot run
+commands and you cannot edit files. Do not try.
+
+Your job is to decide whether an autonomous agent should attempt this issue
+without a human reviewing the plan first. You are not fixing anything.
+
+## What to do
+
+1. Read the issue text below.
+2. Find the code it describes. Grep for the symbols, module names, error
+   messages and file paths it mentions.
+3. Locate the actual defect. Read enough of the surrounding module to be sure
+   the mechanism you have in mind is the real one.
+4. Decide.
+
+## Answer `take` only when all of these hold
+
+- It is a genuine defect: a crash, an exception, wrong output, a security hole.
+  Not a missing feature, not a redesign, not "it would be nice if".
+- You found the cause and can name it as `file:line` plus a mechanism. "Probably
+  somewhere in the scanner" is not a cause.
+- The fix touches three files or fewer, excluding new test files.
+- You can describe a specific test that fails before the fix and passes after.
+  If the only way to prove the bug is a manual click-through, answer `skip`.
+- The behaviour change is local. It does not alter a schema shared across
+  contexts, a public GraphQL contract, a migration that rewrites rows, or
+  anything in `native/` that would force a Rust rebuild across the workspace.
+
+## Answer `skip` when
+
+- The issue is an enhancement, a refactor, or a design question, whatever its
+  label says.
+- The issue is a container: "follow-ups from #524", a checklist, several
+  unrelated defects filed together.
+- Reproducing it needs a real media server, a real indexer, a real device, or
+  credentials.
+- You cannot find the code, or you find several plausible causes and cannot
+  choose between them.
+- The fix is obvious but the *right* fix is a judgement call about product
+  behaviour. Say so in `reason`; that is useful to a human.
+
+Being wrong in the `take` direction is expensive: an agent will spend an hour
+and open a bad PR. Being wrong in the `skip` direction costs almost nothing, a
+human reads one line and overrides you. Skip when unsure.
+
+Set `confidence` to your honest probability that `root_cause` is the actual
+cause. Do not inflate it. A `take` at 0.6 is a useful answer; a `take` at 0.9
+that you do not believe is not.
+
+## Repository orientation
+
+- Phoenix/Elixir under `lib/`, tests under `test/`, mirroring the lib path.
+- The Flutter player is `player/`, a Rust p2p core is `native/`, and a
+  separately deployed metadata proxy is `metadata-relay/`.
+- Deeper notes live next to the code: `lib/mydia/media/README.md`,
+  `priv/repo/README.md`, `test/README.md`, `lib/mydia_web/schema/README.md`,
+  and others listed in the table at the end of `CLAUDE.md`. Read the relevant
+  one before judging blast radius.
+
+Respond with the JSON object required by the schema. No prose outside it.

--- a/.claude/skills/issue-loop/schema/triage.json
+++ b/.claude/skills/issue-loop/schema/triage.json
@@ -1,0 +1,48 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "verdict",
+    "confidence",
+    "reason",
+    "root_cause",
+    "files_to_change",
+    "test_plan",
+    "risk"
+  ],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["take", "skip"],
+      "description": "take only if this is a real defect with a located cause and a bounded fix"
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "how sure you are that the root cause below is the actual cause"
+    },
+    "reason": {
+      "type": "string",
+      "description": "one sentence justifying the verdict"
+    },
+    "root_cause": {
+      "type": "string",
+      "description": "file:line plus the mechanism, or an explanation of why you could not find one"
+    },
+    "files_to_change": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "repo-relative paths the fix would touch, excluding new test files"
+    },
+    "test_plan": {
+      "type": "string",
+      "description": "the specific test that would fail before the fix and pass after"
+    },
+    "risk": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "description": "low means the blast radius is one module and the behaviour change is local"
+    }
+  }
+}

--- a/.claude/skills/issue-loop/scripts/babysit.sh
+++ b/.claude/skills/issue-loop/scripts/babysit.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Phase 3: carry each open PR to merge.
+#
+# The polling itself costs no tokens: `gh pr view` tells us whether checks are
+# green and whether anyone has commented. An agent is only woken when there is
+# something for it to do, and it is woken by resuming the very session that
+# wrote the fix, so it still has the whole change in context.
+#
+# Usage: babysit.sh [--once]
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require gh jq claude
+
+ONCE=0
+[[ ${1:-} == --once ]] && ONCE=1
+POLL="${ISSUE_LOOP_PR_POLL_SECONDS:-120}"
+
+wake() {
+  local issue=$1 reason=$2
+  local uuid rounds resultf promptf
+  uuid=$(state_get "$issue" .uuid)
+  rounds=$(( $(state_get "$issue" .rounds || echo 0) + 1 ))
+  resultf="$STATE_DIR/results/$issue.json"
+  promptf="$STATE_DIR/logs/babysit-$issue-$rounds.md"
+
+  if (( rounds > MAX_ROUNDS )); then
+    state_merge "$issue" '{"phase":"needs_human","note":"exceeded max babysit rounds"}'
+    warn "#$issue -> gave up after $MAX_ROUNDS rounds"
+    return
+  fi
+
+  {
+    cat "$SKILL_DIR/prompts/babysit.md"
+    printf '\n---\n\n## This round\n\n%s\n\n' "$reason"
+    printf -- '- Result file: `%s`\n' "$resultf"
+    printf -- '- Round %s of %s\n\n' "$rounds" "$MAX_ROUNDS"
+  } >"$promptf"
+
+  log "#$issue -> waking agent, round $rounds ($reason)"
+  claude --bg --resume "$uuid" \
+    "${NO_MCP[@]}" \
+    --permission-mode acceptEdits \
+    --permission-prompts none \
+    --max-budget-usd "$FIX_BUDGET" \
+    -p "$(cat "$promptf")" \
+    >"$STATE_DIR/logs/babysit-$issue-$rounds.log" 2>&1 ||
+    warn "#$issue: could not resume session $uuid"
+
+  state_merge "$issue" "$(jq -n --argjson r "$rounds" '{rounds: $r, phase: "babysitting"}')"
+}
+
+check_one() {
+  local issue=$1 pr view state checks failed pending seen latest
+  pr=$(state_get "$issue" .pr)
+  [[ -n $pr ]] || { state_merge "$issue" '{"phase":"needs_human","note":"no PR recorded"}'; return; }
+
+  # An agent woken last round may still be working. Leave it alone until it goes
+  # idle, then read what it decided and put the issue back in the polling pool.
+  if [[ $(state_get "$issue" .phase) == babysitting ]]; then
+    local agent status resultf
+    agent=$(state_get "$issue" .agent)
+    status=$(claude agents --json 2>/dev/null |
+      jq -r --arg a "$agent" '.[] | select(.id == $a) | .status // empty')
+    [[ $status == busy ]] && return
+
+    resultf="$STATE_DIR/results/$issue.json"
+    if [[ -f $resultf ]] && [[ $(jq -r '.outcome // ""' <"$resultf" 2>/dev/null) == needs_human ]]; then
+      state_merge "$issue" "$(jq -c '{phase: "needs_human", note: (.reason // "agent asked for a human")}' <"$resultf")"
+      warn "#$issue -> agent handed back: $(jq -r '.reason // ""' <"$resultf")"
+      return
+    fi
+    state_merge "$issue" '{"phase":"pr_open"}'
+  fi
+
+  view=$(gh pr view "$pr" --repo "$REPO" \
+    --json state,mergeStateStatus,statusCheckRollup,comments,reviews 2>/dev/null) || {
+    warn "#$issue: cannot read PR #$pr"; return
+  }
+
+  state=$(jq -r .state <<<"$view")
+  if [[ $state == MERGED ]]; then
+    state_merge "$issue" '{"phase":"merged"}'
+    log "#$issue -> PR #$pr merged"
+    local agent; agent=$(state_get "$issue" .agent)
+    [[ -n $agent ]] && claude stop "$agent" >/dev/null 2>&1 || true
+    return
+  fi
+  if [[ $state == CLOSED ]]; then
+    state_merge "$issue" '{"phase":"needs_human","note":"PR was closed without merging"}'
+    return
+  fi
+
+  checks=$(jq -r '[.statusCheckRollup[]? | .conclusion // .state // empty]' <<<"$view")
+  failed=$(jq -r '[.[] | select(. == "FAILURE" or . == "TIMED_OUT" or . == "CANCELLED" or . == "ERROR")] | length' <<<"$checks")
+  pending=$(jq -r '[.[] | select(. == "PENDING" or . == "IN_PROGRESS" or . == "QUEUED" or . == null)] | length' <<<"$checks")
+
+  # Newest human or bot comment we have not reacted to yet.
+  latest=$(jq -r '[.comments[]?, (.reviews[]? | select((.body // "") != ""))] | map(.createdAt // .submittedAt) | max // ""' <<<"$view")
+  seen=$(state_get "$issue" .last_comment_at)
+
+  if (( failed > 0 )); then
+    wake "$issue" "CI is red on PR #$pr. $failed failing check(s)."
+  elif [[ -n $latest && $latest != "$seen" ]]; then
+    state_merge "$issue" "$(jq -n --arg t "$latest" '{last_comment_at: $t}')"
+    wake "$issue" "New review activity on PR #$pr since the last round."
+  elif (( pending > 0 )); then
+    log "#$issue -> PR #$pr: $pending check(s) still running"
+  else
+    log "#$issue -> PR #$pr green, waiting on auto-merge"
+  fi
+}
+
+# Turn on auto-merge once per PR, so a green PR lands without another wake-up.
+for issue in $(issues_in_phase pr_open); do
+  pr=$(state_get "$issue" .pr)
+  if [[ -n $pr && $(state_get "$issue" .automerge) != "true" ]]; then
+    if gh pr merge "$pr" --repo "$REPO" --auto --merge >/dev/null 2>&1; then
+      state_merge "$issue" '{"automerge": true}'
+      log "#$issue -> auto-merge enabled on PR #$pr"
+    else
+      warn "#$issue -> could not enable auto-merge on PR #$pr"
+    fi
+  fi
+done
+
+while :; do
+  mapfile -t OPEN < <(issues_in_phase pr_open babysitting)
+  (( ${#OPEN[@]} )) || { log "no PRs left to babysit"; break; }
+
+  for issue in "${OPEN[@]}"; do check_one "$issue"; done
+
+  (( ONCE )) && break
+  mapfile -t STILL < <(issues_in_phase pr_open babysitting)
+  (( ${#STILL[@]} )) || break
+  sleep "$POLL"
+done
+
+"$SKILL_DIR/scripts/status.sh"

--- a/.claude/skills/issue-loop/scripts/fix.sh
+++ b/.claude/skills/issue-loop/scripts/fix.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Phase 2: fix the approved issues, one background agent per issue.
+#
+# Each agent gets its own git worktree (courtesy of `claude --bg -w`) and its own
+# pre-generated session UUID, so phase 3 can resume exactly the session that
+# wrote the fix, with its context intact.
+#
+# Usage: fix.sh [--yolo] [issue...]
+#   --yolo      also run issues triage marked 'skipped' (you asked for it)
+#   issue...    fix only these numbers instead of every approved issue
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require gh jq claude uuidgen
+
+YOLO=0
+EXPLICIT=()
+for arg in "$@"; do
+  case $arg in
+    --yolo) YOLO=1 ;;
+    [0-9]*) EXPLICIT+=("$arg") ;;
+    *)      die "unknown argument: $arg" ;;
+  esac
+done
+
+if (( ${#EXPLICIT[@]} )); then
+  TARGETS=("${EXPLICIT[@]}")
+elif (( YOLO )); then
+  mapfile -t TARGETS < <(issues_in_phase approved skipped)
+else
+  mapfile -t TARGETS < <(issues_in_phase approved)
+fi
+
+(( ${#TARGETS[@]} )) || { log "nothing approved to fix; run triage.sh first"; exit 0; }
+log "${#TARGETS[@]} issue(s) to fix, ${FIX_CONCURRENCY} at a time"
+
+AGENT_NAME_PREFIX="issue-loop"
+mkdir -p "$STATE_DIR/results"
+
+# running_count -- how many of OUR agents are still alive. Matching on the name
+# prefix rather than cwd keeps us from counting the user's own sessions.
+running_count() {
+  claude agents --json 2>/dev/null |
+    jq --arg p "$AGENT_NAME_PREFIX" '[.[] | select(.name // "" | startswith($p))] | length'
+}
+
+launch() {
+  local issue=$1
+  local uuid short branch wt promptf resultf title verdict
+  uuid=$(uuidgen)
+  short=${uuid:0:8}
+  branch="fix/issue-$issue"
+  wt="$MAIN_ROOT/.claude/worktrees/issue-$issue"
+  resultf="$STATE_DIR/results/$issue.json"
+  promptf="$STATE_DIR/logs/prompt-$issue.md"
+  rm -f "$resultf"
+
+  title=$(state_get "$issue" .title)
+  verdict=$(state_get "$issue" '.verdict | tojson')
+
+  {
+    cat "$SKILL_DIR/prompts/fix.md"
+    printf '\n---\n\n## Task data\n\n'
+    printf -- '- Issue: **#%s** in `%s`\n' "$issue" "$REPO"
+    printf -- '- Title: %s\n' "$title"
+    printf -- '- Rename your branch to `%s` as your very first action: `git branch -m %s`\n' "$branch" "$branch"
+    printf -- '- Write your result file to exactly this path: `%s`\n' "$resultf"
+    printf '\n### Triage findings\n\n```json\n%s\n```\n' "$verdict"
+    printf '\n### Issue body\n\n'
+    gh issue view "$issue" --repo "$REPO" --json body -q .body
+    printf '\n### Comments\n\n'
+    gh issue view "$issue" --repo "$REPO" --json comments \
+      -q '.comments[] | "**\(.author.login):** \(.body)\n"' 2>/dev/null || true
+  } >"$promptf"
+
+  claude --bg \
+    -w "issue-$issue" \
+    -n "$AGENT_NAME_PREFIX #$issue" \
+    --session-id "$uuid" \
+    --model "$MODEL" \
+    "${NO_MCP[@]}" \
+    --permission-mode acceptEdits \
+    --permission-prompts none \
+    --max-budget-usd "$FIX_BUDGET" \
+    --append-system-prompt "$(cat "$SKILL_DIR/prompts/guardrails.md")" \
+    -p "$(cat "$promptf")" \
+    >"$STATE_DIR/logs/launch-$issue.log" 2>&1 ||
+    { warn "#$issue: launch failed, see $STATE_DIR/logs/launch-$issue.log"; return 1; }
+
+  state_merge "$issue" "$(jq -n \
+    --arg u "$uuid" --arg s "$short" --arg b "$branch" --arg w "$wt" \
+    '{phase: "fixing", uuid: $u, agent: $s, branch: $b, worktree: $w, idle_polls: 0}')"
+  log "#$issue launched as agent $short in $wt"
+}
+
+for issue in "${TARGETS[@]}"; do
+  while (( $(running_count) >= FIX_CONCURRENCY )); do sleep 20; done
+  launch "$issue" || state_merge "$issue" '{"phase":"failed","note":"agent launch failed"}'
+  sleep 2   # stagger, so N worktree creations do not all compile at once
+done
+
+log "all agents launched; harvesting"
+exec "$SKILL_DIR/scripts/harvest.sh"

--- a/.claude/skills/issue-loop/scripts/harvest.sh
+++ b/.claude/skills/issue-loop/scripts/harvest.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Waits for phase-2 agents to finish and records what each one did.
+#
+# An agent is done when it writes its result file. An agent that has gone idle
+# without writing one is stuck: it hit its budget, ran out of turns, or talked
+# itself into a corner. Those are marked needs_human rather than waited on
+# forever.
+#
+# Usage: harvest.sh [--once]
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require jq claude
+
+ONCE=0
+[[ ${1:-} == --once ]] && ONCE=1
+
+POLL="${ISSUE_LOOP_POLL_SECONDS:-30}"
+IDLE_GRACE="${ISSUE_LOOP_IDLE_GRACE:-3}"   # consecutive idle polls before giving up
+
+harvest_one() {
+  local issue=$1
+  local resultf="$STATE_DIR/results/$issue.json"
+  local agent outcome status idle
+
+  agent=$(state_get "$issue" .agent)
+
+  if [[ -f $resultf ]] && jq -e .outcome >/dev/null 2>&1 <"$resultf"; then
+    outcome=$(jq -r .outcome <"$resultf")
+    case $outcome in
+      pr_opened)
+        state_merge "$issue" "$(jq -c '{phase: "pr_open", pr: .pr, branch: (.branch // ""), note: (.note // "")}' <"$resultf")"
+        log "#$issue -> PR #$(jq -r .pr <"$resultf")"
+        ;;
+      bailout)
+        state_merge "$issue" "$(jq -c '{phase: "skipped", note: ("bailout: " + (.reason // "no reason given"))}' <"$resultf")"
+        log "#$issue -> bailed out: $(jq -r '.reason // ""' <"$resultf")"
+        ;;
+      *)
+        state_merge "$issue" "$(jq -c '{phase: "failed", note: (.reason // "agent reported failure")}' <"$resultf")"
+        warn "#$issue -> failed: $(jq -r '.reason // ""' <"$resultf")"
+        ;;
+    esac
+    [[ -n $agent ]] && claude stop "$agent" >/dev/null 2>&1 || true
+    return
+  fi
+
+  # No result file yet. Is the agent still alive and working?
+  status=$(claude agents --json 2>/dev/null |
+    jq -r --arg a "$agent" '.[] | select(.id == $a) | .status // empty')
+
+  if [[ -z $status ]]; then
+    state_merge "$issue" '{"phase":"needs_human","note":"agent exited without writing a result file"}'
+    warn "#$issue -> agent gone, no result"
+    return
+  fi
+
+  if [[ $status == idle ]]; then
+    idle=$(( $(state_get "$issue" .idle_polls || echo 0) + 1 ))
+    state_merge "$issue" "$(jq -n --argjson i "$idle" '{idle_polls: $i}')"
+    if (( idle >= IDLE_GRACE )); then
+      state_merge "$issue" '{"phase":"needs_human","note":"agent went idle without writing a result file"}'
+      warn "#$issue -> stuck and idle, marked needs_human (claude attach $agent to take over)"
+      claude stop "$agent" >/dev/null 2>&1 || true
+    fi
+  else
+    state_merge "$issue" '{"idle_polls": 0}'
+  fi
+}
+
+while :; do
+  mapfile -t PENDING < <(issues_in_phase fixing)
+  (( ${#PENDING[@]} )) || { log "no agents still fixing"; break; }
+
+  for issue in "${PENDING[@]}"; do harvest_one "$issue"; done
+
+  mapfile -t STILL < <(issues_in_phase fixing)
+  (( ${#STILL[@]} )) || break
+  (( ONCE )) && break
+
+  log "${#STILL[@]} still working: ${STILL[*]}"
+  sleep "$POLL"
+done
+
+"$SKILL_DIR/scripts/status.sh"

--- a/.claude/skills/issue-loop/scripts/lib.sh
+++ b/.claude/skills/issue-loop/scripts/lib.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Shared configuration and state helpers for the issue-loop skill.
+#
+# Every phase sources this. State lives in the MAIN checkout, never in a
+# worktree, so that agents scattered across per-issue worktrees all read and
+# write the same files, and so that deleting a worktree loses nothing.
+
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MAIN_ROOT="$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")"
+STATE_DIR="${ISSUE_LOOP_STATE_DIR:-$MAIN_ROOT/.claude/issue-loop}"
+export SKILL_DIR MAIN_ROOT STATE_DIR
+
+mkdir -p "$STATE_DIR/issues" "$STATE_DIR/logs"
+
+REPO="${ISSUE_LOOP_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo getmydia/mydia)}"
+MODEL="${ISSUE_LOOP_MODEL:-sonnet}"
+TRIAGE_CONCURRENCY="${ISSUE_LOOP_TRIAGE_CONCURRENCY:-10}"
+FIX_CONCURRENCY="${ISSUE_LOOP_FIX_CONCURRENCY:-4}"
+MAX_ROUNDS="${ISSUE_LOOP_MAX_ROUNDS:-3}"
+FIX_BUDGET="${ISSUE_LOOP_FIX_BUDGET:-8}"
+TRIAGE_BUDGET="${ISSUE_LOOP_TRIAGE_BUDGET:-1}"
+BASE_REF="${ISSUE_LOOP_BASE_REF:-origin/master}"
+export REPO MODEL TRIAGE_CONCURRENCY FIX_CONCURRENCY MAX_ROUNDS FIX_BUDGET TRIAGE_BUDGET BASE_REF
+
+# Auto-take gate. An issue must clear every one of these to be fixed without a
+# human looking at it first.
+MIN_CONFIDENCE="${ISSUE_LOOP_MIN_CONFIDENCE:-0.7}"
+MAX_FILES="${ISSUE_LOOP_MAX_FILES:-3}"
+export MIN_CONFIDENCE MAX_FILES
+
+log()  { printf '\033[2m[%s]\033[0m %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+warn() { printf '\033[33m[%s] %s\033[0m\n' "$(date +%H:%M:%S)" "$*" >&2; }
+die()  { printf '\033[31m[%s] %s\033[0m\n' "$(date +%H:%M:%S)" "$*" >&2; exit 1; }
+
+state_file() { printf '%s/issues/%s.json' "$STATE_DIR" "$1"; }
+
+# state_merge <issue> <json-patch>
+# Shallow-merges the patch into the issue's state file under a lock, because
+# several agents finish at once and would otherwise clobber each other.
+state_merge() {
+  local issue=$1 patch=$2 file
+  file=$(state_file "$issue")
+  (
+    flock 9
+    local cur
+    cur=$(cat "$file" 2>/dev/null || echo '{}')
+    jq -n --argjson a "$cur" --argjson b "$patch" \
+      '$a * $b * {updated: (now | todateiso8601)}' >"$file.tmp"
+    mv "$file.tmp" "$file"
+  ) 9>"$file.lock"
+}
+
+# state_get <issue> <jq-path>
+state_get() {
+  local file
+  file=$(state_file "$1")
+  [[ -f $file ]] || return 0
+  jq -r "$2 // empty" "$file" 2>/dev/null || true
+}
+
+# issues_in_phase <phase>...
+issues_in_phase() {
+  local wanted
+  wanted=$(printf '%s\n' "$@" | jq -R . | jq -sc .)
+  find "$STATE_DIR/issues" -name '*.json' -print0 2>/dev/null |
+    xargs -0 -r jq -r --argjson w "$wanted" 'select(.phase as $p | $w | index($p)) | .issue' |
+    sort -n
+}
+
+# throttle <max> blocks until fewer than <max> background jobs are running.
+throttle() {
+  while (( $(jobs -rp | wc -l) >= $1 )); do wait -n; done
+}
+
+# MCP servers are not wanted in any loop agent: they cost tokens, add latency and
+# offer nothing to a triage or fix agent. `--restricted` alone does not drop
+# them, so every launch pairs it with these two flags.
+# (a bash array, so it is inherited by sourcing, not by export)
+NO_MCP=(--strict-mcp-config --mcp-config '{"mcpServers":{}}')
+
+# claude_result <raw-json>
+# `--output-format json` prints a JSON *array* of events. The interesting one is
+# the last `type == "result"`, which carries the answer twice: `structured_output`
+# already parsed (present when --json-schema was used) and `result` as a string.
+# Prefer the parsed form, fall back to parsing the string, and never fail.
+claude_result() {
+  jq -c '
+    (if type == "array" then (map(select(.type == "result")) | last) else . end) as $r
+    | if $r == null then {raw: "no result event"}
+      elif ($r.structured_output // null) != null then $r.structured_output
+      elif ($r.result | type) == "object" then $r.result
+      elif ($r.result | type) == "string" then (try ($r.result | fromjson) catch {raw: $r.result})
+      else {raw: ($r | tostring)}
+      end
+  ' <<<"$1" 2>/dev/null || jq -n --arg s "$1" '{raw: $s}'
+}
+
+require() {
+  local c
+  for c in "$@"; do
+    command -v "$c" >/dev/null || die "missing required command: $c"
+  done
+}

--- a/.claude/skills/issue-loop/scripts/run.sh
+++ b/.claude/skills/issue-loop/scripts/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Runs the whole loop: triage, then a human gate, then fix, then babysit.
+#
+# Every phase is separately resumable, so an interrupted run picks up where it
+# stopped rather than starting over.
+#
+# Usage: run.sh [--yolo] [--no-babysit] [issue...]
+#   --yolo         skip the human gate after triage
+#   --no-babysit   stop once the PRs are open
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require gh jq claude uuidgen
+
+YOLO=0
+BABYSIT=1
+PASS=()
+for arg in "$@"; do
+  case $arg in
+    --yolo)       YOLO=1 ;;
+    --no-babysit) BABYSIT=0 ;;
+    [0-9]*)       PASS+=("$arg") ;;
+    *)            die "unknown argument: $arg" ;;
+  esac
+done
+
+log "phase 1: triage"
+"$SKILL_DIR/scripts/triage.sh" "${PASS[@]}"
+
+mapfile -t APPROVED < <(issues_in_phase approved)
+
+# When the caller named specific issues, do not sweep in ones approved by an
+# earlier run.
+if (( ${#PASS[@]} )); then
+  mapfile -t APPROVED < <(
+    comm -12 <(printf '%s\n' "${APPROVED[@]}" | sort) <(printf '%s\n' "${PASS[@]}" | sort)
+  )
+fi
+
+if ! (( ${#APPROVED[@]} )); then
+  log "triage approved nothing. Review the table above; force one with: fix.sh <issue>"
+  exit 0
+fi
+
+if ! (( YOLO )); then
+  echo
+  echo "Triage approved ${#APPROVED[@]} issue(s): ${APPROVED[*]}"
+  echo "Each will get its own worktree, its own agent, and its own PR."
+  read -r -p "Proceed? [y/N] " reply
+  [[ $reply == [yY]* ]] || { log "stopped at the gate; nothing was changed"; exit 0; }
+fi
+
+log "phase 2: fix"
+"$SKILL_DIR/scripts/fix.sh" "${APPROVED[@]}"
+
+if (( BABYSIT )); then
+  log "phase 3: babysit"
+  "$SKILL_DIR/scripts/babysit.sh"
+fi
+
+"$SKILL_DIR/scripts/status.sh"

--- a/.claude/skills/issue-loop/scripts/status.sh
+++ b/.claude/skills/issue-loop/scripts/status.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Prints the state of every issue the loop knows about.
+# Usage: status.sh [--json]
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [[ ${1:-} == --json ]]; then
+  find "$STATE_DIR/issues" -name '*.json' -print0 2>/dev/null |
+    xargs -0 -r jq -s 'sort_by(.issue)'
+  exit 0
+fi
+
+rows=$(find "$STATE_DIR/issues" -name '*.json' -print0 2>/dev/null |
+  xargs -0 -r jq -r '
+    [ (.issue | tostring),
+      (.phase // "new"),
+      (.agent // "-"),
+      (if .pr then "#\(.pr)" else "-" end),
+      ((.verdict.confidence // "") | tostring),
+      ((.note // .verdict.reason // "") | .[0:64])
+    ] | @tsv' | sort -n)
+
+if [[ -z $rows ]]; then
+  echo "No issue-loop state yet. Run triage.sh first."
+  exit 0
+fi
+
+{
+  printf 'ISSUE\tPHASE\tAGENT\tPR\tCONF\tNOTE\n'
+  printf '%s\n' "$rows"
+} | column -t -s $'\t'
+
+echo
+printf '%s\n' "$rows" | awk -F'\t' '{c[$2]++} END {for (p in c) printf "%s=%d  ", p, c[p]; print ""}'
+
+echo
+echo "attach to an agent: claude attach <AGENT>    tail its output: claude logs <AGENT>"

--- a/.claude/skills/issue-loop/scripts/stop-all.sh
+++ b/.claude/skills/issue-loop/scripts/stop-all.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Kill switch. Stops every agent this loop started, leaving their conversations
+# intact so you can `claude attach <id>` and take over any of them by hand.
+#
+# Usage: stop-all.sh [--rm]
+#   --rm   also delete the sessions and their worktrees, where that is safe
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+RM=0
+[[ ${1:-} == --rm ]] && RM=1
+
+mapfile -t AGENTS < <(claude agents --json 2>/dev/null |
+  jq -r '.[] | select(.name // "" | startswith("issue-loop")) | .id')
+
+(( ${#AGENTS[@]} )) || { log "no issue-loop agents running"; exit 0; }
+
+for a in "${AGENTS[@]}"; do
+  log "stopping $a"
+  claude stop "$a" >/dev/null 2>&1 || warn "could not stop $a"
+  if (( RM )); then
+    claude rm "$a" >/dev/null 2>&1 || warn "could not remove $a"
+  fi
+done
+
+log "stopped ${#AGENTS[@]} agent(s)"
+(( RM )) || log "conversations kept; 'claude attach <id>' to take one over"

--- a/.claude/skills/issue-loop/scripts/triage.sh
+++ b/.claude/skills/issue-loop/scripts/triage.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Phase 1: decide which open issues an agent should attempt.
+#
+# Read-only by construction. Every triage agent runs with --restricted and a
+# tool list of Read,Grep,Glob, so it has no Bash and no Edit and cannot change
+# anything even if it decides it wants to.
+#
+# Usage: triage.sh [--refresh] [issue...]
+#   --refresh   re-triage issues that already have a verdict
+#   issue...    triage only these numbers instead of scanning open issues
+
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+require gh jq claude
+
+REFRESH=0
+EXPLICIT=()
+for arg in "$@"; do
+  case $arg in
+    --refresh) REFRESH=1 ;;
+    [0-9]*)    EXPLICIT+=("$arg") ;;
+    *)         die "unknown argument: $arg" ;;
+  esac
+done
+
+# A single shared worktree for all triage agents. They only read, so one
+# checkout serves every agent and costs far less than one per issue.
+TRIAGE_WT="$MAIN_ROOT/.claude/worktrees/issue-loop-triage"
+if [[ -d $TRIAGE_WT ]]; then
+  git -C "$TRIAGE_WT" fetch --quiet origin || true
+  git -C "$TRIAGE_WT" checkout --quiet --detach "$BASE_REF"
+else
+  log "creating shared triage worktree at $TRIAGE_WT"
+  git -C "$MAIN_ROOT" fetch --quiet origin || true
+  git -C "$MAIN_ROOT" worktree add --quiet --detach "$TRIAGE_WT" "$BASE_REF"
+fi
+
+if (( ${#EXPLICIT[@]} )); then
+  ISSUES=$(
+    for n in "${EXPLICIT[@]}"; do
+      gh issue view "$n" --repo "$REPO" --json number,title,body,labels
+    done | jq -sc .
+  )
+else
+  log "fetching open bug and crash issues from $REPO"
+  ISSUES=$(gh issue list --repo "$REPO" --state open --limit 300 \
+    --json number,title,body,labels |
+    jq -c '[.[] | select([.labels[].name] | any(. == "bug" or . == "crash"))]')
+fi
+
+COUNT=$(jq length <<<"$ISSUES")
+log "$COUNT candidate issue(s)"
+(( COUNT )) || { log "nothing to triage"; exit 0; }
+
+# triage_one <issue> <title> <body> <labels-json>
+triage_one() {
+  local issue=$1 title=$2 body=$3 labels=$4
+  local logf="$STATE_DIR/logs/triage-$issue.log"
+  local out raw gated
+
+  out=$(
+    {
+      cat "$SKILL_DIR/prompts/triage.md"
+      printf '\n---\n\n# Issue #%s\n\n**Title:** %s\n\n**Labels:** %s\n\n**Body:**\n\n%s\n' \
+        "$issue" "$title" "$labels" "$body"
+    } | (
+      cd "$TRIAGE_WT" && claude -p \
+        --model "$MODEL" \
+        --restricted \
+        --tools Read,Grep,Glob \
+        "${NO_MCP[@]}" \
+        --permission-prompts none \
+        --output-format json \
+        --json-schema "$(cat "$SKILL_DIR/schema/triage.json")" \
+        --max-budget-usd "$TRIAGE_BUDGET" \
+        --no-session-persistence
+    ) 2>"$logf"
+  ) || { warn "#$issue: triage agent failed, see $logf"; return 0; }
+
+  raw=$(claude_result "$out")
+  if ! jq -e '.verdict' >/dev/null 2>&1 <<<"$raw"; then
+    warn "#$issue: unparseable verdict, see $logf"
+    printf '%s\n' "$raw" >>"$logf"
+    state_merge "$issue" '{"phase":"needs_human","note":"triage returned no usable verdict"}'
+    return 0
+  fi
+
+  # The gate. Every clause must hold for the loop to proceed unattended.
+  gated=$(jq -c \
+    --argjson minc "$MIN_CONFIDENCE" \
+    --argjson maxf "$MAX_FILES" \
+    --argjson labels "$labels" '
+      . as $v
+      | ($v.verdict == "take"
+         and $v.confidence >= $minc
+         and $v.risk == "low"
+         and ($v.files_to_change | length) <= $maxf
+         and ($labels | any(. == "bug" or . == "crash"))) as $ok
+      | {verdict: $v, phase: (if $ok then "approved" else "skipped" end)}
+    ' <<<"$raw")
+
+  state_merge "$issue" "$gated"
+  log "#$issue -> $(jq -r .phase <<<"$gated") ($(jq -r .verdict <<<"$raw") @ $(jq -r .confidence <<<"$raw"), risk $(jq -r .risk <<<"$raw"))"
+}
+
+# Process substitution, not a pipe: a pipe would run the loop in a subshell and
+# `throttle` would never see the background jobs.
+while read -r row; do
+  n=$(jq -r .number <<<"$row")
+  title=$(jq -r .title <<<"$row")
+  body=$(jq -r '.body // ""' <<<"$row")
+  labels=$(jq -c '[.labels[].name]' <<<"$row")
+
+  existing=$(state_get "$n" .phase)
+  if [[ -n $existing && $existing != new && $REFRESH -eq 0 ]]; then
+    log "#$n already at phase '$existing', skipping (use --refresh to redo)"
+    continue
+  fi
+
+  state_merge "$n" "$(jq -n --argjson i "$n" --arg t "$title" --argjson l "$labels" \
+    '{issue: $i, title: $t, labels: $l, phase: "new", rounds: 0}')"
+
+  throttle "$TRIAGE_CONCURRENCY"
+  triage_one "$n" "$title" "$body" "$labels" &
+done < <(jq -c '.[]' <<<"$ISSUES")
+wait
+
+log "triage complete"
+"$SKILL_DIR/scripts/status.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ terraform.rc
 
 
 .claude/worktrees/
+# Run state for the issue-loop skill: per-issue JSON, rendered prompts, agent logs.
+.claude/issue-loop/
 .opencode/
 .worktrees
 /.devenv/


### PR DESCRIPTION
Adds a project skill that fans Claude Code out over the open issue list, one background agent per issue, taking only bugs and crashes that are genuinely straightforward and carrying each to a merged PR.

## Why this shape

`claude --bg -w <name>` already launches a background session in its own git worktree, and `claude agents --json` / `logs` / `attach` / `stop` manage the fleet. So there is no hand-rolled `xargs -P` and no manual `git worktree add`. The driver only does what the CLI does not: cap concurrency, sequence the phases, and keep per-issue state.

## Phases

**Triage** gives each open `bug` or `crash` issue a read-only agent, launched with `--restricted --tools Read,Grep,Glob` so it has no Bash and no Edit and structurally cannot change anything. Each returns a `--json-schema` validated verdict with a located root cause, the files a fix would touch, and a test plan.

Auto-approval requires all of: verdict `take`, confidence `>= 0.7`, risk `low`, three files or fewer, and a `bug` or `crash` label. Everything else is listed for a human with a one-line reason. The asymmetry is deliberate: a wrong skip costs one line of reading, a wrong take costs a bad PR review.

**Fix** gives each approved issue its own worktree and agent, with a pre-generated `--session-id`. The agent writes a failing regression test first, keeps the diff minimal, runs only the touched tests, and opens a PR ready for review. If it cannot make a test fail, or the fix would exceed five files, it bails out and commits nothing.

**Babysit** polls `gh pr checks` directly, which costs no tokens, and wakes the agent with `--resume` only when CI goes red or someone comments. Because it resumes the same session that wrote the fix, the agent still has the whole change in context. Three rounds, then it hands back.

## Validation

Phase 1 was run against six live issues:

| issue | verdict | confidence |
| --- | --- | --- |
| 706 TranscodeJob `Ecto.StaleEntryError` | approved | 0.88 |
| 708 playback-progress subscription crash | approved | 0.85 |
| 707 OIDC 500 on provider timeout | approved | 0.72 |
| 553 per-account age-rating controls | skipped, feature work | 0.98 |
| 702 manual file attachment | skipped, feature work | 0.98 |
| 525 follow-ups from #524 | skipped, checklist | 0.95 |

The #706 root cause it found is correct: `Repo.update` raises `Ecto.StaleEntryError` when zero rows match, so the existing `error -> error` catch-all can never see it.

Phases 2 and 3 have not been run end to end, because doing so opens real PRs. Their scripts are syntax-checked and their state machine is exercised by the phase-1 run.

## Notes

- Run state lives in `.claude/issue-loop/` in the main checkout, added to `.gitignore`.
- Defaults to Sonnet and a fix concurrency of 4, since each fresh worktree pays a full Elixir recompile plus a Rust NIF build before its first test.
- `stop-all.sh` is the kill switch; it keeps conversations so `claude attach <id>` can take any agent over by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated workflow for triaging eligible issues, applying fixes, opening pull requests, and monitoring CI and review feedback.
  * Added safeguards, approval gates, regression-test requirements, and human handoff paths for autonomous issue handling.
  * Added status reporting and controls for stopping active issue-processing tasks.
* **Documentation**
  * Added guidance for configuring, running, troubleshooting, and understanding the issue-processing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->