### PR TITLE
fix(downloads): stop transcode progress updates raising on a deleted job

### DIFF
--- a/lib/mydia/downloads/transcoding.ex
+++ b/lib/mydia/downloads/transcoding.ex
@@ -10,6 +10,14 @@ defmodule Mydia.Downloads.Transcoding do
   alias Phoenix.PubSub
   require Logger
 
+  # A transcode job row can be deleted while its ffmpeg progress task is still
+  # running: session teardown, the stale-job sweeper, or a user cancelling the
+  # stream. `Repo.update/2` filters by primary key unconditionally and raises
+  # `Ecto.StaleEntryError` when that filter matches zero rows, which crashes
+  # the unsupervised progress task instead of just ending the update. This
+  # mirrors the fix applied to `Downloads.History` in issue #281/#285.
+  @stale_opts [stale_error_field: :id, stale_error_message: "no longer exists"]
+
   ## Public Functions
 
   def get_or_create_job(media_file_id, resolution) do
@@ -91,7 +99,7 @@ defmodule Mydia.Downloads.Transcoding do
 
     case job
          |> TranscodeJob.changeset(attrs)
-         |> Repo.update() do
+         |> Repo.update(@stale_opts) do
       {:ok, updated_job} ->
         broadcast_job_update(updated_job.id)
         {:ok, updated_job}
@@ -111,7 +119,7 @@ defmodule Mydia.Downloads.Transcoding do
            completed_at: DateTime.utc_now(),
            last_accessed_at: DateTime.utc_now()
          })
-         |> Repo.update() do
+         |> Repo.update(@stale_opts) do
       {:ok, updated_job} ->
         broadcast_job_update(updated_job.id)
         {:ok, updated_job}

--- a/test/mydia/downloads/transcode_job_test.exs
+++ b/test/mydia/downloads/transcode_job_test.exs
@@ -226,6 +226,14 @@ defmodule Mydia.Downloads.TranscodeJobTest do
 
       assert DateTime.compare(updated_job.started_at, started_at) == :eq
     end
+
+    test "returns an error instead of raising when the job row was deleted mid-transcode", %{
+      job: job
+    } do
+      Repo.delete!(job)
+
+      assert {:error, %Ecto.Changeset{}} = Downloads.update_job_progress(job, 0.5)
+    end
   end
 
   describe "Downloads.complete_job/3" do
@@ -258,6 +266,15 @@ defmodule Mydia.Downloads.TranscodeJobTest do
       assert completed_job.file_size == file_size
       assert completed_job.completed_at != nil
       assert completed_job.last_accessed_at != nil
+    end
+
+    test "returns an error instead of raising when the job row was deleted mid-transcode", %{
+      job: job
+    } do
+      Repo.delete!(job)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Downloads.complete_job(job, "/path/to/output.mp4", 500_000_000)
     end
   end
 


### PR DESCRIPTION
Fixes #706

## Mechanism

`Transcoding.update_job_progress/2` and `Transcoding.complete_job/3` called
`Repo.update/1` without `:stale_error_field`. Ecto filters every update by
primary key and raises `Ecto.StaleEntryError` when that filter matches zero
rows. A `TranscodeJob` row can be deleted while its ffmpeg progress task is
still running (session teardown, the stale-job sweeper, or a user cancelling
the stream), so the raise crashed the unsupervised progress `Task` instead of
being handled by the `case ... error -> error` clause below it, which only
ever sees a returned value, not a raised exception.

This is the same class of bug fixed for `Download` in `Downloads.History`
(issue #281/#285). The fix here mirrors that one: both calls now pass
`stale_error_field: :id`, so a vanished row returns `{:error, changeset}`
like any other failed write instead of raising.

`fail_job/2` and `touch_last_accessed/1` in the same module have the same
`Repo.update/1` shape and are likely exposed to the same defect, but they
are not named in the issue or its crash telemetry, so they are left alone
here to keep the diff scoped to the reported defect.

## Testing

- Added regression tests that delete the `TranscodeJob` row before calling
  `update_job_progress/2` and `complete_job/3`; both reproduced
  `Ecto.StaleEntryError` before the fix and now assert `{:error, %Ecto.Changeset{}}`.
- `mix test test/mydia/downloads/transcode_job_test.exs` (24 tests, 0 failures)
- `mix format`
- `mix credo --strict` on the changed file (no issues)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented transcoding progress updates from crashing when a job is deleted during processing.
  - Completed or canceled jobs now return an error instead of raising an exception when their record is no longer available.

- **Tests**
  - Added coverage for progress and completion updates on deleted transcoding jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->