### PR TITLE
fix(media): scope provider-id uniqueness by media type, close the check-then-write race

### DIFF
--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -131,10 +131,10 @@ defmodule Mydia.Library.MetadataEnricher do
          match_result,
          config
        ) do
+    provider_key = if provider_type == :tvdb, do: :tvdb, else: :tmdb
+
     existing_item =
-      if provider_type == :tvdb,
-        do: Media.get_media_item_by_tvdb(id),
-        else: Media.get_media_item_by_tmdb(id)
+      Media.find_by_external_ids(%{provider_key => id}, type: media_type_to_string(media_type))
 
     case existing_item do
       nil ->

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -452,19 +452,45 @@ defmodule Mydia.Library.MetadataEnricher do
     end
   end
 
-  defp persist_media_item(%MetadataPreparation{operation: :create, media_item_attrs: attrs}) do
-    Media.create_media_item(attrs, skip_episode_refresh: true)
+  defp persist_media_item(%MetadataPreparation{
+         operation: :create,
+         media_type: media_type,
+         media_item_attrs: attrs
+       }) do
+    ExternalIds.write(
+      attrs,
+      [type: media_type_to_string(media_type), title: attrs[:title]],
+      fn attrs ->
+        Media.create_media_item(attrs, skip_episode_refresh: true)
+      end
+    )
   end
 
+  # `:type` comes from `preparation.media_type`, not `attrs[:type]`: the
+  # `:stamp_source` operation's attrs is bare `%{metadata_source: ...}`, with
+  # no `:type` key of its own, and `media_type` is always present on the
+  # preparation regardless of what the attrs happen to carry.
   defp persist_media_item(%MetadataPreparation{
          operation: operation,
+         media_type: media_type,
          media_item_id: media_item_id,
          media_item_attrs: attrs
        })
        when operation in [:update, :stamp_source] do
     case Repo.get(MediaItem, media_item_id) do
-      nil -> {:error, {:media_item_missing, media_item_id}}
-      media_item -> Media.update_media_item(media_item, attrs, reason: "Metadata enriched")
+      nil ->
+        {:error, {:media_item_missing, media_item_id}}
+
+      media_item ->
+        ExternalIds.write(
+          attrs,
+          [
+            type: media_type_to_string(media_type),
+            exclude_id: media_item.id,
+            title: media_item.title
+          ],
+          fn attrs -> Media.update_media_item(media_item, attrs, reason: "Metadata enriched") end
+        )
     end
   end
 

--- a/lib/mydia/library/metadata_enricher.ex
+++ b/lib/mydia/library/metadata_enricher.ex
@@ -383,6 +383,7 @@ defmodule Mydia.Library.MetadataEnricher do
     # every owner found really is a different item.
     attrs =
       ExternalIds.put_free_ids(attrs, metadata.external_ids,
+        type: media_type_to_string(media_type),
         exclude_id: Map.get(match_result, :exclude_id)
       )
 

--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -147,28 +147,6 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  Gets a single media item by TMDB ID.
-  """
-  @spec get_media_item_by_tmdb(integer(), keyword()) :: MediaItem.t() | nil
-  def get_media_item_by_tmdb(tmdb_id, opts \\ []) do
-    MediaItem
-    |> where([m], m.tmdb_id == ^tmdb_id)
-    |> maybe_preload(opts[:preload])
-    |> Repo.one()
-  end
-
-  @doc """
-  Gets a single media item by TVDB ID.
-  """
-  @spec get_media_item_by_tvdb(integer(), keyword()) :: MediaItem.t() | nil
-  def get_media_item_by_tvdb(tvdb_id, opts \\ []) do
-    MediaItem
-    |> where([m], m.tvdb_id == ^tvdb_id)
-    |> maybe_preload(opts[:preload])
-    |> Repo.one()
-  end
-
-  @doc """
   Finds a media item by external IDs using cascading lookup: IMDB → TVDB → TMDB.
 
   Accepts a map with atom keys: `%{imdb: id, tvdb: id, tmdb: id}`.

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -94,7 +94,12 @@ defmodule Mydia.Media.Add do
       |> Keyword.take(@create_opt_keys)
       |> Keyword.put(:config, config)
 
-    case Media.create_media_item(attrs, create_opts) do
+    result =
+      ExternalIds.write(attrs, [type: attrs[:type], title: attrs[:title]], fn attrs ->
+        Media.create_media_item(attrs, create_opts)
+      end)
+
+    case result do
       {:ok, media_item} -> {:ok, media_item}
       {:error, changeset} -> {:error, {:changeset, changeset}}
     end
@@ -182,13 +187,21 @@ defmodule Mydia.Media.Add do
       |> Enum.reject(fn {key, value} -> Map.get(item, key) == value end)
       |> Map.new()
 
-    if changes == %{} do
-      item
-    else
-      case Media.update_media_item(item, changes, reason: "Cross-referenced provider id") do
-        {:ok, updated} -> updated
-        {:error, _reason} -> item
-      end
+    # The guard lives inside the closure, not before the call: `write/3` can drop
+    # the only remaining key on a retry, and an empty update still emits a
+    # content-free "Cross-referenced provider id" event.
+    result =
+      ExternalIds.write(changes, [type: item.type, exclude_id: item.id, title: item.title], fn
+        changes when changes == %{} ->
+          {:ok, item}
+
+        changes ->
+          Media.update_media_item(item, changes, reason: "Cross-referenced provider id")
+      end)
+
+    case result do
+      {:ok, updated} -> updated
+      {:error, _reason} -> item
     end
   end
 

--- a/lib/mydia/media/add.ex
+++ b/lib/mydia/media/add.ex
@@ -172,6 +172,7 @@ defmodule Mydia.Media.Add do
     merged =
       %{tmdb_id: item.tmdb_id, tvdb_id: item.tvdb_id}
       |> ExternalIds.put_free_ids(%{tmdb: attrs[:tmdb_id], tvdb: xrefs[:tvdb]},
+        type: item.type,
         exclude_id: item.id,
         title: item.title
       )
@@ -276,7 +277,7 @@ defmodule Mydia.Media.Add do
         Map.put(attrs, :metadata_source, opts[:metadata_source])
       end
 
-    ExternalIds.put_free_ids(attrs, metadata.external_ids)
+    ExternalIds.put_free_ids(attrs, metadata.external_ids, type: type_string)
   end
 
   @doc """

--- a/lib/mydia/media/external_ids.ex
+++ b/lib/mydia/media/external_ids.ex
@@ -22,6 +22,7 @@ defmodule Mydia.Media.ExternalIds do
   alias Mydia.Events
   alias Mydia.Media
   alias Mydia.Media.MediaItem
+  alias Mydia.Repo
 
   @type t :: %{
           tmdb: integer() | nil,
@@ -56,6 +57,9 @@ defmodule Mydia.Media.ExternalIds do
   def put_free_ids(attrs, external_ids, opts \\ [])
 
   def put_free_ids(attrs, nil, opts) do
+    # No ids to place, so the binding is unused. `fetch_type!/1` is still
+    # called for its raising side effect: a caller with no external_ids must
+    # still be required to pass a valid :type, the same as every other clause.
     _type = fetch_type!(opts)
     attrs
   end
@@ -133,6 +137,25 @@ defmodule Mydia.Media.ExternalIds do
   Anything that is not a provider-id unique-constraint error, including ordinary
   validation failures, passes straight through.
 
+  ## Ambient transactions
+
+  `fun` may run inside a transaction the caller already opened (the enricher's
+  `persist_in_transaction/1`, or `MediaRequests.insert_approval/4`'s
+  `Multi.run` + `Repo.transaction`). On PostgreSQL, a statement that fails a
+  constraint check aborts the whole transaction at the database level
+  (SQLSTATE `25P02`, `in_failed_sql_transaction`): Ecto still returns
+  `{:error, changeset}` for that call, but every later query on the same
+  connection then raises until an explicit rollback. The re-read this function
+  does right after a collision is exactly such a later query, so every attempt
+  of `fun` runs inside its own savepoint, released on success and rolled back
+  to (not just released) on error -- releasing a savepoint whose statement
+  already failed does not clear the aborted state, only `ROLLBACK TO SAVEPOINT`
+  does. SQLite has no equivalent whole-transaction abort, so this only matters
+  on PostgreSQL, and the savepoint dance is a harmless no-op there. This is a
+  savepoint for error recovery around one write attempt, a different concern
+  from the "no transaction" note above about not using a transaction to close
+  the check-then-write race, and does not reintroduce it.
+
   ## Options
 
   The same `:type` (required), `:exclude_id` and `:title` as `put_free_ids/3`.
@@ -142,16 +165,66 @@ defmodule Mydia.Media.ExternalIds do
   def write(attrs, opts, fun) when is_function(fun, 1) do
     type = fetch_type!(opts)
 
-    case fun.(attrs) do
+    case attempt(fun, attrs) do
       {:error, %Ecto.Changeset{} = changeset} = error ->
         if provider_id_conflict?(changeset) do
-          fun.(drop_taken(attrs, type, opts))
+          attempt(fun, drop_taken(attrs, type, opts))
         else
           error
         end
 
       other ->
         other
+    end
+  end
+
+  # Outside an ambient transaction this is exactly `fun.(attrs)`. Inside one,
+  # wraps the attempt in a savepoint so a constraint failure unwinds only to
+  # the savepoint rather than aborting the whole ambient transaction.
+  #
+  # `Repo.transaction(fn -> fun.(attrs) end, mode: :savepoint)` looks like the
+  # idiomatic way to ask Ecto for that savepoint, but it is not: when already
+  # inside a transaction in the same process, `Ecto.Adapters.SQL` hands
+  # `DBConnection.transaction/3` the same connection struct the outer
+  # transaction stored, already tagged `conn_mode: :transaction`, and
+  # `DBConnection.transaction/3` special-cases that by running the function
+  # directly and discarding `opts` entirely -- no SAVEPOINT is ever issued.
+  # Calling `Repo.rollback/1` inside that nested call is worse than doing
+  # nothing: verified empirically against PostgreSQL, it throws past the
+  # nested call, matches nothing that would catch it there, and disconnects
+  # the connection outright (`DBConnection.ConnectionError: transaction rolling
+  # back`). Ecto's own `mode: :savepoint` option is for a single
+  # `Repo.insert/update/delete` call, not for wrapping an enclosing
+  # `Repo.transaction`, and `fun` here is an opaque closure this module does
+  # not control the internals of, so that option has nowhere to attach.
+  # Issuing the SAVEPOINT / ROLLBACK TO SAVEPOINT / RELEASE SAVEPOINT
+  # statements directly, as below, is what actually works, verified the same
+  # way (`ROLLBACK TO SAVEPOINT` genuinely clears the aborted state, and the
+  # ambient transaction still holds every earlier write in the same test run).
+  defp attempt(fun, attrs) do
+    if Repo.in_transaction?() do
+      attempt_with_savepoint(fun, attrs)
+    else
+      fun.(attrs)
+    end
+  end
+
+  defp attempt_with_savepoint(fun, attrs) do
+    Repo.query!("SAVEPOINT external_ids_write")
+
+    case fun.(attrs) do
+      {:error, _} = error ->
+        Repo.query!("ROLLBACK TO SAVEPOINT external_ids_write")
+        Repo.query!("RELEASE SAVEPOINT external_ids_write")
+        error
+
+      ok ->
+        # RELEASE only merges the savepoint's writes back into the still-open
+        # ambient transaction; it commits nothing on its own. The ambient
+        # transaction commits or rolls back as a whole, same as if this
+        # savepoint had never existed.
+        Repo.query!("RELEASE SAVEPOINT external_ids_write")
+        ok
     end
   end
 

--- a/lib/mydia/media/external_ids.ex
+++ b/lib/mydia/media/external_ids.ex
@@ -171,11 +171,14 @@ defmodule Mydia.Media.ExternalIds do
   # the one the database happened to report. Anything still nil after that
   # re-check was never a candidate and is left alone.
   #
-  # The owner found here may have vanished by the time this runs, or may not
-  # be who the original write collided with -- either is fine, since the id
-  # cannot be proven free and dropping it is always safe.
-  # `Mydia.Jobs.MetadataBackfill` refreshes the row from its own provider
-  # later.
+  # The live re-read decides each remaining id on its own: finding an owner
+  # means the id is still taken, so it is reported and dropped, and the row
+  # left without one is picked up later by `Mydia.Jobs.MetadataBackfill`,
+  # which refreshes it from its own provider. Finding no owner means nothing
+  # currently holds the id, so it is kept and the retry carries it as-is. A
+  # third write claiming the id in the gap between this read and the retry is
+  # the residual race the module accepts: the retry then fails and `write/3`
+  # returns that changeset, the same outcome as any other second collision.
   defp drop_taken(attrs, type, opts) do
     Enum.reduce(@providers, attrs, fn provider, acc ->
       key = attrs_key(provider)

--- a/lib/mydia/media/external_ids.ex
+++ b/lib/mydia/media/external_ids.ex
@@ -106,6 +106,97 @@ defmodule Mydia.Media.ExternalIds do
     end
   end
 
+  @doc """
+  Runs a write that may still collide on a provider id, and degrades a
+  collision into the same warning flow `put_free_ids/3` produces.
+
+  `put_free_ids/3` reads ownership and the caller writes afterwards. Two writers
+  can both see an id as free and the loser fails on the unique index with a raw
+  constraint error rather than the controlled duplicate-provider result.
+
+  A transaction does not close that. At PostgreSQL's default `READ COMMITTED`
+  both writers still read the id as free and one still fails at write time, and
+  SQLite's deferred transactions behave the same. Catching the constraint error
+  and re-reading is what does the work, and it covers stale reads seconds old
+  rather than only the instant.
+
+  On a provider-id unique-constraint error, every provider id present in
+  `attrs` is re-checked live and the ones still taken are looked up, reported
+  and dropped in a single pass, then `fun` runs once more. The database only
+  ever reports the first index it aborts on, never a second one from the same
+  attempt, so dropping only that one id and retrying could still collide on
+  another; checking every present id in the same pass instead means one retry
+  always suffices, because after the pass no provider index can collide. A
+  second collision on the retry needs a third writer claiming the other id
+  between the two attempts, and returns the changeset unchanged.
+
+  Anything that is not a provider-id unique-constraint error, including ordinary
+  validation failures, passes straight through.
+
+  ## Options
+
+  The same `:type` (required), `:exclude_id` and `:title` as `put_free_ids/3`.
+  """
+  @spec write(map(), keyword(), (map() -> {:ok, term()} | {:error, Ecto.Changeset.t()})) ::
+          {:ok, term()} | {:error, Ecto.Changeset.t()}
+  def write(attrs, opts, fun) when is_function(fun, 1) do
+    type = fetch_type!(opts)
+
+    case fun.(attrs) do
+      {:error, %Ecto.Changeset{} = changeset} = error ->
+        if provider_id_conflict?(changeset) do
+          fun.(drop_taken(attrs, type, opts))
+        else
+          error
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp provider_id_conflict?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(@providers, fn provider ->
+      key = attrs_key(provider)
+
+      Enum.any?(errors, fn
+        {^key, {_message, meta}} -> Keyword.get(meta, :constraint) == :unique
+        _ -> false
+      end)
+    end)
+  end
+
+  # A failed write only ever names one violated index, never both at once, so
+  # the retry re-checks every provider id present in `attrs` rather than only
+  # the one the database happened to report. Anything still nil after that
+  # re-check was never a candidate and is left alone.
+  #
+  # The owner found here may have vanished by the time this runs, or may not
+  # be who the original write collided with -- either is fine, since the id
+  # cannot be proven free and dropping it is always safe.
+  # `Mydia.Jobs.MetadataBackfill` refreshes the row from its own provider
+  # later.
+  defp drop_taken(attrs, type, opts) do
+    Enum.reduce(@providers, attrs, fn provider, acc ->
+      key = attrs_key(provider)
+
+      case Map.get(acc, key) do
+        nil ->
+          acc
+
+        id ->
+          case conflicting_item(provider, id, type, opts[:exclude_id]) do
+            nil ->
+              acc
+
+            other ->
+              report_conflict(acc, provider, id, other, opts)
+              Map.delete(acc, key)
+          end
+      end
+    end)
+  end
+
   defp report_conflict(attrs, provider, id, other, opts) do
     title = opts[:title] || Map.get(attrs, :title)
 

--- a/lib/mydia/media/external_ids.ex
+++ b/lib/mydia/media/external_ids.ex
@@ -2,11 +2,14 @@ defmodule Mydia.Media.ExternalIds do
   @moduledoc """
   Decides which provider ids an attrs map may safely take.
 
-  `media_items` carries a unique index on `tmdb_id` and another on `tvdb_id`,
-  so writing a cross-referenced id blindly turns an ordinary metadata refresh
-  into a constraint error. Every path that learns a second provider id for an
-  item goes through `put_free_ids/3`, which adds only the ids no other row
-  already owns and reports the ones it skipped.
+  `media_items` carries a unique index on `(type, tmdb_id)` and another on
+  `(type, tvdb_id)`, so writing a provider id another row of the same type
+  already holds turns an ordinary metadata refresh into a constraint error.
+  TMDB and TVDB number movies and series independently, so a movie and a show
+  may hold the same number without conflicting, and every lookup here is scoped
+  by `:type` for that reason. Every path that learns a second provider id for an
+  item goes through `put_free_ids/3`, which adds only the ids no other row of
+  the same type already owns and reports the ones it skipped.
 
   A skipped id means the library holds two rows for one title. That is worth
   telling the operator about, so it becomes a warning event on the activity
@@ -18,6 +21,7 @@ defmodule Mydia.Media.ExternalIds do
 
   alias Mydia.Events
   alias Mydia.Media
+  alias Mydia.Media.MediaItem
 
   @type t :: %{
           tmdb: integer() | nil,
@@ -37,6 +41,12 @@ defmodule Mydia.Media.ExternalIds do
 
   ## Options
 
+    * `:type` - required. `"movie"` or `"tv_show"`. Provider ids are unique
+      per type, so an unscoped lookup reports a movie as the owner of a show's
+      id. It is an explicit option rather than a read of `attrs[:type]` because
+      two call sites pass a bare changes map that has no `:type` key, and both
+      write to rows that already exist, where a silent fallback does the most
+      damage.
     * `:exclude_id` - id of the media item being updated. A row writing its own
       id back is not a conflict.
     * `:title` - title used in the warning when a conflict is reported.
@@ -45,21 +55,26 @@ defmodule Mydia.Media.ExternalIds do
   @spec put_free_ids(map(), t() | nil, keyword()) :: map()
   def put_free_ids(attrs, external_ids, opts \\ [])
 
-  def put_free_ids(attrs, nil, _opts), do: attrs
+  def put_free_ids(attrs, nil, opts) do
+    _type = fetch_type!(opts)
+    attrs
+  end
 
   def put_free_ids(attrs, external_ids, opts) when is_map(external_ids) do
+    type = fetch_type!(opts)
+
     Enum.reduce(@providers, attrs, fn provider, acc ->
-      put_free_id(acc, provider, Map.get(external_ids, provider), opts)
+      put_free_id(acc, provider, Map.get(external_ids, provider), type, opts)
     end)
   end
 
-  defp put_free_id(attrs, _provider, nil, _opts), do: attrs
+  defp put_free_id(attrs, _provider, nil, _type, _opts), do: attrs
 
-  defp put_free_id(attrs, provider, id, opts) do
+  defp put_free_id(attrs, provider, id, type, opts) do
     key = attrs_key(provider)
 
     if is_nil(Map.get(attrs, key)) do
-      case conflicting_item(provider, id, opts[:exclude_id]) do
+      case conflicting_item(provider, id, type, opts[:exclude_id]) do
         nil -> Map.put(attrs, key, id)
         other -> report_conflict(attrs, provider, id, other, opts)
       end
@@ -71,16 +86,25 @@ defmodule Mydia.Media.ExternalIds do
   defp attrs_key(:tmdb), do: :tmdb_id
   defp attrs_key(:tvdb), do: :tvdb_id
 
-  defp conflicting_item(provider, id, exclude_id) do
-    case lookup(provider, id) do
+  defp fetch_type!(opts) do
+    type = Keyword.get(opts, :type)
+
+    if type in MediaItem.valid_types() do
+      type
+    else
+      raise ArgumentError,
+            "Mydia.Media.ExternalIds requires a :type option, one of " <>
+              "#{inspect(MediaItem.valid_types())}, got: #{inspect(type)}"
+    end
+  end
+
+  defp conflicting_item(provider, id, type, exclude_id) do
+    case Media.find_by_external_ids(%{provider => id}, type: type) do
       nil -> nil
       %{id: ^exclude_id} -> nil
       item -> item
     end
   end
-
-  defp lookup(:tmdb, id), do: Media.get_media_item_by_tmdb(id)
-  defp lookup(:tvdb, id), do: Media.get_media_item_by_tvdb(id)
 
   defp report_conflict(attrs, provider, id, other, opts) do
     title = opts[:title] || Map.get(attrs, :title)

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -114,8 +114,13 @@ defmodule Mydia.Media.MediaItem do
     |> validate_inclusion(:type, @type_values)
     |> validate_number(:year, greater_than: 1800, less_than: 2200)
     |> validate_year_for_movies()
-    |> unique_constraint(:tmdb_id)
-    |> unique_constraint(:tvdb_id)
+    # Named after the partial composite indexes in
+    # `20260905143012_scope_provider_id_uniqueness_by_type.exs`. A bare
+    # `unique_constraint/2` expects `media_items_tmdb_id_index`, which no longer
+    # exists, and an unmatched constraint raises `Ecto.ConstraintError` instead
+    # of returning a changeset.
+    |> unique_constraint(:tmdb_id, name: :media_items_type_tmdb_id_index)
+    |> unique_constraint(:tvdb_id, name: :media_items_type_tvdb_id_index)
     |> foreign_key_constraint(:quality_profile_id)
     |> foreign_key_constraint(:library_path_id)
   end

--- a/lib/mydia/media/metadata_type.ex
+++ b/lib/mydia/media/metadata_type.ex
@@ -247,7 +247,7 @@ defmodule Mydia.Media.MetadataType do
   # through the database exactly as it was written, nil or not.
   #
   # The coercions mirror `Mydia.Metadata.Structs.MediaMetadata`'s own parser:
-  # these ids are handed straight to `Media.get_media_item_by_tmdb/1` and
+  # these ids are handed straight to `Media.find_by_external_ids/2` and
   # friends, which query :integer columns and raise `Ecto.Query.CastError` on a
   # string rather than returning nil. Nothing writes string ids here today, but
   # a metadata map built by hand would, and the two parsers staying identical

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -149,6 +149,7 @@ defmodule Mydia.Media.Refresh do
       }
       |> put_provider_id(source, metadata.id)
       |> ExternalIds.put_free_ids(metadata.external_ids,
+        type: media_item.type,
         exclude_id: media_item.id,
         title: metadata.title
       )

--- a/lib/mydia/media/refresh.ex
+++ b/lib/mydia/media/refresh.ex
@@ -154,7 +154,14 @@ defmodule Mydia.Media.Refresh do
         title: metadata.title
       )
 
-    case Media.update_media_item(media_item, attrs, reason: "Metadata refreshed") do
+    result =
+      ExternalIds.write(
+        attrs,
+        [type: media_item.type, exclude_id: media_item.id, title: metadata.title],
+        fn attrs -> Media.update_media_item(media_item, attrs, reason: "Metadata refreshed") end
+      )
+
+    case result do
       {:ok, updated} ->
         {:ok, updated}
 

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -265,11 +265,26 @@ defmodule Mydia.MediaRequests do
   defp check_duplicate_media(changeset) do
     tmdb_id = Ecto.Changeset.get_field(changeset, :tmdb_id)
     tvdb_id = Ecto.Changeset.get_field(changeset, :tvdb_id)
+    # Provider ids are unique per type. A TV request whose tmdb_id matches a
+    # movie already in the library is not a duplicate of it.
+    type = Ecto.Changeset.get_field(changeset, :media_type)
 
     cond do
-      tmdb_id && Media.get_media_item_by_tmdb(tmdb_id) -> {:error, :duplicate_media}
-      tvdb_id && Media.get_media_item_by_tvdb(tvdb_id) -> {:error, :duplicate_media}
-      true -> :ok
+      # `create_request/1` runs this before inserting, so the changeset may still
+      # be invalid. `find_by_external_ids/2` raises on an unrecognised type, and
+      # an ArgumentError here would mask the validation error the caller is about
+      # to get anyway.
+      type not in MediaRequest.valid_media_types() ->
+        :ok
+
+      tmdb_id && Media.find_by_external_ids(%{tmdb: tmdb_id}, type: type) ->
+        {:error, :duplicate_media}
+
+      tvdb_id && Media.find_by_external_ids(%{tvdb: tvdb_id}, type: type) ->
+        {:error, :duplicate_media}
+
+      true ->
+        :ok
     end
   end
 

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -1372,14 +1372,20 @@ defmodule MydiaWeb.SearchLive.Index do
   end
 
   defp create_media_item_from_metadata(parsed, metadata, user) do
-    # Check if media already exists by provider ID
-    # For TV shows from TVDB, check tvdb_id; otherwise check tmdb_id
-    existing =
+    # Check if media already exists by provider ID, scoped by type: TMDB numbers
+    # movies and series independently, so a movie's tmdb_id is not this show's.
+    # For TV shows from TVDB, check tvdb_id; otherwise check tmdb_id.
+    provider_key =
       if parsed.type == :tv_show and Map.get(metadata, :provider) == :tvdb do
-        Media.get_media_item_by_tvdb(metadata.provider_id)
+        :tvdb
       else
-        Media.get_media_item_by_tmdb(metadata.provider_id)
+        :tmdb
       end
+
+    existing =
+      Media.find_by_external_ids(%{provider_key => metadata.provider_id},
+        type: to_string(parsed.type)
+      )
 
     case existing do
       nil ->

--- a/priv/repo/migrations/20260905143012_scope_provider_id_uniqueness_by_type.exs
+++ b/priv/repo/migrations/20260905143012_scope_provider_id_uniqueness_by_type.exs
@@ -1,0 +1,85 @@
+defmodule Mydia.Repo.Migrations.ScopeProviderIdUniquenessByType do
+  use Ecto.Migration
+
+  @moduledoc """
+  TMDB and TVDB number movies and series in independent namespaces, so a global
+  unique index on `tmdb_id` treats a movie and a show that legitimately share a
+  number as conflicting rows.
+
+  `up` needs no data step. A composite unique index on `(type, tmdb_id)` is
+  strictly weaker than a global one on `tmdb_id`: every row that satisfied the
+  old index satisfies the new one.
+
+  `down` is the direction that can fail, once a library has taken advantage of
+  the relaxation. It checks first and refuses with the offending ids named,
+  rather than letting the adapter raise a bare unique violation partway through
+  and leaving the operator to work out which rows are at fault.
+
+  Both indexes are partial. That is not cosmetic. SQLite reports a partial
+  unique index violation as `UNIQUE constraint failed: index 'name'` and a plain
+  composite one as a column list, which `ecto_sqlite3` rewrites into an
+  Ecto-convention name. Keeping them partial makes SQLite and PostgreSQL report
+  the same literal index name, which is what `MediaItem.changeset/2`'s
+  `unique_constraint` calls have to match.
+  """
+
+  def up do
+    drop unique_index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
+    drop unique_index(:media_items, [:tvdb_id], name: :media_items_tvdb_id_index)
+
+    create unique_index(:media_items, [:type, :tmdb_id],
+             where: "tmdb_id IS NOT NULL",
+             name: :media_items_type_tmdb_id_index
+           )
+
+    create unique_index(:media_items, [:type, :tvdb_id],
+             where: "tvdb_id IS NOT NULL",
+             name: :media_items_type_tvdb_id_index
+           )
+  end
+
+  def down do
+    # Both guards run before any DDL, so a refusal leaves the schema untouched
+    # whether or not the adapter wraps migrations in a transaction.
+    guard_no_cross_type_duplicates!("tmdb_id")
+    guard_no_cross_type_duplicates!("tvdb_id")
+
+    drop unique_index(:media_items, [:type, :tmdb_id], name: :media_items_type_tmdb_id_index)
+    drop unique_index(:media_items, [:type, :tvdb_id], name: :media_items_type_tvdb_id_index)
+
+    create unique_index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
+
+    create unique_index(:media_items, [:tvdb_id],
+             where: "tvdb_id IS NOT NULL",
+             name: :media_items_tvdb_id_index
+           )
+  end
+
+  # `column` is a literal from this module's own call sites, never user input.
+  defp guard_no_cross_type_duplicates!(column) do
+    %{rows: rows} =
+      repo().query!("""
+      SELECT #{column}, MIN(type || ': ' || title), MAX(type || ': ' || title)
+      FROM media_items
+      WHERE #{column} IS NOT NULL
+      GROUP BY #{column}
+      HAVING COUNT(DISTINCT type) > 1
+      """)
+
+    if rows != [] do
+      detail =
+        Enum.map_join(rows, "\n", fn [id, first, second] ->
+          "  #{column} #{id}: #{first} / #{second}"
+        end)
+
+      raise Ecto.MigrationError, """
+      Cannot roll back: #{length(rows)} provider id(s) are held by media items of more than one type.
+
+      #{detail}
+
+      The global unique index this rollback restores cannot hold them. Delete one
+      row of each listed pair, or clear its #{column}, then run the rollback again.
+      """
+    end
+  end
+end

--- a/test/mydia/media/add_test.exs
+++ b/test/mydia/media/add_test.exs
@@ -90,8 +90,8 @@ defmodule Mydia.Media.AddTest do
       assert {:error, {:metadata, _reason}} =
                Add.resolve_attrs({:tvdb, tvdb_id}, :movie, relay_config(bypass))
 
-      refute Mydia.Media.get_media_item_by_tmdb(tvdb_id)
-      refute Mydia.Media.get_media_item_by_tvdb(tvdb_id)
+      refute Mydia.Media.find_by_external_ids(%{tmdb: tvdb_id})
+      refute Mydia.Media.find_by_external_ids(%{tvdb: tvdb_id})
     end
   end
 
@@ -116,7 +116,7 @@ defmodule Mydia.Media.AddTest do
       assert {:error, {:metadata, _reason}} =
                Add.from_provider({:tmdb, id}, :movie, relay_config(bypass))
 
-      refute Mydia.Media.get_media_item_by_tmdb(id)
+      refute Mydia.Media.find_by_external_ids(%{tmdb: id})
     end
 
     test "creates nothing when a TVDB ref is sent down the movie path" do
@@ -126,8 +126,8 @@ defmodule Mydia.Media.AddTest do
       assert {:error, {:metadata, :tvdb_ref_for_movie}} =
                Add.from_provider({:tvdb, tvdb_id}, :movie, relay_config(bypass))
 
-      refute Mydia.Media.get_media_item_by_tmdb(tvdb_id)
-      refute Mydia.Media.get_media_item_by_tvdb(tvdb_id)
+      refute Mydia.Media.find_by_external_ids(%{tmdb: tvdb_id})
+      refute Mydia.Media.find_by_external_ids(%{tvdb: tvdb_id})
     end
   end
 

--- a/test/mydia/media/external_ids_test.exs
+++ b/test/mydia/media/external_ids_test.exs
@@ -123,4 +123,142 @@ defmodule Mydia.Media.ExternalIdsTest do
       ExternalIds.put_free_ids(%{type: "tv_show", title: "New Show"}, nil)
     end
   end
+
+  describe "write/3" do
+    test "retries once without the taken id, and reports the owner" do
+      incumbent =
+        media_item_fixture(%{type: "tv_show", title: "Incumbent", tvdb_id: 121_361})
+
+      # The pre-flight read saw the id as free; by write time it is not. That is
+      # the race, reproduced deterministically by skipping put_free_ids/3.
+      attrs = %{type: "tv_show", title: "Challenger", tvdb_id: 121_361, tmdb_id: 1399}
+
+      {result, log} =
+        with_log(fn ->
+          ExternalIds.write(attrs, [type: "tv_show"], fn attrs ->
+            Mydia.Media.create_media_item(attrs, skip_episode_refresh: true)
+          end)
+        end)
+
+      assert {:ok, created} = result
+      assert log =~ "[ExternalIds] tvdb_id 121361 is already owned by another media item"
+
+      assert is_nil(created.tvdb_id)
+      assert created.tmdb_id == 1399
+      assert created.title == "Challenger"
+
+      assert [event] = Events.list_events(type: "media_item.duplicate_provider_id")
+      assert event.resource_id == incumbent.id
+      assert event.metadata["provider"] == "tvdb"
+      assert event.metadata["provider_id"] == 121_361
+    end
+
+    test "drops both provider ids in one pass when both collide" do
+      media_item_fixture(%{type: "tv_show", title: "Owner A", tvdb_id: 121_361})
+      media_item_fixture(%{type: "tv_show", title: "Owner B", tmdb_id: 1399})
+
+      attrs = %{type: "tv_show", title: "Challenger", tvdb_id: 121_361, tmdb_id: 1399}
+
+      {result, _log} =
+        with_log(fn ->
+          ExternalIds.write(attrs, [type: "tv_show"], fn attrs ->
+            Mydia.Media.create_media_item(attrs, skip_episode_refresh: true)
+          end)
+        end)
+
+      assert {:ok, created} = result
+      assert is_nil(created.tvdb_id)
+      assert is_nil(created.tmdb_id)
+
+      assert length(Events.list_events(type: "media_item.duplicate_provider_id")) == 2
+    end
+
+    test "passes an ordinary validation error through untouched" do
+      # A movie with no year fails validate_year_for_movies/1, which is not a
+      # constraint error and must not trigger a retry or an event.
+      attrs = %{type: "movie", title: "No Year"}
+
+      assert {:error, changeset} =
+               ExternalIds.write(attrs, [type: "movie"], fn attrs ->
+                 Mydia.Media.create_media_item(attrs)
+               end)
+
+      refute changeset.valid?
+      assert Events.list_events(type: "media_item.duplicate_provider_id") == []
+    end
+
+    test "does not treat the row's own id as a conflict" do
+      item = media_item_fixture(%{type: "tv_show", title: "Self", tvdb_id: 121_361})
+
+      assert {:ok, updated} =
+               ExternalIds.write(
+                 %{title: "Self Renamed"},
+                 [type: "tv_show", exclude_id: item.id],
+                 fn attrs ->
+                   Mydia.Media.update_media_item(item, attrs, reason: "test")
+                 end
+               )
+
+      assert updated.title == "Self Renamed"
+      assert updated.tvdb_id == 121_361
+    end
+
+    test "returns the changeset when the retry collides again" do
+      # A third writer claiming the other id between the two attempts. Simulated
+      # by a closure that fails on tvdb first and on tmdb second, which is what
+      # that interleaving looks like from write/3's side.
+      media_item_fixture(%{type: "tv_show", title: "Owner A", tvdb_id: 121_361})
+      media_item_fixture(%{type: "tv_show", title: "Owner B", tmdb_id: 1399})
+
+      attrs = %{type: "tv_show", title: "Challenger", tvdb_id: 121_361}
+
+      {result, _log} =
+        with_log(fn ->
+          ExternalIds.write(attrs, [type: "tv_show"], fn attrs ->
+            # After the first pass drops :tvdb_id, put a taken :tmdb_id back, so
+            # the retry hits a constraint the pre-pass could not have seen.
+            attrs
+            |> Map.put_new(:tmdb_id, 1399)
+            |> Mydia.Media.create_media_item(skip_episode_refresh: true)
+          end)
+        end)
+
+      assert {:error, %Ecto.Changeset{} = changeset} = result
+      assert %{tmdb_id: ["has already been taken"]} = errors_on(changeset)
+    end
+
+    test "an empty changes map after the drop writes nothing and emits no update event" do
+      # Add.backfill_ids/2's shape: a changes map holding only provider ids. The
+      # guard lives in the closure so the retry passes through it, otherwise
+      # Media.update_media_item/3 emits a content-free media_item.updated event.
+      item = media_item_fixture(%{type: "tv_show", title: "Incumbent"})
+      media_item_fixture(%{type: "tv_show", title: "Owner", tvdb_id: 121_361})
+
+      {result, _log} =
+        with_log(fn ->
+          ExternalIds.write(%{tvdb_id: 121_361}, [type: "tv_show", exclude_id: item.id], fn
+            changes when changes == %{} -> {:ok, item}
+            changes -> Mydia.Media.update_media_item(item, changes, reason: "test")
+          end)
+        end)
+
+      assert {:ok, unchanged} = result
+      assert unchanged.id == item.id
+      assert is_nil(unchanged.tvdb_id)
+
+      # `resource_id` is only honoured alongside `resource_type`
+      # (Events.filter_by_resource/3 at lib/mydia/events.ex:320). Both are given.
+      assert Events.list_events(
+               type: "media_item.updated",
+               resource_type: "media_item",
+               resource_id: item.id
+             ) == []
+    end
+
+    test "raises without a :type option" do
+      assert_raise ArgumentError, ~r/requires a :type option/, fn ->
+        ExternalIds.write(%{type: "movie", title: "X"}, [], fn attrs -> {:ok, attrs} end)
+      end
+    end
+  end
 end

--- a/test/mydia/media/external_ids_test.exs
+++ b/test/mydia/media/external_ids_test.exs
@@ -188,19 +188,39 @@ defmodule Mydia.Media.ExternalIdsTest do
     end
 
     test "does not treat the row's own id as a conflict" do
+      # tmdb_id is the id that actually collides (with "Owner", a different
+      # row), so the first attempt genuinely hits the unique index and
+      # write/3 genuinely retries. tvdb_id is item's own current value,
+      # carried in the same attrs map: drop_taken/3 re-checks every present
+      # provider id, not just the one the database reported, so without
+      # exclude_id its live re-read of tvdb_id would find item itself and
+      # wrongly report and drop the row's own id as a conflict with itself.
       item = media_item_fixture(%{type: "tv_show", title: "Self", tvdb_id: 121_361})
+      owner = media_item_fixture(%{type: "tv_show", title: "Owner", tmdb_id: 1399})
 
-      assert {:ok, updated} =
-               ExternalIds.write(
-                 %{title: "Self Renamed"},
-                 [type: "tv_show", exclude_id: item.id],
-                 fn attrs ->
-                   Mydia.Media.update_media_item(item, attrs, reason: "test")
-                 end
-               )
+      attrs = %{title: "Self Renamed", tmdb_id: 1399, tvdb_id: 121_361}
 
+      {result, _log} =
+        with_log(fn ->
+          ExternalIds.write(attrs, [type: "tv_show", exclude_id: item.id], fn attrs ->
+            Mydia.Media.update_media_item(item, attrs, reason: "test")
+          end)
+        end)
+
+      assert {:ok, updated} = result
+      assert updated.id == item.id
       assert updated.title == "Self Renamed"
+      # tmdb_id lost the race to "Owner" and was dropped by the retry.
+      assert is_nil(updated.tmdb_id)
+      # tvdb_id is item's own id. exclude_id kept the live re-read from
+      # treating item as its own conflict, so it survives untouched.
       assert updated.tvdb_id == 121_361
+
+      # Only the genuine tmdb collision with "Owner" is reported; item's own
+      # tvdb_id must not also show up as a bogus self-conflict.
+      assert [event] = Events.list_events(type: "media_item.duplicate_provider_id")
+      assert event.resource_id == owner.id
+      assert event.metadata["provider"] == "tmdb"
     end
 
     test "returns the changeset when the retry collides again" do

--- a/test/mydia/media/external_ids_test.exs
+++ b/test/mydia/media/external_ids_test.exs
@@ -10,7 +10,10 @@ defmodule Mydia.Media.ExternalIdsTest do
   test "adds ids that no other row owns" do
     attrs = %{type: "tv_show", title: "New Show", tmdb_id: 1399}
 
-    result = ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: "tt0944947"})
+    result =
+      ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: "tt0944947"},
+        type: "tv_show"
+      )
 
     assert result.tmdb_id == 1399
     assert result.tvdb_id == 121_361
@@ -19,7 +22,7 @@ defmodule Mydia.Media.ExternalIdsTest do
   test "never overwrites an id the caller already set" do
     attrs = %{type: "tv_show", title: "New Show", tvdb_id: 111}
 
-    result = ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 222, imdb: nil})
+    result = ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 222, imdb: nil}, type: "tv_show")
 
     assert result.tvdb_id == 111
   end
@@ -27,7 +30,8 @@ defmodule Mydia.Media.ExternalIdsTest do
   test "fills a key present but nil" do
     attrs = %{type: "tv_show", title: "New Show", tmdb_id: 1399, tvdb_id: nil}
 
-    result = ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil})
+    result =
+      ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil}, type: "tv_show")
 
     assert result.tvdb_id == 121_361
   end
@@ -40,6 +44,7 @@ defmodule Mydia.Media.ExternalIdsTest do
     {result, log} =
       with_log(fn ->
         ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil},
+          type: "tv_show",
           title: "Override Title"
         )
       end)
@@ -68,7 +73,10 @@ defmodule Mydia.Media.ExternalIdsTest do
     attrs = %{type: "tv_show", title: "Self"}
 
     result =
-      ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil}, exclude_id: item.id)
+      ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil},
+        type: "tv_show",
+        exclude_id: item.id
+      )
 
     assert result.tvdb_id == 121_361
   end
@@ -76,6 +84,43 @@ defmodule Mydia.Media.ExternalIdsTest do
   test "ignores nil external ids" do
     attrs = %{type: "tv_show", title: "New Show", tmdb_id: 1399}
 
-    assert ExternalIds.put_free_ids(attrs, nil) == attrs
+    assert ExternalIds.put_free_ids(attrs, nil, type: "tv_show") == attrs
+  end
+
+  test "a cross-type owner is not a conflict" do
+    media_item_fixture(%{type: "movie", title: "Incumbent Movie", year: 2014, tvdb_id: 121_361})
+
+    attrs = %{type: "tv_show", title: "Challenger Show"}
+
+    result =
+      ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil}, type: "tv_show")
+
+    assert result.tvdb_id == 121_361
+    assert Events.list_events(type: "media_item.duplicate_provider_id") == []
+  end
+
+  test "raises without a :type option" do
+    attrs = %{type: "tv_show", title: "New Show"}
+
+    assert_raise ArgumentError, ~r/requires a :type option/, fn ->
+      ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil})
+    end
+  end
+
+  test "raises on an unrecognised :type option" do
+    attrs = %{type: "tv_show", title: "New Show"}
+
+    assert_raise ArgumentError, ~r/requires a :type option/, fn ->
+      ExternalIds.put_free_ids(attrs, %{tmdb: nil, tvdb: 121_361, imdb: nil}, type: "tvshow")
+    end
+  end
+
+  test "raises without a :type option even when there are no external ids" do
+    # The nil-external_ids clause validates too. A caller that forgot :type has
+    # the same bug either way; letting it pass here hides it until the day a
+    # provider actually cross-references something.
+    assert_raise ArgumentError, ~r/requires a :type option/, fn ->
+      ExternalIds.put_free_ids(%{type: "tv_show", title: "New Show"}, nil)
+    end
   end
 end

--- a/test/mydia/media/metadata_type_test.exs
+++ b/test/mydia/media/metadata_type_test.exs
@@ -373,10 +373,10 @@ defmodule Mydia.Media.MetadataTypeTest do
     end
 
     test "load/1 coerces string external ids to integers" do
-      # tmdb and tvdb feed Media.get_media_item_by_tmdb/1 and its tvdb twin,
-      # which query :integer columns and raise Ecto.Query.CastError on a string
-      # rather than returning nil. TVDB's remoteIds are strings at the source,
-      # so the load path coerces exactly as the API-side parser does.
+      # tmdb and tvdb feed Media.find_by_external_ids/2, which queries :integer
+      # columns and raises Ecto.Query.CastError on a string rather than
+      # returning nil. TVDB's remoteIds are strings at the source, so the load
+      # path coerces exactly as the API-side parser does.
       json =
         Jason.encode!(%{
           "provider_id" => "121361",

--- a/test/mydia/media/provider_id_uniqueness_test.exs
+++ b/test/mydia/media/provider_id_uniqueness_test.exs
@@ -1,0 +1,97 @@
+defmodule Mydia.Media.ProviderIdUniquenessTest do
+  @moduledoc """
+  The index and the changeset have to agree on a name.
+
+  `unique_constraint(:tmdb_id)` with no `:name` expects the index
+  `media_items_tmdb_id_index`. Once the migration replaces that with
+  `media_items_type_tmdb_id_index`, a bare call no longer matches and Ecto
+  raises `Ecto.ConstraintError` instead of returning a changeset: a 500 where
+  there used to be a form error. These tests fail loudly if the two drift apart
+  again.
+  """
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Media
+
+  describe "tmdb_id" do
+    test "a movie and a tv show may share one" do
+      id = System.unique_integer([:positive])
+
+      assert {:ok, movie} =
+               Media.create_media_item(%{
+                 type: "movie",
+                 title: "Cinder Lantern",
+                 year: 2014,
+                 tmdb_id: id
+               })
+
+      assert {:ok, show} =
+               Media.create_media_item(
+                 %{type: "tv_show", title: "Cinder Lantern", tmdb_id: id},
+                 skip_episode_refresh: true
+               )
+
+      assert movie.tmdb_id == id
+      assert show.tmdb_id == id
+    end
+
+    test "two tv shows may not, and the collision is a changeset error not a raise" do
+      id = System.unique_integer([:positive])
+
+      assert {:ok, _} =
+               Media.create_media_item(
+                 %{type: "tv_show", title: "Harrow Bay", tmdb_id: id},
+                 skip_episode_refresh: true
+               )
+
+      assert {:error, changeset} =
+               Media.create_media_item(
+                 %{type: "tv_show", title: "Harrow Bay Redux", tmdb_id: id},
+                 skip_episode_refresh: true
+               )
+
+      assert %{tmdb_id: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
+
+  describe "tvdb_id" do
+    test "a movie and a tv show may share one" do
+      id = System.unique_integer([:positive])
+
+      assert {:ok, movie} =
+               Media.create_media_item(%{
+                 type: "movie",
+                 title: "Pale Orchard",
+                 year: 2018,
+                 tvdb_id: id
+               })
+
+      assert {:ok, show} =
+               Media.create_media_item(
+                 %{type: "tv_show", title: "Pale Orchard", tvdb_id: id},
+                 skip_episode_refresh: true
+               )
+
+      assert movie.tvdb_id == id
+      assert show.tvdb_id == id
+    end
+
+    test "two tv shows may not, and the collision is a changeset error not a raise" do
+      id = System.unique_integer([:positive])
+
+      assert {:ok, _} =
+               Media.create_media_item(
+                 %{type: "tv_show", title: "Vellum Coast", tvdb_id: id},
+                 skip_episode_refresh: true
+               )
+
+      assert {:error, changeset} =
+               Media.create_media_item(
+                 %{type: "tv_show", title: "Vellum Coast Redux", tvdb_id: id},
+                 skip_episode_refresh: true
+               )
+
+      assert %{tvdb_id: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
+end

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -2,7 +2,6 @@ defmodule Mydia.MediaRequestsTest do
   use Mydia.DataCase, async: false
   use Oban.Testing, repo: Mydia.Repo
 
-  import ExUnit.CaptureLog
   import Mydia.SettingsFixtures
 
   alias Mydia.MediaRequests
@@ -260,13 +259,7 @@ defmodule Mydia.MediaRequestsTest do
       assert %{approved_by_id: ["can't be blank"]} = errors_on(changeset)
     end
 
-    # `Add.from_attrs/3`'s pre-flight is scoped to the request's own media type,
-    # while the unique index on tmdb_id is global. A movie holding the id is
-    # therefore invisible to the lookup and only the index catches it, which is
-    # the one path left that reaches insert_approval/4's media_item rollback.
-    # Pinning the behaviour here: closing the cross-type gap needs a composite
-    # (type, tmdb_id) index and so a migration.
-    test "rolls back and leaves the request pending when the other media type owns the tmdb_id",
+    test "approves a tv request whose tmdb_id matches an existing movie",
          %{user: user, admin: admin} do
       bypass = Bypass.open()
       tmdb_id = System.unique_integer([:positive])
@@ -289,24 +282,23 @@ defmodule Mydia.MediaRequestsTest do
 
       before_count = Repo.aggregate(MediaItem, :count)
 
-      log =
-        capture_log(fn ->
-          assert {:error, %Ecto.Changeset{} = changeset} =
-                   MediaRequests.approve_request(request, %{approved_by_id: admin.id},
-                     config: relay_config(bypass)
-                   )
+      # approve_request/3 returns {:ok, %{request: _, media_item: _}}
+      # (lib/mydia/media_requests.ex:111-128).
+      assert {:ok, %{request: approved, media_item: show}} =
+               MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+                 config: relay_config(bypass)
+               )
 
-          assert %{tmdb_id: ["has already been taken"]} = errors_on(changeset)
-        end)
+      # TMDB numbers movies and series independently, so the show and the movie
+      # hold the same tmdb_id without conflicting.
+      assert Repo.aggregate(MediaItem, :count) == before_count + 1
 
-      assert log =~ "Failed to create media item for request #{request.id}"
+      assert approved.status == "approved"
+      assert approved.media_item_id == show.id
 
-      reloaded = Repo.get!(MediaRequest, request.id)
-      assert reloaded.status == "pending"
-      assert is_nil(reloaded.media_item_id)
-
-      assert Repo.aggregate(MediaItem, :count) == before_count
-      assert Media.get_media_item_by_tmdb(tmdb_id).id == movie.id
+      assert show.type == "tv_show"
+      assert show.tmdb_id == tmdb_id
+      refute show.id == movie.id
     end
   end
 

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -4,6 +4,7 @@ defmodule Mydia.MediaRequestsTest do
 
   import Mydia.SettingsFixtures
 
+  alias Mydia.Events
   alias Mydia.MediaRequests
   alias Mydia.{Accounts, Media, Repo}
   alias Mydia.Media.MediaItem
@@ -324,6 +325,95 @@ defmodule Mydia.MediaRequestsTest do
       assert show.type == "tv_show"
       assert show.tmdb_id == tmdb_id
       refute show.id == movie.id
+    end
+  end
+
+  describe "approve_request/3 provider-id constraint race" do
+    setup do
+      user = create_user()
+      admin = create_user(%{role: "admin"})
+      %{user: user, admin: admin}
+    end
+
+    # Regression for the CRITICAL finding on the #473 provider-id-uniqueness
+    # branch: on PostgreSQL, a statement that fails a unique-constraint check
+    # aborts the whole ambient transaction (SQLSTATE 25P02,
+    # `in_failed_sql_transaction`) until an explicit rollback. Before
+    # ExternalIds.write/3 wrapped each attempt in its own savepoint, the
+    # re-read `drop_taken/3` issues right after such a failure ran on that
+    # same poisoned connection and raised, instead of returning the
+    # degraded-warning outcome `put_free_ids/3` would have produced had it won
+    # the race.
+    #
+    # `Add.existing_item/1`'s pre-flight would normally catch an
+    # already-committed same-type collision before ever reaching the insert,
+    # so reproducing this deterministically (rather than via genuinely
+    # concurrent connections) means landing the colliding row in the narrow
+    # window *after* that pre-flight's one SELECT against media_items returns
+    # empty but *before* the insert that follows it, on the very same
+    # connection and inside the very same `Multi.run` + `Repo.transaction`
+    # `insert_approval/4` opens. A `:telemetry` handler on
+    # `[:mydia, :repo, :query]` does exactly that: it fires once, on the first
+    # query sourced from `media_items`, which this request's attrs are built
+    # to guarantee is that pre-flight read (a plain TMDB movie response with
+    # no external_ids cross-reference means `existing_item/1`'s second pass
+    # never queries at all).
+    test "a genuine same-type tmdb_id collision degrades to the warning flow instead of raising",
+         %{user: user, admin: admin} do
+      bypass = Bypass.open()
+      tmdb_id = System.unique_integer([:positive])
+
+      request =
+        create_request(user, %{media_type: "movie", title: "Collision Feature", tmdb_id: tmdb_id})
+
+      stub_tmdb_movie(bypass, tmdb_id, "Collision Feature", "/stub.jpg")
+
+      test_pid = self()
+      handler_id = "provider-id-race-#{inspect(make_ref())}"
+
+      :telemetry.attach(
+        handler_id,
+        [:mydia, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          if metadata.source == "media_items" do
+            :telemetry.detach(handler_id)
+
+            {:ok, owner} =
+              %MediaItem{}
+              |> MediaItem.changeset(%{
+                type: "movie",
+                title: "Incumbent Feature",
+                year: 2019,
+                tmdb_id: tmdb_id
+              })
+              |> Repo.insert()
+
+            send(test_pid, {:owner_inserted, owner.id})
+          end
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      result =
+        MediaRequests.approve_request(request, %{approved_by_id: admin.id},
+          config: relay_config(bypass)
+        )
+
+      assert_received {:owner_inserted, owner_id}
+
+      assert {:ok, %{request: approved, media_item: created}} = result
+      assert approved.status == "approved"
+      assert approved.media_item_id == created.id
+      refute created.id == owner_id
+      assert is_nil(created.tmdb_id)
+      assert created.title == "Collision Feature"
+
+      assert [event] = Events.list_events(type: "media_item.duplicate_provider_id")
+      assert event.resource_id == owner_id
+      assert event.metadata["provider"] == "tmdb"
+      assert event.metadata["provider_id"] == tmdb_id
     end
   end
 

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -193,6 +193,31 @@ defmodule Mydia.MediaRequestsTest do
 
       assert {:error, :duplicate_media} = MediaRequests.create_request(attrs)
     end
+
+    test "accepts a tv request whose tmdb_id belongs to a movie already in the library", %{
+      user: user
+    } do
+      tmdb_id = System.unique_integer([:positive])
+
+      {:ok, _movie} =
+        Media.create_media_item(%{
+          type: "movie",
+          title: "Crossed Type",
+          year: 2023,
+          tmdb_id: tmdb_id
+        })
+
+      assert {:ok, request} =
+               MediaRequests.create_request(%{
+                 media_type: "tv_show",
+                 title: "Crossed Type",
+                 tmdb_id: tmdb_id,
+                 requester_id: user.id
+               })
+
+      assert request.media_type == "tv_show"
+      assert request.tmdb_id == tmdb_id
+    end
   end
 
   describe "approve_request/2" do
@@ -555,7 +580,7 @@ defmodule Mydia.MediaRequestsTest do
                )
 
       assert Repo.get!(MediaRequest, request.id).status == "pending"
-      refute Media.get_media_item_by_tmdb(request.tmdb_id)
+      refute Media.find_by_external_ids(%{tmdb: request.tmdb_id})
     end
 
     test "reports a request with no TMDB or TVDB id rather than creating a shell", %{

--- a/test/mydia/repo/migrations/scope_provider_id_uniqueness_by_type_test.exs
+++ b/test/mydia/repo/migrations/scope_provider_id_uniqueness_by_type_test.exs
@@ -1,0 +1,118 @@
+defmodule Mydia.Repo.Migrations.ScopeProviderIdUniquenessByTypeTest do
+  @moduledoc """
+  `up` is a pure relaxation: a composite unique index on `(type, tmdb_id)` is
+  strictly weaker than a global one on `tmdb_id`, so no existing row can fail
+  it and there is no data step to test. What is worth testing is that the
+  relaxation is real, that it stops exactly where it should, and that `down`
+  refuses rather than half-applying when the library has taken advantage of it.
+  """
+  use Mydia.MigrationCase
+
+  Code.require_file(
+    "priv/repo/migrations/20260905143012_scope_provider_id_uniqueness_by_type.exs"
+  )
+
+  alias Mydia.Repo.Migrations.ScopeProviderIdUniquenessByType
+
+  @version 20_260_905_143_012
+
+  @tag :tmp_dir
+  test "a movie and a tv show may share a tmdb_id after the migration" do
+    seed_schema()
+    run_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    insert_item("a", "movie", "Cinder Lantern", tmdb_id: 4001)
+    insert_item("b", "tv_show", "Cinder Lantern", tmdb_id: 4001)
+
+    assert %{rows: [[2]]} = sql!("SELECT COUNT(*) FROM media_items WHERE tmdb_id = 4001")
+  end
+
+  @tag :tmp_dir
+  test "a movie and a tv show may share a tvdb_id after the migration" do
+    seed_schema()
+    run_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    insert_item("a", "movie", "Harrow Bay", tvdb_id: 4002)
+    insert_item("b", "tv_show", "Harrow Bay", tvdb_id: 4002)
+
+    assert %{rows: [[2]]} = sql!("SELECT COUNT(*) FROM media_items WHERE tvdb_id = 4002")
+  end
+
+  @tag :tmp_dir
+  test "two rows of the same type still may not share a tmdb_id" do
+    seed_schema()
+    run_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    insert_item("a", "tv_show", "Pale Orchard", tmdb_id: 4003)
+
+    assert_raise Exqlite.Error, fn ->
+      insert_item("b", "tv_show", "Pale Orchard Redux", tmdb_id: 4003)
+    end
+  end
+
+  @tag :tmp_dir
+  test "down refuses, naming the ids, when a provider id is held across two types" do
+    seed_schema()
+    run_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    insert_item("a", "movie", "Vellum Coast", tmdb_id: 4004)
+    insert_item("b", "tv_show", "Vellum Coast", tmdb_id: 4004)
+
+    error =
+      assert_raise Ecto.MigrationError, fn ->
+        rollback_migration!(ScopeProviderIdUniquenessByType, @version)
+      end
+
+    assert error.message =~ "4004"
+    assert error.message =~ "Vellum Coast"
+
+    # The guard runs before any DDL, so both rows and the composite index survive.
+    assert %{rows: [[2]]} = sql!("SELECT COUNT(*) FROM media_items WHERE tmdb_id = 4004")
+  end
+
+  @tag :tmp_dir
+  test "down restores the global index when no provider id spans two types" do
+    seed_schema()
+    run_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    insert_item("a", "movie", "Cinder Lantern", tmdb_id: 4005)
+
+    rollback_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    assert_raise Exqlite.Error, fn ->
+      insert_item("b", "tv_show", "Cinder Lantern", tmdb_id: 4005)
+    end
+  end
+
+  # Only the columns and indexes this migration touches. The real table has far
+  # more, none of which the migration reads.
+  defp seed_schema do
+    sql!("""
+    CREATE TABLE media_items (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      title TEXT NOT NULL,
+      tmdb_id INTEGER,
+      tvdb_id INTEGER,
+      inserted_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+    """)
+
+    sql!("CREATE UNIQUE INDEX media_items_tmdb_id_index ON media_items (tmdb_id)")
+
+    sql!(
+      "CREATE UNIQUE INDEX media_items_tvdb_id_index ON media_items (tvdb_id) WHERE tvdb_id IS NOT NULL"
+    )
+  end
+
+  defp insert_item(id, type, title, ids) do
+    sql!(
+      """
+      INSERT INTO media_items (id, type, title, tmdb_id, tvdb_id, inserted_at, updated_at)
+      VALUES (?1, ?2, ?3, ?4, ?5, '2026-09-05 00:00:00', '2026-09-05 00:00:00')
+      """,
+      [id, type, title, ids[:tmdb_id], ids[:tvdb_id]]
+    )
+  end
+end

--- a/test/mydia_web/features/add_config_flow_test.exs
+++ b/test/mydia_web/features/add_config_flow_test.exs
@@ -311,7 +311,7 @@ defmodule MydiaWeb.Features.AddConfigFlowTest do
     added =
       eventually(
         fn ->
-          case Mydia.Media.find_by_external_ids(%{tmdb: 900_001}) do
+          case Mydia.Media.find_by_external_ids(%{tmdb: 900_001}, type: "movie") do
             nil -> :error
             item -> {:ok, item}
           end

--- a/test/mydia_web/features/add_config_flow_test.exs
+++ b/test/mydia_web/features/add_config_flow_test.exs
@@ -311,7 +311,7 @@ defmodule MydiaWeb.Features.AddConfigFlowTest do
     added =
       eventually(
         fn ->
-          case Mydia.Media.get_media_item_by_tmdb(900_001) do
+          case Mydia.Media.find_by_external_ids(%{tmdb: 900_001}) do
             nil -> :error
             item -> {:ok, item}
           end

--- a/test/mydia_web/live/dashboard_live/add_config_test.exs
+++ b/test/mydia_web/live/dashboard_live/add_config_test.exs
@@ -205,7 +205,7 @@ defmodule MydiaWeb.DashboardLive.AddConfigTest do
     refute MapSet.member?(assigns.adding_item_ids, {:tmdb, String.to_integer(provider_id)})
 
     # Belt-and-braces: the add never dispatched, so it can never persist.
-    assert Mydia.Media.get_media_item_by_tmdb(provider_id) == nil
+    assert Mydia.Media.find_by_external_ids(%{tmdb: provider_id}) == nil
   end
 
   # Configure is also reachable from a caret inside the detail modal's own
@@ -308,7 +308,7 @@ defmodule MydiaWeb.DashboardLive.AddConfigTest do
   end
 
   defp wait_until_media_item(provider_id, retries) do
-    case Mydia.Media.get_media_item_by_tmdb(provider_id) do
+    case Mydia.Media.find_by_external_ids(%{tmdb: provider_id}) do
       nil ->
         Process.sleep(10)
         wait_until_media_item(provider_id, retries - 1)

--- a/test/mydia_web/live/discover_live/add_tvdb_result_test.exs
+++ b/test/mydia_web/live/discover_live/add_tvdb_result_test.exs
@@ -69,7 +69,9 @@ defmodule MydiaWeb.DiscoverLive.AddTvdbResultTest do
     render_click(view, "add_to_library", %{"ref" => "imdb:tt3230854", "media_type" => "tv_show"})
 
     assert render(view) =~ "Could not add that item"
-    assert Mydia.Media.get_media_item_by_tvdb(MetadataStubProvider.series_tvdb_id()) == nil
+
+    assert Mydia.Media.find_by_external_ids(%{tvdb: MetadataStubProvider.series_tvdb_id()}) ==
+             nil
   end
 
   # The add lands in a handle_info the render_click round trip does not wait
@@ -81,7 +83,7 @@ defmodule MydiaWeb.DiscoverLive.AddTvdbResultTest do
   end
 
   defp wait_until_media_item(tvdb_id, retries) do
-    case Mydia.Media.get_media_item_by_tvdb(tvdb_id) do
+    case Mydia.Media.find_by_external_ids(%{tvdb: tvdb_id}) do
       nil ->
         Process.sleep(10)
         wait_until_media_item(tvdb_id, retries - 1)

--- a/test/mydia_web/live/discover_live/config_modal_test.exs
+++ b/test/mydia_web/live/discover_live/config_modal_test.exs
@@ -350,7 +350,7 @@ defmodule MydiaWeb.DiscoverLive.ConfigModalTest do
   end
 
   defp wait_until_media_item(provider_id, retries) do
-    case Mydia.Media.get_media_item_by_tmdb(provider_id) do
+    case Mydia.Media.find_by_external_ids(%{tmdb: provider_id}) do
       nil ->
         Process.sleep(10)
         wait_until_media_item(provider_id, retries - 1)

--- a/test/mydia_web/live/media_live/show/add_config_host_test.exs
+++ b/test/mydia_web/live/media_live/show/add_config_host_test.exs
@@ -242,7 +242,7 @@ defmodule MydiaWeb.MediaLive.Show.AddConfigHostTest do
   end
 
   defp wait_until_media_item(tmdb_id, retries) do
-    case Mydia.Media.get_media_item_by_tmdb(tmdb_id) do
+    case Mydia.Media.find_by_external_ids(%{tmdb: tmdb_id}) do
       nil ->
         Process.sleep(10)
         wait_until_media_item(tmdb_id, retries - 1)
@@ -262,7 +262,7 @@ defmodule MydiaWeb.MediaLive.Show.AddConfigHostTest do
   defp media_item_created_within?(_tmdb_id, 0), do: false
 
   defp media_item_created_within?(tmdb_id, retries) do
-    case Mydia.Media.get_media_item_by_tmdb(tmdb_id) do
+    case Mydia.Media.find_by_external_ids(%{tmdb: tmdb_id}) do
       nil ->
         Process.sleep(10)
         media_item_created_within?(tmdb_id, retries - 1)
@@ -387,7 +387,7 @@ defmodule MydiaWeb.MediaLive.Show.AddConfigHostTest do
       })
 
     assert html =~ "That library is no longer available"
-    assert Mydia.Media.get_media_item_by_tmdb(missing_tmdb_id) == nil
+    assert Mydia.Media.find_by_external_ids(%{tmdb: missing_tmdb_id}) == nil
   end
 
   # Server-side authorization must never depend on a hidden UI element. The

--- a/test/mydia_web/live/search_live/add_to_library_test.exs
+++ b/test/mydia_web/live/search_live/add_to_library_test.exs
@@ -74,7 +74,7 @@ defmodule MydiaWeb.SearchLive.AddToLibraryTest do
       assert_redirect(view, ~p"/media/#{1}")
 
       # Verify media item was created
-      media_item = Media.get_media_item_by_tmdb(550)
+      media_item = Media.find_by_external_ids(%{tmdb: 550})
       assert media_item
       assert media_item.title == "Fight Club"
       assert media_item.year == 1999
@@ -125,7 +125,7 @@ defmodule MydiaWeb.SearchLive.AddToLibraryTest do
 
       # Since we can't easily mock external calls, we'll test the duplicate detection
       # logic by directly verifying the database query works
-      duplicate = Media.get_media_item_by_tmdb(550)
+      duplicate = Media.find_by_external_ids(%{tmdb: 550})
       assert duplicate
       assert duplicate.id == existing_item.id
       assert duplicate.title == "Fight Club"
@@ -153,7 +153,7 @@ defmodule MydiaWeb.SearchLive.AddToLibraryTest do
       assert_redirect(view, ~p"/media/#{1}")
 
       # Verify TV show was created
-      media_item = Media.get_media_item_by_tmdb(1396)
+      media_item = Media.find_by_external_ids(%{tmdb: 1396})
       assert media_item
       assert media_item.title == "Breaking Bad"
       assert media_item.type == "tv_show"
@@ -182,7 +182,7 @@ defmodule MydiaWeb.SearchLive.AddToLibraryTest do
       assert_redirect(view, ~p"/media/#{1}")
 
       # Verify all episodes were created
-      media_item = Media.get_media_item_by_tmdb(1396)
+      media_item = Media.find_by_external_ids(%{tmdb: 1396})
       episodes = Media.list_episodes(media_item.id)
       assert length(episodes) == 3
 
@@ -431,14 +431,14 @@ defmodule MydiaWeb.SearchLive.AddToLibraryTest do
           monitored: true
         })
 
-      found = Media.get_media_item_by_tmdb(999)
+      found = Media.find_by_external_ids(%{tmdb: 999})
       assert found
       assert found.id == existing_item.id
       assert found.title == "Existing Movie"
     end
 
     test "returns nil when TMDB ID not found" do
-      result = Media.get_media_item_by_tmdb(99999)
+      result = Media.find_by_external_ids(%{tmdb: 99999})
       assert result == nil
     end
 


### PR DESCRIPTION
Closes #473.

TMDB and TVDB number movies and series in independent namespaces, but `media_items` carried a single global unique index on `tmdb_id` and another on `tvdb_id`. A movie and a show that legitimately share a number were treated as conflicting rows, so adding such a show surfaced the raw `tmdb_id: has already been taken`, and provider-id lookups reported a row of the wrong media type as the owner of an id.

Separately, `ExternalIds.put_free_ids/3` read ownership and the caller wrote afterwards, so two writers could both see an id as free and the loser failed on the unique index instead of getting the controlled duplicate-provider warning.

## What changed

**Indexes.** The two global unique indexes become partial composite ones on `(type, tmdb_id)` and `(type, tvdb_id)`. This is a pure relaxation: the composite index is strictly weaker than the global one, so no existing row can fail it and `up` needs no data step. `down` refuses with the offending provider ids and titles named rather than letting the adapter raise a bare unique violation partway through a rollback, and both guards run before any DDL so a refusal leaves the schema untouched.

Both indexes stay partial deliberately. SQLite reports a partial unique index violation using the literal index name and a plain one using a column list that `ecto_sqlite3` rewrites into an Ecto-convention name. Keeping them partial makes both adapters report the same name, which is what `MediaItem.changeset/2`'s `unique_constraint` calls have to match. Those calls are renamed accordingly; without that a same-type collision would raise `Ecto.ConstraintError` instead of returning a changeset.

**Lookups.** `ExternalIds` now requires an explicit `:type` and routes ownership checks through the type-validating `Media.find_by_external_ids/2`. The untyped `Media.get_media_item_by_tmdb/2` and `get_media_item_by_tvdb/2` are deleted and all callers moved over, so one typed lookup remains in `Media` instead of three overlapping ones and an untyped call is no longer spelled the same way as a typed one. Three production callers were enforcing the old global rule in application code: `MediaRequests.check_duplicate_media/1` rejected a TV request whose `tmdb_id` matched a movie before any insert was attempted, and the scanner and Discover existence probes reported the wrong row as owner.

**The race.** `ExternalIds.write/3` catches a provider-id constraint error, re-reads every provider id in the attrs, reports and drops the ones still taken, and retries once. Dropping all of them in a single pass is what makes one retry always sufficient: a database aborts at the first violated index and never reports a second from the same attempt, so dropping only the id it named could still collide on the retry.

No transaction is used to close the race, because none would. At PostgreSQL's default `READ COMMITTED` both writers still read the id as free and one still fails at write time, and SQLite's deferred transactions behave the same. The catch-and-re-read does the work alone, and it also covers stale reads seconds old rather than only the instant.

Each attempt does run in its own savepoint. On PostgreSQL a statement that fails a constraint check aborts the whole ambient transaction (SQLSTATE `25P02`), and two of the four wrapped call sites run inside a transaction the caller opened, so the re-read that follows a collision raised instead of degrading. Rolling back to the savepoint rather than merely releasing it is the load-bearing detail: releasing a savepoint whose statement already failed does not clear the aborted state. `Repo.transaction(fun, mode: :savepoint)` cannot express this, because for a nested transaction on the same connection `DBConnection.transaction/3` runs the function directly and discards its opts, so no `SAVEPOINT` is ever sent.

## Testing

Full suite green at 10760 tests. The migration, changeset, `ExternalIds` and `write/3` behavior are covered on both adapters, and the constraint-name agreement between SQLite and PostgreSQL is asserted directly, since that is the piece the default SQLite-only suite cannot see.

The race regression test drives a genuine same-type collision through `approve_request/3`, using a telemetry handler to land the colliding row between the pre-flight read and the insert on the same connection inside the same transaction. Verified on PostgreSQL that it fails with `ERROR 25P02` without the savepoint and passes with it.

## Follow-ups, not in this PR

- Five call sites write `tmdb_id`/`tvdb_id` without going through `ExternalIds` (`import_lists.ex`, `jobs/import_list_auto_add.ex`, `media/provider_switch.ex`, `controllers/api/media_controller.ex`, `live/search_live/index.ex`). Not regressions, since the changeset-level constraint rename protects them from the crash class, but they surface an ordinary changeset error rather than the graceful drop-and-warn.
- The migration `down` guard's raw SQL is untested on PostgreSQL: `Mydia.MigrationTestRepo` is SQLite-only and the PostgreSQL job runs `up` via `ecto.migrate`, never `down`.
- No test covers the window where a provider id's owner vanishes between the failed write and `drop_taken/3`'s live re-read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Media provider IDs are now scoped by media type, allowing movies and TV shows to share the same TMDB or TVDB ID.
  * Duplicate detection distinguishes same-type conflicts from valid cross-type matches.
  * Media creation and updates handle provider-ID conflicts more reliably, including race conditions.
* **Bug Fixes**
  * Invalid media types now produce validation errors without triggering lookup failures.
  * Provider-ID uniqueness conflicts return clear validation feedback instead of unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->