### PR TITLE
fix(migrations): drop the provider-id indexes only if they exist

### DIFF
--- a/priv/repo/migrations/20260905143012_scope_provider_id_uniqueness_by_type.exs
+++ b/priv/repo/migrations/20260905143012_scope_provider_id_uniqueness_by_type.exs
@@ -21,11 +21,24 @@ defmodule Mydia.Repo.Migrations.ScopeProviderIdUniquenessByType do
   Ecto-convention name. Keeping them partial makes SQLite and PostgreSQL report
   the same literal index name, which is what `MediaItem.changeset/2`'s
   `unique_constraint` calls have to match.
+
+  The drops are `drop_if_exists` because `media_items_tmdb_id_index` is not
+  present on every install. Until 2025-11-24 the table was created by a raw
+  `CREATE TABLE` carrying `tmdb_id INTEGER UNIQUE` inline, so SQLite enforced
+  the uniqueness through `sqlite_autoindex_media_items_2` and no named index
+  ever existed. A plain `drop` raised `no such index` on those databases, and
+  since `Ecto.Migrator` sits in the supervision tree that is a boot loop, not a
+  failed upgrade.
+
+  Removing that inline constraint needs a table rebuild, which this migration
+  deliberately does not attempt. On such an install the composite indexes are
+  created and correct, but the surviving column-level `UNIQUE` still keeps a
+  movie and a show from sharing a `tmdb_id`.
   """
 
   def up do
-    drop unique_index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
-    drop unique_index(:media_items, [:tvdb_id], name: :media_items_tvdb_id_index)
+    drop_if_exists unique_index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
+    drop_if_exists unique_index(:media_items, [:tvdb_id], name: :media_items_tvdb_id_index)
 
     create unique_index(:media_items, [:type, :tmdb_id],
              where: "tmdb_id IS NOT NULL",

--- a/test/mydia/repo/migrations/scope_provider_id_uniqueness_by_type_test.exs
+++ b/test/mydia/repo/migrations/scope_provider_id_uniqueness_by_type_test.exs
@@ -84,6 +84,38 @@ defmodule Mydia.Repo.Migrations.ScopeProviderIdUniquenessByTypeTest do
     end
   end
 
+  @tag :tmp_dir
+  test "up succeeds on an install whose media_items predates the named tmdb index" do
+    seed_legacy_schema()
+
+    run_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    assert index?("media_items_type_tmdb_id_index")
+    assert index?("media_items_type_tvdb_id_index")
+    refute index?("media_items_tvdb_id_index")
+  end
+
+  @tag :tmp_dir
+  test "the legacy inline UNIQUE still scopes tmdb_id globally after the migration" do
+    seed_legacy_schema()
+    run_migration!(ScopeProviderIdUniquenessByType, @version)
+
+    insert_item("a", "movie", "Cinder Lantern", tmdb_id: 4006)
+
+    # Not the behaviour this migration wants, but the honest state of a
+    # pre-2025-11-24 database: `tmdb_id INTEGER UNIQUE` is a column constraint
+    # and only a table rebuild can remove it. Flipping this to an `assert` is
+    # the test that a rebuild actually landed.
+    assert_raise Exqlite.Error, fn ->
+      insert_item("b", "tv_show", "Cinder Lantern", tmdb_id: 4006)
+    end
+
+    # The tvdb relaxation is unaffected: that index was always a named one.
+    insert_item("c", "movie", "Harrow Bay", tvdb_id: 4007)
+    insert_item("d", "tv_show", "Harrow Bay", tvdb_id: 4007)
+    assert %{rows: [[2]]} = sql!("SELECT COUNT(*) FROM media_items WHERE tvdb_id = 4007")
+  end
+
   # Only the columns and indexes this migration touches. The real table has far
   # more, none of which the migration reads.
   defp seed_schema do
@@ -104,6 +136,44 @@ defmodule Mydia.Repo.Migrations.ScopeProviderIdUniquenessByTypeTest do
     sql!(
       "CREATE UNIQUE INDEX media_items_tvdb_id_index ON media_items (tvdb_id) WHERE tvdb_id IS NOT NULL"
     )
+  end
+
+  # The shape an install created before 2025-11-24 still has: `media_items` came
+  # from a raw `CREATE TABLE` with `tmdb_id INTEGER UNIQUE` inline, so SQLite
+  # enforces it through an autoindex and `media_items_tmdb_id_index` does not
+  # exist. `tvdb_id` arrived later, through a normal migration, so its named
+  # index does.
+  defp seed_legacy_schema do
+    sql!("""
+    CREATE TABLE media_items (
+      id TEXT PRIMARY KEY NOT NULL,
+      type TEXT NOT NULL CHECK(type IN ('movie', 'tv_show')),
+      title TEXT NOT NULL,
+      original_title TEXT,
+      year INTEGER,
+      tmdb_id INTEGER UNIQUE,
+      imdb_id TEXT,
+      metadata TEXT,
+      monitored INTEGER DEFAULT 1 CHECK(monitored IN (0, 1)),
+      inserted_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+    """)
+
+    sql!("ALTER TABLE media_items ADD COLUMN tvdb_id INTEGER")
+
+    sql!(
+      "CREATE UNIQUE INDEX media_items_tvdb_id_index ON media_items (tvdb_id) WHERE tvdb_id IS NOT NULL"
+    )
+
+    refute index?("media_items_tmdb_id_index")
+  end
+
+  defp index?(name) do
+    %{rows: [[count]]} =
+      sql!("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1", [name])
+
+    count == 1
   end
 
   defp insert_item(id, type, title, ids) do


### PR DESCRIPTION
## The failure

Every install whose database was created before **2025-11-24** boot-loops on `20260905143012_scope_provider_id_uniqueness_by_type`, which landed in #712 this morning:

```
== Running 20260905143012 Mydia.Repo.Migrations.ScopeProviderIdUniquenessByType.up/0
   drop index media_items_tmdb_id_index
** (Exqlite.Error) no such index: media_items_tmdb_id_index
```

`Ecto.Migrator` is started from `lib/mydia/application.ex`, so this is a boot failure, not a degraded start. The release never reaches Phoenix and the supervisor restarts it every few seconds forever. My own instance logged 1815 restarts over six hours before I traced it.

## Why the index is missing

The migration opens with an unconditional drop:

```elixir
drop unique_index(:media_items, [:tmdb_id], name: :media_items_tmdb_id_index)
```

Until 2025-11-24, `20251104023000_create_media_items` built the table with raw SQL:

```sql
CREATE TABLE media_items (
  ...
  tmdb_id INTEGER UNIQUE,
  ...
)
```

SQLite enforces a column-level `UNIQUE` with an implicit `sqlite_autoindex_media_items_2`, so `media_items_tmdb_id_index` was never created. `f9521c0c9` ("convert raw SQL to Ecto DSL for multi-database support") rewrote that migration to the DSL, where the constraint became a separate `create unique_index(:media_items, [:tmdb_id])`.

So the name the drop expects exists on databases created after that commit and does not exist on databases created before it. `media_items_tvdb_id_index` is unaffected because `tvdb_id` arrived later, through a normal migration.

PostgreSQL installs are also unaffected: multi-adapter support arrived with the DSL conversion, so a Postgres database has never seen the raw form.

## Why CI did not catch it

`scope_provider_id_uniqueness_by_type_test.exs` seeds `media_items` by hand in the shape the current migration set produces, which always has the named index. Test databases are built from the same current set. Neither can express a database whose schema predates a migration rewrite.

## The fix

`drop_if_exists` for both provider-id indexes.

Two tests are added that seed the pre-conversion shape instead. Reverting the fix, both fail with the exact production error:

```
1) test up succeeds on an install whose media_items predates the named tmdb index
   ** (Exqlite.Error) no such index: media_items_tmdb_id_index
2) test the legacy inline UNIQUE still scopes tmdb_id globally after the migration
   ** (Exqlite.Error) no such index: media_items_tmdb_id_index
```

I also replayed the migration against a live 57-table schema dumped from an affected install; it applies cleanly and produces both composite indexes.

## Known limitation, deliberately not fixed here

Restoring boot does not remove the inline `UNIQUE`. SQLite can only shed a column constraint through a full table rebuild, and `media_items` is the schema's most-referenced table: `preserving_fk_children/2` would snapshot every transitive child, `media_files` and its blob columns included.

On a pre-conversion install the composite indexes are created and correct, but the surviving column-level `UNIQUE` still stops a movie and a show from sharing a `tmdb_id`, so #473 is only half-fixed there. The moduledoc says so, and the second test asserts the current behaviour so that a later rebuild has to flip it deliberately. That rebuild is a separate PR; it should not hold up a fix for a boot loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed migration failures on legacy database schemas where provider ID uniqueness was enforced through automatically generated indexes.
  - Existing legacy constraints are handled safely during migration, while supported provider ID behavior continues to work as expected.

- **Tests**
  - Added coverage for legacy schemas and provider ID uniqueness behavior during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->