### PR TITLE
Skip request_status_map queries for viewers who cannot request

### DIFF
--- a/lib/mydia_web/live/dashboard_live/index.ex
+++ b/lib/mydia_web/live/dashboard_live/index.ex
@@ -113,6 +113,18 @@ defmodule MydiaWeb.DashboardLive.Index do
         0
       end
 
+    # request_status only ever affects the Request button, which only a guest
+    # sees (Authorization.can_submit_request?/1), so a viewer who cannot
+    # submit a request skips the two unfiltered list_requests/1 scans
+    # entirely rather than paying for a result they can never act on.
+    # Mirrors FranchiseEvents/RecommendationEvents (#461).
+    request_status_map =
+      if Authorization.can_submit_request?(socket.assigns.current_user) do
+        MediaRequestHelpers.request_status_map()
+      else
+        %{}
+      end
+
     # Load trending data asynchronously
     send(self(), :load_trending_movies)
     send(self(), :load_trending_tv)
@@ -134,7 +146,7 @@ defmodule MydiaWeb.DashboardLive.Index do
     |> assign(:active_downloads_count, active_downloads_count)
     |> assign(:total_storage, total_storage)
     |> assign(:library_status_map, library_status_map)
-    |> assign(:request_status_map, MediaRequestHelpers.request_status_map())
+    |> assign(:request_status_map, request_status_map)
     |> assign(:recent_episodes, Enum.take(recent_episodes, 10))
     |> assign(:upcoming_episodes, Enum.take(upcoming_episodes, 10))
     |> assign(:pending_requests_count, pending_requests_count)

--- a/lib/mydia_web/live/discover_live/index.ex
+++ b/lib/mydia_web/live/discover_live/index.ex
@@ -13,6 +13,7 @@ defmodule MydiaWeb.DiscoverLive.Index do
   alias Mydia.Media.Recommendations
   alias Mydia.Metadata
   alias Mydia.Metadata.Ref
+  alias Mydia.Accounts.Authorization, as: AccountsAuthorization
   alias Mydia.Settings
   alias MydiaWeb.Live.Authorization
   alias MydiaWeb.Live.Helpers.DetailModal
@@ -139,10 +140,22 @@ defmodule MydiaWeb.DiscoverLive.Index do
       # Load library status map
       library_status_map = Media.get_library_status_map()
 
+      # request_status only ever affects the Request button, which only a
+      # guest sees (Authorization.can_submit_request?/1), so a viewer who
+      # cannot submit a request skips the two unfiltered list_requests/1
+      # scans entirely rather than paying for a result they can never act on.
+      # Mirrors FranchiseEvents/RecommendationEvents (#461).
+      request_status_map =
+        if AccountsAuthorization.can_submit_request?(socket.assigns.current_user) do
+          MediaRequestHelpers.request_status_map()
+        else
+          %{}
+        end
+
       socket =
         socket
         |> assign(:library_status_map, library_status_map)
-        |> assign(:request_status_map, MediaRequestHelpers.request_status_map())
+        |> assign(:request_status_map, request_status_map)
 
       send(self(), :load_data)
 

--- a/test/mydia_web/live/dashboard_live/request_status_map_test.exs
+++ b/test/mydia_web/live/dashboard_live/request_status_map_test.exs
@@ -1,0 +1,63 @@
+defmodule MydiaWeb.DashboardLive.RequestStatusMapTest do
+  @moduledoc """
+  Regression: `load_dashboard_data/1` called `MediaRequestHelpers.request_status_map/0`
+  unconditionally, issuing two unfiltered `list_requests/1` scans on every
+  mount even though the result only ever drives the Request button, which
+  `Accounts.Authorization.can_submit_request?/1` gates to guests only (#464).
+  A non-guest must not pay for a query whose result they can never act on.
+  """
+
+  # async: false — the Postgres non-shared sandbox hides the request row from
+  # the LiveView mount process otherwise (mirrors stat_tiles_test.exs, which
+  # mounts the same LiveView).
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
+  import MydiaWeb.AuthHelpers
+
+  setup do
+    # DashboardLive.Index unconditionally loads both trending rails on
+    # connected mount (#530).
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+    :ok
+  end
+
+  defp create_pending_request(tmdb_id) do
+    requester = user_fixture(%{role: "guest"})
+
+    {:ok, request} =
+      Mydia.MediaRequests.create_request(%{
+        media_type: "movie",
+        title: "A Placeholder Title",
+        tmdb_id: tmdb_id,
+        requester_id: requester.id
+      })
+
+    request
+  end
+
+  test "a non-guest viewer gets an empty request_status_map even with outstanding requests", %{
+    conn: conn
+  } do
+    tmdb_id = System.unique_integer([:positive])
+    create_pending_request(tmdb_id)
+
+    conn = log_in_user(conn, user_fixture(%{role: "user"}))
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert :sys.get_state(view.pid).socket.assigns.request_status_map == %{}
+  end
+
+  test "a guest viewer sees the outstanding request in request_status_map", %{conn: conn} do
+    tmdb_id = System.unique_integer([:positive])
+    create_pending_request(tmdb_id)
+
+    conn = log_in_user(conn, user_fixture(%{role: "guest"}))
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    assert :sys.get_state(view.pid).socket.assigns.request_status_map == %{tmdb_id => "pending"}
+  end
+end

--- a/test/mydia_web/live/discover_live/request_status_map_test.exs
+++ b/test/mydia_web/live/discover_live/request_status_map_test.exs
@@ -1,0 +1,64 @@
+defmodule MydiaWeb.DiscoverLive.RequestStatusMapTest do
+  @moduledoc """
+  Regression: `handle_params/3` called `MediaRequestHelpers.request_status_map/0`
+  unconditionally, issuing two unfiltered `list_requests/1` scans on every
+  navigation even though the result only ever drives the Request button, which
+  `Accounts.Authorization.can_submit_request?/1` gates to guests only (#464).
+  A non-guest must not pay for a query whose result they can never act on.
+  """
+
+  # async: false — the Postgres non-shared sandbox hides the request row from
+  # the LiveView mount process otherwise (mirrors index_test.exs, which
+  # mounts the same LiveView).
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+  import Mydia.MetadataCacheHelpers
+  import MydiaWeb.AuthHelpers
+
+  setup do
+    # DiscoverLive.Index unconditionally loads the movie genre list and its
+    # default (trending) category on connected mount (#530).
+    warm_genre_cache(:movie, [%{"id" => 28, "name" => "Action"}])
+    warm_trending_cache(:movie, [])
+    warm_trending_cache(:tv_show, [])
+    :ok
+  end
+
+  defp create_pending_request(tmdb_id) do
+    requester = user_fixture(%{role: "guest"})
+
+    {:ok, request} =
+      Mydia.MediaRequests.create_request(%{
+        media_type: "movie",
+        title: "A Placeholder Title",
+        tmdb_id: tmdb_id,
+        requester_id: requester.id
+      })
+
+    request
+  end
+
+  test "a non-guest viewer gets an empty request_status_map even with outstanding requests", %{
+    conn: conn
+  } do
+    tmdb_id = System.unique_integer([:positive])
+    create_pending_request(tmdb_id)
+
+    conn = log_in_user(conn, user_fixture(%{role: "user"}))
+    {:ok, view, _html} = live(conn, ~p"/discover")
+
+    assert :sys.get_state(view.pid).socket.assigns.request_status_map == %{}
+  end
+
+  test "a guest viewer sees the outstanding request in request_status_map", %{conn: conn} do
+    tmdb_id = System.unique_integer([:positive])
+    create_pending_request(tmdb_id)
+
+    conn = log_in_user(conn, user_fixture(%{role: "guest"}))
+    {:ok, view, _html} = live(conn, ~p"/discover")
+
+    assert :sys.get_state(view.pid).socket.assigns.request_status_map == %{tmdb_id => "pending"}
+  end
+end


### PR DESCRIPTION
Fixes #464

## Problem

`DashboardLive.Index` (`load_dashboard_data/1`) and `DiscoverLive.Index` (`handle_params/3`) both called `MediaRequestHelpers.request_status_map/0` unconditionally on every mount/navigation. That helper issues two unfiltered `MediaRequests.list_requests/1` scans (one for `pending`, one for `approved`), returning every outstanding request as a full struct with no limit.

The resulting map only ever drives the Request button's enabled/disabled state, and `Accounts.Authorization.can_submit_request?/1` is `true` only for `role: "guest"`. Every admin and regular user was paying for two full-table scans whose result they could never act on, and the UI never renders the button for them anyway.

## Fix

Gate both call sites on `Authorization.can_submit_request?/1`, mirroring the fix already applied to `FranchiseEvents` and `RecommendationEvents` in #461: a viewer who cannot submit a request now gets `%{}` without ever calling `request_status_map/0`.

## Testing

- Added regression tests for both LiveViews asserting that a non-guest's mounted `:request_status_map` assign stays `%{}` even with outstanding pending requests in the database, and that a guest still sees the populated map. Confirmed both new tests fail against the pre-fix code (non-guest saw the populated map) and pass after the fix.
- `./dev mix test test/mydia_web/live/dashboard_live/ test/mydia_web/live/discover_live/ test/mydia_web/live/helpers/` — 174 tests, 0 failures.
- `./dev mix format` — no changes needed.
- `./dev mix credo --strict` on the two changed files — no issues.
