### PR TITLE
feat(accounts): give SSO accounts real usernames

### DIFF
--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -172,17 +172,30 @@ defmodule Mydia.Accounts do
   @doc """
   Writes a derived username onto a user, suffixing past collisions.
 
-  Attempt 1 is the bare slug, attempt N is `slug-N`. The unique index is the
-  arbiter rather than a `SELECT` beforehand, because two people signing in for
-  the first time at once would race a pre-check and one of them would crash on
-  the constraint anyway.
+  Attempt 1 is the bare slug, attempt N is `slug-N`. The unique index on
+  `:username` is case-sensitive, so it alone is not enough: `slugify/1`
+  always downcases, so it would happily write "tonix" next to an existing
+  "Tonix" without ever tripping the constraint, silently shadowing the other
+  account for anything (like media-server profile matching) that compares
+  names case-insensitively. Each attempt therefore also runs a
+  case-insensitive `SELECT`, excluding this user's own row so that an account
+  re-claiming the name it already holds is never suffixed against itself.
+
+  This still leaves a narrow race: two people signing in for the very first
+  time, in the same instant, with names that only differ by case, could both
+  pass the pre-check before either write lands, and end up as case-variant
+  siblings after all. That window is far narrower than doing no check at all,
+  and closing it fully would need a case-insensitive unique index, which is
+  out of scope here. The case-sensitive unique constraint is kept as a second
+  line of defense for the exact-match version of that same race.
 
   Returns `:none` when every attempt is taken, when the write fails for a
-  reason other than the constraint, or when the write itself raises (a
-  dropped database connection, or a constraint other than the declared
-  unique one on `:username`). It never raises: a login must not fail, and a
-  migration that calls this must not crash the boot supervision tree,
-  because two people's IdP names collided or the database briefly misbehaved.
+  reason other than the constraint, or when either the pre-check or the write
+  itself raises (a dropped database connection, or a constraint other than
+  the declared unique one on `:username`). It never raises: a login must not
+  fail, and a migration that calls this must not crash the boot supervision
+  tree, because two people's IdP names collided or the database briefly
+  misbehaved.
   """
   @spec claim_username(User.t(), {UsernameSource.tier(), String.t()}) :: {:ok, User.t()} | :none
   def claim_username(%User{} = user, {tier, slug}) do
@@ -192,20 +205,23 @@ defmodule Mydia.Accounts do
   defp do_claim(_user, _tier, _slug, attempt) when attempt > @username_attempt_limit, do: :none
 
   defp do_claim(user, tier, slug, attempt) do
-    attrs = %{
-      username: UsernameSource.suffixed(slug, attempt),
-      username_source: Atom.to_string(tier)
-    }
-
-    changeset = User.username_changeset(user, attrs)
+    candidate = UsernameSource.suffixed(slug, attempt)
 
     result =
       try do
-        Repo.update(changeset)
+        if case_insensitive_username_taken?(candidate, user.id) do
+          {:error, :case_insensitive_collision}
+        else
+          attrs = %{username: candidate, username_source: Atom.to_string(tier)}
+
+          user
+          |> User.username_changeset(attrs)
+          |> Repo.update()
+        end
       rescue
         error ->
           Logger.warning(
-            "claim_username: Repo.update raised for user #{user.id}: #{Exception.message(error)}"
+            "claim_username: attempt for user #{user.id} raised: #{Exception.message(error)}"
           )
 
           :none
@@ -214,6 +230,9 @@ defmodule Mydia.Accounts do
     case result do
       {:ok, updated} ->
         {:ok, updated}
+
+      {:error, :case_insensitive_collision} ->
+        do_claim(user, tier, slug, attempt + 1)
 
       {:error, changeset} ->
         if username_taken?(changeset) do
@@ -225,6 +244,19 @@ defmodule Mydia.Accounts do
       :none ->
         :none
     end
+  end
+
+  # `lower(?) = lower(?)` works unchanged on SQLite and PostgreSQL, unlike
+  # ILIKE (Postgres-only) or a citext column (a schema change out of scope
+  # here). Excluding `user.id` matters even though `user` may already carry
+  # this exact candidate as its current username: without it, an account
+  # re-claiming its own name on every login would collide with itself and
+  # suffix forever instead of ever landing on the bare slug.
+  defp case_insensitive_username_taken?(candidate, user_id) do
+    User
+    |> where([u], u.id != ^user_id)
+    |> where([u], fragment("lower(?) = lower(?)", u.username, ^candidate))
+    |> Repo.exists?()
   end
 
   defp username_taken?(%Ecto.Changeset{errors: errors}) do

--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -13,7 +13,7 @@ defmodule Mydia.Accounts do
   import Mydia.QueryHelpers
   require Logger
   alias Mydia.Repo
-  alias Mydia.Accounts.{User, ApiKey, UserPreference, ApiKeyRateLimiter, Avatar}
+  alias Mydia.Accounts.{User, ApiKey, UserPreference, ApiKeyRateLimiter, Avatar, UsernameSource}
 
   @changelog_key "last_seen_changelog_version"
   @anime_nudge_key "anime_nudge_dismissed"
@@ -142,6 +142,56 @@ defmodule Mydia.Accounts do
         |> User.oidc_changeset(attrs_without_role)
         |> Repo.update()
     end
+  end
+
+  @username_attempt_limit 50
+
+  @doc """
+  Writes a derived username onto a user, suffixing past collisions.
+
+  Attempt 1 is the bare slug, attempt N is `slug-N`. The unique index is the
+  arbiter rather than a `SELECT` beforehand, because two people signing in for
+  the first time at once would race a pre-check and one of them would crash on
+  the constraint anyway.
+
+  Returns `:none` when every attempt is taken, or when the write fails for a
+  reason other than the constraint. It never raises: a login must not fail
+  because two people's IdP names collided.
+  """
+  @spec claim_username(User.t(), {UsernameSource.tier(), String.t()}) :: {:ok, User.t()} | :none
+  def claim_username(%User{} = user, {tier, slug}) do
+    do_claim(user, tier, slug, 1)
+  end
+
+  defp do_claim(_user, _tier, _slug, attempt) when attempt > @username_attempt_limit, do: :none
+
+  defp do_claim(user, tier, slug, attempt) do
+    attrs = %{
+      username: UsernameSource.suffixed(slug, attempt),
+      username_source: Atom.to_string(tier)
+    }
+
+    user
+    |> User.username_changeset(attrs)
+    |> Repo.update()
+    |> case do
+      {:ok, updated} ->
+        {:ok, updated}
+
+      {:error, changeset} ->
+        if username_taken?(changeset) do
+          do_claim(user, tier, slug, attempt + 1)
+        else
+          :none
+        end
+    end
+  end
+
+  defp username_taken?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn
+      {:username, {_message, opts}} -> Keyword.get(opts, :constraint) == :unique
+      _other -> false
+    end)
   end
 
   @doc """

--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -154,9 +154,12 @@ defmodule Mydia.Accounts do
   the first time at once would race a pre-check and one of them would crash on
   the constraint anyway.
 
-  Returns `:none` when every attempt is taken, or when the write fails for a
-  reason other than the constraint. It never raises: a login must not fail
-  because two people's IdP names collided.
+  Returns `:none` when every attempt is taken, when the write fails for a
+  reason other than the constraint, or when the write itself raises (a
+  dropped database connection, or a constraint other than the declared
+  unique one on `:username`). It never raises: a login must not fail, and a
+  migration that calls this must not crash the boot supervision tree,
+  because two people's IdP names collided or the database briefly misbehaved.
   """
   @spec claim_username(User.t(), {UsernameSource.tier(), String.t()}) :: {:ok, User.t()} | :none
   def claim_username(%User{} = user, {tier, slug}) do
@@ -171,10 +174,21 @@ defmodule Mydia.Accounts do
       username_source: Atom.to_string(tier)
     }
 
-    user
-    |> User.username_changeset(attrs)
-    |> Repo.update()
-    |> case do
+    changeset = User.username_changeset(user, attrs)
+
+    result =
+      try do
+        Repo.update(changeset)
+      rescue
+        error ->
+          Logger.warning(
+            "claim_username: Repo.update raised for user #{user.id}: #{Exception.message(error)}"
+          )
+
+          :none
+      end
+
+    case result do
       {:ok, updated} ->
         {:ok, updated}
 
@@ -184,6 +198,9 @@ defmodule Mydia.Accounts do
         else
           :none
         end
+
+      :none ->
+        :none
     end
   end
 

--- a/lib/mydia/accounts.ex
+++ b/lib/mydia/accounts.ex
@@ -111,6 +111,12 @@ defmodule Mydia.Accounts do
   This ensures that production deployments with OIDC-only auth have an initial admin.
   """
   def upsert_user_from_oidc(oidc_sub, oidc_issuer, attrs) do
+    with {:ok, user} <- do_upsert_user_from_oidc(oidc_sub, oidc_issuer, attrs) do
+      {:ok, apply_derived_username(user, Map.put(attrs, :oidc_sub, oidc_sub))}
+    end
+  end
+
+  defp do_upsert_user_from_oidc(oidc_sub, oidc_issuer, attrs) do
     case get_user_by_oidc(oidc_sub, oidc_issuer) do
       nil ->
         # New user - check if we need to auto-promote to admin
@@ -141,6 +147,23 @@ defmodule Mydia.Accounts do
         user
         |> User.oidc_changeset(attrs_without_role)
         |> Repo.update()
+    end
+  end
+
+  # A name is nice to have, never worth failing a sign-in over. Every failure
+  # here leaves the account exactly as the upsert left it.
+  defp apply_derived_username(%User{} = user, attrs) do
+    with {tier, slug} <- UsernameSource.derive(attrs),
+         true <- UsernameSource.upgrade?(user.username, user.username_source, tier),
+         {:ok, named} <- claim_username(user, {tier, slug}) do
+      named
+    else
+      :none ->
+        Logger.warning("Could not derive or claim a username for user #{user.id}")
+        user
+
+      false ->
+        user
     end
   end
 

--- a/lib/mydia/accounts/user.ex
+++ b/lib/mydia/accounts/user.ex
@@ -13,6 +13,7 @@ defmodule Mydia.Accounts.User do
   @type t :: %__MODULE__{
           id: binary(),
           username: String.t() | nil,
+          username_source: String.t() | nil,
           email: String.t() | nil,
           password_hash: String.t() | nil,
           password: String.t() | nil,
@@ -33,6 +34,7 @@ defmodule Mydia.Accounts.User do
 
   schema "users" do
     field :username, :string
+    field :username_source, :string
     field :email, :string
     field :password_hash, :string
     field :password, :string, virtual: true
@@ -119,6 +121,25 @@ defmodule Mydia.Accounts.User do
     |> cast(attrs, [:role])
     |> validate_required([:role])
     |> validate_inclusion(:role, @role_values)
+  end
+
+  @doc """
+  Changeset for writing a derived username and its provenance.
+
+  Narrow on purpose, like `role_changeset/2`. `oidc_changeset/2` would reject
+  a local account with a blank username for having no `oidc_sub`, and
+  `changeset/2` would demand an email and re-run password validation, so
+  neither can be used to name an arbitrary account.
+
+  The length bounds match `changeset/2` so a derived name is indistinguishable
+  from a chosen one.
+  """
+  def username_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:username, :username_source])
+    |> validate_required([:username])
+    |> validate_length(:username, min: 3, max: 50)
+    |> unique_constraint(:username)
   end
 
   @doc """

--- a/lib/mydia/accounts/username_backfill.ex
+++ b/lib/mydia/accounts/username_backfill.ex
@@ -13,7 +13,10 @@ defmodule Mydia.Accounts.UsernameBackfill do
   `run/0` always returns `:ok`. It is called from a migration, and
   `lib/mydia/application.ex` starts `{Ecto.Migrator, ...}` in the supervision
   tree, so a raise here would be a boot failure on every install rather than a
-  failed deploy step. A row it cannot name keeps `username: nil`, which is why
+  failed deploy step. Both the read that finds nameless rows and the per-row
+  work are guarded: a dropped connection or a decode error while listing the
+  rows is caught here, and an exception naming one particular row is caught in
+  `name_one/2`. A row it cannot name keeps `username: nil`, which is why
   `User.label/1` and `UsernameIndex` stay in place as guards.
   """
 
@@ -27,19 +30,40 @@ defmodule Mydia.Accounts.UsernameBackfill do
 
   @spec run() :: :ok
   def run do
-    stats = Enum.reduce(nameless_users(), %{named: 0, skipped: 0}, &name_one/2)
+    case fetch_nameless_users() do
+      {:ok, users} ->
+        users
+        |> Enum.reduce(%{named: 0, skipped: 0}, &name_one/2)
+        |> log_stats()
 
+        :ok
+
+      :error ->
+        :ok
+    end
+  end
+
+  defp fetch_nameless_users do
+    {:ok, Repo.all(nameless_users_query())}
+  rescue
+    error ->
+      Logger.warning(
+        "Username backfill could not read the user list: #{Exception.message(error)}"
+      )
+
+      :error
+  end
+
+  defp nameless_users_query do
+    where(User, [u], is_nil(u.username) or fragment("trim(?)", u.username) == "")
+  end
+
+  defp log_stats(stats) do
     if stats.named > 0 or stats.skipped > 0 do
       Logger.info("Username backfill: named #{stats.named}, skipped #{stats.skipped}")
     end
 
-    :ok
-  end
-
-  defp nameless_users do
-    User
-    |> where([u], is_nil(u.username) or fragment("trim(?)", u.username) == "")
-    |> Repo.all()
+    stats
   end
 
   defp name_one(%User{} = user, stats) do

--- a/lib/mydia/accounts/username_backfill.ex
+++ b/lib/mydia/accounts/username_backfill.ex
@@ -1,0 +1,60 @@
+defmodule Mydia.Accounts.UsernameBackfill do
+  @moduledoc """
+  Names the accounts that were created before logins derived a username.
+
+  Every install that ran SSO has rows with `username: nil`, and the login path
+  cannot reach an account whose owner does not sign in again. This is the pass
+  that reaches them.
+
+  Only the `:email` and `:sub` tiers are available here: `preferred_username`
+  arrives in a login and nothing else. An account whose owner signs in later
+  gets upgraded to the claim then.
+
+  `run/0` always returns `:ok`. It is called from a migration, and
+  `lib/mydia/application.ex` starts `{Ecto.Migrator, ...}` in the supervision
+  tree, so a raise here would be a boot failure on every install rather than a
+  failed deploy step. A row it cannot name keeps `username: nil`, which is why
+  `User.label/1` and `UsernameIndex` stay in place as guards.
+  """
+
+  import Ecto.Query, warn: false
+
+  require Logger
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.{User, UsernameSource}
+  alias Mydia.Repo
+
+  @spec run() :: :ok
+  def run do
+    stats = Enum.reduce(nameless_users(), %{named: 0, skipped: 0}, &name_one/2)
+
+    if stats.named > 0 or stats.skipped > 0 do
+      Logger.info("Username backfill: named #{stats.named}, skipped #{stats.skipped}")
+    end
+
+    :ok
+  end
+
+  defp nameless_users do
+    User
+    |> where([u], is_nil(u.username) or fragment("trim(?)", u.username) == "")
+    |> Repo.all()
+  end
+
+  defp name_one(%User{} = user, stats) do
+    with {tier, slug} <- UsernameSource.derive(user),
+         {:ok, _named} <- Accounts.claim_username(user, {tier, slug}) do
+      %{stats | named: stats.named + 1}
+    else
+      _other -> skip(user, stats, "no usable name")
+    end
+  rescue
+    error -> skip(user, stats, Exception.message(error))
+  end
+
+  defp skip(%User{id: id}, stats, reason) do
+    Logger.warning("Username backfill skipped user #{id}: #{reason}")
+    %{stats | skipped: stats.skipped + 1}
+  end
+end

--- a/lib/mydia/accounts/username_index.ex
+++ b/lib/mydia/accounts/username_index.ex
@@ -12,10 +12,11 @@ defmodule Mydia.Accounts.UsernameIndex do
   remote profile against a blank Mydia username.
 
   Users with no usable username are absent from the index rather than keyed
-  under `""`. An OIDC account has `username: nil` because
-  `Mydia.Accounts.User.oidc_changeset/2` never casts the field and the column
-  is nullable, so such an account can never be name-matched. The operator maps
-  it by hand in the account-mapping modal instead.
+  under `""`. That is now an edge case rather than the norm: OIDC accounts are
+  named at login by `Mydia.Accounts.UsernameSource`, and existing ones were
+  named by the backfill migration. What is left is the rows the backfill could
+  not name, which stay `nil` on purpose so a migration never fails a boot. The
+  operator maps those by hand in the account-mapping modal.
   """
 
   alias Mydia.Accounts.User

--- a/lib/mydia/accounts/username_source.ex
+++ b/lib/mydia/accounts/username_source.ex
@@ -1,0 +1,129 @@
+defmodule Mydia.Accounts.UsernameSource do
+  @moduledoc """
+  Derives a username for an account that never chose one.
+
+  `User.oidc_changeset/2` does not cast `:username` and the column is
+  nullable, so an OIDC-provisioned account carries `username: nil` unless
+  something puts one there. This module decides what that name should be and
+  which tier produced it; `Mydia.Accounts.claim_username/2` does the writing.
+
+  The tiers, best first:
+
+    * `:idp` - the provider's `preferred_username` claim, which is what the
+      operator sees in their IdP and the closest thing to a name the person
+      chose.
+    * `:email` - the local part of the email address.
+    * `:sub` - `oidc-` plus a prefix of the subject identifier. Ugly, and it
+      cannot match a media-server profile by accident, which is the point: it
+      exists so that every account has some name rather than none.
+
+  A tier whose slug comes out shorter than three characters is skipped rather
+  than padded, because 3..50 is what `User.changeset/2` demands of a local
+  username and the two kinds of account should not disagree about what a name
+  may look like.
+  """
+
+  @type tier :: :idp | :email | :sub
+
+  @min_length 3
+  @max_length 50
+
+  @doc """
+  The longest a username may be.
+  """
+  @spec max_length() :: pos_integer()
+  def max_length, do: @max_length
+
+  @doc """
+  Returns the best available `{tier, slug}` for these attributes, or `:none`.
+
+  Accepts a plain attrs map or a `%Mydia.Accounts.User{}`, so the login path
+  and the backfill can share it. Fields are read with `Map.get/2` rather than
+  the Access syntax, which structs do not implement.
+  """
+  @spec derive(map()) :: {tier(), String.t()} | :none
+  def derive(attrs) do
+    [
+      {:idp, Map.get(attrs, :preferred_username)},
+      {:email, local_part(Map.get(attrs, :email))},
+      {:sub, sub_slug(Map.get(attrs, :oidc_sub))}
+    ]
+    |> Enum.find_value(:none, fn {tier, candidate} ->
+      case slugify(candidate) do
+        nil -> nil
+        slug -> {tier, slug}
+      end
+    end)
+  end
+
+  @doc """
+  The name to try on the given attempt. Attempt 1 is the bare slug.
+
+  The base is truncated so that the suffix fits, because a 50-character slug
+  with `-2` glued on would fail the length validation rather than resolve the
+  collision it was reaching for.
+  """
+  @spec suffixed(String.t(), pos_integer()) :: String.t()
+  def suffixed(slug, 1), do: slug
+
+  def suffixed(slug, attempt) when attempt > 1 do
+    suffix = "-" <> Integer.to_string(attempt)
+    base = String.slice(slug, 0, @max_length - String.length(suffix))
+    base <> suffix
+  end
+
+  @doc """
+  Whether a newly derived tier should replace the stored name.
+
+  An account with no name yet always takes one. A name with no recorded
+  source was chosen locally, by `User.changeset/2` or by an operator, and is
+  never overwritten. Otherwise the name only ever moves up the tiers, so an
+  unchanged claim performs no write at all.
+  """
+  @spec upgrade?(String.t() | nil, String.t() | nil, tier()) :: boolean()
+  def upgrade?(username, stored_source, tier) do
+    cond do
+      blank?(username) -> true
+      is_nil(stored_source) -> false
+      true -> rank(tier) > rank(stored_source)
+    end
+  end
+
+  defp rank(:idp), do: 3
+  defp rank(:email), do: 2
+  defp rank(:sub), do: 1
+  defp rank("idp"), do: 3
+  defp rank("email"), do: 2
+  defp rank("sub"), do: 1
+  defp rank(_other), do: 0
+
+  defp blank?(nil), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(_value), do: false
+
+  defp local_part(nil), do: nil
+  defp local_part(email) when is_binary(email), do: email |> String.split("@") |> List.first()
+  defp local_part(_email), do: nil
+
+  defp sub_slug(nil), do: nil
+  defp sub_slug(sub) when is_binary(sub), do: "oidc-" <> String.slice(sub, 0, 8)
+  defp sub_slug(_sub), do: nil
+
+  defp slugify(nil), do: nil
+
+  defp slugify(value) when is_binary(value) do
+    value
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9._-]+/u, "-")
+    |> String.replace(~r/[-._]{2,}/, "-")
+    |> String.replace(~r/^[-._]+|[-._]+$/, "")
+    |> String.slice(0, @max_length)
+    |> String.replace(~r/[-._]+$/, "")
+    |> case do
+      slug when byte_size(slug) == 0 -> nil
+      slug -> if String.length(slug) >= @min_length, do: slug, else: nil
+    end
+  end
+
+  defp slugify(_value), do: nil
+end

--- a/lib/mydia_web/controllers/auth_controller.ex
+++ b/lib/mydia_web/controllers/auth_controller.ex
@@ -156,12 +156,36 @@ defmodule MydiaWeb.AuthController do
       email: auth.info.email,
       display_name: auth.info.name || auth.info.email,
       avatar_url: auth.info.image,
-      role: determine_role(auth)
+      role: determine_role(auth),
+      preferred_username: preferred_username(auth)
     }
 
     # Create or update user from OIDC
     Accounts.upsert_user_from_oidc(oidc_sub, oidc_issuer, attrs)
   end
+
+  # `preferred_username` is a standard OIDC claim. Ueberauth's Info struct has
+  # a `nickname` field and the OIDC strategies map the claim onto it, but not
+  # every strategy does, so the raw userinfo is the second look.
+  defp preferred_username(auth) do
+    userinfo =
+      case auth.extra do
+        %{raw_info: %{userinfo: userinfo}} when is_map(userinfo) -> userinfo
+        _other -> %{}
+      end
+
+    blank_to_nil(Map.get(auth.info, :nickname)) ||
+      blank_to_nil(Map.get(userinfo, "preferred_username"))
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp blank_to_nil(_value), do: nil
 
   # Determine user role from OIDC claims
   # Can be customized based on your OIDC provider's group/role claims

--- a/lib/mydia_web/live/admin_users_live/index.html.heex
+++ b/lib/mydia_web/live/admin_users_live/index.html.heex
@@ -105,18 +105,20 @@
                       <div class="avatar placeholder">
                         <div class="bg-primary text-primary-content rounded-full w-12">
                           <%= if user.avatar_url do %>
-                            <img src={user.avatar_url} alt={user.username} />
+                            <img src={user.avatar_url} alt={User.label(user)} />
                           <% else %>
                             <span class="text-lg">
-                              {String.first(user.username || "?")}
+                              {user |> User.label() |> String.first() |> String.upcase()}
                             </span>
                           <% end %>
                         </div>
                       </div>
                       <div>
-                        <div class="font-bold">{user.username}</div>
+                        <div class="font-bold" id={"user-name-#{user.id}"}>
+                          {User.label(user)}
+                        </div>
                         <div class="text-sm text-base-content/70">{user.email}</div>
-                        <%= if user.display_name && user.display_name != user.username do %>
+                        <%= if user.display_name && user.display_name != User.label(user) do %>
                           <div class="text-xs text-base-content/50">{user.display_name}</div>
                         <% end %>
                       </div>
@@ -415,8 +417,8 @@
     <div class="modal modal-open">
       <div class="modal-box">
         <h3 class="font-bold text-lg mb-4">Edit User Role</h3>
-        <p class="text-sm text-base-content/70 mb-4">
-          Change role for <strong>{@selected_user.username}</strong>
+        <p class="text-sm text-base-content/70 mb-4" id="edit-role-modal-title">
+          Change role for <strong>{User.label(@selected_user)}</strong>
         </p>
 
         <.form
@@ -466,7 +468,7 @@
       <div class="modal-box">
         <h3 class="font-bold text-lg mb-4">Reset Password</h3>
         <p class="text-sm text-base-content/70 mb-4">
-          Reset password for <strong>{@selected_user.username}</strong>
+          Reset password for <strong>{User.label(@selected_user)}</strong>
         </p>
 
         <%= if @password_reset_success do %>
@@ -656,8 +658,8 @@
     <div class="modal modal-open">
       <div class="modal-box">
         <h3 class="font-bold text-lg mb-4 text-error">Delete User</h3>
-        <p class="text-sm text-base-content/70 mb-4">
-          Are you sure you want to delete <strong>{@selected_user.username}</strong>?
+        <p class="text-sm text-base-content/70 mb-4" id="delete-modal-prompt">
+          Are you sure you want to delete <strong>{User.label(@selected_user)}</strong>?
         </p>
 
         <div class="alert alert-error">

--- a/priv/repo/migrations/20260905143000_add_username_source_to_users.exs
+++ b/priv/repo/migrations/20260905143000_add_username_source_to_users.exs
@@ -1,0 +1,21 @@
+defmodule Mydia.Repo.Migrations.AddUsernameSourceToUsers do
+  use Ecto.Migration
+
+  @moduledoc """
+  Records which tier produced a derived username.
+
+  Without it, "upgrade the name only when the IdP offers a better one" is not
+  decidable: a stored `robin` could equally be what the operator typed or what
+  a backfill took from an email address, and only one of those may be
+  overwritten. NULL means the name was chosen locally.
+
+  `:text` rather than `:string`, which would be varchar(255) on PostgreSQL and
+  unconstrained TEXT on SQLite.
+  """
+
+  def change do
+    alter table(:users) do
+      add :username_source, :text
+    end
+  end
+end

--- a/priv/repo/migrations/20260905143001_backfill_usernames.exs
+++ b/priv/repo/migrations/20260905143001_backfill_usernames.exs
@@ -1,0 +1,25 @@
+defmodule Mydia.Repo.Migrations.BackfillUsernames do
+  use Ecto.Migration
+
+  @moduledoc """
+  Names the accounts that OIDC created before logins derived a username.
+
+  The work lives in `Mydia.Accounts.UsernameBackfill` so it can be tested like
+  ordinary code rather than only through a migration, the way
+  `20260902200320_relink_existing_multi_episode_files.exs` delegates to
+  `Mydia.Library.MultiEpisodeRelink`.
+
+  `run/0` cannot fail. That is deliberate: this runs inside the supervision
+  tree's migrator, so a raise would stop the application booting.
+  """
+
+  def up do
+    :ok = Mydia.Accounts.UsernameBackfill.run()
+  end
+
+  def down do
+    # The names are real data by now, and dropping them would put every
+    # install back in the state that produced the crash this fixes.
+    :ok
+  end
+end

--- a/test/mydia/accounts/claim_username_test.exs
+++ b/test/mydia/accounts/claim_username_test.exs
@@ -1,6 +1,9 @@
 defmodule Mydia.Accounts.ClaimUsernameTest do
   use Mydia.DataCase, async: true
 
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Accounts
   alias Mydia.Accounts.User
 
   describe "username_changeset/2" do
@@ -31,6 +34,42 @@ defmodule Mydia.Accounts.ClaimUsernameTest do
 
       assert changeset.valid?
       assert Ecto.Changeset.get_change(changeset, :role) == nil
+    end
+  end
+
+  describe "claim_username/2" do
+    test "takes a free name as-is and records the tier" do
+      user = user_fixture(%{username: "someone-else"})
+
+      assert {:ok, claimed} = Accounts.claim_username(user, {:idp, "robin"})
+      assert claimed.username == "robin"
+      assert claimed.username_source == "idp"
+    end
+
+    test "suffixes past a name that is taken" do
+      _taken = user_fixture(%{username: "robin"})
+      user = user_fixture(%{username: "someone-else"})
+
+      assert {:ok, claimed} = Accounts.claim_username(user, {:email, "robin"})
+      assert claimed.username == "robin-2"
+      assert claimed.username_source == "email"
+    end
+
+    test "walks forward over a run of taken suffixes" do
+      _taken = user_fixture(%{username: "robin"})
+      _taken_2 = user_fixture(%{username: "robin-2"})
+      _taken_3 = user_fixture(%{username: "robin-3"})
+      user = user_fixture(%{username: "someone-else"})
+
+      assert {:ok, claimed} = Accounts.claim_username(user, {:email, "robin"})
+      assert claimed.username == "robin-4"
+    end
+
+    test "returns :none rather than raising when the name cannot be validated" do
+      user = user_fixture(%{username: "someone-else"})
+
+      assert Accounts.claim_username(user, {:idp, "ab"}) == :none
+      assert Mydia.Repo.reload(user).username == "someone-else"
     end
   end
 end

--- a/test/mydia/accounts/claim_username_test.exs
+++ b/test/mydia/accounts/claim_username_test.exs
@@ -1,0 +1,36 @@
+defmodule Mydia.Accounts.ClaimUsernameTest do
+  use Mydia.DataCase, async: true
+
+  alias Mydia.Accounts.User
+
+  describe "username_changeset/2" do
+    test "writes a username and its source onto an account with neither" do
+      changeset = User.username_changeset(%User{}, %{username: "robin", username_source: "email"})
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :username) == "robin"
+      assert Ecto.Changeset.get_change(changeset, :username_source) == "email"
+    end
+
+    test "requires a username" do
+      changeset = User.username_changeset(%User{}, %{username_source: "email"})
+
+      refute changeset.valid?
+      assert %{username: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "rejects a username outside three to fifty characters" do
+      refute User.username_changeset(%User{}, %{username: "ab"}).valid?
+      refute User.username_changeset(%User{}, %{username: String.duplicate("a", 51)}).valid?
+      assert User.username_changeset(%User{}, %{username: "abc"}).valid?
+    end
+
+    test "does not touch fields outside its two" do
+      changeset =
+        User.username_changeset(%User{role: "user"}, %{username: "robin", role: "admin"})
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :role) == nil
+    end
+  end
+end

--- a/test/mydia/accounts/claim_username_test.exs
+++ b/test/mydia/accounts/claim_username_test.exs
@@ -71,5 +71,11 @@ defmodule Mydia.Accounts.ClaimUsernameTest do
       assert Accounts.claim_username(user, {:idp, "ab"}) == :none
       assert Mydia.Repo.reload(user).username == "someone-else"
     end
+
+    test "returns :none rather than raising when the write itself raises" do
+      user = %User{id: Ecto.UUID.generate(), username: "gone", role: "user"}
+
+      assert Accounts.claim_username(user, {:idp, "robin"}) == :none
+    end
   end
 end

--- a/test/mydia/accounts/claim_username_test.exs
+++ b/test/mydia/accounts/claim_username_test.exs
@@ -77,5 +77,34 @@ defmodule Mydia.Accounts.ClaimUsernameTest do
 
       assert Accounts.claim_username(user, {:idp, "robin"}) == :none
     end
+
+    test "a derived lowercase name does not shadow an existing mixed-case username" do
+      _taken = user_fixture(%{username: "Tonix"})
+      user = user_fixture(%{username: "someone-else"})
+
+      assert {:ok, claimed} = Accounts.claim_username(user, {:idp, "tonix"})
+      assert claimed.username == "tonix-2"
+    end
+
+    test "the suffix walk is also case-insensitive" do
+      _taken = user_fixture(%{username: "Tonix"})
+      _taken_2 = user_fixture(%{username: "Tonix-2"})
+      user = user_fixture(%{username: "someone-else"})
+
+      assert {:ok, claimed} = Accounts.claim_username(user, {:idp, "tonix"})
+      assert claimed.username == "tonix-3"
+    end
+
+    test "reclaiming a name against one's own differently-cased current name does not suffix" do
+      # The user's stored username is mixed-case while the candidate is the
+      # lowercase slug `slugify/1` always produces, so a case-insensitive
+      # lookup that did NOT exclude this user's own row would find it as a
+      # "collision" and wrongly suffix to "tonix-2". Only the self-exclusion
+      # clause lets attempt 1 land on the bare "tonix".
+      user = user_fixture(%{username: "Tonix"})
+
+      assert {:ok, claimed} = Accounts.claim_username(user, {:idp, "tonix"})
+      assert claimed.username == "tonix"
+    end
   end
 end

--- a/test/mydia/accounts/oidc_username_test.exs
+++ b/test/mydia/accounts/oidc_username_test.exs
@@ -1,0 +1,89 @@
+defmodule Mydia.Accounts.OidcUsernameTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Accounts
+
+  defp upsert(attrs, sub \\ nil) do
+    sub = sub || "sub-#{System.unique_integer([:positive])}"
+    {:ok, user} = Accounts.upsert_user_from_oidc(sub, "https://issuer.example.test", attrs)
+    user
+  end
+
+  setup do
+    # An admin has to exist first, or upsert_user_from_oidc/3 promotes the
+    # account under test to admin and the role assertions read oddly.
+    admin_user_fixture(%{username: "installer"})
+    :ok
+  end
+
+  test "a new SSO account is named from the IdP claim" do
+    user = upsert(%{email: "robin@example.test", preferred_username: "tonix", role: "user"})
+
+    assert user.username == "tonix"
+    assert user.username_source == "idp"
+  end
+
+  test "a new SSO account with no claim is named from its email" do
+    user = upsert(%{email: "robin.vega@example.test", role: "user"})
+
+    assert user.username == "robin.vega"
+    assert user.username_source == "email"
+  end
+
+  test "a new SSO account with neither is named from its sub" do
+    user = upsert(%{role: "user"}, "abcdef1234567890")
+
+    assert user.username == "oidc-abcdef12"
+    assert user.username_source == "sub"
+  end
+
+  test "a later login upgrades an email-derived name to the IdP claim" do
+    sub = "sub-upgrade"
+    first = upsert(%{email: "robin@example.test", role: "user"}, sub)
+    assert first.username == "robin"
+
+    second = upsert(%{email: "robin@example.test", preferred_username: "tonix"}, sub)
+
+    assert second.username == "tonix"
+    assert second.username_source == "idp"
+  end
+
+  test "a later login never downgrades the name" do
+    sub = "sub-downgrade"
+    first = upsert(%{email: "robin@example.test", preferred_username: "tonix"}, sub)
+    assert first.username == "tonix"
+
+    second = upsert(%{email: "robin@example.test"}, sub)
+
+    assert second.username == "tonix"
+    assert second.username_source == "idp"
+  end
+
+  test "a colliding claim suffixes rather than failing the sign-in" do
+    user_fixture(%{username: "tonix"})
+
+    user = upsert(%{email: "robin@example.test", preferred_username: "tonix", role: "user"})
+
+    assert user.username == "tonix-2"
+    assert user.username_source == "idp"
+  end
+
+  test "a locally chosen name is never overwritten by a login" do
+    sub = "sub-local"
+    first = upsert(%{email: "robin@example.test", role: "user"}, sub)
+
+    {:ok, renamed} =
+      first
+      |> Mydia.Accounts.User.username_changeset(%{username: "chosen-by-hand"})
+      |> Ecto.Changeset.put_change(:username_source, nil)
+      |> Mydia.Repo.update()
+
+    assert renamed.username_source == nil
+
+    second = upsert(%{email: "robin@example.test", preferred_username: "tonix"}, sub)
+
+    assert second.username == "chosen-by-hand"
+  end
+end

--- a/test/mydia/accounts/oidc_username_test.exs
+++ b/test/mydia/accounts/oidc_username_test.exs
@@ -70,6 +70,15 @@ defmodule Mydia.Accounts.OidcUsernameTest do
     assert user.username_source == "idp"
   end
 
+  test "an SSO login never lands on a case-variant of an existing local username" do
+    local = user_fixture(%{username: "Tonix"})
+
+    sso = upsert(%{email: "robin@example.test", preferred_username: "tonix", role: "user"})
+
+    assert sso.username == "tonix-2"
+    refute String.downcase(sso.username) == String.downcase(local.username)
+  end
+
   test "a locally chosen name is never overwritten by a login" do
     sub = "sub-local"
     first = upsert(%{email: "robin@example.test", role: "user"}, sub)

--- a/test/mydia/accounts/username_backfill_test.exs
+++ b/test/mydia/accounts/username_backfill_test.exs
@@ -1,0 +1,64 @@
+defmodule Mydia.Accounts.UsernameBackfillTest do
+  use Mydia.DataCase, async: true
+
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Accounts.UsernameBackfill
+  alias Mydia.Repo
+
+  test "names an account from its email" do
+    user = nameless_user_fixture(%{email: "robin.vega@example.test"})
+
+    assert UsernameBackfill.run() == :ok
+
+    reloaded = Repo.reload(user)
+    assert reloaded.username == "robin.vega"
+    assert reloaded.username_source == "email"
+  end
+
+  test "falls back to the sub when there is no email" do
+    user = nameless_user_fixture(%{email: nil, oidc_sub: "abcdef1234567890"})
+
+    assert UsernameBackfill.run() == :ok
+
+    reloaded = Repo.reload(user)
+    assert reloaded.username == "oidc-abcdef12"
+    assert reloaded.username_source == "sub"
+  end
+
+  test "suffixes past a name a local account already holds" do
+    _taken = user_fixture(%{username: "robin"})
+    user = nameless_user_fixture(%{email: "robin@example.test"})
+
+    assert UsernameBackfill.run() == :ok
+    assert Repo.reload(user).username == "robin-2"
+  end
+
+  test "leaves accounts that already have a name alone" do
+    local = user_fixture(%{username: "installer"})
+
+    assert UsernameBackfill.run() == :ok
+
+    reloaded = Repo.reload(local)
+    assert reloaded.username == "installer"
+    assert reloaded.username_source == nil
+  end
+
+  test "skips a row it cannot name rather than failing" do
+    unnameable = nameless_user_fixture(%{email: nil, oidc_sub: nil})
+    nameable = nameless_user_fixture(%{email: "robin@example.test"})
+
+    assert UsernameBackfill.run() == :ok
+    assert Repo.reload(unnameable).username == nil
+    assert Repo.reload(nameable).username == "robin"
+  end
+
+  test "is safe to run twice" do
+    user = nameless_user_fixture(%{email: "robin@example.test"})
+
+    assert UsernameBackfill.run() == :ok
+    assert UsernameBackfill.run() == :ok
+
+    assert Repo.reload(user).username == "robin"
+  end
+end

--- a/test/mydia/accounts/username_backfill_test.exs
+++ b/test/mydia/accounts/username_backfill_test.exs
@@ -61,4 +61,19 @@ defmodule Mydia.Accounts.UsernameBackfillTest do
 
     assert Repo.reload(user).username == "robin"
   end
+
+  test "returns :ok even when the read that finds nameless rows fails" do
+    # Renaming the table out from under the query is the cleanest way to make
+    # Repo.all/1 raise inside a sandboxed test: both SQLite and PostgreSQL
+    # support this DDL, and the sandbox transaction rolls it back regardless.
+    # The rename-back also happens explicitly in `after`, so a failing
+    # assertion here cannot leave the schema broken for the rest of the file.
+    Repo.query!("ALTER TABLE users RENAME TO users_backfill_test_tmp")
+
+    try do
+      assert UsernameBackfill.run() == :ok
+    after
+      Repo.query!("ALTER TABLE users_backfill_test_tmp RENAME TO users")
+    end
+  end
 end

--- a/test/mydia/accounts/username_source_test.exs
+++ b/test/mydia/accounts/username_source_test.exs
@@ -1,0 +1,105 @@
+defmodule Mydia.Accounts.UsernameSourceTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Accounts.UsernameSource
+
+  describe "derive/1 tiers" do
+    test "prefers the IdP claim" do
+      attrs = %{
+        preferred_username: "tonix",
+        email: "robin@example.test",
+        oidc_sub: "abcdef1234567890"
+      }
+
+      assert UsernameSource.derive(attrs) == {:idp, "tonix"}
+    end
+
+    test "falls back to the email local part when there is no claim" do
+      attrs = %{email: "robin.vega@example.test", oidc_sub: "abcdef1234567890"}
+
+      assert UsernameSource.derive(attrs) == {:email, "robin.vega"}
+    end
+
+    test "falls back to a sub prefix when there is no email" do
+      assert UsernameSource.derive(%{oidc_sub: "abcdef1234567890"}) == {:sub, "oidc-abcdef12"}
+    end
+
+    test "returns :none when every tier is absent" do
+      assert UsernameSource.derive(%{}) == :none
+    end
+
+    test "skips a tier that slugs to fewer than three characters" do
+      attrs = %{preferred_username: "ab", email: "robin@example.test", oidc_sub: "s1"}
+
+      assert UsernameSource.derive(attrs) == {:email, "robin"}
+    end
+
+    test "reads a %User{} struct as readily as an attrs map" do
+      user = %Mydia.Accounts.User{email: "robin@example.test", oidc_sub: "abcdef1234567890"}
+
+      assert UsernameSource.derive(user) == {:email, "robin"}
+    end
+  end
+
+  describe "derive/1 slugging" do
+    test "downcases and replaces characters a username may not hold" do
+      assert UsernameSource.derive(%{preferred_username: "Robin Vega!"}) == {:idp, "robin-vega"}
+    end
+
+    test "collapses runs of separators and trims them from both ends" do
+      assert UsernameSource.derive(%{preferred_username: "--robin__vega--"}) ==
+               {:idp, "robin-vega"}
+    end
+
+    test "truncates to fifty characters without leaving a trailing separator" do
+      claim = String.duplicate("a", 49) <> " tail"
+
+      {:idp, slug} = UsernameSource.derive(%{preferred_username: claim})
+
+      assert String.length(slug) == 49
+      assert slug == String.duplicate("a", 49)
+    end
+  end
+
+  describe "suffixed/2" do
+    test "leaves the first attempt alone" do
+      assert UsernameSource.suffixed("robin", 1) == "robin"
+    end
+
+    test "appends the attempt number from the second attempt on" do
+      assert UsernameSource.suffixed("robin", 2) == "robin-2"
+      assert UsernameSource.suffixed("robin", 17) == "robin-17"
+    end
+
+    test "keeps the suffixed name inside the length limit" do
+      slug = String.duplicate("a", 50)
+
+      assert UsernameSource.suffixed(slug, 12) == String.duplicate("a", 47) <> "-12"
+      assert String.length(UsernameSource.suffixed(slug, 12)) == 50
+    end
+  end
+
+  describe "upgrade?/3" do
+    test "always writes when there is no username yet" do
+      assert UsernameSource.upgrade?(nil, nil, :sub)
+      assert UsernameSource.upgrade?("", nil, :sub)
+      assert UsernameSource.upgrade?("   ", nil, :sub)
+    end
+
+    test "never touches a name with no recorded source" do
+      refute UsernameSource.upgrade?("robin", nil, :idp)
+    end
+
+    test "moves up the tiers" do
+      assert UsernameSource.upgrade?("oidc-abcdef12", "sub", :email)
+      assert UsernameSource.upgrade?("robin", "email", :idp)
+    end
+
+    test "never moves down and never rewrites the same tier" do
+      refute UsernameSource.upgrade?("tonix", "idp", :email)
+      refute UsernameSource.upgrade?("tonix", "idp", :sub)
+      refute UsernameSource.upgrade?("tonix", "idp", :idp)
+      refute UsernameSource.upgrade?("robin", "email", :email)
+    end
+  end
+end

--- a/test/mydia/media_server/jellyfin/users_test.exs
+++ b/test/mydia/media_server/jellyfin/users_test.exs
@@ -64,9 +64,12 @@ defmodule Mydia.MediaServer.Jellyfin.UsersTest do
     config: config
   } do
     # Same defect as #705 on the Plex side, in code copied from it. Unreported
-    # only because fewer operators pair Jellyfin with SSO.
+    # only because fewer operators pair Jellyfin with SSO. The nameless
+    # account models an install from before the username backfill (or one
+    # that skipped it), inserted directly rather than through the OIDC
+    # upsert path, which would derive and claim a name of its own.
     user = admin_user_fixture(%{username: "tonix"})
-    _sso = oidc_user_fixture(%{})
+    _sso = nameless_user_fixture(%{})
 
     Bypass.expect_once(bypass, "GET", "/Users", fn conn ->
       conn

--- a/test/mydia/media_server/jellyfin/users_test.exs
+++ b/test/mydia/media_server/jellyfin/users_test.exs
@@ -99,6 +99,30 @@ defmodule Mydia.MediaServer.Jellyfin.UsersTest do
     assert Settings.list_media_server_user_links(config.id) == []
   end
 
+  test "an SSO account is matched by its derived username", %{bypass: bypass, config: config} do
+    # The point of naming SSO accounts. Before, an SSO-only install got no
+    # automatic links at all and the operator mapped every profile by hand.
+    admin_user_fixture(%{username: "installer"})
+
+    {:ok, sso} =
+      Mydia.Accounts.upsert_user_from_oidc(
+        "sub-jellyfin-match",
+        "https://issuer.example.test",
+        %{email: "robin@example.test", preferred_username: "tonix", role: "user"}
+      )
+
+    assert sso.username == "tonix"
+
+    Bypass.expect_once(bypass, "GET", "/Users", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, ~s([{"Id":"jf1","Name":"Tonix"}]))
+    end)
+
+    assert {:ok, %SeedResult{linked: [link]}} = Users.seed_links(config)
+    assert link.user_id == sso.id
+  end
+
   test "does not create a link that carries an access token", %{
     bypass: bypass,
     config: config

--- a/test/mydia/media_server/plex/home_test.exs
+++ b/test/mydia/media_server/plex/home_test.exs
@@ -170,10 +170,12 @@ defmodule Mydia.MediaServer.Plex.HomeTest do
         |> Plug.Conn.resp(200, Jason.encode!(%{"authToken" => "kid-token"}))
       end)
 
-      # Created first so an admin exists and the OIDC upsert does not
-      # auto-promote the SSO account.
+      # The nameless account models an install from before the username
+      # backfill (or one that skipped it): a real account with username: nil,
+      # inserted directly rather than through the OIDC upsert path, which
+      # would derive and claim a name of its own.
       user = Mydia.AccountsFixtures.admin_user_fixture(%{username: "kid"})
-      _sso = Mydia.AccountsFixtures.oidc_user_fixture(%{})
+      _sso = Mydia.AccountsFixtures.nameless_user_fixture(%{})
       {:ok, saved} = Mydia.Settings.create_media_server_config(persistable(config))
 
       assert {:ok, %SeedResult{linked: [link]}} = Home.seed_links(saved, plex_tv_base: base)

--- a/test/mydia_web/live/admin_media_servers_live_test.exs
+++ b/test/mydia_web/live/admin_media_servers_live_test.exs
@@ -376,9 +376,12 @@ defmodule MydiaWeb.AdminMediaServersLiveTest do
     test "the modal still opens and suggests a match when an SSO account exists",
          %{conn: conn, bypass: bypass} do
       # initial_mapping/3 built its own unguarded username index, so opening
-      # the modal on an install with SSO crashed the LiveView outright.
+      # the modal on an install with SSO crashed the LiveView outright. The
+      # nameless account models an install from before the username backfill
+      # (or one that skipped it), inserted directly rather than through the
+      # OIDC upsert path, which would derive and claim a name of its own.
       user = Mydia.AccountsFixtures.user_fixture(%{username: "tonix"})
-      _sso = Mydia.AccountsFixtures.oidc_user_fixture(%{display_name: "Robin Vega"})
+      _sso = Mydia.AccountsFixtures.nameless_user_fixture(%{display_name: "Robin Vega"})
       server = sync_enabled_server(bypass)
 
       stub_jellyfin_users(bypass, [%{"Id" => "guid-1", "Name" => "Tonix"}])

--- a/test/mydia_web/live/admin_users_live_test.exs
+++ b/test/mydia_web/live/admin_users_live_test.exs
@@ -1,0 +1,63 @@
+defmodule MydiaWeb.AdminUsersLiveTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture(%{username: "installer"})
+    {:ok, token, _claims} = Mydia.Auth.Guardian.encode_and_sign(admin)
+
+    conn =
+      conn
+      |> init_test_session(%{})
+      |> put_session(:guardian_default_token, token)
+      |> put_req_header("authorization", "Bearer #{token}")
+
+    %{conn: conn, admin: admin}
+  end
+
+  describe "an account with no username" do
+    setup do
+      %{nameless: nameless_user_fixture(%{display_name: "Robin Vega"})}
+    end
+
+    test "the name cell falls back instead of rendering empty", %{
+      conn: conn,
+      nameless: nameless
+    } do
+      {:ok, view, _html} = live(conn, ~p"/admin/users")
+
+      assert has_element?(view, "#user-name-#{nameless.id}", "Robin Vega")
+    end
+
+    test "a local account still shows its username in the name cell", %{
+      conn: conn,
+      admin: admin
+    } do
+      {:ok, view, _html} = live(conn, ~p"/admin/users")
+
+      assert has_element?(view, "#user-name-#{admin.id}", "installer")
+    end
+
+    test "the edit-role modal names them", %{conn: conn, nameless: nameless} do
+      {:ok, view, _html} = live(conn, ~p"/admin/users")
+
+      view
+      |> element(~s{button[phx-click="open_edit_role_modal"][phx-value-id="#{nameless.id}"]})
+      |> render_click()
+
+      assert has_element?(view, "#edit-role-modal-title", "Robin Vega")
+    end
+
+    test "the delete modal names them", %{conn: conn, nameless: nameless} do
+      {:ok, view, _html} = live(conn, ~p"/admin/users")
+
+      view
+      |> element(~s{button[phx-click="open_delete_modal"][phx-value-id="#{nameless.id}"]})
+      |> render_click()
+
+      assert has_element?(view, "#delete-modal-prompt", "Robin Vega")
+    end
+  end
+end

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -32,11 +32,15 @@ defmodule Mydia.AccountsFixtures do
   end
 
   @doc """
-  Generate an OIDC-provisioned user, which has no username.
+  Generate an OIDC-provisioned user.
 
   `Accounts.upsert_user_from_oidc/3` is the only path that creates one:
   `create_user/1` runs `User.changeset/2`, which requires a username, so it
   cannot build the account shape that SSO installs actually have.
+
+  The login path now derives a username from the email address, so the
+  returned user carries one (e.g. `sso123`). Pass `preferred_username:` to
+  exercise the `:idp` tier instead.
   """
   def oidc_user_fixture(attrs \\ %{}) do
     n = System.unique_integer([:positive])
@@ -51,5 +55,27 @@ defmodule Mydia.AccountsFixtures do
       Accounts.upsert_user_from_oidc("oidc-sub-#{n}", "https://issuer.example.test", attrs)
 
     user
+  end
+
+  @doc """
+  Generate a user with no username at all.
+
+  `oidc_user_fixture/1` no longer produces one: the login path derives a name
+  from the email address. This fixture inserts the row directly, bypassing
+  every changeset, so it can still build the shape a pre-backfill install has
+  and the shape a backfill skip leaves behind.
+  """
+  def nameless_user_fixture(attrs \\ %{}) do
+    n = System.unique_integer([:positive])
+
+    Mydia.Repo.insert!(%Mydia.Accounts.User{
+      username: nil,
+      username_source: nil,
+      email: Map.get(attrs, :email, "nameless#{n}@example.test"),
+      display_name: Map.get(attrs, :display_name),
+      oidc_sub: Map.get(attrs, :oidc_sub, "oidc-sub-#{n}"),
+      oidc_issuer: "https://issuer.example.test",
+      role: Map.get(attrs, :role, "user")
+    })
   end
 end


### PR DESCRIPTION
Follow-up to #710, which stopped nil usernames crashing media-server seeding but deliberately left the nil usernames themselves. Closes the two items that PR deferred.

`User.oidc_changeset/2` never cast `:username` and the column is nullable, so every OIDC-provisioned account carried `username: nil` for its whole life. Three consequences: the Admin Users table rendered blank names and modal headings, SSO accounts could never be name-matched so an SSO install got zero automatic Plex or Jellyfin links, and `username` remained the identity key everywhere while one class of account simply had none.

## What changes

`Mydia.Accounts.UsernameSource` derives a name and records where it came from. Best tier first: the IdP's `preferred_username` claim, then the email local part, then `oidc-` plus a prefix of the sub. Slugs match what `changeset/2` already demands of a local username, 3 to 50 characters.

A new nullable `users.username_source` column records the tier. NULL means the name was chosen locally and is never overwritten. Without provenance, "upgrade the name only when the IdP offers a better one" is undecidable: a stored `robin` could equally be what an operator typed or what a backfill derived.

`Accounts.claim_username/2` writes the name and suffixes past collisions. Logins claim on the way through `upsert_user_from_oidc/3`, upgrade-only, so an unchanged claim performs no write. A migration backfills the accounts that already exist, since the login path cannot reach an account whose owner never signs in again.

The Admin Users table now uses the existing `User.label/1` at all seven sites.

## Two things worth a reviewer's attention

**The backfill cannot fail.** `application.ex` starts `Ecto.Migrator` in the supervision tree, so a raising migration is a boot failure on every install rather than a failed deploy. `run/0` returns `:ok` unconditionally: the read is guarded, each row is guarded, and `claim_username/2` rescues its own write. A row that cannot be named stays `username: nil`, which is why the column stays nullable and `label/1` and `UsernameIndex` remain as guards.

**Case-sensitivity was a real trap.** Derived names are always lowercase but the unique index on `users.username` is case-sensitive, so a derived `tonix` could be written next to an existing `Tonix` without tripping the constraint. `UsernameIndex` normalises both sides and `Map.new` keeps only one of them, so `MediaServerLinkSeed` could then attach a Plex or Jellyfin profile to the wrong account and merge two people's watch history, silently. Each claim attempt now also runs a case-insensitive check excluding the user's own row. The constraint stays as the second line of defence for the exact-match race between two simultaneous first logins.

## Behaviour change

SSO accounts become eligible for automatic media-server name matching. That is the point rather than a side effect: an IdP-supplied or email-derived name is as trustworthy a match key as a local username, which the feature already stakes watch history on.

## Out of scope

Case-insensitive uniqueness in general, `NOT NULL` on `username`, and editing a username from the admin UI.

## Verification

`mix precommit` green: 10807 tests, 0 failures, format and Credo clean. PostgreSQL suite green (295 tests). Migrations verified applying from scratch, including the backfill as a no-op against an empty table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSO accounts now receive readable usernames from identity-provider names, email addresses, or a fallback identifier.
  * Username conflicts are handled automatically with numeric suffixes.
  * Existing accounts can be upgraded when a better identity-provider name becomes available, while locally chosen names remain unchanged.
  * Accounts without usernames now display their full name in administration screens and related prompts.
* **Data Updates**
  * Existing nameless accounts are automatically assigned usernames where possible, while unresolvable accounts remain available for manual handling.
* **Bug Fixes**
  * Improved media-server account matching for SSO users and accounts without usernames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->