### PR TITLE
test(accounts): stop the backfill test racing other async tests

### DIFF
--- a/test/mydia/accounts/username_backfill_test.exs
+++ b/test/mydia/accounts/username_backfill_test.exs
@@ -1,5 +1,10 @@
 defmodule Mydia.Accounts.UsernameBackfillTest do
-  use Mydia.DataCase, async: true
+  # Not async. "returns :ok when the user list cannot be read" renames the
+  # users table inside its sandbox transaction, and on PostgreSQL that rename
+  # holds an ACCESS EXCLUSIVE lock until the transaction ends. Any other async
+  # test touching users would block on it and eventually time out, which is the
+  # flake class .github/ci-flakes.md already catalogues.
+  use Mydia.DataCase, async: false
 
   import Mydia.AccountsFixtures
 


### PR DESCRIPTION
Follow-up to #713, from a CodeRabbit finding that landed as that PR merged.

`test/mydia/accounts/username_backfill_test.exs` ran `async: true`. One of its tests proves the backfill returns `:ok` when the user list cannot be read, and it does that by renaming the `users` table inside its sandbox transaction. On PostgreSQL that rename holds an ACCESS EXCLUSIVE lock on `users` until the transaction ends, so any other async test touching `users` blocks on it and eventually times out. Fifteen other files under `test/mydia/accounts` are async and use the user fixtures.

This is the flake class `.github/ci-flakes.md` already catalogues, so the comment explains the constraint rather than just flipping the flag.

The PostgreSQL run on #713 passed because it covered a subset of the suite and the timing did not line up. That is luck, not evidence.

Verification: `mix precommit` green, 10829 tests, 0 failures. The file now reports `0.00s async, 0.1s sync`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test execution settings to prevent database lock conflicts and intermittent timeouts during the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->