### PR TITLE
Swallow subscription publish failures during Absinthe.Subscription boot gap

### DIFF
--- a/lib/mydia/remote_access.ex
+++ b/lib/mydia/remote_access.ex
@@ -981,7 +981,7 @@ defmodule Mydia.RemoteAccess do
       event: event_type
     }
 
-    Absinthe.Subscription.publish(
+    MydiaWeb.Schema.Publish.publish(
       MydiaWeb.Endpoint,
       event_payload,
       device_status_changed: "device_status:#{device.user_id}"

--- a/lib/mydia_web/schema/publish.ex
+++ b/lib/mydia_web/schema/publish.ex
@@ -1,0 +1,37 @@
+defmodule MydiaWeb.Schema.Publish do
+  @moduledoc """
+  Best-effort wrapper around `Absinthe.Subscription.publish/3`.
+
+  `Absinthe.Subscription` starts after `MydiaWeb.Endpoint` in the supervision
+  tree (see `Mydia.Application`), since it needs the endpoint's pubsub to
+  exist first. That leaves a boot window where the endpoint accepts requests
+  before the subscription registry is up, and `Absinthe.Subscription.publish/3`
+  raises `ArgumentError` in that window. Publishing is telemetry for live
+  subscribers, so it must never turn an already-committed write into a
+  mutation error.
+  """
+
+  require Logger
+
+  @spec publish(Absinthe.Subscription.Pubsub.t(), term(), keyword() | String.t()) :: :ok
+  def publish(pubsub, value, topic) do
+    Absinthe.Subscription.publish(pubsub, value, topic)
+    :ok
+  rescue
+    error ->
+      Logger.warning(
+        "Absinthe.Subscription.publish/3 failed, skipping subscription event: " <>
+          Exception.message(error)
+      )
+
+      :ok
+  catch
+    :exit, reason ->
+      Logger.warning(
+        "Absinthe.Subscription.publish/3 exited, skipping subscription event: " <>
+          inspect(reason)
+      )
+
+      :ok
+  end
+end

--- a/lib/mydia_web/schema/resolvers/playback_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/playback_resolver.ex
@@ -24,7 +24,7 @@ defmodule MydiaWeb.Schema.Resolvers.PlaybackResolver do
             formatted_progress = format_progress(progress)
 
             # Publish subscription event
-            Absinthe.Subscription.publish(
+            MydiaWeb.Schema.Publish.publish(
               MydiaWeb.Endpoint,
               formatted_progress,
               progress_updated: movie_id
@@ -56,7 +56,7 @@ defmodule MydiaWeb.Schema.Resolvers.PlaybackResolver do
             formatted_progress = format_progress(progress)
 
             # Publish subscription event
-            Absinthe.Subscription.publish(
+            MydiaWeb.Schema.Publish.publish(
               MydiaWeb.Endpoint,
               formatted_progress,
               progress_updated: episode_id

--- a/test/mydia_web/schema/playback_test.exs
+++ b/test/mydia_web/schema/playback_test.exs
@@ -294,6 +294,49 @@ defmodule MydiaWeb.Schema.PlaybackTest do
     end
   end
 
+  describe "updateMovieProgress/updateEpisodeProgress mutations when Absinthe.Subscription is down (issue #708)" do
+    setup do
+      :ok = Supervisor.terminate_child(Mydia.Supervisor, Absinthe.Subscription)
+
+      on_exit(fn ->
+        {:ok, _pid} = Supervisor.restart_child(Mydia.Supervisor, Absinthe.Subscription)
+      end)
+
+      movie = MediaFixtures.media_item_fixture(%{type: "movie"})
+      %{movie: movie}
+    end
+
+    test "still saves movie progress and returns ok", ctx do
+      result =
+        run_query(
+          @update_movie_progress_mutation,
+          %{"movieId" => ctx.movie.id, "positionSeconds" => 42, "durationSeconds" => 100},
+          ctx.user
+        )
+
+      assert {:ok, %{data: %{"updateMovieProgress" => %{"positionSeconds" => 42}}}} = result
+
+      progress = Playback.get_progress(ctx.user.id, media_item_id: ctx.movie.id)
+      assert progress.position_seconds == 42
+    end
+
+    test "still saves episode progress and returns ok", ctx do
+      episode = hd(ctx.episodes)
+
+      result =
+        run_query(
+          @update_episode_progress_mutation,
+          %{"episodeId" => episode.id, "positionSeconds" => 15, "durationSeconds" => 60},
+          ctx.user
+        )
+
+      assert {:ok, %{data: %{"updateEpisodeProgress" => %{"positionSeconds" => 15}}}} = result
+
+      progress = Playback.get_progress(ctx.user.id, episode_id: episode.id)
+      assert progress.position_seconds == 15
+    end
+  end
+
   defp run_query(query, variables, user \\ nil) do
     context = if user, do: %{current_user: user}, else: %{}
     Absinthe.run(query, MydiaWeb.Schema, variables: variables, context: context)


### PR DESCRIPTION
Fixes #708

## Mechanism

`Mydia.Application` starts `MydiaWeb.Endpoint` before `{Absinthe.Subscription, MydiaWeb.Endpoint}`, since the subscription supervisor needs the endpoint's pubsub already running. That leaves a boot window where the endpoint accepts requests before the subscription registry exists.

`MydiaWeb.Schema.Resolvers.PlaybackResolver.update_movie_progress/3` and `update_episode_progress/3` call `Absinthe.Subscription.publish/3` unconditionally right after `Playback.save_progress/3` commits, with no rescue. A mutation landing in that boot gap hits `Registry.meta/2` for the not-yet-running `MydiaWeb.Endpoint.Registry`, which raises `ArgumentError`. Because nothing catches it, the exception propagates out of the resolver, so the client sees a failed mutation even though the progress row was already persisted. `Mydia.RemoteAccess.publish_device_event/2` has the identical unguarded call.

Publishing a subscription event is best-effort telemetry for live subscribers, not something that should ever fail an already-successful write. This adds `MydiaWeb.Schema.Publish.publish/3`, a thin wrapper around `Absinthe.Subscription.publish/3` that logs a warning and swallows any raise or exit, and switches all three call sites to use it.

## Testing

- Added `test/mydia_web/schema/playback_test.exs` regression tests that stop the `Absinthe.Subscription` child under `Mydia.Supervisor` before invoking `updateMovieProgress`/`updateEpisodeProgress`, matching the exact `Registry.meta/2` -> `ArgumentError` crash from the issue. Verified these fail against the pre-fix code with the identical stack trace, and pass after the fix, with the progress row still saved.
- `mix test test/mydia_web/schema/playback_test.exs test/mydia_web/schema/remote_access_test.exs test/mydia/remote_access` — 125 tests, 0 failures.
- `mix format` and `mix credo --strict` on the changed files — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for movie and episode progress updates when live subscription delivery is temporarily unavailable.
  - Device status changes and playback progress can now be saved successfully even if real-time event notifications fail.
  - Subscription delivery failures are logged without preventing completed changes from being reported as successful.

- **Tests**
  - Added coverage confirming progress changes remain successful and persisted when subscription services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->