### PR TITLE
Floor phone-width grid columns for compact and dense density

### DIFF
--- a/lib/mydia_web/components/grid_density_components.ex
+++ b/lib/mydia_web/components/grid_density_components.ex
@@ -27,10 +27,15 @@ defmodule MydiaWeb.GridDensityComponents do
 
   @default "comfortable"
 
+  # The unprefixed (phone-width) count is floored to 2 for every density.
+  # Compact and Dense only diverge from Comfortable at sm: and up: the poster
+  # card body was never designed to hold its content at a quarter of a
+  # phone's width, so a desktop-chosen density (an account-wide preference)
+  # cannot force 3 or 4 columns onto a phone. See issue #700.
   @classes %{
     "comfortable" => "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6",
-    "compact" => "grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8",
-    "dense" => "grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
+    "compact" => "grid-cols-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8",
+    "dense" => "grid-cols-2 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
   }
 
   # A 1 → 3 → many progression. The labels used to carry the meaning; once

--- a/test/mydia_web/live/components/grid_density_toggle_test.exs
+++ b/test/mydia_web/live/components/grid_density_toggle_test.exs
@@ -20,9 +20,16 @@ defmodule MydiaWeb.Components.GridDensityToggleTest do
     compact = GridDensityComponents.grid_columns_class("compact")
     dense = GridDensityComponents.grid_columns_class("dense")
 
-    assert compact == "grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8"
-    assert dense == "grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
+    assert compact == "grid-cols-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8"
+    assert dense == "grid-cols-2 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
     refute compact == dense
+  end
+
+  test "no density exceeds 2 unprefixed columns, so a phone never gets compact or dense's desktop column count" do
+    for density <- ["comfortable", "compact", "dense"] do
+      assert GridDensityComponents.grid_columns_class(density) =~ ~r/^grid-cols-2(\s|$)/,
+             "#{density} must floor its unprefixed (phone-width) column count to 2"
+    end
   end
 
   test "an unknown density falls back to comfortable" do


### PR DESCRIPTION
## Problem

Grid density (`comfortable` / `compact` / `dense`) is a single account-wide preference (`Mydia.Accounts.UserPreference`), so whatever a user last chose on desktop also applies on their phone. The class map in `MydiaWeb.GridDensityComponents` used an unprefixed (no min-width breakpoint) column count of 3 for `compact` and 4 for `dense`, so a phone rendered 3 or 4 poster columns per row instead of the 2 the poster card body was designed to hold. Media info got hidden and buttons overlapped, as reported in the issue.

## Fix

Floor the unprefixed column count to 2 for every density. `compact` and `dense` now only diverge from `comfortable` at `sm:` and up, per the issue's Option 2 (a pure class-map change, no schema or preference-key change):

```
"comfortable" => "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6"
"compact"     => "grid-cols-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8"
"dense"       => "grid-cols-2 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12"
```

This fixes every existing account without a migration. Option 1 (per-device `localStorage` storage) is a more correct long-term model for a view preference, and is called out in the issue as a separate, non-exclusive follow-up if the density control grows further.

## Testing

- Added a regression test asserting no density's unprefixed class exceeds `grid-cols-2`; confirmed it fails against the old class map (`grid-cols-3`/`grid-cols-4`) and passes after the fix.
- Updated the existing `compact`/`dense` literal-string assertions to match the new floored values.
- `./dev mix test test/mydia_web/live/components/grid_density_toggle_test.exs test/mydia_web/live/grid_density_test.exs test/mydia/accounts/grid_density_preference_test.exs` — 17 tests, 0 failures.
- `./dev mix format` and `./dev mix credo --strict` on the touched files — clean.

Fixes #700
