### PR TITLE
fix(requests): scope request deduplication and status maps by media type

### DIFF
--- a/lib/mydia/media.ex
+++ b/lib/mydia/media.ex
@@ -7,7 +7,7 @@ defmodule Mydia.Media do
   import Mydia.QueryHelpers
   require Logger
   alias Mydia.Repo
-  alias Mydia.Media.{AvailabilityStatus, MediaItem, Episode, CategoryClassifier}
+  alias Mydia.Media.{AvailabilityStatus, MediaItem, Episode, CategoryClassifier, ProviderKey}
   alias Mydia.Media.Structs.CalendarEntry
   alias Mydia.Metadata.Access, as: MetadataAccess
   alias Mydia.Events
@@ -989,11 +989,15 @@ defmodule Mydia.Media do
   end
 
   @doc """
-  Returns a map of provider IDs to library status for efficient lookup.
+  Returns a map of `{type, provider, provider_id}` to library status for
+  efficient lookup.
 
-  Returns a map where:
-  - TMDB IDs are integer keys: `12345 => %{...}`
-  - TVDB IDs are tuple keys: `{:tvdb, 67890} => %{...}`
+  The key is a 3-tuple because neither of its parts is unique on its own. TMDB
+  and TVDB number their catalogues independently, so `671` names a different
+  title on each, and since provider-id uniqueness was scoped by type a movie
+  and a show may hold the same provider id legitimately. Keying on the bare
+  integer collapsed all three of those into one entry, and whichever row the
+  query happened to reach last won.
 
   Values are maps with:
   - `:in_library` - boolean
@@ -1005,8 +1009,8 @@ defmodule Mydia.Media do
 
       iex> get_library_status_map()
       %{
-        12345 => %{in_library: true, monitored: true, type: "movie", id: 1},
-        {:tvdb, 67890} => %{in_library: true, monitored: false, type: "tv_show", id: 2}
+        {:movie, :tmdb, 12345} => %{in_library: true, monitored: true, type: "movie", id: 1},
+        {:tv_show, :tvdb, 67890} => %{in_library: true, monitored: false, type: "tv_show", id: 2}
       }
   """
   @spec get_library_status_map() :: map()
@@ -1018,12 +1022,13 @@ defmodule Mydia.Media do
     |> Enum.reduce(%{}, fn {tmdb_id, tvdb_id, monitored, type, id}, acc ->
       entry = %{in_library: true, monitored: monitored, type: type, id: id}
 
-      acc =
-        if tmdb_id, do: Map.put(acc, tmdb_id, entry), else: acc
-
-      if tvdb_id, do: Map.put(acc, {:tvdb, tvdb_id}, entry), else: acc
+      acc = put_status(acc, ProviderKey.new(type, :tmdb, tmdb_id), entry)
+      put_status(acc, ProviderKey.new(type, :tvdb, tvdb_id), entry)
     end)
   end
+
+  defp put_status(acc, nil, _entry), do: acc
+  defp put_status(acc, key, entry), do: Map.put(acc, key, entry)
 
   @doc """
   Returns library status for a specific set of TMDB ids, scoped to one type.
@@ -1040,7 +1045,12 @@ defmodule Mydia.Media do
   ## Examples
 
       iex> library_status_for_tmdb_ids([671, 672], "movie")
-      %{671 => %{in_library: true, monitored: true, type: "movie", id: "..."}}
+      %{{:movie, :tmdb, 671} => %{in_library: true, monitored: true, type: "movie", id: "..."}}
+
+  The key shape matches `get_library_status_map/0` even though this query is
+  already scoped to one type and one provider, so the two are interchangeable
+  wherever a status map is consumed. `MediaAddHelpers.enrich_with_library_status/2`
+  takes either one and needs only a single lookup.
   """
   @spec library_status_for_tmdb_ids([integer()], String.t()) :: map()
   def library_status_for_tmdb_ids([], _type), do: %{}
@@ -1051,7 +1061,8 @@ defmodule Mydia.Media do
     |> select([m], {m.tmdb_id, m.monitored, m.type, m.id})
     |> Repo.all()
     |> Map.new(fn {tmdb_id, monitored, type, id} ->
-      {tmdb_id, %{in_library: true, monitored: monitored, type: type, id: id}}
+      {ProviderKey.new(type, :tmdb, tmdb_id),
+       %{in_library: true, monitored: monitored, type: type, id: id}}
     end)
   end
 

--- a/lib/mydia/media/franchises.ex
+++ b/lib/mydia/media/franchises.ex
@@ -169,7 +169,9 @@ defmodule Mydia.Media.Franchises do
   defp decorate(entry, status, %MediaItem{tmdb_id: current_tmdb_id}) do
     entry = %{entry | current?: entry.tmdb_id == current_tmdb_id}
 
-    case Map.get(status, entry.tmdb_id) do
+    # A franchise is always movies, which is also the type the status map was
+    # built for a few lines up in `build/2`.
+    case Map.get(status, {:movie, :tmdb, entry.tmdb_id}) do
       %{id: media_item_id, monitored: monitored} ->
         %{entry | in_library?: true, media_item_id: media_item_id, monitored: monitored}
 

--- a/lib/mydia/media/media_item.ex
+++ b/lib/mydia/media/media_item.ex
@@ -181,4 +181,24 @@ defmodule Mydia.Media.MediaItem do
   Returns the list of valid type values.
   """
   def valid_types, do: @type_values
+
+  @doc """
+  The stored `type` string as the atom the status maps and card APIs key on.
+
+  Mirrors `Mydia.Media.MediaRequest.media_type_atom/1` so a media item and a
+  request for it produce the same key half.
+
+  Raises on anything else rather than defaulting, following
+  `Media.find_by_external_ids/2`: a value outside `@type_values` cannot reach
+  the column through `changeset/2`, so if one ever appears it is a corrupted
+  row and silently keying it as a movie would hide that.
+  """
+  @spec type_atom(String.t() | atom()) :: :movie | :tv_show
+  def type_atom(type) when type in [:movie, "movie"], do: :movie
+  def type_atom(type) when type in [:tv_show, "tv_show"], do: :tv_show
+
+  def type_atom(type) do
+    raise ArgumentError,
+          "invalid media item type #{inspect(type)}, expected one of #{inspect(@type_values)}"
+  end
 end

--- a/lib/mydia/media/provider_key.ex
+++ b/lib/mydia/media/provider_key.ex
@@ -1,0 +1,97 @@
+defmodule Mydia.Media.ProviderKey do
+  @moduledoc """
+  The `{media_type, provider, provider_id}` key that library- and request-status
+  maps are keyed on.
+
+  None of the three parts identifies a title on its own. TMDB and TVDB number
+  their catalogues independently, so `671` names a different title on each. And
+  since `20260905143012_scope_provider_id_uniqueness_by_type` scoped provider-id
+  uniqueness by media type, a movie and a show may hold the same number on the
+  same provider legitimately.
+
+  Keying a status map on the bare id let all three collide, and whichever row
+  was written last won: a pending TV request for id 550 rendered a movie with
+  tmdb_id 550 as already "Requested", and a library movie with tmdb_id 550
+  blocked a TV request for id 550 as a duplicate.
+
+  Every producer and consumer of those maps builds its keys through this module,
+  so the two sides cannot drift into disagreeing about the shape.
+  """
+
+  alias Mydia.Media.MediaItem
+
+  @type provider :: :tmdb | :tvdb
+  @type media_type :: :movie | :tv_show
+  @type t :: {media_type(), provider(), integer()}
+
+  @doc """
+  Builds a key, or `nil` when there is no provider id to key on.
+
+  Raises through `MediaItem.type_atom/1` on a type outside `movie`/`tv_show`,
+  which is unreachable for a persisted row and means a corrupted one if it ever
+  fires.
+  """
+  @spec new(String.t() | atom(), provider(), integer() | nil) :: t() | nil
+  def new(_type, _provider, nil), do: nil
+
+  def new(type, provider, id) when provider in [:tmdb, :tvdb] and is_integer(id) do
+    {MediaItem.type_atom(type), provider, id}
+  end
+
+  @doc """
+  Builds the key for a card item, or `nil` when the item cannot be keyed.
+
+  Card items are `Mydia.Metadata.Structs.SearchResult`s and the plain maps the
+  recommendation and franchise rails build, which carry `:provider_id` plus the
+  `:media_type` and `:provider` it belongs to.
+
+  Returns `nil` rather than guessing when `:media_type` is missing. A guess
+  would be a coin flip that renders a show's status on a movie's card, which is
+  the bug this key exists to prevent; `nil` reads as "no status known", which is
+  what the callers already render for an item that is not in the library.
+
+  A `:provider_id` that is not a number also yields `nil`. `Add.parse_provider_id/1`
+  raises on one, and a malformed id from a provider response should not take a
+  whole rail down.
+  """
+  @spec from_card(map()) :: t() | nil
+  def from_card(item) do
+    with type when type in [:movie, :tv_show] <- card_media_type(item),
+         id when is_integer(id) <- card_provider_id(item) do
+      {type, card_provider(item), id}
+    else
+      _ -> nil
+    end
+  end
+
+  defp card_media_type(item) do
+    case Map.get(item, :media_type) do
+      type when type in [:movie, "movie"] -> :movie
+      type when type in [:tv_show, "tv_show"] -> :tv_show
+      _ -> nil
+    end
+  end
+
+  # Anything that is not explicitly TVDB is a TMDB id. TMDB is the default
+  # provider throughout the add and discover flows, and only the TVDB-sourced
+  # show paths set `:provider` at all.
+  defp card_provider(item) do
+    if Map.get(item, :provider) == :tvdb, do: :tvdb, else: :tmdb
+  end
+
+  defp card_provider_id(item) do
+    case Map.get(item, :provider_id) do
+      nil -> nil
+      id when is_integer(id) -> id
+      id when is_binary(id) -> parse_binary_id(id)
+      _ -> nil
+    end
+  end
+
+  defp parse_binary_id(id) do
+    case Integer.parse(id) do
+      {int, ""} -> int
+      _ -> nil
+    end
+  end
+end

--- a/lib/mydia/media_requests.ex
+++ b/lib/mydia/media_requests.ex
@@ -250,17 +250,51 @@ defmodule Mydia.MediaRequests do
   end
 
   @doc """
-  Checks if a request with the given TMDB ID is pending.
+  Checks if a request of the given media type with the given TMDB ID is pending.
+
+  Scoped by type because TMDB numbers movies and series independently: without
+  it a pending TV request for id 550 reported a movie with tmdb_id 550 as
+  already requested, and blocked it from being requested at all.
+
+  `media_type` must be `"movie"` or `"tv_show"`; anything else, `nil` included,
+  is `false`. A caller with no type cannot ask a meaningful question here, and
+  `create_request/1` reaches this before its own validation has run.
   """
-  def pending_request_exists?(tmdb_id) when is_integer(tmdb_id) do
-    MediaRequest
-    |> where([r], r.tmdb_id == ^tmdb_id and r.status == "pending")
-    |> Repo.exists?()
+  @spec pending_request_exists?(String.t() | atom(), integer()) :: boolean()
+  def pending_request_exists?(media_type, tmdb_id) when is_integer(tmdb_id) do
+    pending_exists?(:tmdb_id, media_type, tmdb_id)
   end
 
-  def pending_request_exists?(_), do: false
+  def pending_request_exists?(_media_type, _tmdb_id), do: false
 
   # Private functions
+
+  # A TVDB-sourced request has no tmdb_id, so pending_request_exists?/2 (which
+  # is documented and tested as TMDB-only) never sees it. Kept private and
+  # separate rather than widening that public function's contract.
+  defp pending_tvdb_request_exists?(media_type, tvdb_id) when is_integer(tvdb_id) do
+    pending_exists?(:tvdb_id, media_type, tvdb_id)
+  end
+
+  defp pending_tvdb_request_exists?(_media_type, _tvdb_id), do: false
+
+  # `field` is a literal from this module's own two call sites, never user
+  # input. An unrecognised media_type answers false rather than querying: the
+  # question "is a request of no particular type pending" has no useful answer,
+  # and create_request/1 asks this before its own validation has rejected the
+  # changeset.
+  defp pending_exists?(field, media_type, id) do
+    type = media_type && to_string(media_type)
+
+    if type in MediaRequest.valid_media_types() do
+      MediaRequest
+      |> where([r], r.media_type == ^type and r.status == "pending")
+      |> where([r], field(r, ^field) == ^id)
+      |> Repo.exists?()
+    else
+      false
+    end
+  end
 
   defp check_duplicate_media(changeset) do
     tmdb_id = Ecto.Changeset.get_field(changeset, :tmdb_id)
@@ -291,21 +325,16 @@ defmodule Mydia.MediaRequests do
   defp check_duplicate_request(changeset) do
     tmdb_id = Ecto.Changeset.get_field(changeset, :tmdb_id)
     tvdb_id = Ecto.Changeset.get_field(changeset, :tvdb_id)
+    # Same reasoning as check_duplicate_media/1: a pending TV request for a
+    # given tmdb_id is not a duplicate of a movie request for that number, and
+    # an invalid type falls through to the caller's own validation error.
+    type = Ecto.Changeset.get_field(changeset, :media_type)
 
     cond do
-      tmdb_id && pending_request_exists?(tmdb_id) -> {:error, :duplicate_request}
-      tvdb_id && pending_tvdb_request_exists?(tvdb_id) -> {:error, :duplicate_request}
+      tmdb_id && pending_request_exists?(type, tmdb_id) -> {:error, :duplicate_request}
+      tvdb_id && pending_tvdb_request_exists?(type, tvdb_id) -> {:error, :duplicate_request}
       true -> :ok
     end
-  end
-
-  # A TVDB-sourced request has no tmdb_id, so pending_request_exists?/1 (which
-  # is documented and tested as TMDB-only) never sees it. Kept private and
-  # separate rather than widening that public function's contract.
-  defp pending_tvdb_request_exists?(tvdb_id) do
-    MediaRequest
-    |> where([r], r.tvdb_id == ^tvdb_id and r.status == "pending")
-    |> Repo.exists?()
   end
 
   @doc """

--- a/lib/mydia_web/live/helpers/media_add_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_add_helpers.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   alias Mydia.Media.AddDefaults
   alias Mydia.MediaRequests
   alias Mydia.Media.FranchiseEntry
+  alias Mydia.Media.ProviderKey
   alias Mydia.Metadata
   alias Mydia.Metadata.Ref
   alias Mydia.Metadata.Structs.SearchResult
@@ -87,15 +88,19 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
 
   For each item, adds `:in_library`, `:monitored`, and `:id` fields
   based on the library_status_map.
+
+  Takes either status map `Mydia.Media` builds, `get_library_status_map/0` or
+  `library_status_for_tmdb_ids/2`: both key on `Mydia.Media.ProviderKey`, so one
+  lookup on the item's own `{media_type, provider, provider_id}` covers both.
+  An item that cannot be keyed at all reads as not in the library.
   """
   def enrich_with_library_status(items, library_status_map) do
     Enum.map(items, fn item ->
-      provider_id_int = Add.parse_provider_id(item.provider_id)
-
       library_status =
-        Map.get(library_status_map, provider_id_int) ||
-          Map.get(library_status_map, {:tvdb, provider_id_int}) ||
-          %{in_library: false}
+        case ProviderKey.from_card(item) do
+          nil -> %{in_library: false}
+          key -> Map.get(library_status_map, key, %{in_library: false})
+        end
 
       Map.merge(item, %{
         in_library: library_status[:in_library] || false,
@@ -495,14 +500,15 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
   defp presence(""), do: nil
   defp presence(value), do: value
 
-  # The untagged key space is TMDB-only (see `enrich_with_library_status/2`
-  # above, which reads it before the tagged `{:tvdb, id}` key). Keying it off
-  # `Ref.id(ref)` used to put a TVDB add's own id there whenever the ref was
-  # `{:tvdb, id}`, since a ref's bare id carries no provider information once
-  # extracted -- a TMDB result with the same numeric id would then read the
-  # TVDB item's status. `media_item.tmdb_id` is the show's actual TMDB id (nil
-  # unless the add resolved a cross-reference), so a TVDB-only add no longer
-  # writes anything into this slot.
+  # Writes the same keys `Media.get_library_status_map/0` would have produced
+  # for this row, so a freshly added item is found by exactly the lookup
+  # `enrich_with_library_status/2` performs, without refetching the whole map.
+  #
+  # Keying off `Ref.id(ref)` instead would put a TVDB add's own id under the
+  # TMDB key whenever the ref was `{:tvdb, id}`, since a ref's bare id carries
+  # no provider information once extracted. `media_item.tmdb_id` is the show's
+  # actual TMDB id (nil unless the add resolved a cross-reference), so a
+  # TVDB-only add writes nothing into the TMDB slot.
   defp update_library_status_map(library_status_map, media_item) do
     entry = %{
       in_library: true,
@@ -511,17 +517,11 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpers do
       id: media_item.id
     }
 
-    map =
-      if media_item.tmdb_id do
-        Map.put(library_status_map, media_item.tmdb_id, entry)
-      else
-        library_status_map
-      end
-
-    if media_item.tvdb_id do
-      Map.put(map, {:tvdb, media_item.tvdb_id}, entry)
-    else
-      map
-    end
+    [
+      ProviderKey.new(media_item.type, :tmdb, media_item.tmdb_id),
+      ProviderKey.new(media_item.type, :tvdb, media_item.tvdb_id)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reduce(library_status_map, &Map.put(&2, &1, entry))
   end
 end

--- a/lib/mydia_web/live/helpers/media_request_helpers.ex
+++ b/lib/mydia_web/live/helpers/media_request_helpers.ex
@@ -7,8 +7,8 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   DiscoverLive so the request button behaves identically on both.
   """
 
-  alias Mydia.Media.Add
   alias Mydia.Media.MediaRequest
+  alias Mydia.Media.ProviderKey
   alias Mydia.MediaRequests
   alias Mydia.Metadata.Ref
   alias Mydia.Metadata.Structs.SearchResult
@@ -25,16 +25,17 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   @backfill_timeout 30_000
 
   @doc """
-  Maps a provider id to request status for every outstanding request.
+  Maps a `Mydia.Media.ProviderKey` to request status for every outstanding
+  request.
 
-  TMDB and TVDB ids are both plain integers and can collide (a movie and a
-  show sharing the same numeric id on their respective providers), so a TVDB
-  entry is keyed under a tagged `{:tvdb, id}` tuple, mirroring
-  `MediaAddHelpers.update_library_status_map/3`. A TMDB entry keeps the bare
-  integer key. `enrich_with_request_status/2` looks up the same tagged shape.
+  The media type is part of the key because TMDB numbers movies and series
+  independently: keyed on the bare id, a pending TV request for 550 rendered a
+  movie with tmdb_id 550 as already "Requested". `enrich_with_request_status/2`
+  looks up the same shape, and so does the library status map, so the Request
+  and Add buttons on one card agree about which title they are describing.
 
   Deliberately not scoped to a requester. `MediaRequests.create_request/1`
-  rejects duplicates globally via `pending_request_exists?/1`, so a per-user map
+  rejects duplicates globally via `pending_request_exists?/2`, so a per-user map
   would show a second guest an enabled button that errors on click.
   """
   @spec request_status_map() :: map()
@@ -54,33 +55,23 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpers do
   """
   def enrich_with_request_status(items, request_status_map) do
     Enum.map(items, fn item ->
-      status = Map.get(request_status_map, item_status_key(item))
+      status =
+        case ProviderKey.from_card(item) do
+          nil -> nil
+          key -> Map.get(request_status_map, key)
+        end
+
       Map.put(item, :request_status, status)
     end)
   end
 
-  # A request stores exactly one of tmdb_id/tvdb_id (see
-  # handle_request_media/3). TMDB keeps the plain integer key; TVDB is tagged
-  # so it cannot collide with a same-numbered TMDB id.
+  # A request stores exactly one of tmdb_id/tvdb_id (see handle_request_media/3),
+  # and `external_ref/1` reports which, so the provider half of the key is never
+  # a guess here.
   defp status_map_key(request) do
     case MediaRequest.external_ref(request) do
-      {:tmdb, id} -> id
-      {:tvdb, id} -> {:tvdb, id}
+      {provider, id} -> ProviderKey.new(MediaRequest.media_type_atom(request), provider, id)
       nil -> nil
-    end
-  end
-
-  # Mirrors the write path in handle_request_media/3: only a TV show sourced
-  # from TVDB is stored (and therefore looked up) under the tagged key; every
-  # other case, movies always and TV shows sourced from TMDB, uses the bare
-  # provider id.
-  defp item_status_key(item) do
-    provider_id = Add.parse_provider_id(item.provider_id)
-
-    if Map.get(item, :media_type) == :tv_show and Map.get(item, :provider) == :tvdb do
-      {:tvdb, provider_id}
-    else
-      provider_id
     end
   end
 

--- a/lib/mydia_web/live/media_live/show/detail_modal_events.ex
+++ b/lib/mydia_web/live/media_live/show/detail_modal_events.ex
@@ -163,6 +163,7 @@ defmodule MydiaWeb.MediaLive.Show.DetailModalEvents do
     status = Mydia.Media.library_status_for_tmdb_ids(tmdb_ids, media_item.type)
 
     results
+    |> RecommendationEvents.stamp_media_type(media_item.type)
     |> MediaAddHelpers.enrich_with_library_status(status)
     |> MediaRequestHelpers.enrich_with_request_status(MediaRequestHelpers.request_status_map())
   end

--- a/lib/mydia_web/live/media_live/show/franchise_events.ex
+++ b/lib/mydia_web/live/media_live/show/franchise_events.ex
@@ -7,6 +7,7 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
   alias Mydia.Accounts.Authorization, as: AccountsAuthorization
   alias Mydia.Media.FranchiseEntry
   alias Mydia.Media.Franchises
+  alias Mydia.Media.ProviderKey
   alias Mydia.Metadata.Ref
   alias Mydia.Metadata.Structs.SearchResult
   alias MydiaWeb.Live.Authorization
@@ -241,7 +242,10 @@ defmodule MydiaWeb.MediaLive.Show.FranchiseEvents do
 
       entries =
         Enum.map(franchise.entries, fn entry ->
-          %{entry | request_status: Map.get(status_map, entry.tmdb_id)}
+          # A franchise is a TMDB movie collection, so both halves of the key
+          # are fixed; only the id varies per entry.
+          key = ProviderKey.new(:movie, :tmdb, entry.tmdb_id)
+          %{entry | request_status: key && Map.get(status_map, key)}
         end)
 
       %{franchise | entries: entries}

--- a/lib/mydia_web/live/media_live/show/recommendation_events.ex
+++ b/lib/mydia_web/live/media_live/show/recommendation_events.ex
@@ -9,6 +9,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
   alias Mydia.Accounts.Authorization, as: AccountsAuthorization
   alias Mydia.Media
   alias Mydia.Media.Add
+  alias Mydia.Media.MediaItem
   alias Mydia.Media.Recommendations
   alias Mydia.Metadata.Ref
   alias MydiaWeb.Live.Authorization
@@ -193,6 +194,15 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
            socket.assigns.current_user.id
          ) do
       {:ok, request, status_updates} ->
+        # Merged onto a full map, not applied alone. `handle_request_media/3`
+        # returns a single-entry map for the row just requested, and enriching
+        # with that alone sets :request_status to nil on every *other* card,
+        # clearing statuses the rail had already resolved. DashboardLive and
+        # DiscoverLive merge it into the map they hold in an assign; this module
+        # keeps no such assign, so it re-reads one, which already contains the
+        # request just written.
+        status_map = Map.merge(MediaRequestHelpers.request_status_map(), status_updates)
+
         socket =
           socket
           |> assign(:requesting_recommendation_id, nil)
@@ -200,14 +210,14 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
             :recommendations,
             MediaRequestHelpers.enrich_with_request_status(
               socket.assigns.recommendations,
-              status_updates
+              status_map
             )
           )
           |> assign(
             :selected_recommendations,
             MediaRequestHelpers.enrich_with_request_status(
               socket.assigns[:selected_recommendations] || [],
-              status_updates
+              status_map
             )
           )
 
@@ -321,6 +331,7 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     status = Media.library_status_for_tmdb_ids(tmdb_ids, media_item.type)
 
     results
+    |> stamp_media_type(media_item.type)
     |> MediaAddHelpers.enrich_with_library_status(status)
     |> maybe_enrich_with_request_status(current_user)
     |> Enum.map(fn item ->
@@ -342,6 +353,24 @@ defmodule MydiaWeb.MediaLive.Show.RecommendationEvents do
     else
       results
     end
+  end
+
+  @doc """
+  Stamps each recommendation with the media type it was fetched for.
+
+  TMDB's recommendation payload carries no media type of its own: a show's
+  recommendations are shows and a movie's are movies, and the provider leaves
+  that implicit in which endpoint was called. The status maps are keyed by
+  `Mydia.Media.ProviderKey`, which needs the type, so it is stamped here at the
+  one place that still knows it. Without it every recommendation card reads as
+  having no library or request status at all.
+
+  Public because the detail dialog's own rail decorates the same results.
+  """
+  @spec stamp_media_type([map()], String.t()) :: [map()]
+  def stamp_media_type(results, type) do
+    media_type = MediaItem.type_atom(type)
+    Enum.map(results, &Map.put(&1, :media_type, media_type))
   end
 
   @doc """

--- a/lib/mydia_web/schema/resolvers/media_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/media_resolver.ex
@@ -6,6 +6,7 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
   import Absinthe.Resolution.Helpers, only: [batch: 3]
 
   alias Mydia.{Media, Library, Playback}
+  alias Mydia.Media.MediaItem
   alias Mydia.Playback.WatchStatus
 
   alias Mydia.Metadata.Access, as: MetadataAccess
@@ -81,10 +82,11 @@ defmodule MydiaWeb.Schema.Resolvers.MediaResolver do
   def resolve_similar(parent, _args, _info) do
     tmdb_ids = MetadataAccess.get_field(parent, :recommended_tmdb_ids) || []
     status = Media.library_status_for_tmdb_ids(tmdb_ids, parent.type)
+    type_atom = MediaItem.type_atom(parent.type)
 
     matched_ids =
       tmdb_ids
-      |> Enum.map(&get_in(status, [&1, :id]))
+      |> Enum.map(&get_in(status, [{type_atom, :tmdb, &1}, :id]))
       |> Enum.reject(&is_nil/1)
 
     items_by_id =

--- a/priv/repo/migrations/20260905173317_index_media_requests_by_type_and_provider_id.exs
+++ b/priv/repo/migrations/20260905173317_index_media_requests_by_type_and_provider_id.exs
@@ -1,0 +1,33 @@
+defmodule Mydia.Repo.Migrations.IndexMediaRequestsByTypeAndProviderId do
+  use Ecto.Migration
+
+  @moduledoc """
+  Supports the type-scoped pending-request lookups in `Mydia.MediaRequests`.
+
+  `check_duplicate_request/1` now asks "is there a pending request of this type
+  for this provider id", two predicates where it used to ask one. Both columns
+  are nullable and only one is set per row, so these stay plain (non-unique)
+  indexes: a request is allowed to be made again after an earlier one was
+  rejected, which is what `status` in the index covers.
+  """
+
+  def up do
+    create index(:media_requests, [:media_type, :tmdb_id, :status],
+             name: :media_requests_type_tmdb_id_status_index
+           )
+
+    create index(:media_requests, [:media_type, :tvdb_id, :status],
+             name: :media_requests_type_tvdb_id_status_index
+           )
+  end
+
+  def down do
+    drop index(:media_requests, [:media_type, :tvdb_id, :status],
+           name: :media_requests_type_tvdb_id_status_index
+         )
+
+    drop index(:media_requests, [:media_type, :tmdb_id, :status],
+           name: :media_requests_type_tmdb_id_status_index
+         )
+  end
+end

--- a/test/mydia/media/library_status_map_test.exs
+++ b/test/mydia/media/library_status_map_test.exs
@@ -1,0 +1,80 @@
+defmodule Mydia.Media.LibraryStatusMapTest do
+  @moduledoc """
+  `Media.get_library_status_map/0` is what DashboardLive and DiscoverLive read to
+  decide whether a card says "Add" or "In library". Keyed on the bare provider
+  id, a movie and a show sharing one TMDB number collapsed into a single entry
+  and whichever row the query reached last decided both cards (#463).
+  """
+
+  use Mydia.DataCase, async: true
+
+  import Mydia.MediaFixtures
+
+  alias Mydia.Media
+
+  test "keys a movie and a show sharing one tmdb id separately" do
+    shared = System.unique_integer([:positive])
+
+    movie = media_item_fixture(%{type: "movie", title: "Harbour Lights", tmdb_id: shared})
+
+    show =
+      media_item_fixture(%{type: "tv_show", title: "Harbour Lights: The Series", tmdb_id: shared})
+
+    map = Media.get_library_status_map()
+
+    assert map[{:movie, :tmdb, shared}][:id] == movie.id
+    assert map[{:tv_show, :tmdb, shared}][:id] == show.id
+  end
+
+  test "keys a tmdb id and a tvdb id of the same number separately" do
+    shared = System.unique_integer([:positive])
+
+    by_tmdb = media_item_fixture(%{type: "tv_show", title: "Signal Hill", tmdb_id: shared})
+    by_tvdb = media_item_fixture(%{type: "tv_show", title: "Second Signal", tvdb_id: shared})
+
+    map = Media.get_library_status_map()
+
+    assert map[{:tv_show, :tmdb, shared}][:id] == by_tmdb.id
+    assert map[{:tv_show, :tvdb, shared}][:id] == by_tvdb.id
+  end
+
+  test "an item holding both ids is findable under either" do
+    tmdb_id = System.unique_integer([:positive])
+    tvdb_id = System.unique_integer([:positive])
+
+    show =
+      media_item_fixture(%{
+        type: "tv_show",
+        title: "Both Ids",
+        tmdb_id: tmdb_id,
+        tvdb_id: tvdb_id
+      })
+
+    map = Media.get_library_status_map()
+
+    assert map[{:tv_show, :tmdb, tmdb_id}][:id] == show.id
+    assert map[{:tv_show, :tvdb, tvdb_id}][:id] == show.id
+  end
+
+  test "carries the monitored flag and type through" do
+    tmdb_id = System.unique_integer([:positive])
+
+    media_item_fixture(%{
+      type: "movie",
+      title: "Unwatched",
+      tmdb_id: tmdb_id,
+      monitored: false
+    })
+
+    assert %{in_library: true, monitored: false, type: "movie"} =
+             Media.get_library_status_map()[{:movie, :tmdb, tmdb_id}]
+  end
+
+  test "skips rows with no provider id at all" do
+    media_item_fixture(%{type: "movie", title: "No Provider Ids", imdb_id: "tt9999999"})
+
+    refute Enum.any?(Media.get_library_status_map(), fn {_key, entry} ->
+             entry[:type] == "movie" and entry[:id] == nil
+           end)
+  end
+end

--- a/test/mydia/media/library_status_test.exs
+++ b/test/mydia/media/library_status_test.exs
@@ -11,13 +11,13 @@ defmodule Mydia.Media.LibraryStatusTest do
 
     status = Media.library_status_for_tmdb_ids([671, 999_001], "movie")
 
-    assert %{671 => entry} = status
+    assert %{{:movie, :tmdb, 671} => entry} = status
     assert entry.in_library == true
     assert entry.monitored == owned.monitored
     assert entry.type == "movie"
     assert entry.id == owned.id
-    refute Map.has_key?(status, 999_001)
-    refute Map.has_key?(status, 672)
+    refute Map.has_key?(status, {:movie, :tmdb, 999_001})
+    refute Map.has_key?(status, {:movie, :tmdb, 672})
   end
 
   test "returns an empty map for an empty id list" do
@@ -45,9 +45,20 @@ defmodule Mydia.Media.LibraryStatusTest do
         monitored: false
       })
 
-    assert %{673 => %{monitored: false, id: id}} =
+    assert %{{:movie, :tmdb, 673} => %{monitored: false, id: id}} =
              Media.library_status_for_tmdb_ids([673], "movie")
 
     assert id == unmonitored.id
+  end
+
+  test "keys a tv show under its own type, not a same-numbered movie's" do
+    show =
+      media_item_fixture(%{type: "tv_show", title: "Harbour Lights", tmdb_id: 674, year: 2011})
+
+    status = Media.library_status_for_tmdb_ids([674], "tv_show")
+
+    assert %{{:tv_show, :tmdb, 674} => %{id: id}} = status
+    assert id == show.id
+    refute Map.has_key?(status, {:movie, :tmdb, 674})
   end
 end

--- a/test/mydia/media/provider_key_test.exs
+++ b/test/mydia/media/provider_key_test.exs
@@ -1,0 +1,71 @@
+defmodule Mydia.Media.ProviderKeyTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Media.ProviderKey
+  alias Mydia.Metadata.Structs.SearchResult
+
+  describe "new/3" do
+    test "builds a key from a stored type string" do
+      assert ProviderKey.new("movie", :tmdb, 550) == {:movie, :tmdb, 550}
+      assert ProviderKey.new("tv_show", :tvdb, 550) == {:tv_show, :tvdb, 550}
+    end
+
+    test "accepts the type as an atom" do
+      assert ProviderKey.new(:tv_show, :tmdb, 42) == {:tv_show, :tmdb, 42}
+    end
+
+    test "returns nil when there is no id to key on" do
+      assert ProviderKey.new("movie", :tmdb, nil) == nil
+    end
+
+    test "raises on a type that cannot reach the column" do
+      assert_raise ArgumentError, ~r/invalid media item type/, fn ->
+        ProviderKey.new("tvshow", :tmdb, 1)
+      end
+    end
+
+    test "separates the same number across types and providers" do
+      keys =
+        for type <- ["movie", "tv_show"], provider <- [:tmdb, :tvdb] do
+          ProviderKey.new(type, provider, 550)
+        end
+
+      assert length(Enum.uniq(keys)) == 4
+    end
+  end
+
+  describe "from_card/1" do
+    test "keys a search result by its own type, provider and id" do
+      card = %SearchResult{provider_id: "550", provider: :tmdb, media_type: :movie}
+
+      assert ProviderKey.from_card(card) == {:movie, :tmdb, 550}
+    end
+
+    test "treats an absent provider as TMDB" do
+      assert ProviderKey.from_card(%{provider_id: "7", media_type: :tv_show}) ==
+               {:tv_show, :tmdb, 7}
+    end
+
+    test "accepts an integer provider id and a string media type" do
+      assert ProviderKey.from_card(%{provider_id: 7, media_type: "movie"}) == {:movie, :tmdb, 7}
+    end
+
+    test "returns nil rather than guessing when the media type is missing" do
+      assert ProviderKey.from_card(%{provider_id: "7"}) == nil
+      assert ProviderKey.from_card(%{provider_id: "7", media_type: nil}) == nil
+    end
+
+    test "returns nil for a non-numeric or absent provider id" do
+      assert ProviderKey.from_card(%{provider_id: "not-a-number", media_type: :movie}) == nil
+      assert ProviderKey.from_card(%{provider_id: "12abc", media_type: :movie}) == nil
+      assert ProviderKey.from_card(%{provider_id: nil, media_type: :movie}) == nil
+    end
+
+    test "a movie and a show sharing one TMDB number key apart" do
+      movie = %SearchResult{provider_id: "550", provider: :tmdb, media_type: :movie}
+      show = %SearchResult{provider_id: "550", provider: :tmdb, media_type: :tv_show}
+
+      refute ProviderKey.from_card(movie) == ProviderKey.from_card(show)
+    end
+  end
+end

--- a/test/mydia/media_requests_test.exs
+++ b/test/mydia/media_requests_test.exs
@@ -219,6 +219,87 @@ defmodule Mydia.MediaRequestsTest do
       assert request.media_type == "tv_show"
       assert request.tmdb_id == tmdb_id
     end
+
+    test "accepts a tv request whose tmdb_id matches a pending movie request", %{user: user} do
+      tmdb_id = System.unique_integer([:positive])
+
+      assert {:ok, _movie_request} =
+               MediaRequests.create_request(%{
+                 media_type: "movie",
+                 title: "Harbour Lights",
+                 tmdb_id: tmdb_id,
+                 requester_id: user.id
+               })
+
+      assert {:ok, show_request} =
+               MediaRequests.create_request(%{
+                 media_type: "tv_show",
+                 title: "Harbour Lights: The Series",
+                 tmdb_id: tmdb_id,
+                 requester_id: user.id
+               })
+
+      assert show_request.media_type == "tv_show"
+      assert show_request.tmdb_id == tmdb_id
+    end
+
+    test "accepts a movie request whose tvdb_id matches a pending tv request", %{user: user} do
+      tvdb_id = System.unique_integer([:positive])
+
+      assert {:ok, _show_request} =
+               MediaRequests.create_request(%{
+                 media_type: "tv_show",
+                 title: "Signal Hill",
+                 tvdb_id: tvdb_id,
+                 requester_id: user.id
+               })
+
+      assert {:ok, movie_request} =
+               MediaRequests.create_request(%{
+                 media_type: "movie",
+                 title: "Signal Hill",
+                 tvdb_id: tvdb_id,
+                 requester_id: user.id
+               })
+
+      assert movie_request.media_type == "movie"
+    end
+
+    test "still rejects a second request of the same type and tmdb id", %{user: user} do
+      tmdb_id = System.unique_integer([:positive])
+
+      attrs = %{
+        media_type: "tv_show",
+        title: "Signal Hill",
+        tmdb_id: tmdb_id,
+        requester_id: user.id
+      }
+
+      assert {:ok, _request} = MediaRequests.create_request(attrs)
+      assert {:error, :duplicate_request} = MediaRequests.create_request(attrs)
+    end
+
+    test "surfaces the validation error when media_type is missing", %{user: user} do
+      # The duplicate checks run before the changeset is validated, so an
+      # absent media_type must fall through to the real error rather than
+      # short-circuiting as a false duplicate.
+      assert {:ok, _first} =
+               MediaRequests.create_request(%{
+                 media_type: "movie",
+                 title: "Harbour Lights",
+                 tmdb_id: 778_811,
+                 requester_id: user.id
+               })
+
+      assert {:error, changeset} =
+               MediaRequests.create_request(%{
+                 title: "Harbour Lights",
+                 tmdb_id: 778_811,
+                 requester_id: user.id
+               })
+
+      assert %{media_type: _} = errors_on(changeset)
+    end
   end
 
   describe "approve_request/2" do
@@ -762,7 +843,7 @@ defmodule Mydia.MediaRequestsTest do
     end
   end
 
-  describe "pending_request_exists?/1" do
+  describe "pending_request_exists?/2" do
     setup do
       user = create_user()
       %{user: user}
@@ -771,13 +852,29 @@ defmodule Mydia.MediaRequestsTest do
     test "returns true if pending request exists with TMDB ID", %{user: user} do
       _request = create_request(user, %{tmdb_id: 12345})
 
-      assert MediaRequests.pending_request_exists?(12345) == true
-      assert MediaRequests.pending_request_exists?(99999) == false
+      assert MediaRequests.pending_request_exists?("movie", 12345) == true
+      assert MediaRequests.pending_request_exists?("movie", 99999) == false
+    end
+
+    test "does not see a request of the other media type", %{user: user} do
+      _request =
+        create_request(user, %{media_type: "tv_show", title: "Harbour Lights", tmdb_id: 550})
+
+      assert MediaRequests.pending_request_exists?("tv_show", 550) == true
+      assert MediaRequests.pending_request_exists?("movie", 550) == false
+    end
+
+    test "accepts the media type as an atom", %{user: user} do
+      _request = create_request(user, %{tmdb_id: 4242})
+
+      assert MediaRequests.pending_request_exists?(:movie, 4242) == true
     end
 
     test "returns false for nil or invalid input" do
-      assert MediaRequests.pending_request_exists?(nil) == false
-      assert MediaRequests.pending_request_exists?("invalid") == false
+      assert MediaRequests.pending_request_exists?("movie", nil) == false
+      assert MediaRequests.pending_request_exists?("movie", "invalid") == false
+      assert MediaRequests.pending_request_exists?(nil, 12345) == false
+      assert MediaRequests.pending_request_exists?("nonsense", 12345) == false
     end
   end
 

--- a/test/mydia/media_test.exs
+++ b/test/mydia/media_test.exs
@@ -3143,9 +3143,11 @@ defmodule Mydia.MediaTest do
 
       status = Media.library_status_for_tmdb_ids([603, 999], "movie")
 
-      assert %{in_library: true, monitored: true, type: "movie", id: id} = status[603]
+      assert %{in_library: true, monitored: true, type: "movie", id: id} =
+               status[{:movie, :tmdb, 603}]
+
       assert id == movie.id
-      refute Map.has_key?(status, 999)
+      refute Map.has_key?(status, {:movie, :tmdb, 999})
     end
 
     test "does not match a tv show when asked for movies" do
@@ -3153,7 +3155,8 @@ defmodule Mydia.MediaTest do
 
       status = Media.library_status_for_tmdb_ids([603], "movie")
 
-      refute Map.has_key?(status, 603)
+      refute Map.has_key?(status, {:movie, :tmdb, 603})
+      refute Map.has_key?(status, {:tv_show, :tmdb, 603})
     end
 
     test "matches tv shows when asked for tv_show" do
@@ -3161,7 +3164,7 @@ defmodule Mydia.MediaTest do
 
       status = Media.library_status_for_tmdb_ids([1396], "tv_show")
 
-      assert status[1396].id == show.id
+      assert status[{:tv_show, :tmdb, 1396}].id == show.id
     end
 
     test "returns an empty map for an empty id list" do

--- a/test/mydia_web/live/discover_live/hide_owned_test.exs
+++ b/test/mydia_web/live/discover_live/hide_owned_test.exs
@@ -226,7 +226,12 @@ defmodule MydiaWeb.DiscoverLive.HideOwnedTest do
       seed_curated_page(2, 2, [curated_result(visible_id, "Paper Comet")])
 
       library_status_map = %{
-        owned_id => %{in_library: true, monitored: true, type: "movie", id: "owned"}
+        {:movie, :tmdb, owned_id} => %{
+          in_library: true,
+          monitored: true,
+          type: "movie",
+          id: "owned"
+        }
       }
 
       socket = curated_socket(%{library_status_map: library_status_map})
@@ -259,8 +264,8 @@ defmodule MydiaWeb.DiscoverLive.HideOwnedTest do
       seed_curated_page(2, 2, [curated_result(next_page_id, "Velvet Static")])
 
       library_status_map = %{
-        owned_a => %{in_library: true, monitored: true, type: "movie", id: "a"},
-        owned_b => %{in_library: true, monitored: true, type: "movie", id: "b"}
+        {:movie, :tmdb, owned_a} => %{in_library: true, monitored: true, type: "movie", id: "a"},
+        {:movie, :tmdb, owned_b} => %{in_library: true, monitored: true, type: "movie", id: "b"}
       }
 
       socket = curated_socket(%{library_status_map: library_status_map})
@@ -288,7 +293,12 @@ defmodule MydiaWeb.DiscoverLive.HideOwnedTest do
       seed_curated_page(2, 9, [curated_result(owned_id, "Marooned Aurora")])
 
       library_status_map = %{
-        owned_id => %{in_library: true, monitored: true, type: "movie", id: "owned"}
+        {:movie, :tmdb, owned_id} => %{
+          in_library: true,
+          monitored: true,
+          type: "movie",
+          id: "owned"
+        }
       }
 
       socket =
@@ -312,7 +322,12 @@ defmodule MydiaWeb.DiscoverLive.HideOwnedTest do
       end
 
       library_status_map = %{
-        owned_id => %{in_library: true, monitored: true, type: "movie", id: "owned"}
+        {:movie, :tmdb, owned_id} => %{
+          in_library: true,
+          monitored: true,
+          type: "movie",
+          id: "owned"
+        }
       }
 
       socket = curated_socket(%{library_status_map: library_status_map})

--- a/test/mydia_web/live/helpers/media_add_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_add_helpers_test.exs
@@ -206,11 +206,10 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
 
     # TMDB and TVDB number their catalogs independently, so a TVDB add's own
     # numeric id can collide with an unrelated TMDB title's id.
-    # `update_library_status_map/2` used to write that bare id into the
-    # untagged (TMDB) key space, which `enrich_with_library_status/2` reads
-    # before the tagged `{:tvdb, id}` key -- a TMDB result sharing that
-    # integer would then render as already in the library.
-    test "TVDB add does not leak its id into the untagged (TMDB) key space",
+    # `update_library_status_map/2` used to write that bare id into the TMDB
+    # key space, so a TMDB result sharing that integer rendered as already in
+    # the library.
+    test "TVDB add does not leak its id into the TMDB key space",
          %{bypass: bypass, config: config} do
       tvdb_id = System.unique_integer([:positive])
       stub_tvdb_extended(bypass, tvdb_id, "TVDB Only Show")
@@ -225,8 +224,9 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
 
       assert item.tvdb_id == tvdb_id
       assert item.tmdb_id == nil
-      assert updated_map[{:tvdb, tvdb_id}][:in_library] == true
-      refute Map.has_key?(updated_map, tvdb_id)
+      assert updated_map[{:tv_show, :tvdb, tvdb_id}][:in_library] == true
+      refute Map.has_key?(updated_map, {:tv_show, :tmdb, tvdb_id})
+      refute Map.has_key?(updated_map, {:movie, :tmdb, tvdb_id})
     end
   end
 
@@ -264,7 +264,7 @@ defmodule MydiaWeb.Live.Helpers.MediaAddHelpersTest do
                MediaAddHelpers.handle_add_media_to_library({:tmdb, id}, :movie, %{}, config)
 
       assert item.id == existing.id
-      assert updated_map[id][:in_library] == true
+      assert updated_map[{:movie, :tmdb, id}][:in_library] == true
     end
   end
 

--- a/test/mydia_web/live/helpers/media_request_helpers_test.exs
+++ b/test/mydia_web/live/helpers/media_request_helpers_test.exs
@@ -57,7 +57,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
       assert request.tmdb_id == tmdb_id
       assert request.status == "pending"
       assert request.requester_id == user.id
-      assert map[tmdb_id] == "pending"
+      assert map[{:movie, :tmdb, tmdb_id}] == "pending"
     end
 
     test "reports a duplicate when a pending request already exists" do
@@ -102,9 +102,9 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
       assert request.tvdb_id == tvdb_id
       assert is_nil(request.tmdb_id)
       assert MediaRequest.external_ref(request) == {:tvdb, tvdb_id}
-      # Tagged, not bare: a bare key would collide with a TMDB movie or show
-      # that happens to share this same numeric id.
-      assert map[{:tvdb, tvdb_id}] == "pending"
+      # Fully qualified: neither the bare id nor the provider alone separates
+      # this from a TMDB movie or a TMDB show sharing the same number.
+      assert map[{:tv_show, :tvdb, tvdb_id}] == "pending"
     end
 
     # There is no TVDB movie catalog, so a movie card tagged provider: :tvdb
@@ -144,8 +144,29 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
 
       # The second guest must see it as already requested: create_request/1
       # rejects duplicates globally, so an enabled button would only error.
-      assert MediaRequestHelpers.request_status_map()[tmdb_id] == "pending"
+      assert MediaRequestHelpers.request_status_map()[{:movie, :tmdb, tmdb_id}] == "pending"
       assert second.id != first.id
+    end
+
+    test "keys a TV request separately from a movie request with the same tmdb id" do
+      requester = guest()
+      shared_id = System.unique_integer([:positive])
+
+      {:ok, _show_request} =
+        MediaRequests.create_request(%{
+          media_type: "tv_show",
+          title: "Harbour Lights",
+          tmdb_id: shared_id,
+          requester_id: requester.id
+        })
+
+      map = MediaRequestHelpers.request_status_map()
+
+      # The whole point of #463: TMDB numbers movies and series independently,
+      # so the pending show must not make a same-numbered movie read as
+      # requested.
+      assert map[{:tv_show, :tmdb, shared_id}] == "pending"
+      refute Map.has_key?(map, {:movie, :tmdb, shared_id})
     end
 
     test "includes a TVDB-sourced pending request" do
@@ -160,9 +181,9 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
           requester_id: guest_user.id
         })
 
-      # Tagged, not bare: a bare key would collide with a TMDB movie or show
-      # that happens to share this same numeric id.
-      assert MediaRequestHelpers.request_status_map()[{:tvdb, tvdb_id}] == "pending"
+      # Fully qualified: neither the bare id nor the provider alone separates
+      # this from a TMDB movie or a TMDB show sharing the same number.
+      assert MediaRequestHelpers.request_status_map()[{:tv_show, :tvdb, tvdb_id}] == "pending"
     end
   end
 
@@ -170,7 +191,7 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
     test "stamps the status onto matching items and nil onto the rest" do
       requested = System.unique_integer([:positive])
       untouched = System.unique_integer([:positive])
-      map = %{requested => "pending"}
+      map = %{{:movie, :tmdb, requested} => "pending"}
 
       [a, b] =
         MediaRequestHelpers.enrich_with_request_status(
@@ -193,9 +214,9 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
         tvdb_item(shared_id, "Shared Id Series")
         |> Map.put(:media_type, :tv_show)
 
-      # Only the TMDB movie has an outstanding request, keyed bare as
+      # Only the TMDB movie has an outstanding request, keyed exactly as
       # request_status_map/0 would store it.
-      map = %{shared_id => "pending"}
+      map = %{{:movie, :tmdb, shared_id} => "pending"}
 
       [enriched_movie, enriched_series] =
         MediaRequestHelpers.enrich_with_request_status([movie, series], map)
@@ -215,15 +236,57 @@ defmodule MydiaWeb.Live.Helpers.MediaRequestHelpersTest do
         tvdb_item(shared_id, "Other Shared Id Series")
         |> Map.put(:media_type, :tv_show)
 
-      # No TMDB movie request exists; only the TVDB show does, keyed tagged
+      # No TMDB movie request exists; only the TVDB show does, keyed exactly
       # as request_status_map/0 would store it.
-      map = %{{:tvdb, shared_id} => "pending"}
+      map = %{{:tv_show, :tvdb, shared_id} => "pending"}
 
       [enriched_movie, enriched_series] =
         MediaRequestHelpers.enrich_with_request_status([movie, series], map)
 
       assert is_nil(enriched_movie.request_status)
       assert enriched_series.request_status == "pending"
+    end
+
+    test "does not let a TMDB show read as requested off a same-numbered TMDB movie" do
+      shared_id = System.unique_integer([:positive])
+
+      movie = item(shared_id, "Harbour Lights")
+
+      # A TV show sourced from TMDB, the ordinary case on a TMDB-configured
+      # instance: same provider, same number, unrelated title. The provider
+      # half of the key cannot separate these two; only the type can.
+      show = %SearchResult{
+        provider_id: to_string(shared_id),
+        provider: :tmdb,
+        media_type: :tv_show,
+        title: "Harbour Lights: The Series",
+        year: 2024
+      }
+
+      map = %{{:movie, :tmdb, shared_id} => "pending"}
+
+      [enriched_movie, enriched_show] =
+        MediaRequestHelpers.enrich_with_request_status([movie, show], map)
+
+      assert enriched_movie.request_status == "pending"
+      assert is_nil(enriched_show.request_status)
+    end
+
+    test "leaves an item with no media type unkeyed rather than guessing" do
+      id = System.unique_integer([:positive])
+      untyped = Map.put(item(id), :media_type, nil)
+      map = %{{:movie, :tmdb, id} => "pending"}
+
+      [enriched] = MediaRequestHelpers.enrich_with_request_status([untyped], map)
+
+      assert is_nil(enriched.request_status)
+    end
+
+    test "survives a non-numeric provider id" do
+      malformed = Map.put(item(1), :provider_id, "not-a-number")
+
+      assert [%{request_status: nil}] =
+               MediaRequestHelpers.enrich_with_request_status([malformed], %{})
     end
   end
 end


### PR DESCRIPTION
Closes #463. Replaces #709, which should be closed in favour of this.

#709 fixed #463 and #473 together. #712 has since landed and closed #473, so
everything belonging to that issue is gone from here: the `media_items` index
migration, the `ExternalIds` type scoping, the changeset constraint names, the
concurrent-add recovery in `Add.from_attrs/3`, and the overloaded
`get_media_item_by_tmdb`/`get_media_item_by_tvdb` clauses (#712 deleted those
two functions outright in favour of the existing type-validating
`Media.find_by_external_ids/2`).

What remains is the half #712 did not touch: request deduplication, and the
status maps the Add and Request buttons read. This branch is rebased onto
post-#712 master rather than merged, which is why it is a new PR.

## The bug

TMDB numbers movies and series independently, so `550` names two unrelated
titles. Every status map in the app keyed on that bare number, and the request
layer deduplicated on it:

- A pending TV request for id 550 made a movie with `tmdb_id` 550 render as
  already "Requested", and blocked it from being requested at all.
- Two library rows sharing a provider number, which #712 now permits, collapsed
  into one entry in `get_library_status_map/0`. Whichever row the query reached
  last decided both cards.
- A TVDB id and a TMDB id of the same number collided the same way. The old code
  half-covered that with a tagged `{:tvdb, id}` key, which fixed the
  provider collision but not the type one.

#712 fixed `check_duplicate_media/1`, so a cross-type request is no longer
rejected. Without this PR that leaves the two sides disagreeing in the other
direction: the button says "Requested" while the request would in fact succeed.

## What changed

**One key shape, one module.** `Mydia.Media.ProviderKey` builds the
`{media_type, provider, provider_id}` key that every status map is keyed on, and
every producer and consumer goes through it. `new/3` builds one from a persisted
row, `from_card/1` from a search result or rail item. Both status-map producers
(`Media.get_library_status_map/0`, `Media.library_status_for_tmdb_ids/2`) now
emit that shape, so `enrich_with_library_status/2` takes either map and needs a
single lookup instead of a chain of fallbacks.

`from_card/1` returns `nil` rather than guessing when an item carries no
`:media_type`. A guess is a coin flip that renders a show's status on a movie's
card, which is the failure this key exists to prevent; `nil` reads as "no status
known", which is what the callers already render for anything not in the
library.

**Requests are deduplicated by type.** `pending_request_exists?/2` and the
private TVDB counterpart both take a media type, and `check_duplicate_request/1`
passes it, matching what #712 did for `check_duplicate_media/1`. Both share one
`pending_exists?/3` query builder. An unrecognised type answers `false` rather
than querying: `create_request/1` reaches these before its own validation has
run, and a false duplicate would mask the real changeset error.

**Recommendations get stamped.** TMDB's recommendation payload carries no media
type; the endpoint that was called implies it. `RecommendationEvents.stamp_media_type/2`
adds it back at the one place that still knows, for both the detail page rail and
the dialog's.

**One unrelated bug fixed in passing.** `RecommendationEvents.submit_request/3`
passed `handle_request_media/3`'s single-entry return map straight to
`enrich_with_request_status/2`, which cleared `:request_status` on every *other*
card in the rail. DashboardLive and DiscoverLive both merge it into the full map
they hold in an assign; this module holds none, so it re-reads one. This was
reachable before this PR and is not caused by the key change, but it sits in the
lines the key change rewrites.

**Indexes.** A migration adds `(media_type, tmdb_id, status)` and
`(media_type, tvdb_id, status)` on `media_requests` to support the now
two-predicate pending lookups. Plain, not unique: a rejected request may be made
again, which is what `status` in the index covers.

## Call sites moved off the bare key

`Franchises.decorate/3` and `MediaResolver.resolve_similar/3` read
`library_status_for_tmdb_ids/2` directly rather than through the enrichment
helper, so both were updated too. Neither had a cross-type bug of its own (both
queries are already scoped to one type), but leaving them on the old shape would
have meant two key conventions in the codebase.

## Testing

`mix precommit` clean on compile, format, Credo and migrations. Full suite at
10808 tests with one unrelated Bypass flake
(`RelayRecommendationsTest`, a stubbed relay returning 500), which passes in
isolation and lives in code this branch does not touch.

New coverage for `ProviderKey` (both constructors, the
missing-type and non-numeric-id cases, and that one number keys four different
ways across two types and two providers), for `get_library_status_map/0`, which
had none at all, and for the cross-type request cases: a TV request whose
`tmdb_id` matches a pending movie request, the TVDB mirror of it, and a check
that a same-type duplicate is still rejected.

## Not in this PR

- `Add.parse_provider_id/1` still raises on a non-numeric binary. `ProviderKey`
  no longer calls it, and the two rails that do already guard with their own
  `safe_provider_id/1`, but the raising contract remains.
- A library row added from TMDB with no `tvdb_id` is still not matched by a
  TVDB-sourced search result for the same title. That gap predates this PR and
  is a cross-reference question, not a key-shape one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Library and request statuses now distinguish movies and TV shows, even when they share the same provider ID.
  - TMDB and TVDB titles are tracked separately for more accurate status displays.
  - Media cards and recommendations now consistently show library and request status across supported providers.

- **Bug Fixes**
  - Prevented incorrectly matching pending requests across different media types.
  - Preserved existing request statuses when submitting requests from recommendation lists.
  - Items without valid provider IDs no longer produce incorrect status matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->