### PR TITLE
Catch exits from a timed-out Ueberauth provider worker

### DIFF
--- a/lib/mydia_web/plugs/runtime_ueberauth.ex
+++ b/lib/mydia_web/plugs/runtime_ueberauth.ex
@@ -9,9 +9,22 @@ defmodule MydiaWeb.Plugs.RuntimeUeberauth do
 
   This plug calls `Ueberauth.init/1` at runtime (during each request), ensuring it
   always has the latest configuration from runtime.exs.
+
+  `oidcc` strategies resolve the client context via a `GenServer.call/2` to a
+  provider-configuration worker that refreshes discovery metadata in the
+  background. If that worker is busy against a slow or unreachable IdP, the
+  call times out and the exit propagates up through Ueberauth's strategy
+  pipeline, which has no exit trap of its own. Left unguarded, that turns a
+  slow identity provider into a 500 instead of the login-failure redirect
+  `MydiaWeb.AuthController` already implements, so it is caught here and
+  routed to the same fallback.
   """
 
   @behaviour Plug
+
+  require Logger
+
+  import Phoenix.Controller, only: [put_flash: 3, redirect: 2]
 
   @impl Plug
   def init(opts), do: opts
@@ -23,5 +36,13 @@ defmodule MydiaWeb.Plugs.RuntimeUeberauth do
 
     # Call Ueberauth with the runtime-initialized routes
     Ueberauth.call(conn, routes)
+  catch
+    :exit, reason ->
+      Logger.error("Ueberauth request exited: #{inspect(reason)}")
+
+      conn
+      |> put_flash(:error, "The identity provider did not respond in time. Please try again.")
+      |> redirect(to: "/auth/login")
+      |> Plug.Conn.halt()
   end
 end

--- a/test/mydia_web/plugs/runtime_ueberauth_test.exs
+++ b/test/mydia_web/plugs/runtime_ueberauth_test.exs
@@ -1,0 +1,30 @@
+defmodule MydiaWeb.Plugs.RuntimeUeberauthTest do
+  use MydiaWeb.ConnCase
+
+  setup do
+    original = Application.get_env(:ueberauth, Ueberauth)
+
+    Application.put_env(:ueberauth, Ueberauth,
+      providers: [timeout_provider: {MydiaWeb.TimeoutUeberauthStrategy, []}]
+    )
+
+    on_exit(fn ->
+      if original do
+        Application.put_env(:ueberauth, Ueberauth, original)
+      else
+        Application.delete_env(:ueberauth, Ueberauth)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "GET /auth/:provider when the provider worker times out" do
+    test "redirects to the login page with a flash error instead of crashing", %{conn: conn} do
+      conn = get(conn, ~p"/auth/timeout_provider")
+
+      assert redirected_to(conn) == ~p"/auth/login"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "identity provider"
+    end
+  end
+end

--- a/test/support/timeout_ueberauth_strategy.ex
+++ b/test/support/timeout_ueberauth_strategy.ex
@@ -1,0 +1,19 @@
+defmodule MydiaWeb.TimeoutUeberauthStrategy do
+  @moduledoc """
+  A Ueberauth strategy whose request phase exits the way `oidcc`'s
+  provider-configuration worker does when it misses the default 5s
+  `GenServer.call/2` timeout while fetching a slow IdP's discovery document.
+
+  Used to reproduce https://github.com/getmydia/mydia/issues/707 without a
+  live, slow identity provider: `Ueberauth.Strategy.Oidcc.handle_request!/1`
+  calls into `:gen_server.call/2` and lets a timeout's `exit/1` propagate, so
+  this strategy does the same thing directly.
+  """
+
+  use Ueberauth.Strategy
+
+  @impl Ueberauth.Strategy
+  def handle_request!(_conn) do
+    exit({:timeout, {:gen_server, :call, [self(), :get_provider_configuration]}})
+  end
+end


### PR DESCRIPTION
Fixes #707

## Mechanism

`oidcc` (behind `ueberauth_oidcc`) resolves the OIDC client context via a
`GenServer.call/2` to a provider-configuration worker that refreshes discovery
metadata from the IdP in the background. When that call misses its default
5s timeout (a slow or unreachable identity provider), the resulting `exit`
propagates straight up through `Ueberauth.Strategy.Oidcc.handle_request!/1`
and Ueberauth's strategy pipeline, neither of which traps it.

`MydiaWeb.Plugs.RuntimeUeberauth` calls `Ueberauth.call/2` unguarded, so the
exit escapes the plug pipeline entirely, before the request ever reaches
`MydiaWeb.AuthController`'s existing `ueberauth_failure` handling. The result
is a 500 error page instead of the login-failure redirect the controller
already implements for every other kind of auth failure.

## Fix

`RuntimeUeberauth.call/2` now catches `:exit` around `Ueberauth.call/2`,
logs the reason, and routes the request into the same fallback the
controller uses elsewhere: flash an error naming the identity provider as
unreachable and redirect to `/auth/login`. Since this plug wraps both the
request and callback legs of every OIDC route, the callback path
(`handle_callback!/1`, which resolves the client context the same way) is
covered by the same fix.

## Testing

Added `test/support/timeout_ueberauth_strategy.ex`, a fake Ueberauth
strategy whose `handle_request!/1` raises the same
`exit({:timeout, {:gen_server, :call, [...]}})` oidcc produces on a worker
timeout, and `test/mydia_web/plugs/runtime_ueberauth_test.exs`, which
configures it as a provider and hits `GET /auth/:provider` through the real
router pipeline.

- Confirmed the test crashes the request (matching the issue's stack trace)
  against the pre-fix plug.
- Confirmed it passes (redirect to `/auth/login` with a flash error, no
  unhandled exit) after the fix.
- `./dev mix test test/mydia_web/plugs/runtime_ueberauth_test.exs
  test/mydia_web/controllers/auth_controller_test.exs
  test/mydia_web/features/auth_test.exs` — all passing.
- `./dev mix format` and `./dev mix credo --strict` on the touched files —
  clean.
