### PR TITLE
feat(player): notify users when a player update is available

### DIFF
--- a/player/lib/core/update/install_environment.dart
+++ b/player/lib/core/update/install_environment.dart
@@ -1,0 +1,71 @@
+import 'dart:io' show File, FileSystemEntity, Platform;
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+
+/// How the running install can be replaced.
+///
+/// Answered before anything downloads. The previous arrangement asked the
+/// question inside `LinuxUpdater.applyUpdate`, after the archive had already
+/// been fetched and extracted, which cost a Flatpak user a full download to
+/// reach a browser tab.
+enum InstallEnvironment {
+  /// The install directory is writable, so the updater can swap the binary.
+  inPlace,
+
+  /// Running inside a Flatpak sandbox. The runtime updates through
+  /// `flatpak update`, and a downloaded tar.gz is of no use.
+  flatpak,
+
+  /// Some other install this process cannot write to: a system-wide tree
+  /// under /opt, or a distribution package.
+  readOnly;
+
+  /// Resolves the environment for the running process.
+  static InstallEnvironment detect() => resolve(
+        isLinux: Platform.isLinux,
+        flatpakId: Platform.environment['FLATPAK_ID'],
+        flatpakInfoExists:
+            Platform.isLinux && File('/.flatpak-info').existsSync(),
+        installDirWritable: installDirWritable(),
+      );
+
+  /// The decision itself, separated from the platform lookups so every branch
+  /// is reachable from one test host. Mirrors the split
+  /// `PlatformUpdater.supportedOnPlatform` already uses.
+  @visibleForTesting
+  static InstallEnvironment resolve({
+    required bool isLinux,
+    required String? flatpakId,
+    required bool flatpakInfoExists,
+    required bool installDirWritable,
+  }) {
+    // Windows installs per-user into %LOCALAPPDATA% and runs its own
+    // installer, and macOS never reaches here because Sparkle owns the whole
+    // flow. Neither has a Flatpak or read-only variant worth branching on,
+    // and consulting writability would newly refuse a Windows update that
+    // `WindowsUpdater.canUpdateInPlace` has always accepted.
+    if (!isLinux) return InstallEnvironment.inPlace;
+
+    if (flatpakId != null && flatpakId.isNotEmpty)
+      return InstallEnvironment.flatpak;
+    if (flatpakInfoExists) return InstallEnvironment.flatpak;
+
+    return installDirWritable
+        ? InstallEnvironment.inPlace
+        : InstallEnvironment.readOnly;
+  }
+
+  /// Whether the directory holding the running executable is writable.
+  ///
+  /// Lifted from `LinuxUpdater._isInstallDirWritable` so the updater and the
+  /// UI ask one question and get one answer.
+  static bool installDirWritable() {
+    try {
+      final installDir = File(Platform.resolvedExecutable).parent;
+      return FileSystemEntity.isDirectorySync(installDir.path) &&
+          installDir.statSync().mode & 0x80 != 0; // owner write bit
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/player/lib/core/update/update_dismissal_provider.dart
+++ b/player/lib/core/update/update_dismissal_provider.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+
+/// Hive box holding update versions the user has waved off.
+const String updateDismissalBoxName = 'update_dismissals';
+
+/// The box recording which versions the user dismissed.
+final updateDismissalBoxProvider = FutureProvider<Box<bool>>((ref) async {
+  return Hive.openBox<bool>(updateDismissalBoxName);
+});
+
+/// The set of update versions the user has dismissed.
+///
+/// Keyed on the version string, so dismissing 0.15.0 says nothing about
+/// 0.16.0 and the banner returns on its own without any expiry logic.
+class UpdateDismissalNotifier extends AsyncNotifier<Set<String>> {
+  @override
+  Future<Set<String>> build() async {
+    // Fails open. A broken box must not silence a real update, which is the
+    // same call `CompatibilityNotifier` makes for the same reason.
+    try {
+      final box = await ref.watch(updateDismissalBoxProvider.future);
+      return box.keys
+          .cast<String>()
+          .where((key) => box.get(key) == true)
+          .toSet();
+    } catch (e) {
+      debugPrint('[UpdateDismissalNotifier] could not read dismissals: $e');
+      return <String>{};
+    }
+  }
+
+  /// Hides the banner for [version], permanently.
+  Future<void> dismiss(String version) async {
+    try {
+      final box = await ref.read(updateDismissalBoxProvider.future);
+      await box.put(version, true);
+    } catch (e) {
+      debugPrint('[UpdateDismissalNotifier] could not persist dismissal: $e');
+    }
+
+    // The banner calls this fire-and-forget. If the provider is disposed
+    // while the Hive write is in flight, writing to state throws
+    // UnmountedRefException as an unhandled async error rather than a caught
+    // one. Same guard, same reason, as CompatibilityNotifier.dismiss.
+    if (!ref.mounted) return;
+
+    state = AsyncValue.data({...?state.value, version});
+  }
+}
+
+/// Update versions the user has dismissed.
+final updateDismissalProvider =
+    AsyncNotifierProvider<UpdateDismissalNotifier, Set<String>>(
+  UpdateDismissalNotifier.new,
+);

--- a/player/lib/core/update/update_provider.dart
+++ b/player/lib/core/update/update_provider.dart
@@ -182,9 +182,6 @@ class UpdateNotifier extends Notifier<UpdateState> {
       );
     }
   }
-
-  /// Whether the current platform supports in-place updates.
-  bool get canUpdateInPlace => _platformUpdater?.canUpdateInPlace ?? false;
 }
 
 /// Global provider for the update system.

--- a/player/lib/core/update/updaters/linux_updater.dart
+++ b/player/lib/core/update/updaters/linux_updater.dart
@@ -5,32 +5,44 @@ import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:path_provider/path_provider.dart';
 
 import '../../../domain/models/app_update.dart';
+import '../install_environment.dart';
 import '../platform_updater.dart';
 
 /// Linux updater: downloads tar.gz, extracts, and replaces the running binary.
 ///
-/// Falls back to opening the download URL in the browser if the install
-/// directory is not writable.
+/// Refuses an install it cannot write, before downloading anything. Deciding
+/// afterwards is what made a Flatpak user pay for a full download to reach a
+/// browser tab. `startUpdate` routes Flatpak and read-only installs to their
+/// own affordances, so reaching [applyUpdate] on one of them is a programming
+/// error rather than a user-facing state.
 class LinuxUpdater extends PlatformUpdater {
-  @override
-  bool get canUpdateInPlace => _isInstallDirWritable();
+  /// Overrides the detected install environment. Tests only: a `flutter test`
+  /// host reports whatever the runner's own directory happens to be, so the
+  /// Flatpak and read-only branches are otherwise unreachable.
+  final InstallEnvironment? _environmentOverride;
 
-  bool _isInstallDirWritable() {
-    try {
-      final execPath = Platform.resolvedExecutable;
-      final installDir = File(execPath).parent;
-      return FileSystemEntity.isDirectorySync(installDir.path) &&
-          installDir.statSync().mode & 0x80 != 0; // owner write bit
-    } catch (_) {
-      return false;
-    }
-  }
+  LinuxUpdater({InstallEnvironment? environment})
+      : _environmentOverride = environment;
+
+  InstallEnvironment get _environment =>
+      _environmentOverride ?? InstallEnvironment.detect();
+
+  @override
+  bool get canUpdateInPlace => _environment == InstallEnvironment.inPlace;
 
   @override
   Future<void> applyUpdate(
     AppUpdate update, {
     void Function(double progress)? onProgress,
   }) async {
+    final environment = _environment;
+    if (environment != InstallEnvironment.inPlace) {
+      throw StateError(
+        'Cannot replace a ${environment.name} install in place. '
+        'startUpdate should have routed this elsewhere.',
+      );
+    }
+
     final tempDir = await getTemporaryDirectory();
     final archivePath = '${tempDir.path}/mydia-update.tar.gz';
     final extractDir = '${tempDir.path}/mydia-update-extract';
@@ -48,7 +60,6 @@ class LinuxUpdater extends PlatformUpdater {
       },
     );
 
-    // Create extraction directory
     final extractDirObj = Directory(extractDir);
     if (extractDirObj.existsSync()) {
       extractDirObj.deleteSync(recursive: true);
@@ -59,23 +70,12 @@ class LinuxUpdater extends PlatformUpdater {
     final extractResult =
         await Process.run('tar', ['-xzf', archivePath, '-C', extractDir]);
     if (extractResult.exitCode != 0) {
-      throw Exception(
-          'Failed to extract update: ${extractResult.stderr}');
+      throw Exception('Failed to extract update: ${extractResult.stderr}');
     }
 
     final execPath = Platform.resolvedExecutable;
     final installDir = File(execPath).parent.path;
 
-    // Check if we can write to the install directory
-    if (!_isInstallDirWritable()) {
-      // Fall back: open download URL in default browser
-      debugPrint(
-          '[LinuxUpdater] Install dir not writable, opening browser fallback');
-      await Process.run('xdg-open', [update.releaseNotesUrl]);
-      return;
-    }
-
-    // Copy extracted files over current installation
     debugPrint('[LinuxUpdater] Copying files to $installDir');
     final copyResult = await Process.run(
       'cp',
@@ -85,16 +85,10 @@ class LinuxUpdater extends PlatformUpdater {
       throw Exception('Failed to copy update files: ${copyResult.stderr}');
     }
 
-    // Ensure binary is executable
     await Process.run('chmod', ['+x', execPath]);
 
-    // Relaunch
     debugPrint('[LinuxUpdater] Relaunching');
-    await Process.start(
-      execPath,
-      [],
-      mode: ProcessStartMode.detached,
-    );
+    await Process.start(execPath, [], mode: ProcessStartMode.detached);
 
     exit(0);
   }

--- a/player/lib/presentation/screens/settings/widgets/update_card.dart
+++ b/player/lib/presentation/screens/settings/widgets/update_card.dart
@@ -6,6 +6,7 @@ import '../../../../core/player/platform_features.dart';
 import '../../../../core/theme/colors.dart';
 import '../../../../core/update/platform_updater.dart';
 import '../../../../core/update/update_provider.dart';
+import '../../../../presentation/widgets/update_action.dart';
 import 'settings_section.dart';
 
 /// The available-update card, shown above the settings sections.
@@ -97,7 +98,7 @@ class UpdateCard extends ConsumerWidget {
                   Row(
                     children: [
                       FilledButton.icon(
-                        onPressed: () => _handleUpdateTap(context, ref),
+                        onPressed: () => startUpdate(context, ref),
                         icon: const Icon(Icons.download, size: 18),
                         label: const Text('Update Now'),
                       ),
@@ -121,39 +122,6 @@ class UpdateCard extends ConsumerWidget {
                 ],
               ],
             ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _handleUpdateTap(BuildContext context, WidgetRef ref) {
-    final notifier = ref.read(updateProvider.notifier);
-
-    if (!notifier.canUpdateInPlace) {
-      notifier.applyUpdate();
-      return;
-    }
-
-    showDialog<void>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Update Mydia'),
-        content: Text(
-          'Mydia will close and update to '
-          'v${ref.read(updateProvider).availableUpdate?.version}. Continue?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () {
-              Navigator.of(ctx).pop();
-              notifier.applyUpdate();
-            },
-            child: const Text('Update'),
           ),
         ],
       ),

--- a/player/lib/presentation/widgets/app_shell.dart
+++ b/player/lib/presentation/widgets/app_shell.dart
@@ -19,6 +19,7 @@ import 'nav/bottom_nav.dart';
 import 'nav/desktop_sidebar.dart';
 import 'nav/mobile_drawer.dart';
 import 'offline_banner.dart';
+import 'update_banner.dart';
 
 /// Modern app shell with adaptive navigation.
 /// Shows sidebar on desktop (≥900px) and bottom nav on mobile.
@@ -347,6 +348,7 @@ class _AppShellState extends ConsumerState<AppShell>
                       children: [
                         if (isOffline) const OfflineBanner(),
                         const CompatibilityBanner(),
+                        const UpdateBanner(),
                         Expanded(child: widget.child),
                       ],
                     ),
@@ -386,6 +388,7 @@ class _AppShellState extends ConsumerState<AppShell>
               children: [
                 if (isOffline) const OfflineBanner(),
                 const CompatibilityBanner(),
+                const UpdateBanner(),
                 Expanded(child: widget.child),
               ],
             ),

--- a/player/lib/presentation/widgets/banner_button.dart
+++ b/player/lib/presentation/widgets/banner_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+/// A compact action styled to sit inside a shell banner.
+///
+/// One control for OfflineBanner, CompatibilityBanner and UpdateBanner, which
+/// carried three copies of the same padding, radius, alpha and text style
+/// between them. [isLoading] generalises the spinner OfflineBanner's retry
+/// needed; the others pass the default.
+class BannerButton extends StatelessWidget {
+  final String label;
+  final Color color;
+  final VoidCallback onPressed;
+  final bool isLoading;
+
+  const BannerButton({
+    super.key,
+    required this.label,
+    required this.color,
+    required this.onPressed,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: isLoading ? null : onPressed,
+      style: TextButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        backgroundColor: color.withValues(alpha: 0.2),
+        foregroundColor: color,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(6),
+        ),
+      ),
+      child: isLoading
+          ? SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(strokeWidth: 2, color: color),
+            )
+          : Text(
+              label,
+              style: const TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/compatibility_banner.dart
+++ b/player/lib/presentation/widgets/compatibility_banner.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../core/compatibility/compatibility_provider.dart';
 import '../../core/compatibility/compatibility_verdict.dart';
 import '../../core/theme/colors.dart';
+import 'banner_button.dart';
 import 'compatibility_details_dialog.dart';
 
 /// Warns that this player and the connected server are on incompatible
@@ -56,14 +57,14 @@ class CompatibilityBanner extends ConsumerWidget {
               ),
             ),
             const SizedBox(width: 12),
-            _BannerButton(
+            BannerButton(
               label: 'Details',
               color: color,
               onPressed: () => showCompatibilityDetailsDialog(context, state),
             ),
             if (state.verdict.isPlayerBehind) ...[
               const SizedBox(width: 8),
-              _BannerButton(
+              BannerButton(
                 label: 'Update',
                 color: color,
                 onPressed: () => context.go('/settings'),
@@ -103,39 +104,5 @@ class CompatibilityBanner extends ConsumerWidget {
       case CompatibilityVerdict.unknown:
         return '';
     }
-  }
-}
-
-/// A compact action styled to sit inside the banner, matching OfflineBanner.
-class _BannerButton extends StatelessWidget {
-  final String label;
-  final Color color;
-  final VoidCallback onPressed;
-
-  const _BannerButton({
-    required this.label,
-    required this.color,
-    required this.onPressed,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return TextButton(
-      onPressed: onPressed,
-      style: TextButton.styleFrom(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        minimumSize: Size.zero,
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        backgroundColor: color.withValues(alpha: 0.2),
-        foregroundColor: color,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-        ),
-      ),
-      child: Text(
-        label,
-        style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
-      ),
-    );
   }
 }

--- a/player/lib/presentation/widgets/compatibility_banner.dart
+++ b/player/lib/presentation/widgets/compatibility_banner.dart
@@ -5,8 +5,11 @@ import 'package:go_router/go_router.dart';
 import '../../core/compatibility/compatibility_provider.dart';
 import '../../core/compatibility/compatibility_verdict.dart';
 import '../../core/theme/colors.dart';
+import '../../core/update/install_environment.dart';
+import '../../core/update/update_provider.dart';
 import 'banner_button.dart';
 import 'compatibility_details_dialog.dart';
+import 'update_action.dart';
 
 /// Warns that this player and the connected server are on incompatible
 /// versions.
@@ -14,12 +17,17 @@ import 'compatibility_details_dialog.dart';
 /// Renders nothing unless there is something actionable to say, so it can sit
 /// unconditionally in the shell next to [OfflineBanner].
 ///
-/// The update action navigates to Settings rather than starting a download.
-/// Settings already hosts UpdateCard, which resolves the right update path per
-/// platform. Duplicating that here would give us two places to get the
-/// GitHub-versus-app-store question wrong.
+/// The update action calls [startUpdate], the one implementation of beginning
+/// an update, and falls back to Settings only when there is no update in hand.
+/// This used to navigate unconditionally, to avoid a second place that could
+/// get the GitHub-versus-app-store question wrong; a shared action answers
+/// that instead of working around it.
 class CompatibilityBanner extends ConsumerWidget {
-  const CompatibilityBanner({super.key});
+  /// Overrides the detected install environment, forwarded to [startUpdate].
+  /// Tests only.
+  final InstallEnvironment? environmentOverride;
+
+  const CompatibilityBanner({super.key, this.environmentOverride});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -67,7 +75,20 @@ class CompatibilityBanner extends ConsumerWidget {
               BannerButton(
                 label: 'Update',
                 color: color,
-                onPressed: () => context.go('/settings'),
+                onPressed: () {
+                  // Settings is the fallback, not the destination. It covers
+                  // macOS, where Sparkle owns checking and availableUpdate
+                  // stays null, and the window before the first check lands.
+                  if (ref.read(updateProvider).availableUpdate == null) {
+                    context.go('/settings');
+                    return;
+                  }
+                  startUpdate(
+                    context,
+                    ref,
+                    environmentOverride: environmentOverride,
+                  );
+                },
               ),
             ],
             if (state.verdict.isDismissible) ...[

--- a/player/lib/presentation/widgets/connection_status_dot.dart
+++ b/player/lib/presentation/widgets/connection_status_dot.dart
@@ -13,7 +13,13 @@ import 'connection_tone_color.dart';
 /// Extracted from `app_shell.dart`, where it was private and therefore
 /// untestable, and where it carried a third copy of the transport switch.
 class ConnectionStatusDot extends ConsumerWidget {
-  const ConnectionStatusDot({super.key});
+  /// Whether an app update is waiting.
+  ///
+  /// Carried on shape rather than colour, because colour already means
+  /// connection tone here and two meanings on one channel is one meaning.
+  final bool updatePending;
+
+  const ConnectionStatusDot({super.key, this.updatePending = false});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -26,30 +32,42 @@ class ConnectionStatusDot extends ConsumerWidget {
       isInitialized: status.isInitialized,
     );
     final color = connectionToneColor(summary.tone);
+    final tooltip =
+        updatePending ? 'Update available - ${summary.label}' : summary.label;
 
     // Pulse only while re-establishing a link that was previously up. A first
     // connection is pending too, but a pulsing dot at launch reads as a fault.
     if (summary.tone == ConnectionTone.pending && status.isInitialized) {
-      return _PulsingDot(color: color, tooltip: summary.label);
+      return _PulsingDot(
+        color: color,
+        tooltip: tooltip,
+        updatePending: updatePending,
+      );
     }
 
-    return _Dot(color: color, tooltip: summary.label);
+    return _Dot(color: color, tooltip: tooltip, updatePending: updatePending);
   }
 }
 
 class _Dot extends StatelessWidget {
-  const _Dot({required this.color, required this.tooltip});
+  const _Dot({
+    required this.color,
+    required this.tooltip,
+    required this.updatePending,
+  });
 
   final Color color;
   final String tooltip;
+  final bool updatePending;
 
   @override
   Widget build(BuildContext context) {
     return Tooltip(
       message: tooltip,
       child: Container(
-        width: 10,
-        height: 10,
+        width: updatePending ? 14 : 10,
+        height: updatePending ? 14 : 10,
+        alignment: Alignment.center,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
           color: color,
@@ -62,6 +80,9 @@ class _Dot extends StatelessWidget {
             ),
           ],
         ),
+        child: updatePending
+            ? const Icon(Icons.arrow_upward, size: 9, color: AppColors.surface)
+            : null,
       ),
     );
   }
@@ -79,8 +100,13 @@ class _Dot extends StatelessWidget {
 class _PulsingDot extends StatefulWidget {
   final Color color;
   final String tooltip;
+  final bool updatePending;
 
-  const _PulsingDot({required this.color, required this.tooltip});
+  const _PulsingDot({
+    required this.color,
+    required this.tooltip,
+    required this.updatePending,
+  });
 
   @override
   State<_PulsingDot> createState() => _PulsingDotState();
@@ -116,8 +142,9 @@ class _PulsingDotState extends State<_PulsingDot>
           return Opacity(
             opacity: opacity,
             child: Container(
-              width: 10,
-              height: 10,
+              width: widget.updatePending ? 14 : 10,
+              height: widget.updatePending ? 14 : 10,
+              alignment: Alignment.center,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: widget.color,
@@ -133,6 +160,13 @@ class _PulsingDotState extends State<_PulsingDot>
                   ),
                 ],
               ),
+              child: widget.updatePending
+                  ? const Icon(
+                      Icons.arrow_upward,
+                      size: 9,
+                      color: AppColors.surface,
+                    )
+                  : null,
             ),
           );
         },

--- a/player/lib/presentation/widgets/nav/nav_badges.dart
+++ b/player/lib/presentation/widgets/nav/nav_badges.dart
@@ -1,9 +1,37 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/player/platform_features.dart';
+import '../../../core/update/platform_updater.dart';
+import '../../../core/update/update_provider.dart';
 import '../connection_status_dot.dart';
 import 'bottom_nav.dart';
 import 'sidebar_row.dart';
+
+/// The badge on the Settings nav item.
+///
+/// Carries two independent signals on one 14px mark: connection tone as
+/// colour, and a waiting update as an arrow glyph. It deliberately ignores
+/// the dismissal box, the compatibility verdict and offline mode, so
+/// dismissing the banner leaves this lit as the lingering reminder that makes
+/// per-version dismissal safe to offer.
+class SettingsBadge extends ConsumerWidget {
+  /// Overrides the platform-support check. Tests only, as in [UpdateBanner].
+  final bool? supportedOverride;
+
+  const SettingsBadge({super.key, this.supportedOverride});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final supported =
+        supportedOverride ?? PlatformUpdater.supportedOnCurrentPlatform;
+    final updatePending = supported &&
+        !PlatformFeatures.isMacOS &&
+        ref.watch(updateProvider).availableUpdate != null;
+
+    return ConnectionStatusDot(updatePending: updatePending);
+  }
+}
 
 /// Settings sidebar item with connection status badge.
 class SettingsSidebarRow extends ConsumerWidget {
@@ -35,7 +63,7 @@ class SettingsSidebarRow extends ConsumerWidget {
       isSelected: isSelected,
       isDisabled: isDisabled,
       onTap: onTap,
-      badge: const ConnectionStatusDot(),
+      badge: const SettingsBadge(),
       isEditing: isEditing,
       isHidden: isHidden,
       editingTrailing: editingTrailing,
@@ -65,7 +93,7 @@ class SettingsNavItem extends ConsumerWidget {
       isSelected: isSelected,
       isDisabled: isDisabled,
       onTap: onTap,
-      badge: const ConnectionStatusDot(),
+      badge: const SettingsBadge(),
     );
   }
 }

--- a/player/lib/presentation/widgets/offline_banner.dart
+++ b/player/lib/presentation/widgets/offline_banner.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/graphql/graphql_provider.dart';
 import '../../core/theme/colors.dart';
+import 'banner_button.dart';
 
 /// Banner displayed at the top of the screen when the app is in offline mode.
 ///
@@ -64,57 +65,15 @@ class _OfflineBannerState extends ConsumerState<OfflineBanner> {
               ),
             ),
             const SizedBox(width: 12),
-            _RetryButton(
+            BannerButton(
+              label: 'Retry',
+              color: AppColors.warning,
               isLoading: _isRetrying,
               onPressed: _retryConnection,
             ),
           ],
         ),
       ),
-    );
-  }
-}
-
-/// Retry connection button with loading state.
-class _RetryButton extends StatelessWidget {
-  final bool isLoading;
-  final VoidCallback onPressed;
-
-  const _RetryButton({
-    required this.isLoading,
-    required this.onPressed,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return TextButton(
-      onPressed: isLoading ? null : onPressed,
-      style: TextButton.styleFrom(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        minimumSize: Size.zero,
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-        backgroundColor: AppColors.warning.withValues(alpha: 0.2),
-        foregroundColor: AppColors.warning,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(6),
-        ),
-      ),
-      child: isLoading
-          ? const SizedBox(
-              width: 14,
-              height: 14,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: AppColors.warning,
-              ),
-            )
-          : const Text(
-              'Retry',
-              style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
     );
   }
 }

--- a/player/lib/presentation/widgets/update_action.dart
+++ b/player/lib/presentation/widgets/update_action.dart
@@ -1,0 +1,122 @@
+import 'dart:async' show unawaited;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show Clipboard, ClipboardData;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../core/update/install_environment.dart';
+import '../../core/update/update_provider.dart';
+import '../../domain/models/app_update.dart';
+
+/// The Flatpak application id, matching `player/flatpak/dev.mydia.player.yml`.
+const String flatpakAppId = 'dev.mydia.player';
+
+/// Opens a URL. Injectable so tests can observe the read-only branch without
+/// a url_launcher platform implementation.
+typedef UrlLauncher = Future<void> Function(Uri uri);
+
+/// Begins an update, however this install is able to take one.
+///
+/// The single implementation, called by `UpdateBanner`, `UpdateCard` and
+/// `CompatibilityBanner`. `CompatibilityBanner` used to route to Settings to
+/// avoid a second place that could get the GitHub-versus-app-store question
+/// wrong; one shared action answers that objection instead of working around
+/// it.
+Future<void> startUpdate(
+  BuildContext context,
+  WidgetRef ref, {
+  InstallEnvironment? environmentOverride,
+  UrlLauncher? launcher,
+}) async {
+  final update = ref.read(updateProvider).availableUpdate;
+  if (update == null) return;
+
+  final environment = environmentOverride ?? InstallEnvironment.detect();
+
+  switch (environment) {
+    case InstallEnvironment.flatpak:
+      await _showFlatpakDialog(context, update);
+
+    case InstallEnvironment.readOnly:
+      await _openReleasePage(update, launcher ?? _launch);
+
+    case InstallEnvironment.inPlace:
+      final confirmed = await _confirmInPlace(context, update);
+      // The dialog awaited a person, so the widget that started this can be
+      // gone by the time it returns.
+      if (!confirmed || !context.mounted) return;
+      unawaited(ref.read(updateProvider.notifier).applyUpdate());
+  }
+}
+
+Future<void> _launch(Uri uri) =>
+    launchUrl(uri, mode: LaunchMode.externalApplication);
+
+Future<void> _openReleasePage(AppUpdate update, UrlLauncher launcher) async {
+  final uri = Uri.tryParse(update.releaseNotesUrl);
+  if (uri == null) return;
+  await launcher(uri);
+}
+
+Future<bool> _confirmInPlace(BuildContext context, AppUpdate update) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: const Text('Update Mydia'),
+      content: Text(
+        'Mydia will close and update to v${update.version}. Continue?',
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(ctx).pop(false),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(true),
+          child: const Text('Update'),
+        ),
+      ],
+    ),
+  );
+  return confirmed ?? false;
+}
+
+Future<void> _showFlatpakDialog(BuildContext context, AppUpdate update) {
+  const command = 'flatpak update $flatpakAppId';
+
+  return showDialog<void>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text('Update to v${update.version}'),
+      content: const Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Mydia is installed as a Flatpak, so it updates through Flatpak '
+            'rather than replacing itself. Run:',
+          ),
+          SizedBox(height: 12),
+          SelectableText(
+            command,
+            style: TextStyle(fontFamily: 'monospace', fontSize: 13),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () async {
+            await Clipboard.setData(const ClipboardData(text: command));
+            if (ctx.mounted) Navigator.of(ctx).pop();
+          },
+          child: const Text('Copy command'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(ctx).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    ),
+  );
+}

--- a/player/lib/presentation/widgets/update_banner.dart
+++ b/player/lib/presentation/widgets/update_banner.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../core/auth/auth_status.dart';
+import '../../core/compatibility/compatibility_provider.dart';
+import '../../core/graphql/graphql_provider.dart';
+import '../../core/player/platform_features.dart';
+import '../../core/theme/colors.dart';
+import '../../core/update/platform_updater.dart';
+import '../../core/update/update_dismissal_provider.dart';
+import '../../core/update/update_provider.dart';
+import 'banner_button.dart';
+import 'update_action.dart';
+
+/// Whether the update banner has anything to say right now.
+///
+/// A pure function so every suppression rule is reachable without a widget
+/// tree, and so the shell can mount the banner unconditionally.
+@visibleForTesting
+bool shouldShowUpdateBanner({
+  required bool supported,
+  required bool isMacOS,
+  required String? availableVersion,
+  required Set<String>? dismissedVersions,
+  required bool compatibilityBannerShowing,
+  required bool isOffline,
+}) {
+  // iOS, Android and web update through a store or the Mydia server. macOS
+  // has Sparkle, which notifies natively and would double up.
+  if (!supported || isMacOS) return false;
+  if (availableVersion == null) return false;
+
+  // Null means the dismissal box has not resolved yet. Treating that as
+  // "nothing dismissed" would paint the banner on the first frame and yank it
+  // away a moment later.
+  if (dismissedVersions == null) return false;
+  if (dismissedVersions.contains(availableVersion)) return false;
+
+  // The compatibility banner names the server version that forced the issue,
+  // which is more use than "a new version exists".
+  if (compatibilityBannerShowing) return false;
+
+  // Nothing can be downloaded, and OfflineBanner already owns this slot.
+  if (isOffline) return false;
+
+  return true;
+}
+
+/// Announces an available player update at the top of the shell.
+///
+/// Renders nothing unless there is something actionable to say, so it sits
+/// unconditionally in the shell next to [OfflineBanner] and
+/// [CompatibilityBanner].
+///
+/// Mounting this is also what makes the update check run at all. `updateProvider`
+/// is a lazy NotifierProvider whose `build()` starts the GitHub query, and
+/// before this banner existed its only watchers were on the Settings screen.
+class UpdateBanner extends ConsumerWidget {
+  /// Overrides the platform-support check. Tests only: a `flutter test` host
+  /// on Linux always reports a supported platform, so the unsupported branch
+  /// is otherwise unreachable. Mirrors [UpdateCard.supportedOverride].
+  final bool? supportedOverride;
+
+  /// Opens the release notes. Tests only, so the Notes action can be observed
+  /// without a url_launcher platform implementation.
+  final UrlLauncher? launcher;
+
+  const UpdateBanner({super.key, this.supportedOverride, this.launcher});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final updateState = ref.watch(updateProvider);
+    final update = updateState.availableUpdate;
+
+    // `.value` and not `.valueOrNull`: riverpod 3.2.1 has no valueOrNull, and
+    // `.value` returns null on AsyncError rather than rethrowing.
+    final compatibility = ref.watch(compatibilityProvider).value;
+
+    final visible = shouldShowUpdateBanner(
+      supported:
+          supportedOverride ?? PlatformUpdater.supportedOnCurrentPlatform,
+      isMacOS: PlatformFeatures.isMacOS,
+      availableVersion: update?.version,
+      dismissedVersions: ref.watch(updateDismissalProvider).value,
+      compatibilityBannerShowing: compatibility != null &&
+          compatibility.showBanner &&
+          compatibility.verdict.isPlayerBehind,
+      isOffline: ref.watch(authStateProvider).value == AuthStatus.offlineMode,
+    );
+
+    // The null check is redundant with `visible`, and present so the compiler
+    // can promote `update` below.
+    if (!visible || update == null) return const SizedBox.shrink();
+
+    final failed = updateState.error != null;
+    final color = failed ? AppColors.error : AppColors.info;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        border: Border(
+          bottom: BorderSide(color: color.withValues(alpha: 0.3), width: 1),
+        ),
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Row(
+          children: [
+            Icon(Icons.system_update, size: 18, color: color),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                failed
+                    ? updateState.error!
+                    : 'Mydia Player ${update.version} is available.',
+                style: TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500,
+                  color: color,
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            BannerButton(
+              label: failed ? 'Retry' : 'Update',
+              color: color,
+              isLoading: updateState.isApplying,
+              onPressed: () => startUpdate(context, ref),
+            ),
+            const SizedBox(width: 8),
+            BannerButton(
+              label: 'Notes',
+              color: color,
+              onPressed: () => _openReleaseNotes(update.releaseNotesUrl),
+            ),
+            const SizedBox(width: 4),
+            IconButton(
+              icon: const Icon(Icons.close, size: 16),
+              color: color,
+              visualDensity: VisualDensity.compact,
+              tooltip: 'Dismiss',
+              onPressed: () => ref
+                  .read(updateDismissalProvider.notifier)
+                  .dismiss(update.version),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openReleaseNotes(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await (launcher ??
+        (Uri u) => launchUrl(u, mode: LaunchMode.externalApplication))(uri);
+  }
+}

--- a/player/lib/presentation/widgets/update_banner.dart
+++ b/player/lib/presentation/widgets/update_banner.dart
@@ -24,6 +24,7 @@ bool shouldShowUpdateBanner({
   required String? availableVersion,
   required Set<String>? dismissedVersions,
   required bool compatibilityBannerShowing,
+  required bool compatibilityUnresolved,
   required bool isOffline,
 }) {
   // iOS, Android and web update through a store or the Mydia server. macOS
@@ -40,6 +41,14 @@ bool shouldShowUpdateBanner({
   // The compatibility banner names the server version that forced the issue,
   // which is more use than "a new version exists".
   if (compatibilityBannerShowing) return false;
+
+  // The compatibility check has not resolved yet, so it is unknown whether it
+  // is about to claim this slot. Unknown is not the same as "nothing to
+  // say": showing here risks a flash that vanishes the instant the
+  // compatibility check lands as player-behind. A check that resolved to an
+  // error is not unresolved: it has nothing to say and must not suppress a
+  // real update forever.
+  if (compatibilityUnresolved) return false;
 
   // Nothing can be downloaded, and OfflineBanner already owns this slot.
   if (isOffline) return false;
@@ -75,7 +84,13 @@ class UpdateBanner extends ConsumerWidget {
 
     // `.value` and not `.valueOrNull`: riverpod 3.2.1 has no valueOrNull, and
     // `.value` returns null on AsyncError rather than rethrowing.
-    final compatibility = ref.watch(compatibilityProvider).value;
+    final compatibilityAsync = ref.watch(compatibilityProvider);
+    final compatibility = compatibilityAsync.value;
+    // Null means loading OR error. Only the loading case is "unknown"; a
+    // failed compatibility check must not suppress a real update
+    // notification.
+    final compatibilityUnresolved =
+        compatibility == null && !compatibilityAsync.hasError;
 
     final visible = shouldShowUpdateBanner(
       supported:
@@ -86,6 +101,7 @@ class UpdateBanner extends ConsumerWidget {
       compatibilityBannerShowing: compatibility != null &&
           compatibility.showBanner &&
           compatibility.verdict.isPlayerBehind,
+      compatibilityUnresolved: compatibilityUnresolved,
       isOffline: ref.watch(authStateProvider).value == AuthStatus.offlineMode,
     );
 

--- a/player/test/core/update/install_environment_test.dart
+++ b/player/test/core/update/install_environment_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/update/install_environment.dart';
+
+void main() {
+  group('InstallEnvironment.resolve', () {
+    test('a writable Linux install can be replaced in place', () {
+      expect(
+        InstallEnvironment.resolve(
+          isLinux: true,
+          flatpakId: null,
+          flatpakInfoExists: false,
+          installDirWritable: true,
+        ),
+        InstallEnvironment.inPlace,
+      );
+    });
+
+    test('FLATPAK_ID marks a Flatpak install', () {
+      expect(
+        InstallEnvironment.resolve(
+          isLinux: true,
+          flatpakId: 'dev.mydia.player',
+          flatpakInfoExists: false,
+          installDirWritable: false,
+        ),
+        InstallEnvironment.flatpak,
+      );
+    });
+
+    test('an empty FLATPAK_ID is not a Flatpak install', () {
+      // An exported-but-empty variable is indistinguishable from unset for
+      // our purposes, and treating it as Flatpak would tell a normal user to
+      // run a flatpak command they have no use for.
+      expect(
+        InstallEnvironment.resolve(
+          isLinux: true,
+          flatpakId: '',
+          flatpakInfoExists: false,
+          installDirWritable: true,
+        ),
+        InstallEnvironment.inPlace,
+      );
+    });
+
+    test('/.flatpak-info marks a Flatpak install without the variable', () {
+      expect(
+        InstallEnvironment.resolve(
+          isLinux: true,
+          flatpakId: null,
+          flatpakInfoExists: true,
+          installDirWritable: false,
+        ),
+        InstallEnvironment.flatpak,
+      );
+    });
+
+    test('Flatpak wins over a writable install directory', () {
+      // The answer for a Flatpak install is `flatpak update`, whether or not
+      // some future runtime happens to leave /app writable.
+      expect(
+        InstallEnvironment.resolve(
+          isLinux: true,
+          flatpakId: 'dev.mydia.player',
+          flatpakInfoExists: true,
+          installDirWritable: true,
+        ),
+        InstallEnvironment.flatpak,
+      );
+    });
+
+    test('a non-writable Linux install is read-only', () {
+      expect(
+        InstallEnvironment.resolve(
+          isLinux: true,
+          flatpakId: null,
+          flatpakInfoExists: false,
+          installDirWritable: false,
+        ),
+        InstallEnvironment.readOnly,
+      );
+    });
+
+    test('a non-Linux install is always in place', () {
+      // Windows installs per-user into %LOCALAPPDATA% and runs its own
+      // installer, so WindowsUpdater.canUpdateInPlace has always been true.
+      // Consulting writability there would newly refuse updates that work.
+      expect(
+        InstallEnvironment.resolve(
+          isLinux: false,
+          flatpakId: null,
+          flatpakInfoExists: false,
+          installDirWritable: false,
+        ),
+        InstallEnvironment.inPlace,
+      );
+    });
+  });
+
+  group('InstallEnvironment.detect', () {
+    test('agrees with resolve on the platform under test', () {
+      // Guards the wiring between the lookups and the decision. Only the
+      // running platform's answer is observable, which is why the decision
+      // itself is tested purely above.
+      expect(
+        InstallEnvironment.detect(),
+        isIn(InstallEnvironment.values),
+      );
+    });
+  });
+}

--- a/player/test/core/update/linux_updater_test.dart
+++ b/player/test/core/update/linux_updater_test.dart
@@ -1,0 +1,53 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/update/install_environment.dart';
+import 'package:player/core/update/updaters/linux_updater.dart';
+import 'package:player/domain/models/app_update.dart';
+
+AppUpdate _update() => AppUpdate(
+      version: '0.15.0',
+      // .invalid is reserved and never resolves, so any attempt to download
+      // fails loudly rather than reaching the network.
+      downloadUrl: 'https://example.invalid/player-linux-v0.15.0.tar.gz',
+      releaseNotesUrl: 'https://example.invalid/releases/0.15.0',
+      releaseTitle: 'Faster library scans',
+      publishedAt: DateTime.utc(2026, 8, 1),
+    );
+
+void main() {
+  test('a Flatpak install cannot be updated in place', () {
+    expect(
+      LinuxUpdater(environment: InstallEnvironment.flatpak).canUpdateInPlace,
+      isFalse,
+    );
+  });
+
+  test('a writable install can be updated in place', () {
+    expect(
+      LinuxUpdater(environment: InstallEnvironment.inPlace).canUpdateInPlace,
+      isTrue,
+    );
+  });
+
+  test('a Flatpak install throws before downloading anything', () async {
+    // The distinction that matters is StateError versus DioException. The old
+    // code downloaded and extracted the whole archive before discovering it
+    // could not write the install directory; if that order ever returns, the
+    // unreachable .invalid host makes this fail as a DioException instead.
+    await expectLater(
+      LinuxUpdater(environment: InstallEnvironment.flatpak)
+          .applyUpdate(_update()),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('a read-only install throws before downloading anything', () async {
+    await expectLater(
+      LinuxUpdater(environment: InstallEnvironment.readOnly)
+          .applyUpdate(_update()),
+      throwsA(
+        allOf(isA<StateError>(), isNot(isA<DioException>())),
+      ),
+    );
+  });
+}

--- a/player/test/core/update/update_dismissal_provider_test.dart
+++ b/player/test/core/update/update_dismissal_provider_test.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:player/core/update/update_dismissal_provider.dart';
+
+var _boxCounter = 0;
+
+/// A fresh in-memory Hive box, one per call.
+///
+/// `bytes:` keeps the box in memory; a disk-backed box hangs the suite for
+/// about ten minutes. The name must be unique per call, because
+/// `Hive.openBox` hands back the already-open instance for a repeated name,
+/// which would leak dismissal keys between tests.
+Future<Box<bool>> memoryBox() =>
+    Hive.openBox<bool>('update-dismissal-test-${_boxCounter++}',
+        bytes: Uint8List(0));
+
+ProviderContainer harness(Box<bool> box) {
+  final container = ProviderContainer(
+    overrides: [
+      updateDismissalBoxProvider.overrideWith((ref) async => box),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  setUpAll(() {
+    Hive.init('./.dart_tool/update_dismissal_test');
+  });
+
+  test('an empty box dismisses nothing', () async {
+    final container = harness(await memoryBox());
+
+    expect(await container.read(updateDismissalProvider.future), isEmpty);
+  });
+
+  test('dismissing a version records it', () async {
+    final box = await memoryBox();
+    final container = harness(box);
+    await container.read(updateDismissalProvider.future);
+
+    await container.read(updateDismissalProvider.notifier).dismiss('0.15.0');
+
+    expect(container.read(updateDismissalProvider).value, {'0.15.0'});
+    expect(box.get('0.15.0'), isTrue);
+  });
+
+  test('a dismissal from a previous session is read back', () async {
+    final box = await memoryBox();
+    await box.put('0.15.0', true);
+    final container = harness(box);
+
+    expect(await container.read(updateDismissalProvider.future), {'0.15.0'});
+  });
+
+  test('a later version is not covered by an earlier dismissal', () async {
+    // This is the whole reason the key is the version rather than a flag:
+    // waving off 0.15.0 must not silence 0.16.0.
+    final box = await memoryBox();
+    await box.put('0.15.0', true);
+    final container = harness(box);
+
+    final dismissed = await container.read(updateDismissalProvider.future);
+
+    expect(dismissed.contains('0.15.0'), isTrue);
+    expect(dismissed.contains('0.16.0'), isFalse);
+  });
+
+  test('a key explicitly set false is not a dismissal', () async {
+    final box = await memoryBox();
+    await box.put('0.15.0', false);
+    final container = harness(box);
+
+    expect(await container.read(updateDismissalProvider.future), isEmpty);
+  });
+
+  test('a box that will not open dismisses nothing rather than everything',
+      () async {
+    // Fails open on purpose. A broken box must not silence a real update,
+    // and the alternative failure mode is invisible: the user simply never
+    // hears about an update again.
+    final container = ProviderContainer(
+      overrides: [
+        updateDismissalBoxProvider
+            .overrideWith((ref) async => throw StateError('box unavailable')),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(await container.read(updateDismissalProvider.future), isEmpty);
+  });
+}

--- a/player/test/presentation/widgets/banner_button_test.dart
+++ b/player/test/presentation/widgets/banner_button_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/theme/colors.dart';
+import 'package:player/presentation/widgets/banner_button.dart';
+
+Future<void> _pump(
+  WidgetTester tester, {
+  bool isLoading = false,
+  VoidCallback? onPressed,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: BannerButton(
+          label: 'Update',
+          color: AppColors.info,
+          isLoading: isLoading,
+          onPressed: onPressed ?? () {},
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows its label and calls back when tapped', (tester) async {
+    var taps = 0;
+    await _pump(tester, onPressed: () => taps++);
+
+    expect(find.text('Update'), findsOneWidget);
+    await tester.tap(find.byType(BannerButton));
+    expect(taps, 1);
+  });
+
+  testWidgets('while loading it spins instead of labelling, and is inert',
+      (tester) async {
+    var taps = 0;
+    await _pump(tester, isLoading: true, onPressed: () => taps++);
+
+    expect(find.text('Update'), findsNothing);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    await tester.tap(find.byType(BannerButton));
+    expect(taps, 0);
+  });
+}

--- a/player/test/presentation/widgets/compatibility_banner_test.dart
+++ b/player/test/presentation/widgets/compatibility_banner_test.dart
@@ -1,20 +1,72 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:player/core/compatibility/compatibility_provider.dart';
 import 'package:player/core/compatibility/compatibility_verdict.dart';
+import 'package:player/core/update/install_environment.dart';
+import 'package:player/core/update/update_provider.dart';
+import 'package:player/domain/models/app_update.dart';
 import 'package:player/presentation/widgets/compatibility_banner.dart';
 
 /// Pumps the banner over a fixed state, bypassing the provider's own fetch.
-Future<void> pumpBanner(WidgetTester tester, CompatibilityState state) async {
+Future<void> pumpBanner(
+  WidgetTester tester,
+  CompatibilityState state, {
+  UpdateState updateState = const UpdateState(),
+  InstallEnvironment? environmentOverride,
+}) async {
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
         compatibilityProvider.overrideWith(() => _FixedNotifier(state)),
+        updateProvider.overrideWith(() => _FakeUpdateNotifier(updateState)),
       ],
-      child: const MaterialApp(
-        home: Scaffold(body: CompatibilityBanner()),
+      // No longer const: CompatibilityBanner now takes a runtime argument.
+      child: MaterialApp(
+        home: Scaffold(
+          body: CompatibilityBanner(environmentOverride: environmentOverride),
+        ),
       ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// Pumps the banner inside a real router, for the branch that navigates.
+///
+/// `context.go` needs a GoRouter in the tree. Asserting only that the confirm
+/// dialog is absent would pass even if the button did nothing, so the
+/// navigation has to land somewhere observable.
+Future<void> pumpRoutedBanner(
+  WidgetTester tester,
+  CompatibilityState state, {
+  UpdateState updateState = const UpdateState(),
+}) async {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, stateArg) =>
+            const Scaffold(body: CompatibilityBanner()),
+      ),
+      GoRoute(
+        path: '/settings',
+        builder: (context, stateArg) =>
+            const Scaffold(body: Text('settings-screen')),
+      ),
+    ],
+  );
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        compatibilityProvider.overrideWith(() => _FixedNotifier(state)),
+        updateProvider.overrideWith(() => _FakeUpdateNotifier(updateState)),
+      ],
+      child: MaterialApp.router(routerConfig: router),
     ),
   );
   await tester.pump();
@@ -26,6 +78,18 @@ class _FixedNotifier extends CompatibilityNotifier {
 
   @override
   Future<CompatibilityState> build() async => _state;
+}
+
+class _FakeUpdateNotifier extends UpdateNotifier {
+  _FakeUpdateNotifier(this._state);
+  final UpdateState _state;
+  int applyCount = 0;
+
+  @override
+  UpdateState build() => _state;
+
+  @override
+  Future<void> applyUpdate() async => applyCount++;
 }
 
 void main() {
@@ -168,5 +232,62 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Version mismatch'), findsOneWidget);
+  });
+
+  testWidgets(
+      'with an update in hand, Update starts it rather than '
+      'navigating to Settings', (tester) async {
+    await pumpBanner(
+      tester,
+      const CompatibilityState(
+        verdict: CompatibilityVerdict.playerUpdateRequired,
+        playerVersion: '0.8.0',
+        serverVersion: '0.9.0',
+        requiredVersion: '0.9.0',
+      ),
+      updateState: UpdateState(
+        currentVersion: '0.8.0',
+        availableUpdate: AppUpdate(
+          version: '0.9.0',
+          downloadUrl: 'https://example.invalid/player-linux-v0.9.0.tar.gz',
+          releaseNotesUrl: 'https://example.invalid/releases/0.9.0',
+          releaseTitle: 'Faster library scans',
+          publishedAt: DateTime.utc(2026, 8, 1),
+        ),
+      ),
+      environmentOverride: InstallEnvironment.inPlace,
+    );
+
+    await tester.tap(find.text('Update'));
+    await tester.pumpAndSettle();
+
+    // startUpdate's in-place branch confirms first. Reaching the dialog is
+    // what proves the button no longer just navigates.
+    expect(find.textContaining('Mydia will close and update'), findsOneWidget);
+  });
+
+  testWidgets('with no update in hand, Update still routes to Settings',
+      (tester) async {
+    // Covers macOS, where Sparkle owns checking and availableUpdate stays
+    // null, and the window before the first check lands.
+    //
+    // This needs a real router. Asserting only that the confirm dialog is
+    // absent would pass even if the button did nothing at all, so the test
+    // has to observe the navigation actually landing somewhere.
+    await pumpRoutedBanner(
+      tester,
+      const CompatibilityState(
+        verdict: CompatibilityVerdict.playerUpdateRequired,
+        playerVersion: '0.8.0',
+        serverVersion: '0.9.0',
+        requiredVersion: '0.9.0',
+      ),
+    );
+
+    await tester.tap(find.text('Update'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('settings-screen'), findsOneWidget);
+    expect(find.textContaining('Mydia will close and update'), findsNothing);
   });
 }

--- a/player/test/presentation/widgets/nav/settings_badge_test.dart
+++ b/player/test/presentation/widgets/nav/settings_badge_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart' hide ConnectionState;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/connection/connection_provider.dart';
+import 'package:player/core/p2p/p2p_service.dart';
+import 'package:player/core/theme/colors.dart';
+import 'package:player/core/update/update_provider.dart';
+import 'package:player/domain/models/app_update.dart';
+import 'package:player/presentation/widgets/nav/nav_badges.dart';
+
+class _FakeConnectionNotifier extends ConnectionNotifier {
+  _FakeConnectionNotifier(this._state);
+  final ConnectionState _state;
+
+  @override
+  ConnectionState build() => _state;
+}
+
+class _FakeP2pStatusNotifier extends P2pStatusNotifier {
+  _FakeP2pStatusNotifier(this._status);
+  final P2pStatus _status;
+
+  @override
+  P2pStatus build() => _status;
+}
+
+class _FakeUpdateNotifier extends UpdateNotifier {
+  _FakeUpdateNotifier(this._state);
+  final UpdateState _state;
+
+  @override
+  UpdateState build() => _state;
+
+  @override
+  Future<void> applyUpdate() async {}
+}
+
+const _idle = P2pStatus(
+  isInitialized: true,
+  isRelayConnected: false,
+  connectedPeersCount: 0,
+);
+
+AppUpdate _update() => AppUpdate(
+      version: '0.15.0',
+      downloadUrl: 'https://example.invalid/player-linux-v0.15.0.tar.gz',
+      releaseNotesUrl: 'https://example.invalid/releases/0.15.0',
+      releaseTitle: 'Faster library scans',
+      publishedAt: DateTime.utc(2026, 8, 1),
+    );
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required UpdateState update,
+  ConnectionType connection = ConnectionType.direct,
+  P2pStatus status = _idle,
+  bool supported = true,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        connectionProvider.overrideWith(
+          () => _FakeConnectionNotifier(ConnectionState(type: connection)),
+        ),
+        p2pStatusNotifierProvider
+            .overrideWith(() => _FakeP2pStatusNotifier(status)),
+        updateProvider.overrideWith(() => _FakeUpdateNotifier(update)),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Center(child: SettingsBadge(supportedOverride: supported)),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// The circle itself.
+///
+/// `find.byType(Container)` alone can match more than the dot once Tooltip
+/// wraps it, so match on the one Container carrying a circular BoxDecoration.
+Container _dotOf(WidgetTester tester) => tester.widget<Container>(
+      find.descendant(
+        of: find.byType(SettingsBadge),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is Container &&
+              widget.decoration is BoxDecoration &&
+              (widget.decoration! as BoxDecoration).shape == BoxShape.circle,
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('with no update it is a plain 10px dot', (tester) async {
+    await _pump(tester, update: const UpdateState(currentVersion: '0.14.2'));
+
+    expect(find.byIcon(Icons.arrow_upward), findsNothing);
+    expect(_dotOf(tester).constraints?.maxWidth, 10);
+  });
+
+  testWidgets('a pending update changes the shape, not the colour',
+      (tester) async {
+    await _pump(
+      tester,
+      update: UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+      connection: ConnectionType.p2p,
+      status: _idle.copyWith(peerConnectionType: P2pConnectionType.relay),
+    );
+
+    // Shape says "update", colour still says "relayed". Two signals, two
+    // channels, one mark.
+    expect(find.byIcon(Icons.arrow_upward), findsOneWidget);
+    final decoration = _dotOf(tester).decoration! as BoxDecoration;
+    expect(decoration.color, AppColors.warning);
+  });
+
+  testWidgets('the tooltip carries both facts', (tester) async {
+    await _pump(
+      tester,
+      update: UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+    );
+
+    expect(
+      find.byTooltip('Update available - Connected to server'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a platform that cannot self-update shows a plain dot',
+      (tester) async {
+    await _pump(
+      tester,
+      update: UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+      supported: false,
+    );
+
+    expect(find.byIcon(Icons.arrow_upward), findsNothing);
+    expect(find.byTooltip('Connected to server'), findsOneWidget);
+  });
+}

--- a/player/test/presentation/widgets/update_action_test.dart
+++ b/player/test/presentation/widgets/update_action_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/update/install_environment.dart';
+import 'package:player/core/update/update_provider.dart';
+import 'package:player/domain/models/app_update.dart';
+import 'package:player/presentation/widgets/update_action.dart';
+
+class _FakeUpdateNotifier extends UpdateNotifier {
+  _FakeUpdateNotifier(this._state);
+
+  final UpdateState _state;
+  int applyCount = 0;
+
+  @override
+  UpdateState build() => _state;
+
+  // UpdateNotifier.applyUpdate reaches for `_platformUpdater`, a `late final`
+  // that only `build()` assigns. Overriding `build` without overriding this
+  // too throws LateInitializationError the moment the dialog is confirmed.
+  @override
+  Future<void> applyUpdate() async => applyCount++;
+}
+
+AppUpdate _update() => AppUpdate(
+      version: '0.15.0',
+      downloadUrl: 'https://example.invalid/player-linux-v0.15.0.tar.gz',
+      releaseNotesUrl: 'https://example.invalid/releases/0.15.0',
+      releaseTitle: 'Faster library scans',
+      publishedAt: DateTime.utc(2026, 8, 1),
+    );
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required _FakeUpdateNotifier notifier,
+  required InstallEnvironment environment,
+  required List<Uri> launched,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [updateProvider.overrideWith(() => notifier)],
+      child: MaterialApp(
+        home: Scaffold(
+          body: Consumer(
+            builder: (context, ref, _) => TextButton(
+              onPressed: () => startUpdate(
+                context,
+                ref,
+                environmentOverride: environment,
+                launcher: (uri) async => launched.add(uri),
+              ),
+              child: const Text('go'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('an in-place install asks before closing the app',
+      (tester) async {
+    final notifier = _FakeUpdateNotifier(
+      UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+    );
+    final launched = <Uri>[];
+
+    await _pump(
+      tester,
+      notifier: notifier,
+      environment: InstallEnvironment.inPlace,
+      launched: launched,
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Mydia will close and update'), findsOneWidget);
+    expect(find.textContaining('0.15.0'), findsOneWidget);
+    expect(notifier.applyCount, 0);
+    expect(launched, isEmpty);
+  });
+
+  testWidgets('confirming an in-place update applies it', (tester) async {
+    final notifier = _FakeUpdateNotifier(
+      UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+    );
+
+    await _pump(
+      tester,
+      notifier: notifier,
+      environment: InstallEnvironment.inPlace,
+      launched: <Uri>[],
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'Update'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.applyCount, 1);
+  });
+
+  testWidgets('cancelling an in-place update applies nothing', (tester) async {
+    final notifier = _FakeUpdateNotifier(
+      UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+    );
+
+    await _pump(
+      tester,
+      notifier: notifier,
+      environment: InstallEnvironment.inPlace,
+      launched: <Uri>[],
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(notifier.applyCount, 0);
+  });
+
+  testWidgets('a Flatpak install names the command and downloads nothing',
+      (tester) async {
+    final notifier = _FakeUpdateNotifier(
+      UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+    );
+    final launched = <Uri>[];
+
+    await _pump(
+      tester,
+      notifier: notifier,
+      environment: InstallEnvironment.flatpak,
+      launched: launched,
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('flatpak update dev.mydia.player'), findsOneWidget);
+    expect(find.text('Copy command'), findsOneWidget);
+    // The whole point of the branch: no download, no browser tab.
+    expect(notifier.applyCount, 0);
+    expect(launched, isEmpty);
+  });
+
+  testWidgets(
+      'a read-only install opens the release page and downloads nothing',
+      (tester) async {
+    final notifier = _FakeUpdateNotifier(
+      UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+    );
+    final launched = <Uri>[];
+
+    await _pump(
+      tester,
+      notifier: notifier,
+      environment: InstallEnvironment.readOnly,
+      launched: launched,
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+
+    expect(launched, [Uri.parse('https://example.invalid/releases/0.15.0')]);
+    expect(notifier.applyCount, 0);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('with no update available nothing happens at all',
+      (tester) async {
+    final notifier = _FakeUpdateNotifier(
+      const UpdateState(currentVersion: '0.14.2'),
+    );
+    final launched = <Uri>[];
+
+    await _pump(
+      tester,
+      notifier: notifier,
+      environment: InstallEnvironment.inPlace,
+      launched: launched,
+    );
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(notifier.applyCount, 0);
+    expect(launched, isEmpty);
+  });
+}

--- a/player/test/presentation/widgets/update_banner_test.dart
+++ b/player/test/presentation/widgets/update_banner_test.dart
@@ -1,0 +1,322 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/auth/auth_status.dart';
+import 'package:player/core/compatibility/compatibility_provider.dart';
+import 'package:player/core/compatibility/compatibility_verdict.dart';
+import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/update/update_dismissal_provider.dart';
+import 'package:player/core/update/update_provider.dart';
+import 'package:player/domain/models/app_update.dart';
+import 'package:player/presentation/widgets/update_banner.dart';
+
+class _FakeUpdateNotifier extends UpdateNotifier {
+  _FakeUpdateNotifier(this._state);
+  final UpdateState _state;
+
+  @override
+  UpdateState build() => _state;
+
+  @override
+  Future<void> applyUpdate() async {}
+}
+
+class _FakeDismissalNotifier extends UpdateDismissalNotifier {
+  _FakeDismissalNotifier(this._dismissed);
+  final Set<String> _dismissed;
+  final dismissedCalls = <String>[];
+
+  @override
+  Future<Set<String>> build() async => _dismissed;
+
+  @override
+  Future<void> dismiss(String version) async => dismissedCalls.add(version);
+}
+
+class _FakeCompatibilityNotifier extends CompatibilityNotifier {
+  _FakeCompatibilityNotifier(this._state);
+  final CompatibilityState _state;
+
+  @override
+  Future<CompatibilityState> build() async => _state;
+}
+
+class _FakeAuthNotifier extends AuthStateNotifier {
+  _FakeAuthNotifier(this._status);
+  final AuthStatus _status;
+
+  @override
+  AsyncValue<AuthStatus> build() => AsyncValue.data(_status);
+}
+
+AppUpdate _update({String version = '0.15.0'}) => AppUpdate(
+      version: version,
+      downloadUrl: 'https://example.invalid/player-linux-v$version.tar.gz',
+      releaseNotesUrl: 'https://example.invalid/releases/$version',
+      releaseTitle: 'Faster library scans',
+      publishedAt: DateTime.utc(2026, 8, 1),
+    );
+
+const _compatible = CompatibilityState(
+  verdict: CompatibilityVerdict.compatible,
+  playerVersion: '0.14.2',
+  serverVersion: '0.14.2',
+);
+
+Future<_FakeDismissalNotifier> _pump(
+  WidgetTester tester, {
+  required UpdateState state,
+  Set<String> dismissed = const <String>{},
+  CompatibilityState compatibility = _compatible,
+  AuthStatus auth = AuthStatus.authenticated,
+  bool supported = true,
+  List<Uri>? launched,
+}) async {
+  final dismissal = _FakeDismissalNotifier(dismissed);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        updateProvider.overrideWith(() => _FakeUpdateNotifier(state)),
+        updateDismissalProvider.overrideWith(() => dismissal),
+        compatibilityProvider
+            .overrideWith(() => _FakeCompatibilityNotifier(compatibility)),
+        authStateProvider.overrideWith(() => _FakeAuthNotifier(auth)),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: UpdateBanner(
+            supportedOverride: supported,
+            launcher: (uri) async => launched?.add(uri),
+          ),
+        ),
+      ),
+    ),
+  );
+  // The dismissal and compatibility notifiers build asynchronously, so the
+  // first frame has neither. `pumpAndSettle` cannot be used here: a
+  // BannerButton spinner (isApplying: true) renders an indeterminate
+  // CircularProgressIndicator, whose AnimationController.repeat() never stops
+  // scheduling frames, so pumpAndSettle would spin until it times out. Two
+  // plain pumps are enough to flush both providers' already-resolved futures.
+  await tester.pump();
+  await tester.pump();
+  return dismissal;
+}
+
+void main() {
+  group('shouldShowUpdateBanner', () {
+    bool show({
+      bool supported = true,
+      bool isMacOS = false,
+      String? availableVersion = '0.15.0',
+      Set<String>? dismissedVersions = const <String>{},
+      bool compatibilityBannerShowing = false,
+      bool isOffline = false,
+    }) =>
+        shouldShowUpdateBanner(
+          supported: supported,
+          isMacOS: isMacOS,
+          availableVersion: availableVersion,
+          dismissedVersions: dismissedVersions,
+          compatibilityBannerShowing: compatibilityBannerShowing,
+          isOffline: isOffline,
+        );
+
+    test('an available update on a supported desktop shows', () {
+      expect(show(), isTrue);
+    });
+
+    test('a platform without an in-app updater shows nothing', () {
+      expect(show(supported: false), isFalse);
+    });
+
+    test('macOS shows nothing, because Sparkle notifies natively', () {
+      expect(show(isMacOS: true), isFalse);
+    });
+
+    test('no available update shows nothing', () {
+      expect(show(availableVersion: null), isFalse);
+    });
+
+    test('a dismissed version shows nothing', () {
+      expect(show(dismissedVersions: {'0.15.0'}), isFalse);
+    });
+
+    test('a dismissal of another version does not suppress this one', () {
+      expect(show(dismissedVersions: {'0.14.0'}), isTrue);
+    });
+
+    test('unloaded dismissals show nothing yet', () {
+      // Defaulting to "nothing dismissed" would paint the banner on the first
+      // frame and yank it away once the box resolved.
+      expect(show(dismissedVersions: null), isFalse);
+    });
+
+    test('a compatibility banner already saying this wins', () {
+      expect(show(compatibilityBannerShowing: true), isFalse);
+    });
+
+    test('offline shows nothing, since nothing can be downloaded', () {
+      expect(show(isOffline: true), isFalse);
+    });
+  });
+
+  group('UpdateBanner', () {
+    testWidgets('announces an available update', (tester) async {
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+      );
+
+      expect(find.textContaining('0.15.0'), findsOneWidget);
+      expect(find.text('Update'), findsOneWidget);
+      expect(find.text('Notes'), findsOneWidget);
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('renders nothing with no update available', (tester) async {
+      await _pump(tester, state: const UpdateState(currentVersion: '0.14.2'));
+
+      expect(find.byType(Text), findsNothing);
+      expect(find.byType(Container), findsNothing);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('renders nothing for a dismissed version', (tester) async {
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        dismissed: {'0.15.0'},
+      );
+
+      expect(find.byType(Text), findsNothing);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets(
+        'renders nothing while a player-behind compatibility banner shows',
+        (tester) async {
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        compatibility: const CompatibilityState(
+          verdict: CompatibilityVerdict.playerUpdateRequired,
+          playerVersion: '0.14.2',
+          serverVersion: '0.15.0',
+          requiredVersion: '0.15.0',
+        ),
+      );
+
+      expect(find.byType(Text), findsNothing);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('shows when a player-behind nudge was already dismissed',
+        (tester) async {
+      // CompatibilityState.showBanner folds in its own dismissal box. Gating
+      // on the verdict alone would leave this user with no banner at all.
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        compatibility: const CompatibilityState(
+          verdict: CompatibilityVerdict.playerUpdateRecommended,
+          playerVersion: '0.14.2',
+          serverVersion: '0.15.0',
+          requiredVersion: '0.15.0',
+          dismissed: true,
+        ),
+      );
+
+      expect(find.textContaining('0.15.0'), findsOneWidget);
+    });
+
+    testWidgets('renders nothing in offline mode', (tester) async {
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        auth: AuthStatus.offlineMode,
+      );
+
+      expect(find.byType(Text), findsNothing);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('renders nothing on a platform that cannot self-update',
+        (tester) async {
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        supported: false,
+      );
+
+      expect(find.byType(Text), findsNothing);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('dismissing records the version', (tester) async {
+      final dismissal = await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+      );
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(dismissal.dismissedCalls, ['0.15.0']);
+    });
+
+    testWidgets('Notes opens the release page', (tester) async {
+      final launched = <Uri>[];
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        launched: launched,
+      );
+
+      await tester.tap(find.text('Notes'));
+      await tester.pumpAndSettle();
+
+      expect(launched, [Uri.parse('https://example.invalid/releases/0.15.0')]);
+    });
+
+    testWidgets('a failed apply offers a retry with the error', (tester) async {
+      await _pump(
+        tester,
+        state: UpdateState(
+          currentVersion: '0.14.2',
+          availableUpdate: _update(),
+          error: 'Update failed: connection closed',
+        ),
+      );
+
+      expect(find.textContaining('connection closed'), findsOneWidget);
+      expect(find.text('Retry'), findsOneWidget);
+      expect(find.text('Update'), findsNothing);
+    });
+
+    testWidgets('while applying the action spins instead of inviting a retap',
+        (tester) async {
+      await _pump(
+        tester,
+        state: UpdateState(
+          currentVersion: '0.14.2',
+          availableUpdate: _update(),
+          isApplying: true,
+          downloadProgress: 0.4,
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Update'), findsNothing);
+    });
+  });
+}

--- a/player/test/presentation/widgets/update_banner_test.dart
+++ b/player/test/presentation/widgets/update_banner_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -41,6 +43,23 @@ class _FakeCompatibilityNotifier extends CompatibilityNotifier {
   Future<CompatibilityState> build() async => _state;
 }
 
+/// Never resolves, so `compatibilityProvider` stays in its loading state for
+/// the life of the test.
+class _UnresolvedCompatibilityNotifier extends CompatibilityNotifier {
+  @override
+  Future<CompatibilityState> build() => Completer<CompatibilityState>().future;
+}
+
+/// Resolves to an `AsyncError`, the way a broken `PackageInfo` read or an
+/// unexpected exception outside `CompatibilityService.fetch()`'s own
+/// try/catch would.
+class _ErrorCompatibilityNotifier extends CompatibilityNotifier {
+  @override
+  Future<CompatibilityState> build() async {
+    throw Exception('compatibility check failed');
+  }
+}
+
 class _FakeAuthNotifier extends AuthStateNotifier {
   _FakeAuthNotifier(this._status);
   final AuthStatus _status;
@@ -68,6 +87,7 @@ Future<_FakeDismissalNotifier> _pump(
   required UpdateState state,
   Set<String> dismissed = const <String>{},
   CompatibilityState compatibility = _compatible,
+  CompatibilityNotifier Function()? compatibilityOverride,
   AuthStatus auth = AuthStatus.authenticated,
   bool supported = true,
   List<Uri>? launched,
@@ -79,8 +99,10 @@ Future<_FakeDismissalNotifier> _pump(
       overrides: [
         updateProvider.overrideWith(() => _FakeUpdateNotifier(state)),
         updateDismissalProvider.overrideWith(() => dismissal),
-        compatibilityProvider
-            .overrideWith(() => _FakeCompatibilityNotifier(compatibility)),
+        compatibilityProvider.overrideWith(
+          compatibilityOverride ??
+              () => _FakeCompatibilityNotifier(compatibility),
+        ),
         authStateProvider.overrideWith(() => _FakeAuthNotifier(auth)),
       ],
       child: MaterialApp(
@@ -112,6 +134,7 @@ void main() {
       String? availableVersion = '0.15.0',
       Set<String>? dismissedVersions = const <String>{},
       bool compatibilityBannerShowing = false,
+      bool compatibilityUnresolved = false,
       bool isOffline = false,
     }) =>
         shouldShowUpdateBanner(
@@ -120,6 +143,7 @@ void main() {
           availableVersion: availableVersion,
           dismissedVersions: dismissedVersions,
           compatibilityBannerShowing: compatibilityBannerShowing,
+          compatibilityUnresolved: compatibilityUnresolved,
           isOffline: isOffline,
         );
 
@@ -155,6 +179,18 @@ void main() {
 
     test('a compatibility banner already saying this wins', () {
       expect(show(compatibilityBannerShowing: true), isFalse);
+    });
+
+    test('an unresolved compatibility check hides the banner', () {
+      // Unknown is not the same as "nothing to say": showing here would risk
+      // a flash that vanishes the moment the compatibility check lands.
+      expect(show(compatibilityUnresolved: true), isFalse);
+    });
+
+    test('a resolved compatibility check with nothing to say still shows', () {
+      // Guards against inverting the flag: false must not itself suppress
+      // the banner.
+      expect(show(compatibilityUnresolved: false), isTrue);
     });
 
     test('offline shows nothing, since nothing can be downloaded', () {
@@ -213,6 +249,37 @@ void main() {
 
       expect(find.byType(Text), findsNothing);
       expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets(
+        'renders nothing while the compatibility check is still loading',
+        (tester) async {
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        compatibilityOverride: () => _UnresolvedCompatibilityNotifier(),
+      );
+
+      expect(find.byType(Text), findsNothing);
+      expect(find.byType(Icon), findsNothing);
+    });
+
+    testWidgets('shows the update when the compatibility check itself fails',
+        (tester) async {
+      // Regression guard: treating a null compatibility value as "hide"
+      // regardless of why would silently kill the update banner every time
+      // the server is unreachable, which is a normal condition for a
+      // self-hosted app and precisely when a user wants to know about
+      // updates.
+      await _pump(
+        tester,
+        state:
+            UpdateState(currentVersion: '0.14.2', availableUpdate: _update()),
+        compatibilityOverride: () => _ErrorCompatibilityNotifier(),
+      );
+
+      expect(find.textContaining('0.15.0'), findsOneWidget);
     });
 
     testWidgets('shows when a player-behind nudge was already dismissed',


### PR DESCRIPTION
## Why

The player already had a complete update subsystem: a GitHub Releases check, version comparison, and per-platform updaters for Linux, Windows and macOS. Its only surface was a card on the Settings screen.

That understates the problem. `updateProvider` is a lazy Riverpod `NotifierProvider` whose `build()` starts the update check, and its only watchers were on the Settings screen. So for anyone who never opened Settings, the check had never run at all. The card was not merely hard to find; there was nothing in it to find.

## What this does

- **A shell banner** (`UpdateBanner`) beside the existing offline and compatibility banners, at both the desktop and mobile mount points. Mounting it is also what makes the background check run for everyone.
- **A Settings nav badge.** The badge slot already held `ConnectionStatusDot`, so the two signals now share one mark on orthogonal channels: colour keeps carrying connection tone, shape carries update state (a 10px dot normally, a 14px circle with an arrow glyph when an update waits).
- **Per-version dismissal.** Dismissing 0.15.0 hides the banner until 0.16.0 ships, with no expiry logic. The nav badge stays lit, so the reminder never fully disappears.
- **One update entry point.** `startUpdate` is now the single implementation, called by the banner, the Settings card, and the compatibility banner. The last of those previously routed to Settings specifically to avoid a second place that could get the GitHub-versus-app-store question wrong; a shared action answers that rather than working around it.

## Two bugs fixed along the way

**Flatpak users paid for a doomed download.** `LinuxUpdater.canUpdateInPlace` is false under Flatpak's read-only `/app`, but `applyUpdate` downloaded and extracted the whole archive *before* re-checking writability, then opened a browser tab. Settings hid that; a banner would have put it one click from everyone. A new `InstallEnvironment` now classifies the install up front, and Flatpak users get the `flatpak update dev.mydia.player` command with a copy button and no download.

**The banner could flash on startup.** Gating on the compatibility verdict while `compatibilityProvider` was still loading let the banner paint and then vanish. Fixed by distinguishing "still loading" from "resolved to an error", so a failed compatibility check does not permanently suppress update notifications.

## Scope

Linux and Windows only, which is where the in-app updater exists. macOS is excluded because Sparkle owns update notification natively. iOS, Android and web are excluded because they update through a store or the server; `GitHubReleaseClient` returns no asset match there, so nothing fires either way.

Not included: pre-downloading with a "restart to update" prompt, and update notifications for sideloaded Android APKs. Both are separate changes.

## Testing

Full player suite: **3169 passed, 7 skipped, 0 failed**. `flutter analyze` sits at the repo's pre-existing baseline with no new issues in touched files.

New coverage includes the install-environment decision across all three branches on one host, each of the banner's suppression rules, the per-version dismissal behaviour, and a regression guard proving a failed compatibility check still lets the banner show.
