### PR TITLE
fix(downloads): scope indexer session cookies on the queue download path

### DIFF
--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -1431,9 +1431,9 @@ defmodule Mydia.Downloads.Queue do
 
     if download_config.flaresolverr_enabled do
       Logger.info("Using FlareSolverr for download from: #{indexer_name}")
-      download_via_flaresolverr(url, download_config.cookies)
+      download_via_flaresolverr(url, indexer_name, download_config.cookies)
     else
-      download_direct(url, download_config.cookie_header)
+      download_direct(url, indexer_name, download_config.cookie_header)
     end
   end
 
@@ -1464,7 +1464,7 @@ defmodule Mydia.Downloads.Queue do
   end
 
   # Download directly with cookies
-  defp download_direct(url, cookie_header) do
+  defp download_direct(url, indexer_name, cookie_header) do
     if cookie_header != "" do
       Logger.debug("Using auth cookies for download")
     end
@@ -1474,14 +1474,21 @@ defmodule Mydia.Downloads.Queue do
 
     # First check if the URL redirects to a magnet link
     # by manually following redirects (Req can't handle magnet: scheme)
-    case follow_to_final_url(encoded_url, cookie_header) do
+    case follow_to_final_url(encoded_url, indexer_name, cookie_header) do
       {:ok, {:magnet, magnet_url}} ->
         Logger.debug("URL redirected to magnet link")
         {:ok, {:magnet, magnet_url}}
 
       {:ok, {:http, final_url}} ->
-        # Download the actual torrent file with auth cookies
-        req_opts = if cookie_header != "", do: [headers: [{"cookie", cookie_header}]], else: []
+        # Download the actual torrent file with auth cookies, scoped to this
+        # indexer's own hosts (the final URL may be a different host than the
+        # one the request started at).
+        scoped_cookie_header = scoped_cookie_header(final_url, indexer_name, cookie_header)
+
+        req_opts =
+          if scoped_cookie_header != "",
+            do: [headers: [{"cookie", scoped_cookie_header}]],
+            else: []
 
         case Req.get(final_url, req_opts) do
           {:ok, %{status: 200, body: body}} when is_binary(body) ->
@@ -1536,11 +1543,25 @@ defmodule Mydia.Downloads.Queue do
   end
 
   # Download via FlareSolverr for Cloudflare-protected sites
-  defp download_via_flaresolverr(url, cookies) do
+  defp download_via_flaresolverr(url, indexer_name, cookies) do
     alias Mydia.Indexers.FlareSolverr
 
     if FlareSolverr.enabled?() do
-      # Pass cookies to FlareSolverr request
+      # Pass cookies to FlareSolverr request, scoped to this indexer's own
+      # hosts. FlareSolverr used to receive the session unconditionally for
+      # any url at all; it now consults the same scope the direct path does.
+      cookies =
+        if cookies != [] and
+             not Indexers.cardigann_download_credential_allowed?(indexer_name, url) do
+          Logger.warning(
+            "Withholding indexer session cookies from #{url}: not a trusted origin for #{indexer_name}"
+          )
+
+          []
+        else
+          cookies
+        end
+
       flaresolverr_opts =
         if cookies != [] do
           [cookies: cookies]
@@ -1570,14 +1591,18 @@ defmodule Mydia.Downloads.Queue do
     end
   end
 
-  defp follow_to_final_url(url, cookie_header, redirects_remaining \\ 10)
-  defp follow_to_final_url(_url, _cookie_header, 0), do: {:error, :too_many_redirects}
+  defp follow_to_final_url(url, indexer_name, cookie_header, redirects_remaining \\ 10)
 
-  defp follow_to_final_url(url, cookie_header, redirects_remaining) do
-    # Build request options with cookies if available
+  defp follow_to_final_url(_url, _indexer_name, _cookie_header, 0),
+    do: {:error, :too_many_redirects}
+
+  defp follow_to_final_url(url, indexer_name, cookie_header, redirects_remaining) do
+    # Build request options with cookies scoped to this hop's own host - a
+    # cookie trusted at the previous hop must not follow a redirect off the
+    # indexer's origin.
     req_opts =
       [redirect: false] ++
-        if(cookie_header != "", do: [headers: [{"cookie", cookie_header}]], else: [])
+        cookie_header_opt(scoped_cookie_header(url, indexer_name, cookie_header))
 
     # Try HEAD request first - use redirect: false to get redirect responses directly
     # instead of following them, which avoids exception handling
@@ -1594,7 +1619,12 @@ defmodule Mydia.Downloads.Queue do
               {:ok, {:magnet, location}}
             else
               # Follow the redirect, encoding the location URL to handle special characters
-              follow_to_final_url(encode_url(location), cookie_header, redirects_remaining - 1)
+              follow_to_final_url(
+                encode_url(location),
+                indexer_name,
+                cookie_header,
+                redirects_remaining - 1
+              )
             end
         end
 
@@ -1604,7 +1634,7 @@ defmodule Mydia.Downloads.Queue do
 
       {:ok, %{status: 405}} ->
         # HEAD not allowed, try GET as fallback
-        follow_to_final_url_with_get(url, cookie_header, redirects_remaining)
+        follow_to_final_url_with_get(url, indexer_name, cookie_header, redirects_remaining)
 
       {:ok, %{status: status, body: body}} ->
         body_preview =
@@ -1629,12 +1659,12 @@ defmodule Mydia.Downloads.Queue do
     end
   end
 
-  defp follow_to_final_url_with_get(url, cookie_header, redirects_remaining) do
+  defp follow_to_final_url_with_get(url, indexer_name, cookie_header, redirects_remaining) do
     # Fallback to GET when HEAD is not allowed
-    # Build request options with cookies if available
+    # Build request options with cookies scoped to this hop's own host
     req_opts =
       [redirect: false] ++
-        if(cookie_header != "", do: [headers: [{"cookie", cookie_header}]], else: [])
+        cookie_header_opt(scoped_cookie_header(url, indexer_name, cookie_header))
 
     case Req.get(url, req_opts) do
       {:ok, %{status: status} = response} when status in 301..308 ->
@@ -1649,7 +1679,12 @@ defmodule Mydia.Downloads.Queue do
               {:ok, {:magnet, location}}
             else
               # Follow the redirect, encoding the location URL to handle special characters
-              follow_to_final_url(encode_url(location), cookie_header, redirects_remaining - 1)
+              follow_to_final_url(
+                encode_url(location),
+                indexer_name,
+                cookie_header,
+                redirects_remaining - 1
+              )
             end
         end
 
@@ -1680,6 +1715,31 @@ defmodule Mydia.Downloads.Queue do
         {:error, {:http_error, exception}}
     end
   end
+
+  # Withholds the indexer's session cookie header from a request whose target
+  # is not one of the indexer's own hosts, per
+  # Indexers.cardigann_download_credential_allowed?/2. `download_url` is
+  # remote content chosen by the indexer's own search results (or a redirect
+  # from them), so this is consulted before every request that would carry
+  # the cookie - including once per redirect hop, since a hop can move the
+  # request off the indexer's origin. The request still goes out; withhold
+  # and continue rather than failing the download.
+  defp scoped_cookie_header(_url, _indexer_name, ""), do: ""
+
+  defp scoped_cookie_header(url, indexer_name, cookie_header) do
+    if Indexers.cardigann_download_credential_allowed?(indexer_name, url) do
+      cookie_header
+    else
+      Logger.warning(
+        "Withholding indexer session cookie from #{url}: not a trusted origin for #{indexer_name}"
+      )
+
+      ""
+    end
+  end
+
+  defp cookie_header_opt(""), do: []
+  defp cookie_header_opt(cookie_header), do: [headers: [{"cookie", cookie_header}]]
 
   defp get_location_header(headers) do
     Enum.find_value(headers, fn

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -31,6 +31,7 @@ defmodule Mydia.Indexers do
   alias Mydia.Indexers.CardigannAuth
   alias Mydia.Indexers.CardigannDownload
   alias Mydia.Indexers.CardigannParser
+  alias Mydia.Indexers.Cardigann.CredentialScope
   alias Mydia.Indexers.Structs.IndexerProgress
   alias Mydia.Settings
   alias Mydia.Repo
@@ -898,6 +899,40 @@ defmodule Mydia.Indexers do
   end
 
   def resolve_cardigann_download(_indexer_name, _download_url), do: :not_applicable
+
+  @doc """
+  True when `download_url` may receive the named indexer's session cookies,
+  per `Cardigann.CredentialScope`: the URL's origin must be one of the
+  definition's own hosts, and the URL must not be cleartext to a
+  non-loopback host.
+
+  `download_url` is a release's download link, chosen by the indexer's own
+  search results (or a redirect from them) rather than by the operator, so
+  this is the same scope check the search and auth paths already apply
+  before attaching a session cookie. Callers on the download path (see
+  `Mydia.Downloads.Queue`) consult it per request - including once per
+  redirect hop, since a hop can move the request off the indexer's origin.
+
+  Returns `false` for an unknown or unparseable indexer, which withholds
+  the credential rather than leaking it.
+  """
+  @spec cardigann_download_credential_allowed?(binary() | nil, binary()) :: boolean()
+  def cardigann_download_credential_allowed?(nil, _download_url), do: false
+
+  def cardigann_download_credential_allowed?(indexer_name, download_url)
+      when is_binary(indexer_name) do
+    with %CardigannDefinition{} = definition <- get_cardigann_definition_by_name(indexer_name),
+         {:ok, parsed} <- CardigannParser.parse_definition(definition.definition) do
+      trusted_origins = CredentialScope.trusted_origins(parsed, definition.config || %{})
+
+      not CredentialScope.cleartext?(download_url) and
+        CredentialScope.allows?(trusted_origins, download_url)
+    else
+      _ -> false
+    end
+  end
+
+  def cardigann_download_credential_allowed?(_indexer_name, _download_url), do: false
 
   @doc """
   Enables a Cardigann indexer definition.

--- a/test/mydia/downloads/queue_cookie_scope_test.exs
+++ b/test/mydia/downloads/queue_cookie_scope_test.exs
@@ -1,0 +1,129 @@
+defmodule Mydia.Downloads.QueueCookieScopeTest do
+  @moduledoc """
+  Regression for #607: the cookie-scoping rules #601/#606 established for the
+  Cardigann search and auth paths (`Mydia.Indexers.Cardigann.CredentialScope`)
+  never reached `Mydia.Downloads.Queue`'s own download path
+  (`download_torrent_file/2`). A tracker's session cookie followed
+  `download_url` to any host at all, with no origin check, and survived a
+  redirect off that host.
+  """
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Downloads.Queue
+  alias Mydia.Indexers.CardigannAuth
+  alias Mydia.Indexers.CardigannDefinition
+  alias Mydia.Indexers.SearchResult
+  alias Mydia.Repo
+
+  @yaml """
+  ---
+  id: cookiescopetest
+  name: CookieScopeTest
+  description: "Test indexer for the #607 cookie scope regression"
+  language: en-US
+  type: private
+  encoding: UTF-8
+  links:
+    - http://localhost:PORT/
+  caps:
+    modes:
+      search: [q]
+  settings: []
+  search:
+    paths:
+      - path: "search"
+    rows:
+      selector: tr
+    fields:
+      title:
+        text: x
+      size:
+        text: "0"
+      seeders:
+        text: "0"
+  """
+
+  defp store_definition!(port) do
+    yaml = String.replace(@yaml, "PORT", to_string(port))
+
+    %CardigannDefinition{}
+    |> CardigannDefinition.changeset(%{
+      indexer_id: "cookiescopetest",
+      name: "CookieScopeTest",
+      type: "private",
+      links: %{"main" => "http://localhost:#{port}/"},
+      capabilities: %{},
+      definition: yaml,
+      schema_version: "1",
+      enabled: true
+    })
+    |> Repo.insert!()
+  end
+
+  defp search_result(download_url) do
+    %SearchResult{
+      title: "Some.Release.1080p",
+      indexer: "CookieScopeTest",
+      download_url: download_url,
+      size: 1_000,
+      seeders: 1,
+      leechers: 1,
+      download_protocol: :torrent
+    }
+  end
+
+  test "a download host outside the indexer's own origins never receives the session cookie" do
+    home = Bypass.open()
+    foreign = Bypass.open()
+    test_pid = self()
+
+    definition = store_definition!(home.port)
+    {:ok, _session} = CardigannAuth.store_session(definition.id, ["session=topsecret"])
+
+    Bypass.stub(foreign, "HEAD", "/download", fn conn ->
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
+    Bypass.stub(foreign, "GET", "/download", fn conn ->
+      send(test_pid, {:cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+      Plug.Conn.resp(conn, 200, "d8:announce")
+    end)
+
+    Queue.select_and_add_to_client(search_result("http://localhost:#{foreign.port}/download"), [])
+
+    assert_receive {:cookie_header, cookie_header}, 2_000
+    assert cookie_header == []
+  end
+
+  test "a session cookie does not survive a redirect off the indexer's own host" do
+    home = Bypass.open()
+    foreign = Bypass.open()
+    test_pid = self()
+
+    definition = store_definition!(home.port)
+    {:ok, _session} = CardigannAuth.store_session(definition.id, ["session=topsecret"])
+
+    Bypass.expect_once(home, "HEAD", "/download", fn conn ->
+      send(test_pid, {:home_cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+
+      conn
+      |> Plug.Conn.put_resp_header("location", "http://localhost:#{foreign.port}/download")
+      |> Plug.Conn.resp(302, "")
+    end)
+
+    Bypass.stub(foreign, "HEAD", "/download", fn conn ->
+      Plug.Conn.resp(conn, 200, "")
+    end)
+
+    Bypass.stub(foreign, "GET", "/download", fn conn ->
+      send(test_pid, {:foreign_cookie_header, Plug.Conn.get_req_header(conn, "cookie")})
+      Plug.Conn.resp(conn, 200, "d8:announce")
+    end)
+
+    Queue.select_and_add_to_client(search_result("http://localhost:#{home.port}/download"), [])
+
+    assert_receive {:home_cookie_header, ["session=topsecret"]}, 2_000
+    assert_receive {:foreign_cookie_header, foreign_cookie_header}, 2_000
+    assert foreign_cookie_header == []
+  end
+end


### PR DESCRIPTION
Fixes #607

## Problem

`Mydia.Downloads.Queue.download_torrent_file/2` attached a Cardigann indexer's session cookies to any `download_url` with no origin check, and `follow_to_final_url/3` carried the same cookie header across every redirect hop regardless of destination host. `download_url` comes from an indexer's own search results (or a redirect from them), so a tracker, a hijacked mirror, or a poisoned result row could point the request at a host that should never see the session, and a redirect could move a trusted request off-origin mid-flight.

`Mydia.Indexers.Cardigann.CredentialScope` already gates this on the Cardigann search and auth paths (#601/#606), but `Downloads.Queue` never called it: it only carries `indexer_name`, not the parsed definition, so the scope check couldn't be applied without new plumbing.

## Fix

- Added `Mydia.Indexers.cardigann_download_credential_allowed?/2`, which resolves the named indexer's definition, parses it, and checks the URL against `CredentialScope.trusted_origins/2` and `cleartext?/1`. Unknown/unparseable indexers return `false`, withholding rather than leaking.
- `Queue` now consults this before attaching cookies in three places: the FlareSolverr request, the initial direct-download request, and each redirect hop inside `follow_to_final_url/4` individually (both the HEAD and GET fallback paths), so a hop that moves the request off the indexer's own host drops the cookie for that request instead of carrying it forward.
- Withholds and continues rather than failing the download, matching the existing behavior on the Cardigann search path.

## Testing

- Added `test/mydia/downloads/queue_cookie_scope_test.exs` with two Bypass-backed regressions: a download URL pointing directly at a foreign host, and a same-origin URL that 302s to a foreign host. Both failed against the old code (the cookie reached the foreign host) and pass now.
- `./dev mix test test/mydia/downloads/queue_test.exs test/mydia/downloads/queue_cookie_scope_test.exs test/mydia/downloads/cardigann_download_grab_test.exs test/mydia/indexers/cardigann_search_engine_redirect_test.exs test/mydia/indexers_test.exs` — 92 tests, 0 failures.
- `./dev mix format` and `./dev mix credo --strict` on the touched files — clean.
