### PR TITLE
feat(relay-worker): rebuild the metadata relay as a Cloudflare Worker

### DIFF
--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -582,6 +582,46 @@ average 43 from a concurrent agent plus `./dev mix compile --force`. Check `upti
 before concluding a `render_async` failure is real, and trust the CI job over a
 loaded local box.
 
+## relay-worker (vitest-pool-workers)
+
+**`test/obs/ratelimit.test.ts`, "returns 429 with a Retry-After header once
+the budget is spent" and "logs the final 429 status..."**, `expected 500 to
+be 429`. Both loop a real `SELF.fetch` against `PROXY_LIMITER` (`limit: 300,
+period: 60` in `wrangler.jsonc`) until a 429 appears, capped at a fixed
+iteration count. Seen in two independent review sessions at roughly once in
+four to six full-suite runs.
+
+Root cause is the local simulator, not the Worker: `miniflare`'s rate-limit
+worker resets its whole counter on wall-clock time rather than on
+consumption --
+`node_modules/miniflare/dist/src/workers/ratelimit/ratelimit.worker.js`:
+
+```js
+let epoch = Math.floor(Date.now() / (period * 1e3));
+epoch != this.epoch && (this.epoch = epoch, this.buckets.clear());
+```
+
+The original loop cap was 305 -- five iterations of margin over the 300
+threshold. If a real 60-second wall-clock boundary falls anywhere inside the
+loop, `buckets.clear()` wipes the in-flight count to zero and the budget can
+no longer reach 300 within the remaining five iterations, so the loop
+exhausts with the route's own unthrottled response (500, from this test's
+intentionally-unmocked upstream) instead of a 429.
+
+Mitigated (not eliminated -- two resets in one loop would still lose) by
+raising the cap to `2 * limit + margin` (610), which survives exactly one
+mid-loop reset: up to `limit - 1` requests before it, a full `limit + 1`
+after. `if (last.status === 429) break` keeps the ordinary (no-reset) case at
+its original ~301 iterations and cost. Production is unaffected either way --
+real rate limiting there is Cloudflare's own service, not this
+fixed-window-per-process approximation.
+
+**Generalise from this.** A loop that drives a counter-based simulator to its
+threshold needs margin against the simulator's own reset behavior, not just
+against the threshold itself. Margin sized only to the limit ("five over 300
+is plenty") is a coin flip against any reset condition the simulator can hit
+independently of the test's own request count.
+
 ## E2E
 
 **`MydiaWeb.Features.AuthTest`** raising `(RuntimeError) invalid session id` from

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,9 +1,33 @@
 name: Deploy / Relay
 
+# Two independent release rituals share this file until Task 17 of
+# docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md
+# deletes the Elixir side and renames this file to deploy-relay-worker.yml:
+#
+# - `docker` (metadata-relay/, the Elixir service): tag-triggered, unchanged.
+# - `deploy-worker` (relay-worker/, the Cloudflare Worker): triggered by a
+#   push to master/main that touches relay-worker/**, since `wrangler deploy`
+#   is now that ritual rather than a version tag.
+#
+# `paths` filters are never evaluated for tag pushes (only for branch
+# pushes), so adding one here does not gate the tag-triggered `docker` job.
+# It DOES mean this workflow now also runs on a plain branch push, which is
+# new -- hence the `if:` guard on each job below. Without it, a
+# relay-worker-only commit to master would also invoke `docker`, which
+# parses a semver out of `${GITHUB_REF#refs/tags/metadata-relay-v}`; fed a
+# branch ref instead of a tag, that expansion doesn't strip anything and the
+# job would fail trying to build a Docker tag from a literal
+# "refs/heads/master".
 on:
   push:
     tags:
       - "metadata-relay-v*"
+    branches:
+      - master
+      - main
+    paths:
+      - "relay-worker/**"
+      - ".github/workflows/deploy-relay.yml"
 
 env:
   REGISTRY: ghcr.io
@@ -12,6 +36,7 @@ env:
 jobs:
   docker:
     name: Docker / Build and Push
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,3 +97,62 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+  deploy-worker:
+    name: Deploy relay Worker
+    if: github.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    # Cloudflare auth is a bearer token in CLOUDFLARE_API_TOKEN, not the
+    # workflow's GITHUB_TOKEN, so nothing here needs write access to the repo.
+    permissions:
+      contents: read
+    # A second push landing mid-deploy would race wrangler against itself;
+    # queue instead of overlapping, but don't cancel a deploy already in
+    # flight (unlike a CI job, a cancelled `wrangler deploy` can leave D1
+    # migrations applied against code that never actually shipped).
+    concurrency:
+      group: deploy-relay-worker
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: relay-worker/package-lock.json
+
+      - name: Install
+        working-directory: relay-worker
+        run: npm ci
+
+      - name: Test
+        working-directory: relay-worker
+        run: npm test
+
+      - name: Typecheck
+        working-directory: relay-worker
+        run: npm run typecheck
+
+      # Runs before `wrangler deploy` so a new binding never reaches a
+      # database without its table. `--remote` targets the real D1 database
+      # (see relay-worker/README.md); omitting it would silently touch a
+      # local-only DB instead. Requires the D1 database and KV namespace in
+      # wrangler.jsonc to already be real Cloudflare resources, not the
+      # `placeholder_local_dev_only` ids checked in for local dev/test --
+      # see relay-worker/README.md's "One-time cloud setup" section.
+      - name: Apply D1 migrations
+        working-directory: relay-worker
+        run: npx wrangler d1 migrations apply mydia-relay --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Deploy
+        working-directory: relay-worker
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-relay.yml
+++ b/.github/workflows/deploy-relay.yml
@@ -1,8 +1,8 @@
 name: Deploy / Relay
 
-# Two independent release rituals share this file until Task 17 of
-# docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md
-# deletes the Elixir side and renames this file to deploy-relay-worker.yml:
+# Two independent release rituals share this file until the Elixir relay is
+# decommissioned, at which point its job goes away and this file becomes
+# deploy-relay-worker.yml:
 #
 # - `docker` (metadata-relay/, the Elixir service): tag-triggered, unchanged.
 # - `deploy-worker` (relay-worker/, the Cloudflare Worker): triggered by a

--- a/relay-worker/.gitignore
+++ b/relay-worker/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.env
+.env.local
+.env.*.local
+dist/
+build/
+*.log
+npm-debug.log*
+.DS_Store

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -11,6 +11,38 @@ Through Task 16, `relay.mydia.dev` is still served by the Elixir relay; this
 Worker deploys continuously but does not yet own any production traffic. See
 that plan for the full route-by-route parity work and the cutover sequence.
 
+## What this migration changed
+
+Four things an operator who knew the Elixir relay would not expect:
+
+- **Responses are actually cached at Cloudflare's edge now.** The Elixir
+  relay sent `cache-control: max-age=0, private, must-revalidate` on every
+  response, so `cf-cache-status` was `DYNAMIC` on every hit — nothing was
+  ever cached at the edge despite `metadata-relay/`'s own in-process cache.
+  The Worker emits real `public, s-maxage=..., stale-while-revalidate=...,
+  stale-if-error=...` headers and gets genuine `HIT`s. This is a real
+  latency and TMDB/TVDB-quota improvement, not a no-op port, and it's why
+  the cutover verification checks `cf-cache-status` explicitly rather than
+  just a 200.
+- **A crash-storm occurrence count can be a floor, not an exact number.**
+  D1's write budget is bounded per install-per-hour (`ingest_buckets`); once
+  a bucket saturates, further occurrences in that hour are not written. The
+  dashboard marks the affected error group's `count_is_floor` sticky (it
+  only ever ratchets from 0 to 1, never back down, even once traffic quiets
+  down) so `/admin/errors` can render "500+" instead of a wrong exact
+  number. If a total looks suspiciously round or capped, that column is why.
+- **The maintainer dashboards moved to `/admin/errors` and
+  `/admin/feedback`.** They used to be `/errors` and `/feedback` in the
+  original brief; that collided with `POST /feedback`'s public path, since
+  Cloudflare Access (like Hono's router) has no HTTP-method dimension to
+  separate them. Bookmarks and any saved links need updating.
+- **The deploy ritual is a `git push`, not a tag.** The Elixir relay ships on
+  a `metadata-relay-v*` tag, built into a Docker image, picked up by Keel's
+  five-minute GHCR poll. The Worker ships on every push to `master`/`main`
+  that touches `relay-worker/**`, straight to `wrangler deploy` — no tag, no
+  version bump, no image, no poll delay. `git log` on `relay-worker/` is now
+  effectively the release history.
+
 ## Bindings
 
 Declared in `wrangler.jsonc` (KV, D1, rate limiters, vars) and `src/env.ts`
@@ -377,6 +409,275 @@ later adds `relay.mydia.dev` routes, but the Worker is live on
      (currently 20,000,000) if real-world archives never approach it, trading
      rejected-but-legitimate edge cases for headroom.
 
+### Step 4: production cutover (Task 16)
+
+Everything below is **manual** and moves real traffic. Nothing in this repo
+adds a production route ahead of time — `wrangler.jsonc` has no `routes` key
+today, on purpose. Add it by hand, deliberately, following this sequence.
+
+**Preconditions, all must already be true:**
+
+- Steps 0-3 above are done: real Cloudflare resources exist (not
+  `placeholder_local_dev_only`), the four secrets are set, CI has deployed at
+  least once to the Worker's `*.workers.dev` subdomain, and the Step 3 CPU
+  measurement has a recorded number.
+- **The `/admin*` Access application from Step 1 exists and both its
+  verification curls pass.** This is the ordering constraint that matters
+  most in this whole runbook: neither a Worker route nor a Cloudflare Access
+  application can be scoped by HTTP method, only by path. A bare
+  `relay.mydia.dev/*` route (added below in 4b) exposes every path the
+  Worker answers, `/admin/errors` and `/admin/feedback` included, to
+  anonymous traffic the instant it deploys — regardless of what Access
+  policy exists for any other path. Do not add the wildcard route on the
+  assumption Access can follow "right after." If Step 1 isn't done, stop and
+  do it first.
+- `POST /feedback` and `POST /crashes/report` must stay reachable with no
+  Access in front of them, at every point in this rollout, not just at the
+  end. They are what every mydia install in the field already calls
+  unauthenticated. Access is scoped to `/admin*` and only `/admin*` — never
+  the hostname root, never these two paths individually.
+
+**4a. Run the contract diff against staging, and read the output, not just
+the exit code:**
+
+```bash
+cd relay-worker
+CONTRACT_WORKER_URL=https://mydia-relay-staging.<subdomain>.workers.dev npm run test:contract
+```
+
+This is the real gate Step 2 above deferred out of CI. Read the summary line
+before trusting it:
+
+- If it says something like `42 skipped`, `CONTRACT_WORKER_URL` did not take
+  effect (typo in the URL, wrong shell, env not exported) and this run has
+  compared nothing. Vitest still exits 0 for an all-skipped run — a green
+  exit code alone is not evidence anything ran. Fix the invocation and rerun
+  before reading anything else into it.
+- Once tests are actually running, do not proceed on a single mismatch,
+  **except** these two documented, expected ones:
+  - `/music/search` and `/openlibrary/search` are fuzzy-ranked. Two
+    near-simultaneous identical requests can come back reordered or
+    rescored against real MusicBrainz/OpenLibrary — this was observed live
+    during Task 9, not theorized. A failure on either route: rerun just that
+    one route in isolation before concluding the port regressed. Do not add
+    retry logic to the harness itself; a silent retry would also hide a
+    genuine regression.
+  - `/tvdb/series/:id/episodes` returns 400 from **both** the Elixir and the
+    Worker. The Elixir builds `/series/{id}/episodes/default/page/{page}`,
+    which has never been a valid TVDB v4 path (TVDB's own OpenAPI spec wants
+    `/series/{id}/episodes/{season-type}` with `page` as a *query* param,
+    not a path segment). Nothing in mydia calls this route — the real
+    client uses `/series/:id/extended` and `/seasons/:id/extended` instead
+    — so it has been silently broken since it was introduced and nobody
+    noticed. The Worker is deliberately bug-compatible with it. A matching
+    400 on both sides here is correct, not a false pass. If this route ever
+    shows a **genuine diff** (one side 400, the other something else) at a
+    later cutover, that means someone fixed the Elixir's URL construction,
+    not that the Worker regressed — go verify which side changed before
+    treating it as a blocker, and if it's the Elixir, port the fix into the
+    Worker to keep them matching.
+
+**4b. Add production routes for the metadata paths only:**
+
+```jsonc
+  "routes": [
+    { "pattern": "relay.mydia.dev/configuration", "zone_name": "mydia.dev" },
+    { "pattern": "relay.mydia.dev/tmdb/*", "zone_name": "mydia.dev" },
+    { "pattern": "relay.mydia.dev/tvdb/*", "zone_name": "mydia.dev" },
+    { "pattern": "relay.mydia.dev/api/v1/subtitles/*", "zone_name": "mydia.dev" },
+    { "pattern": "relay.mydia.dev/music/*", "zone_name": "mydia.dev" },
+    { "pattern": "relay.mydia.dev/openlibrary/*", "zone_name": "mydia.dev" }
+  ]
+```
+
+`cae1-1.relay.mydia.dev` is a different hostname (iroh-relay) and none of
+these patterns touch it — confirm that by eye before deploying, then:
+
+```bash
+cd relay-worker && npx wrangler deploy
+```
+
+Verify from outside:
+
+```bash
+# Worker is serving, with real edge caching (not the Elixir's DYNAMIC).
+curl -sI "https://relay.mydia.dev/tmdb/genre/movie?_cb=$RANDOM" | grep -iE 'cache-control|cf-cache-status'
+# expect: cache-control: public, s-maxage=..., stale-if-error=...
+
+# iroh relay still answers on its own hostname, untouched.
+curl -sI https://cae1-1.relay.mydia.dev/ | head -1
+
+# Anything not in the route list above is still the Elixir relay.
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/health
+```
+
+Watch Workers Logs and the Cloudflare dashboard's request analytics for at
+least an hour before moving on. Rollback at this stage is removing the
+routes from `wrangler.jsonc` and redeploying — the Elixir relay is still
+live and still routed for everything else.
+
+**4c. Move the remaining paths — only after the Access precondition above is
+confirmed, again:**
+
+```jsonc
+  "routes": [{ "pattern": "relay.mydia.dev/*", "zone_name": "mydia.dev" }]
+```
+
+```bash
+cd relay-worker && npx wrangler deploy
+```
+
+Verify pairing, crash ingest and feedback ingest end to end. Note the real
+response field name below — it is `claim_code`, not `code`:
+
+```bash
+CLAIM=$(curl -sS -X POST https://relay.mydia.dev/pairing/claim \
+  -H 'content-type: application/json' \
+  -d '{"node_addr":"{\"id\":\"testnode\"}"}' | python3 -c 'import sys,json;print(json.load(sys.stdin)["claim_code"])')
+curl -sS "https://relay.mydia.dev/pairing/claim/$CLAIM"
+curl -sS -X DELETE -o /dev/null -w '%{http_code}\n' "https://relay.mydia.dev/pairing/claim/$CLAIM"
+
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://relay.mydia.dev/crashes/report \
+  -H 'content-type: application/json' \
+  -d '{"error_type":"RuntimeError","error_message":"cutover smoke test","version":"0.0.0"}'
+# expect 201, NOT 202: CrashReporter.Sender matches only 201 as success and
+# retries/logs-failed on anything else.
+
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/admin/errors
+# expect 302 (Access login redirect) -- confirms the smoke-test crash landed
+# behind Access, not on an unauthenticated path.
+
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://relay.mydia.dev/feedback \
+  -H 'content-type: application/json' -d '{"type":"idea","message":"cutover smoke test"}'
+# expect 201, with NO Access redirect -- this must never require login.
+```
+
+**Note on the plan document's Verification checklist:** the checklist at the
+end of `docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md`
+still says the crash report "returns 202" and appears at "`/errors`", and
+that "`GET /errors` and `GET /feedback` redirect to Access" — all three are
+stale. Task 15 moved both dashboards to `/admin/errors` and `/admin/feedback`
+and Task 11 established 201 as the only success status the real producer
+accepts; this section supersedes that checklist. Use the commands above, not
+that list, when actually running the cutover.
+
+Commit only `relay-worker/wrangler.jsonc` once the whole hostname is moved
+and stable — see the plan's Task 16 Step 5 for the commit message shape.
+
+### Step 5: decommission the Elixir relay on can-1 (Task 17)
+
+Do not start this until Step 4 has been stable in production for real
+traffic. This is a staged, mostly-irreversible sequence — read it end to end
+before running the first command. The ordering below is deliberate: each
+stage is either reversible in seconds or a pure archival step, right up
+until the last one, which is neither.
+
+**5a. Soak with the Elixir relay running but unrouted, at least 7 days.**
+Once Step 4c lands, `relay.mydia.dev` no longer sends the Elixir pod any
+traffic, but nothing has stopped it. Leave it running. Confirm from Workers
+Logs that the Worker is serving every route and that error rates match the
+pre-cutover baseline. The pod costs nothing while idle and it is the entire
+rollback plan for this stage — if anything looks wrong, the fix is
+re-pointing `wrangler.jsonc`'s routes back, not touching can-1 at all.
+
+**5b. Archive the crash history — from the host path, never from inside the
+pod.**
+
+```bash
+ssh root@can-1 'cp /var/lib/rancher/k3s/storage/pvc-*_metadata-relay_metadata-relay-data/metadata_relay.db /var/tmp/metadata_relay_archive.db'
+scp root@can-1:/var/tmp/metadata_relay_archive.db ~/archive/
+ssh root@can-1 'rm /var/tmp/metadata_relay_archive.db'
+```
+
+Two details in that command are load-bearing, not stylistic:
+
+- **Copy from the host filesystem, not `kubectl exec` into the pod.** The
+  pod's memory limit is 512Mi and the database is roughly 634MB; opening or
+  querying it in-pod has OOM-killed this service in production before. A
+  plain host-side `cp` never loads the file into the container's memory at
+  all.
+- **Use `/var/tmp`, not `/tmp`.** `/tmp` on can-1 is a 3.8G tmpfs on a 7G
+  box — copying a 634MB database into it is a meaningful fraction of total
+  RAM on a host that is not provisioned for that spike. `/var/tmp` is
+  regular disk.
+
+**5c. Dump the live k8s secret before running `infra/deploy` again for any
+reason, and before Step 5d touches it.**
+
+```bash
+ssh root@can-1 'sudo k3s kubectl get secret metadata-relay-secrets -n metadata-relay -o yaml' \
+  > metadata-relay-secrets-backup.yaml
+```
+
+`infra/deploy`'s `metadata_relay_secret_data()` (`infra/deploy:1027`) only
+knows five keys: `RELAY_TOKEN_SECRET`, `TMDB_API_KEY`, `TVDB_API_KEY`,
+`SMTP_PASSWORD`, `SUBDL_API_KEY`. If the live secret has ever been hand-edited
+(`kubectl edit secret ...`) to add or rotate something this function was
+never taught about, that value exists only on the live cluster object —
+nowhere in this repo, nowhere in `infra/config.yaml`. Step 5d below deletes
+the entire `metadata-relay` namespace, which deletes the Secret outright.
+Take this backup before that point; there is no merge or patch semantics to
+save an unknown key from a namespace deletion.
+
+**5d. Scale to zero and wait 48 hours before deleting anything.**
+
+```bash
+ssh root@can-1 'sudo k3s kubectl -n metadata-relay scale deploy/metadata-relay --replicas=0'
+ssh root@can-1 'sudo k3s kubectl -n metadata-relay scale deploy/redis --replicas=0'
+```
+
+Scaling to zero is reversible in seconds (`--replicas=1`). Nothing after
+this point is.
+
+**5e. Delete the manifests, the namespace, and the `infra/deploy` entry —
+last, and only after 5b and 5c are confirmed done:**
+
+```bash
+ssh root@can-1 'sudo k3s kubectl delete namespace metadata-relay'
+git rm infra/kubernetes/apps/metadata-relay/{deployment,redis,pvc,service,ingress,configmap,secret.yaml.example}.yaml
+```
+
+Update `infra/kubernetes/apps/metadata-relay/kustomization.yaml` to drop the
+removed resources (or delete the directory entirely if nothing remains), and
+remove the metadata-relay entry from `infra/deploy`'s
+`metadata_relay_secret_data`/`metadata_relay_configmap_data`/`phase_metadata_relay`
+so a future `infra/deploy` run does not try to recreate what was just torn
+down.
+
+Deleting the namespace deletes the PVC and everything on it. This is the one
+genuinely irreversible step in this whole runbook — it must come after 5b
+(archive taken), 5c (secret backed up) and 5d (48-hour soak at zero replicas
+with no surprises), never before.
+
+**5f. Retire the Elixir service source and its CI.**
+
+Delete `metadata-relay/` and `.github/workflows/ci-relay.yml`, remove the
+`docker` job from `.github/workflows/deploy-relay.yml` (leaving only
+`deploy-worker`), and rename that file to `deploy-relay-worker.yml`.
+
+**Before doing this, understand what it costs:** `metadata-relay/`'s source
+is the reference implementation this entire Worker port was verified
+against, task by task, for 15 tasks — every route table, every TTL, every
+edge case (the SubDL field names, the pairing `claim_code` shape, the
+crash-report status code, the CORS preflight behaviour) was confirmed
+correct by reading that code, not by guessing. Deleting the directory
+removes the ability to answer any future "does the Worker actually match
+what the Elixir did here" question by reading source — git history still
+holds every line (`git log --all -- metadata-relay/`, or check out the last
+commit before this deletion), but that is a materially higher-friction path
+than a file in the working tree, and it is easy to forget the history is
+there at all once the directory is gone from `HEAD`. Make sure whoever runs
+this step knows that trade before running `git rm -r metadata-relay/`.
+
+**5g. Update the docs.** `lib/mydia/metadata/README.md`: note that
+`relay.mydia.dev` is now a Worker, and that the `append_to_response`
+behaviour it documents is preserved by the no-allowlist forwarding rule in
+`relay-worker/src/proxy/forward.ts`. `AGENTS.md`'s Metadata Relay Service
+section: point it at `relay-worker/` and `wrangler deploy` as the deploy
+ritual — as of this writing that section doesn't actually name the old
+`metadata-relay-v*` tag or Keel, so there is nothing incorrect to remove
+there, only `relay-worker/` to add.
+
 ## Brief vs. reality
 
 This task's brief (`task-15-brief.md`) assumed several things that don't
@@ -442,3 +743,18 @@ re-discover them the hard way:
 - **The Step 6 CPU measurement was never performed**, for the reason stated
   in Task 6's report: it needs a deployed Worker, which didn't exist yet.
   See the runbook's Step 3 above.
+- **Task 16 Step 4's own pairing-verification snippet reads the wrong JSON
+  field.** It parses the claim response as `["code"]`; the route actually
+  returns `{"claim_code": "..."}` (`src/pairing/routes.ts`, and confirmed
+  against both `remote_access.ex` and the Flutter client during Task 10) —
+  the original snippet would `KeyError` before ever reaching the GET/DELETE
+  checks. Fixed in this runbook's Step 4c.
+- **The plan's final "Verification checklist"** (the very end of the plan
+  document, distinct from Task 16 Step 4's own inline verification, which
+  Task 15 already corrected) **was never updated for the `/admin/*` move or
+  the 201 status code.** It still says a crash report "returns 202" and
+  appears at "`/errors`", and that "`GET /errors` and `GET /feedback`
+  redirect to Access" — all three predate Task 11 (201 is the only status
+  the real producer accepts) and Task 15 (both dashboards moved to
+  `/admin/*`). This runbook's Step 4c commands are the corrected version;
+  do not run the plan document's own checklist verbatim.

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -5,11 +5,10 @@ service). It proxies TMDB, TVDB, SubDL, MusicBrainz and OpenLibrary for every
 mydia install, plus pairing, crash ingest and feedback. TypeScript, Hono for
 routing, no server and no tunnel — Cloudflare's edge is the whole runtime.
 
-This is one of 17 tasks in
-`docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md`.
-Through Task 16, `relay.mydia.dev` is still served by the Elixir relay; this
-Worker deploys continuously but does not yet own any production traffic. See
-that plan for the full route-by-route parity work and the cutover sequence.
+**Nothing has cut over yet.** `relay.mydia.dev` is still served by the Elixir
+relay; this Worker deploys continuously but does not yet own any production
+traffic. The runbook at the bottom of this file is the cutover sequence, and
+none of it has been executed.
 
 ## What this migration changed
 
@@ -32,8 +31,8 @@ Things an operator who knew the Elixir relay would not expect:
   down) so `/admin/errors` can render "500+" instead of a wrong exact
   number. If a total looks suspiciously round or capped, that column is why.
 - **The maintainer dashboards moved to `/admin/errors` and
-  `/admin/feedback`.** They used to be `/errors` and `/feedback` in the
-  original brief; that collided with `POST /feedback`'s public path, since
+  `/admin/feedback`.** The obvious paths were `/errors` and `/feedback`,
+  but that collided with `POST /feedback`'s public path, since
   Cloudflare Access (like Hono's router) has no HTTP-method dimension to
   separate them. Bookmarks and any saved links need updating.
 - **The deploy ritual is a `git push`, not a tag.** The Elixir relay ships on
@@ -82,7 +81,7 @@ for the binding, not provisioned cloud resources — there is nothing to create
 for them in the dashboard, unlike `CACHE_KV` and `DB`.
 
 **Requires wrangler >= 4.36.0.** The `ratelimits` config key was silently
-dropped by older wrangler versions with no error (Task 8's finding) — the
+dropped by older wrangler versions with no error, found the hard way — the
 binding would be `undefined` at runtime and every proxy route would 500. This
 repo pins an exact version in `package.json`; do not loosen that pin without
 re-checking this.
@@ -155,12 +154,11 @@ A test or typecheck failure stops the job before step 3, so a broken commit
 on `master` cannot reach Cloudflare — but note that today nothing runs these
 checks on the pull request itself (no `ci-relay-worker.yml` equivalent of
 `ci-relay.yml` exists yet); the first automated signal a PR gets is this job,
-after merge. See the runbook's "What Task 15 did not do" for why this wasn't
-added here.
+after merge. See "Known gaps" at the end of this file.
 
 The Docker/GHCR job in the same workflow file is the **Elixir** relay's
 unrelated, still-live release path (tag-triggered on `metadata-relay-v*`);
-the two share the file until Task 17 deletes the Elixir side. `if:` guards on
+the two share the file until the Elixir side is decommissioned. `if:` guards on
 both jobs keep a relay-worker-only commit from also invoking the Docker job
 (and vice versa) — see the comment at the top of the workflow file.
 
@@ -258,8 +256,8 @@ not a real Cloudflare resource. `wrangler deploy` and
    ```
 
 3. **Mint a Cloudflare API token for CI**, and find the account ID.
-   The brief for this task assumed the token and ID in `infra/config.yaml`
-   could be reused. They cannot — see "Brief vs. reality" below. Create a new
+   The token and ID already in `infra/config.yaml` cannot be reused for this
+   — see "Known gaps" below for exactly why. Create a new
    token at <https://dash.cloudflare.com/profile/api-tokens> scoped to at
    least:
    - Account / Workers Scripts: Edit
@@ -295,16 +293,14 @@ having deployed anything broken (the failure is expected and safe).
 including instance identifiers. **Nothing may be routed to a public hostname
 before the Access application below exists.** This is not a recommendation to
 configure Access soon after cutover — it is a precondition of cutover.
-(Today, before Task 16, this Worker has no production route yet, so the
-constraint is not yet live — but it must be satisfied before Task 16 adds
-`relay.mydia.dev/*` routes to `wrangler.jsonc`. Task 16's own plan text now
-carries this same precondition on its Step 4 — see
-`docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md`
-— so it's enforced at the point someone would otherwise miss it.)
+(Today this Worker has no production route, so the constraint is not yet
+live — but it must be satisfied before Step 4 below adds `relay.mydia.dev/*`
+routes to `wrangler.jsonc`. Step 4 repeats this precondition inline, at the
+point someone would otherwise miss it.)
 
 **Why both dashboards live under `/admin/*` instead of their naive
-`/errors`/`/feedback` paths:** the brief's original Step 1 asked for an
-Access application covering literal `/errors` and `/feedback`. That doesn't
+`/errors`/`/feedback` paths:** an Access application covering literal
+`/errors` and `/feedback` is the obvious approach and it doesn't
 work. Cloudflare Access self-hosted applications match on **hostname + path
 only** — there is no HTTP-method selector in Access's own policy engine
 (Access policy selectors are identity/context attributes: email, country, IP
@@ -373,12 +369,11 @@ application's path scope before proceeding with cutover.
 `npm run test:contract` (see Testing above) is **not** part of the
 `deploy-worker` CI job. Two reasons:
 
-1. **There is nothing meaningful to diff against at Task 15's CI-job
-   deploy time.** The job deploys the Worker being tested; running the
-   contract diff immediately after would compare the freshly deployed Worker
-   against itself moments later, which (per Task 9's finding) proves the
-   harness mechanics and nothing about correctness of the change just
-   shipped.
+1. **There is nothing meaningful to diff against at CI deploy time.** The
+   job deploys the Worker being tested; running the contract diff immediately
+   after would compare the freshly deployed Worker against itself moments
+   later. A self-comparison proves the harness mechanics and nothing about
+   the correctness of the change just shipped.
 2. **An all-skipped run exits 0.** `CONTRACT_WORKER_URL` unset means the
    entire suite is `describe.skipIf`-skipped, and Vitest's exit code cannot
    distinguish that from every test passing. A CI job that ran this
@@ -386,7 +381,7 @@ application's path scope before proceeding with cutover.
    gate that can rubber-stamp a cutover having compared nothing — worse than
    no gate, because it looks like one.
 
-**The real gate lives in Task 16, Step 1** — a human runs
+**The real gate is manual, in Step 4 below** — a human runs
 `CONTRACT_WORKER_URL=https://<staging>.workers.dev npm run test:contract`
 against a staging deploy before flipping any production route, watches the
 output, and does not proceed on a single mismatch. That manual supervision is
@@ -399,19 +394,18 @@ the suite at all) — never trust the bare exit code.
 
 ### Step 3: real platform CPU measurement (subtitle download path)
 
-Task 6 shipped `src/proxy/subdl.ts`'s archive extraction (`extractSubtitle`)
-with a **local-only** CPU measurement: 0.1630ms mean / 0.3049ms p99 over a
-~10KB archive, measured with Node's `perf_hooks`, explicitly caveated in
-`task-6-report.md` as a different engine (V8 in Node vs. workerd) and
-different silicon than production. It was never validated against the real
+`src/proxy/subdl.ts`'s archive extraction (`extractSubtitle`) shipped with a
+**local-only** CPU measurement: 0.1630ms mean / 0.3049ms p99 over a ~10KB
+archive, measured with Node's `perf_hooks`. That is a different engine (V8 in
+Node vs. workerd) on different silicon than production, so treat it as an
+order of magnitude, not a number. It has never been validated against the real
 constraint — the Workers **free plan's 10ms CPU-time-per-invocation limit** —
-because that requires a deployed Worker, which did not exist when Task 6 ran.
-It still doesn't, as of this task.
+because that requires a deployed Worker, and none exists yet.
 
 **Do this once the first real deploy exists** — i.e., after Step 0 above
 succeeds and `deploy-worker` has pushed to the Worker's `workers.dev`
-subdomain for the first time (this happens automatically; Task 16 is what
-later adds `relay.mydia.dev` routes, but the Worker is live on
+subdomain for the first time (this happens automatically; the cutover in
+Step 4 is what later adds `relay.mydia.dev` routes, but the Worker is live on
 `*.workers.dev` from the very first successful CI deploy):
 
 1. Trigger a real request through the download path against a live SubDL
@@ -442,7 +436,7 @@ later adds `relay.mydia.dev` routes, but the Worker is live on
      (currently 20,000,000) if real-world archives never approach it, trading
      rejected-but-legitimate edge cases for headroom.
 
-### Step 4: production cutover (Task 16)
+### Step 4: production cutover
 
 Everything below is **manual** and moves real traffic. Nothing in this repo
 adds a production route ahead of time — `wrangler.jsonc` has no `routes` key
@@ -490,8 +484,8 @@ before trusting it:
   **except** these two documented, expected ones:
   - `/music/search` and `/openlibrary/search` are fuzzy-ranked. Two
     near-simultaneous identical requests can come back reordered or
-    rescored against real MusicBrainz/OpenLibrary — this was observed live
-    during Task 9, not theorized. A failure on either route: rerun just that
+    rescored against real MusicBrainz/OpenLibrary — this was observed live,
+    not theorized. A failure on either route: rerun just that
     one route in isolation before concluding the port regressed. Do not add
     retry logic to the harness itself; a silent retry would also hide a
     genuine regression.
@@ -585,19 +579,16 @@ curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://relay.mydia.dev/feedba
 # expect 201, with NO Access redirect -- this must never require login.
 ```
 
-**Note on the plan document's Verification checklist:** the checklist at the
-end of `docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md`
-still says the crash report "returns 202" and appears at "`/errors`", and
-that "`GET /errors` and `GET /feedback` redirect to Access" — all three are
-stale. Task 15 moved both dashboards to `/admin/errors` and `/admin/feedback`
-and Task 11 established 201 as the only success status the real producer
-accepts; this section supersedes that checklist. Use the commands above, not
-that list, when actually running the cutover.
+**The commands above are the verification list.** Watch for two stale claims
+that circulate about this cutover: the crash report returns **201**, not 202,
+and the dashboards are at `/admin/errors` and `/admin/feedback`, not `/errors`
+and `/feedback`. Anything asserting otherwise predates the `/admin/*` move and
+the status-code fix.
 
 Commit only `relay-worker/wrangler.jsonc` once the whole hostname is moved
-and stable — see the plan's Task 16 Step 5 for the commit message shape.
+and stable.
 
-### Step 5: decommission the Elixir relay on can-1 (Task 17)
+### Step 5: decommission the Elixir relay on can-1
 
 Do not start this until Step 4 has been stable in production for real
 traffic. This is a staged, mostly-irreversible sequence — read it end to end
@@ -711,21 +702,19 @@ ritual — as of this writing that section doesn't actually name the old
 `metadata-relay-v*` tag or Keel, so there is nothing incorrect to remove
 there, only `relay-worker/` to add.
 
-## Brief vs. reality
+## Known gaps and traps
 
-This task's brief (`task-15-brief.md`) assumed several things that don't
-match this repository as it stands. Recorded here so the next person doesn't
-re-discover them the hard way:
+Wrong assumptions this port already paid for, plus what is still missing.
+Recorded so the next person doesn't re-discover them the hard way:
 
-- **The Access path split as specified (`/errors` and `/feedback`) doesn't
-  work.** See Step 1 above — Access matches by path only, not method, and
-  `/feedback` used to serve both the public POST and the dashboard GET on the
-  identical path. Fixed by moving both dashboards under `/admin/*`, a path no
-  public endpoint shares. This was the biggest gap found in this task;
-  everything else below is comparatively minor.
-- **"The Cloudflare API token and zone id already exist in
-  `infra/config.yaml`; add them as repository secrets if they are not there
-  yet"** conflates three different things:
+- **Splitting Access by `/errors` and `/feedback` doesn't work.** See Step 1
+  above — Access matches by path only, not method, and `/feedback` served
+  both the public POST and the dashboard GET on the identical path. Fixed by
+  moving both dashboards under `/admin/*`, a path no public endpoint shares.
+  This was the biggest design gap found; everything else below is
+  comparatively minor.
+- **The Cloudflare credentials in `infra/config.yaml` cannot be reused for
+  this**, tempting as it looks. Three separate reasons:
   - `infra/config.yaml` is a **local, git-ignored** operator file consumed by
     the `infra/deploy` Python tool. Nothing in it is automatically a GitHub
     Actions secret; there is no sync between the two.
@@ -742,18 +731,13 @@ re-discover them the hard way:
     edit, not Workers/D1/KV edit).
 - **`d1_databases[0].database_id` and `kv_namespaces[0].id` are
   placeholders**, not real Cloudflare resources — `wrangler.jsonc`'s own
-  comments say so. The brief's CI snippet assumes `wrangler d1 migrations
-  apply --remote` and `wrangler deploy` just work once secrets exist; they
-  don't, until the D1 database and KV namespace are actually created (Step 0
-  above) and the placeholder IDs are replaced.
-- **Action versions.** The brief's Step 2 snippet uses
-  `actions/checkout@v4` and `actions/setup-node@v4`. This repository's own
-  workflows (including the `docker` job already in this same file) use
-  `@v7` for both; the shipped workflow matches the repository's convention
-  instead.
+  comments say so. `wrangler d1 migrations apply --remote` and
+  `wrangler deploy` do not start working the moment the secrets exist; the D1
+  database and KV namespace have to be actually created (Step 0 above) and
+  the placeholder IDs replaced first.
 - **Adding a bare `paths:` filter to the existing tag-triggered push block
-  would have been a silent trap**, not the drop-in change Step 3 describes —
-  except it turns out fine, for a documented reason: GitHub Actions does not
+  looks like a silent trap** — and it turns out fine, for a reason worth
+  writing down: GitHub Actions does not
   evaluate `paths` filters on tag pushes at all, only on branch pushes. So
   adding `paths: ["relay-worker/**"]` alongside the existing `tags:` trigger
   doesn't gate the Docker job's tag trigger — but it does mean the workflow
@@ -771,23 +755,11 @@ re-discover them the hard way:
   only runs after a merge to `master`, and it is safe (a failing test/
   typecheck step stops the job before `wrangler deploy` runs), but it means a
   broken PR currently gets no automated feedback before merge — only after.
-  This wasn't in Task 15's authorized scope (CI/README only); flagging it as
-  a gap worth a small follow-up rather than fixing it here.
-- **The Step 6 CPU measurement was never performed**, for the reason stated
-  in Task 6's report: it needs a deployed Worker, which didn't exist yet.
-  See the runbook's Step 3 above.
-- **Task 16 Step 4's own pairing-verification snippet reads the wrong JSON
-  field.** It parses the claim response as `["code"]`; the route actually
-  returns `{"claim_code": "..."}` (`src/pairing/routes.ts`, and confirmed
-  against both `remote_access.ex` and the Flutter client during Task 10) —
-  the original snippet would `KeyError` before ever reaching the GET/DELETE
-  checks. Fixed in this runbook's Step 4c.
-- **The plan's final "Verification checklist"** (the very end of the plan
-  document, distinct from Task 16 Step 4's own inline verification, which
-  Task 15 already corrected) **was never updated for the `/admin/*` move or
-  the 201 status code.** It still says a crash report "returns 202" and
-  appears at "`/errors`", and that "`GET /errors` and `GET /feedback`
-  redirect to Access" — all three predate Task 11 (201 is the only status
-  the real producer accepts) and Task 15 (both dashboards moved to
-  `/admin/*`). This runbook's Step 4c commands are the corrected version;
-  do not run the plan document's own checklist verbatim.
+  Worth a small follow-up workflow.
+- **The real CPU measurement was never performed**, because it needs a
+  deployed Worker and none exists. See Step 3 of the runbook above.
+- **The pairing claim response field is `claim_code`, not `code`.** Anything
+  parsing `["code"]` out of `POST /pairing/claims` gets a `KeyError`;
+  `src/pairing/routes.ts` returns `{"claim_code": "..."}`, confirmed against
+  both `remote_access.ex` and the Flutter client. Step 4c above has the
+  correct snippet.

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -13,7 +13,7 @@ that plan for the full route-by-route parity work and the cutover sequence.
 
 ## What this migration changed
 
-Four things an operator who knew the Elixir relay would not expect:
+Things an operator who knew the Elixir relay would not expect:
 
 - **Responses are actually cached at Cloudflare's edge now.** The Elixir
   relay sent `cache-control: max-age=0, private, must-revalidate` on every
@@ -42,6 +42,19 @@ Four things an operator who knew the Elixir relay would not expect:
   that touches `relay-worker/**`, straight to `wrangler deploy` — no tag, no
   version bump, no image, no poll delay. `git log` on `relay-worker/` is now
   effectively the release history.
+- **A bulk metadata refresh can now consume rate-limit budget it never used
+  to.** `src/obs/ratelimit.ts`'s proxy limiter used to check the budget
+  *after* running the request, specifically so it could look at
+  `x-relay-cache` and skip charging a cache hit. That shape ran the real
+  upstream `fetch()` before the check could ever stop it — a final review
+  found a throttled request still made its real TMDB/TVDB/SubDL/MusicBrainz/
+  OpenLibrary call every time, which defeats the limiter's actual purpose
+  (protecting upstream quota, worst for SubDL's shared 2000/day key). The fix
+  moves the check ahead of the request, which means it now also charges cache
+  hits: a "refresh every show's metadata" pass that used to be served
+  entirely from cache, for free, can now spend rate-limit budget on hits it
+  didn't touch before. Accepted deliberately as the stricter, fail-closed
+  direction — see the comment above `rateLimitMiddleware` in that file.
 
 ## Bindings
 
@@ -61,9 +74,10 @@ production; a missing secret degrades a route to a 503/502, not a crash.
 | `DB` | D1 database | `wrangler d1 create mydia-relay` | Pairing claims, crash reports/occurrences, feedback submissions, the two rate-limit bucket tables |
 | `PROXY_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Shared per-edge-IP budget across the metadata/music/openlibrary/subtitle proxy routes |
 | `PAIRING_CREATE_LIMITER` / `PAIRING_READ_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Remote-access pairing claim creation/lookup |
+| `CRASH_INGEST_LIMITER` / `FEEDBACK_INGEST_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Atomic, D1-free burst guards in front of crash ingest's and feedback ingest's D1-backed hourly budgets — see those files' comments for why the D1 accounting alone isn't safe under concurrency |
 | Cron Trigger `0 * * * *` | scheduled | `wrangler.jsonc` (`triggers.crons`) | Hourly sweep (`src/obs/sweep.ts`): evicts stale `feedback_rate_limits` rows and expired `pairing_claims` |
 
-`ratelimits[].namespace_id` values (`1001`-`1003`) are arbitrary identifiers
+`ratelimits[].namespace_id` values (`1001`-`1005`) are arbitrary identifiers
 for the binding, not provisioned cloud resources — there is nothing to create
 for them in the dashboard, unlike `CACHE_KV` and `DB`.
 

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -204,6 +204,25 @@ relay-worker/
 └── package.json
 ```
 
+## Migrations: stop amending in place after the first real deploy
+
+Every migration in `migrations/` has so far been amended in place rather than
+superseded by a new numbered file. That was safe because nothing had ever been
+deployed: `database_id` was a placeholder, the CI `deploy-worker` job had never
+run, and every local and test database is rebuilt from scratch on each apply.
+
+**That stops being true the moment the first deploy lands.** Wrangler tracks
+applied D1 migrations by filename, not by content. Once
+`wrangler d1 migrations apply mydia-relay --remote` has run against the real
+database, every filename in `migrations/` is recorded as applied. Editing one of
+those files afterwards silently does nothing to the remote schema, while local
+runs and CI keep passing because they reapply from an empty database. The
+divergence stays invisible until a query hits a column that exists in every
+developer's database and not in production.
+
+So: after the first successful remote apply, a schema change is a NEW numbered
+migration, always. Never an edit to an existing one.
+
 ## Runbook: one-time and manual deployment steps
 
 Everything above this line is code and CI, already working. Everything below

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -120,13 +120,22 @@ both jobs keep a relay-worker-only commit from also invoking the Docker job
 
 ### Dashboards
 
-`GET /errors` and `GET /feedback` are maintainer dashboards, replacing the
-Elixir's ErrorTracker page and `FeedbackLive.Index`. **Cloudflare Access
-guards them, not code.** The Worker holds no dashboard credentials at all —
-no `DASHBOARD_USERNAME`/`DASHBOARD_PASSWORD` equivalent exists in `Env`, and
-none should ever be added; that pattern is exactly what Access retires (see
-the runbook below for the operational trap it closes). Setting up Access is a
-manual, one-time dashboard step — see the runbook.
+`GET /admin/errors` and `GET /admin/feedback` are maintainer dashboards,
+replacing the Elixir's ErrorTracker page and `FeedbackLive.Index`. Both live
+under a shared `/admin/*` prefix **on purpose**: it lets one Cloudflare
+Access application, scoped to `/admin*`, cover every maintainer-only route by
+construction, so adding a third dashboard later inherits the gate instead of
+needing its own conscious Access decision. Neither dashboard shares a path
+with a public endpoint — the public ingest routes (`POST /feedback`,
+`POST /crashes/report`) stay exactly where every mydia install already calls
+them.
+
+**Cloudflare Access guards `/admin/*`, not code.** The Worker holds no
+dashboard credentials at all — no `DASHBOARD_USERNAME`/`DASHBOARD_PASSWORD`
+equivalent exists in `Env`, and none should ever be added; that pattern is
+exactly what Access retires (see the runbook below for the operational trap
+it closes). Setting up the Access application is a manual, one-time step —
+see the runbook.
 
 ## Project structure
 
@@ -140,7 +149,7 @@ relay-worker/
 │   ├── pairing/            # remote-access pairing claims
 │   ├── crashes/            # crash report ingest
 │   ├── feedback/           # feedback ingest (public POST) + email notification
-│   ├── dashboards/         # errors + feedback maintainer dashboards (GET)
+│   ├── dashboards/         # errors + feedback maintainer dashboards, under /admin/*
 │   ├── archive/             # SubDL zip extraction with size caps
 │   └── obs/                # rate limiting, request logging, scheduled sweep
 ├── migrations/              # D1 migrations, applied by wrangler + vitest-pool-workers
@@ -216,82 +225,64 @@ having deployed anything broken (the failure is expected and safe).
 
 ### Step 1: Cloudflare Access — hard ordering constraint
 
-**The dashboards are currently unauthenticated.** `GET /errors` and
-`GET /feedback` expose crash reports and user-submitted feedback, including
-instance identifiers. **Nothing may be routed to a public hostname before the
-Access application below exists.** This is not a recommendation to configure
-Access soon after cutover — it is a precondition of cutover. (Today, before
-Task 16, this Worker has no production route yet, so the constraint is not
-yet live — but it must be satisfied before Task 16 adds
-`relay.mydia.dev/*` routes to `wrangler.jsonc`.)
+**The dashboards are currently unauthenticated.** `GET /admin/errors` and
+`GET /admin/feedback` expose crash reports and user-submitted feedback,
+including instance identifiers. **Nothing may be routed to a public hostname
+before the Access application below exists.** This is not a recommendation to
+configure Access soon after cutover — it is a precondition of cutover.
+(Today, before Task 16, this Worker has no production route yet, so the
+constraint is not yet live — but it must be satisfied before Task 16 adds
+`relay.mydia.dev/*` routes to `wrangler.jsonc`. Task 16's own plan text now
+carries this same precondition on its Step 4 — see
+`docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md`
+— so it's enforced at the point someone would otherwise miss it.)
 
-**`/errors` can be protected exactly as the brief describes. `/feedback`
-cannot, as written** — this is the most consequential finding in this
-runbook; read it before touching the Access dashboard.
-
-Cloudflare Access self-hosted applications match on **hostname + path only**.
-There is no HTTP-method selector in Access's own policy engine — Access
-policy selectors are identity/context attributes (email, country, IP range,
-device posture, service token, login method); "HTTP Method" exists only as a
-selector for Gateway HTTP policies, a different product that inspects
+**Why both dashboards live under `/admin/*` instead of their naive
+`/errors`/`/feedback` paths:** the brief's original Step 1 asked for an
+Access application covering literal `/errors` and `/feedback`. That doesn't
+work. Cloudflare Access self-hosted applications match on **hostname + path
+only** — there is no HTTP-method selector in Access's own policy engine
+(Access policy selectors are identity/context attributes: email, country, IP
+range, device posture, service token, login method; "HTTP Method" exists only
+as a selector for Gateway HTTP policies, a different product inspecting
 WARP-proxied client-side traffic, not inbound requests to a self-hosted
-Access application. (Verified against Cloudflare's current documentation for
-Access policy selectors and for Gateway HTTP policy selectors, which lists
-HTTP Method only in the latter.)
+Access application — verified against Cloudflare's current documentation for
+each). `POST /feedback` (public ingest, called by every install) used to
+share a literal path with `GET /feedback` (the maintainer dashboard); an
+Access application scoped to that path would have gated **both** methods,
+since Access cannot tell them apart, breaking feedback submission fleet-wide
+the moment Access was configured.
 
-`POST /feedback` (public ingest, called by every install) and
-`GET /feedback` (the maintainer dashboard) are **the same path**
-(`src/index.ts` registers `registerFeedbackRoutes` — POST only — and
-`registerFeedbackDashboard` — GET only — as separate Hono route
-registrations on the identical `/feedback` string). An Access application
-scoped to `/feedback` gates **both methods**, because Access cannot tell them
-apart. Adding `/feedback` to the Access application as the brief's Step 1
-describes would put the public ingest endpoint behind an SSO login page,
-breaking feedback submission fleet-wide the moment Access is configured —
-before any dashboard is even used.
+**The fix, now shipped in code:** the maintainer dashboards moved to
+`/admin/errors` and `/admin/feedback` — entirely separate paths from any
+public endpoint. `POST /feedback` and `POST /crashes/report` did **not**
+move; they are wire contracts every deployed mydia instance already calls.
+One Access application scoped to `/admin*` now cleanly covers both
+dashboards, present and future, with no per-route decision and no path
+collision with anything public.
 
-**What to actually configure, today:**
+**What to configure:**
 
 1. Create one self-hosted Access application:
    - Application domain: `relay.mydia.dev`
-   - Path: `/errors*` (covers `/errors`, `/errors/:fingerprint`, and the two
-     mutation routes `/errors/:fingerprint/resolve` and
-     `/errors/:fingerprint/unresolve` — all maintainer-only, no public
-     consumer ever calls anything under `/errors`)
+   - Path: `/admin*` (covers `/admin/errors`, `/admin/errors/:fingerprint`,
+     `/admin/errors/:fingerprint/resolve`, `/admin/errors/:fingerprint/unresolve`,
+     `/admin/feedback`, `/admin/feedback/:id/state`, and
+     `/admin/feedback/:id/github` — every maintainer-only route in the
+     Worker, and any future one added under the same prefix)
    - Policy: Allow, Include → Emails → the maintainer address
-2. **Do not add `/feedback` to this application, or any application, in a
-   way that covers the whole path.** Leave it out entirely for now.
 
-**The feedback dashboard is left with no safe Access configuration until a
-small Worker code change lands** (out of scope for this task — Task 15 was
-authorized to touch CI, README, and this runbook, not `src/dashboards/` or
-`src/feedback/`). The fix is straightforward and should be a fast follow
-before cutover reaches `/feedback`: move the maintainer dashboard's `GET`
-handler off the shared path — for example to `/feedback/dashboard` or a
-shared `/admin/*` prefix alongside `/errors` — so Access can scope to the new
-path while the public `POST /feedback` ingest endpoint (which must never
-move; it's a wire contract every deployed mydia instance already calls)
-stays completely outside any Access application. Until that ships, treat the
-feedback dashboard as **not safely exposable** on the production hostname —
-it is not covered by the Access application above and has no other guard.
+That's it — one application, one path pattern, no exclusion list to maintain.
 
-(A Cloudflare WAF custom rule can match on `http.request.method`, unlike
-Access, and in principle could complement Access here — e.g. challenging bare
-GETs to `/feedback` while leaving POST alone. This was not verified: there is
-no dashboard access in this environment to confirm the phase ordering between
-a zone-level WAF custom rule and a Workers-backed self-hosted Access
-application, and getting that ordering wrong could just as easily reopen the
-hole it's meant to close. Prefer the path-split code fix; treat WAF-layering
-as an unverified fallback only if that fix is delayed.)
-
-**Verify both halves after configuring Access** (the two curls the brief
-specifies remain the correct verification for `/errors`; the `/feedback`
-curl should be read as confirming the *current* state, not a target state,
-until the path split above ships):
+**Verify both halves after configuring Access:**
 
 ```bash
-# /errors: must now require login
-curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/errors
+# GET /admin/errors: must require login
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/admin/errors
+# expect: 302 (redirect to the Access login)
+
+# GET /admin/feedback: must also require login
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/admin/feedback
 # expect: 302 (redirect to the Access login)
 
 # POST /feedback: must NOT require login — this is every install's ingest path
@@ -300,16 +291,17 @@ curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://relay.mydia.dev/feedba
   -d '{"type":"idea","message":"access check"}'
 # expect: 201
 
-# GET /feedback: today this is still open (see above) — confirm it is NOT
-# accidentally 302'd by an application scoped too broadly, and treat a bare
-# 200 here as the known, tracked gap, not a surprise
+# GET /feedback (the OLD path): must be a plain 404, never the dashboard —
+# regression-tested in test/dashboards/feedback.test.ts, but worth confirming
+# against the real deploy too, since Access config is exactly the kind of
+# thing that regresses independently of the code.
 curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/feedback
+# expect: 404
 ```
 
-If the `/errors` curl ever comes back 200 instead of 302, or the `POST
-/feedback` curl ever comes back anything but 201, stop and re-check the
-Access application's path scope before proceeding with cutover — one of the
-two halves has regressed.
+If either `/admin/*` curl ever comes back 200 instead of 302, or the `POST
+/feedback` curl comes back anything but 201, stop and re-check the Access
+application's path scope before proceeding with cutover.
 
 ### Step 2: contract diff — not wired into CI, on purpose
 
@@ -391,10 +383,12 @@ This task's brief (`task-15-brief.md`) assumed several things that don't
 match this repository as it stands. Recorded here so the next person doesn't
 re-discover them the hard way:
 
-- **The Access path split as specified doesn't work.** See Step 1 above —
-  Access matches by path only, not method, and `/feedback` serves both the
-  public POST and the dashboard GET on the identical path. This is the
-  biggest gap; everything else below is comparatively minor.
+- **The Access path split as specified (`/errors` and `/feedback`) doesn't
+  work.** See Step 1 above — Access matches by path only, not method, and
+  `/feedback` used to serve both the public POST and the dashboard GET on the
+  identical path. Fixed by moving both dashboards under `/admin/*`, a path no
+  public endpoint shares. This was the biggest gap found in this task;
+  everything else below is comparatively minor.
 - **"The Cloudflare API token and zone id already exist in
   `infra/config.yaml`; add them as repository secrets if they are not there
   yet"** conflates three different things:

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -1,0 +1,450 @@
+# Metadata Relay Worker
+
+A Cloudflare Worker replacement for `metadata-relay/` (the Elixir/Bandit
+service). It proxies TMDB, TVDB, SubDL, MusicBrainz and OpenLibrary for every
+mydia install, plus pairing, crash ingest and feedback. TypeScript, Hono for
+routing, no server and no tunnel — Cloudflare's edge is the whole runtime.
+
+This is one of 17 tasks in
+`docs/superpowers/plans/2026-09-05-metadata-relay-on-cloudflare-workers.md`.
+Through Task 16, `relay.mydia.dev` is still served by the Elixir relay; this
+Worker deploys continuously but does not yet own any production traffic. See
+that plan for the full route-by-route parity work and the cutover sequence.
+
+## Bindings
+
+Declared in `wrangler.jsonc` (KV, D1, rate limiters, vars) and `src/env.ts`
+(the full `Env` interface, including secrets). Nothing below is optional in
+production; a missing secret degrades a route to a 503/502, not a crash.
+
+| Binding | Kind | Set via | Used for |
+| --- | --- | --- | --- |
+| `TMDB_API_KEY` | secret | `wrangler secret put` | TMDB proxy routes (`/tmdb/*`, `/configuration`) |
+| `TVDB_API_KEY` | secret | `wrangler secret put` | TVDB proxy routes (`/tvdb/*`), including token auth |
+| `SUBDL_API_KEY` | secret | `wrangler secret put` | Subtitle search/download (`/api/v1/subtitles/*`) |
+| `RESEND_API_KEY` | secret | `wrangler secret put` | Feedback notification emails. Absent = notifications silently skipped, ingest still works |
+| `RELAY_VERSION` | var | `wrangler.jsonc` | Reported by `/health` and `/stats` |
+| `FEEDBACK_FROM` / `FEEDBACK_TO` | var | `wrangler.jsonc` | Sender/recipient for feedback notification emails |
+| `CACHE_KV` | KV namespace | `wrangler kv namespace create CACHE_KV` | TVDB JWT cache and the SubDL search response cache. Everything else caches in the Cache API only |
+| `DB` | D1 database | `wrangler d1 create mydia-relay` | Pairing claims, crash reports/occurrences, feedback submissions, the two rate-limit bucket tables |
+| `PROXY_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Shared per-edge-IP budget across the metadata/music/openlibrary/subtitle proxy routes |
+| `PAIRING_CREATE_LIMITER` / `PAIRING_READ_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Remote-access pairing claim creation/lookup |
+| Cron Trigger `0 * * * *` | scheduled | `wrangler.jsonc` (`triggers.crons`) | Hourly sweep (`src/obs/sweep.ts`): evicts stale `feedback_rate_limits` rows and expired `pairing_claims` |
+
+`ratelimits[].namespace_id` values (`1001`-`1003`) are arbitrary identifiers
+for the binding, not provisioned cloud resources — there is nothing to create
+for them in the dashboard, unlike `CACHE_KV` and `DB`.
+
+**Requires wrangler >= 4.36.0.** The `ratelimits` config key was silently
+dropped by older wrangler versions with no error (Task 8's finding) — the
+binding would be `undefined` at runtime and every proxy route would 500. This
+repo pins an exact version in `package.json`; do not loosen that pin without
+re-checking this.
+
+## Local development
+
+```bash
+npm ci
+npm run dev        # wrangler dev
+```
+
+`wrangler dev` runs entirely locally (Miniflare) against the placeholder
+`database_id`/KV `id` values checked into `wrangler.jsonc` — no Cloudflare
+account needed for this. Provider secrets are unset locally by default, so
+proxy routes 503/502 until you add a `.dev.vars` file (git-ignored) with the
+four secret keys above, if you want to exercise real upstream calls.
+
+## Testing
+
+```bash
+npm test          # vitest run — full suite, workerd runtime (Miniflare)
+npm run typecheck # tsc --noEmit — covers src/ AND test/
+```
+
+Both must pass before every deploy; the CI job below runs them in that order
+and stops before touching Cloudflare if either fails.
+
+### Contract diff
+
+```bash
+npm run test:contract
+```
+
+Replays a fixed request list (`test/contract/routes.json`) against a deployed
+Worker and the live Elixir relay, diffing status and body
+(`test/contract/contract.test.ts`). Runs as a separate Vitest project under
+plain Node (workerd's own root CA store does not trust every TLS-intercepting
+proxy a given network puts in front of outbound HTTPS — see the file's own
+comment for how that was diagnosed).
+
+**Skipped by default.** `CONTRACT_WORKER_URL` is unset in ordinary
+`npm test`/CI runs, so the whole suite no-ops:
+
+```bash
+CONTRACT_WORKER_URL=https://<staging>.workers.dev npm run test:contract
+```
+
+**This is not wired into CI** (see the runbook below for why and where the
+real gate lives). If you ever do wire it in, you must assert the skip count is
+zero — or that `CONTRACT_WORKER_URL` is set — before trusting a green run.
+Vitest exits 0 for a run that is entirely `describe.skipIf`-skipped, identical
+to a run where every test genuinely passed; a gate that only checks the exit
+code can rubber-stamp a cutover having compared nothing.
+
+## Deployment
+
+**`wrangler deploy` is the release ritual.** There is no `metadata-relay-v*`
+tag for this Worker and no version bump to make first — CI deploys on every
+push to `master`/`main` that touches `relay-worker/**` (the `deploy-worker`
+job in `.github/workflows/deploy-relay.yml`):
+
+1. `npm ci`
+2. `npm test` && `npm run typecheck`
+3. `npx wrangler d1 migrations apply mydia-relay --remote` — always before the
+   deploy step, so a new binding a commit adds never reaches a database that
+   doesn't have its table yet
+4. `npx wrangler deploy`
+
+A test or typecheck failure stops the job before step 3, so a broken commit
+on `master` cannot reach Cloudflare — but note that today nothing runs these
+checks on the pull request itself (no `ci-relay-worker.yml` equivalent of
+`ci-relay.yml` exists yet); the first automated signal a PR gets is this job,
+after merge. See the runbook's "What Task 15 did not do" for why this wasn't
+added here.
+
+The Docker/GHCR job in the same workflow file is the **Elixir** relay's
+unrelated, still-live release path (tag-triggered on `metadata-relay-v*`);
+the two share the file until Task 17 deletes the Elixir side. `if:` guards on
+both jobs keep a relay-worker-only commit from also invoking the Docker job
+(and vice versa) — see the comment at the top of the workflow file.
+
+### Dashboards
+
+`GET /errors` and `GET /feedback` are maintainer dashboards, replacing the
+Elixir's ErrorTracker page and `FeedbackLive.Index`. **Cloudflare Access
+guards them, not code.** The Worker holds no dashboard credentials at all —
+no `DASHBOARD_USERNAME`/`DASHBOARD_PASSWORD` equivalent exists in `Env`, and
+none should ever be added; that pattern is exactly what Access retires (see
+the runbook below for the operational trap it closes). Setting up Access is a
+manual, one-time dashboard step — see the runbook.
+
+## Project structure
+
+```
+relay-worker/
+├── src/
+│   ├── index.ts          # Hono app, route registration, scheduled() entrypoint
+│   ├── env.ts             # Env interface (bindings + secrets)
+│   ├── proxy/              # tmdb/tvdb/subdl/passthrough (music, openlibrary) handlers
+│   ├── cache/              # cache key derivation + get/put over Cache API + KV
+│   ├── pairing/            # remote-access pairing claims
+│   ├── crashes/            # crash report ingest
+│   ├── feedback/           # feedback ingest (public POST) + email notification
+│   ├── dashboards/         # errors + feedback maintainer dashboards (GET)
+│   ├── archive/             # SubDL zip extraction with size caps
+│   └── obs/                # rate limiting, request logging, scheduled sweep
+├── migrations/              # D1 migrations, applied by wrangler + vitest-pool-workers
+├── test/                   # mirrors src/, plus test/contract (see above)
+├── wrangler.jsonc
+└── package.json
+```
+
+## Runbook: one-time and manual deployment steps
+
+Everything above this line is code and CI, already working. Everything below
+is **manual** — it needs Cloudflare dashboard/API access this repo's CI and
+local dev environment do not have, and nobody has executed it yet. Follow it
+in order; each step depends on the one before it.
+
+### Step 0: Cloudflare account setup (before the CI job can succeed at all)
+
+`wrangler.jsonc`'s `d1_databases[0].database_id` and `kv_namespaces[0].id` are
+`"placeholder_local_dev_only"` — real for Miniflare/vitest-pool-workers, but
+not a real Cloudflare resource. `wrangler deploy` and
+`wrangler d1 migrations apply --remote` will fail against them. Before the
+`deploy-worker` CI job can succeed even once:
+
+1. **Create the D1 database and KV namespace** (needs a Cloudflare account
+   with Workers/D1/KV enabled):
+   ```bash
+   cd relay-worker
+   npx wrangler d1 create mydia-relay
+   npx wrangler kv namespace create CACHE_KV
+   ```
+   Copy the `database_id` and `id` each command prints into
+   `wrangler.jsonc`, replacing both `placeholder_local_dev_only` values.
+   Commit that change separately from this task's CI/README commit.
+
+2. **Set the four secrets** (once, against the real Worker):
+   ```bash
+   npx wrangler secret put TMDB_API_KEY
+   npx wrangler secret put TVDB_API_KEY
+   npx wrangler secret put SUBDL_API_KEY
+   npx wrangler secret put RESEND_API_KEY
+   ```
+
+3. **Mint a Cloudflare API token for CI**, and find the account ID.
+   The brief for this task assumed the token and ID in `infra/config.yaml`
+   could be reused. They cannot — see "Brief vs. reality" below. Create a new
+   token at <https://dash.cloudflare.com/profile/api-tokens> scoped to at
+   least:
+   - Account / Workers Scripts: Edit
+   - Account / Workers KV Storage: Edit
+   - Account / D1: Edit
+   - Account / Account Settings: Read (needed to resolve the account by ID)
+
+   Find the account ID on the Workers & Pages overview page (right sidebar).
+
+4. **Add two repository secrets** (Settings → Secrets and variables →
+   Actions), named exactly as the workflow reads them:
+   - `CLOUDFLARE_API_TOKEN` — the token from step 3. This name **already
+     exists** in this repository, reused by `deploy-site.yml` and
+     `deploy-web-player.yml` for `wrangler pages deploy`. Check its scope
+     before assuming it already works here: a Pages-only token does not
+     carry Workers Scripts/D1/KV edit rights. Either broaden the existing
+     token to cover both, accepting that a leak or misuse now affects Pages
+     deploys too, or store the new token under a different secret name and
+     point this job's two `CLOUDFLARE_API_TOKEN` references at that name
+     instead. Either is fine; pick one and document which.
+   - `CLOUDFLARE_ACCOUNT_ID` — does not exist yet anywhere in this
+     repository's secrets or config.
+
+Only after all of the above will the `deploy-worker` CI job's first run
+succeed. Until then, every push to `master` touching `relay-worker/**` will
+fail at the "Apply D1 migrations" or "Deploy" step — loudly, in CI, without
+having deployed anything broken (the failure is expected and safe).
+
+### Step 1: Cloudflare Access — hard ordering constraint
+
+**The dashboards are currently unauthenticated.** `GET /errors` and
+`GET /feedback` expose crash reports and user-submitted feedback, including
+instance identifiers. **Nothing may be routed to a public hostname before the
+Access application below exists.** This is not a recommendation to configure
+Access soon after cutover — it is a precondition of cutover. (Today, before
+Task 16, this Worker has no production route yet, so the constraint is not
+yet live — but it must be satisfied before Task 16 adds
+`relay.mydia.dev/*` routes to `wrangler.jsonc`.)
+
+**`/errors` can be protected exactly as the brief describes. `/feedback`
+cannot, as written** — this is the most consequential finding in this
+runbook; read it before touching the Access dashboard.
+
+Cloudflare Access self-hosted applications match on **hostname + path only**.
+There is no HTTP-method selector in Access's own policy engine — Access
+policy selectors are identity/context attributes (email, country, IP range,
+device posture, service token, login method); "HTTP Method" exists only as a
+selector for Gateway HTTP policies, a different product that inspects
+WARP-proxied client-side traffic, not inbound requests to a self-hosted
+Access application. (Verified against Cloudflare's current documentation for
+Access policy selectors and for Gateway HTTP policy selectors, which lists
+HTTP Method only in the latter.)
+
+`POST /feedback` (public ingest, called by every install) and
+`GET /feedback` (the maintainer dashboard) are **the same path**
+(`src/index.ts` registers `registerFeedbackRoutes` — POST only — and
+`registerFeedbackDashboard` — GET only — as separate Hono route
+registrations on the identical `/feedback` string). An Access application
+scoped to `/feedback` gates **both methods**, because Access cannot tell them
+apart. Adding `/feedback` to the Access application as the brief's Step 1
+describes would put the public ingest endpoint behind an SSO login page,
+breaking feedback submission fleet-wide the moment Access is configured —
+before any dashboard is even used.
+
+**What to actually configure, today:**
+
+1. Create one self-hosted Access application:
+   - Application domain: `relay.mydia.dev`
+   - Path: `/errors*` (covers `/errors`, `/errors/:fingerprint`, and the two
+     mutation routes `/errors/:fingerprint/resolve` and
+     `/errors/:fingerprint/unresolve` — all maintainer-only, no public
+     consumer ever calls anything under `/errors`)
+   - Policy: Allow, Include → Emails → the maintainer address
+2. **Do not add `/feedback` to this application, or any application, in a
+   way that covers the whole path.** Leave it out entirely for now.
+
+**The feedback dashboard is left with no safe Access configuration until a
+small Worker code change lands** (out of scope for this task — Task 15 was
+authorized to touch CI, README, and this runbook, not `src/dashboards/` or
+`src/feedback/`). The fix is straightforward and should be a fast follow
+before cutover reaches `/feedback`: move the maintainer dashboard's `GET`
+handler off the shared path — for example to `/feedback/dashboard` or a
+shared `/admin/*` prefix alongside `/errors` — so Access can scope to the new
+path while the public `POST /feedback` ingest endpoint (which must never
+move; it's a wire contract every deployed mydia instance already calls)
+stays completely outside any Access application. Until that ships, treat the
+feedback dashboard as **not safely exposable** on the production hostname —
+it is not covered by the Access application above and has no other guard.
+
+(A Cloudflare WAF custom rule can match on `http.request.method`, unlike
+Access, and in principle could complement Access here — e.g. challenging bare
+GETs to `/feedback` while leaving POST alone. This was not verified: there is
+no dashboard access in this environment to confirm the phase ordering between
+a zone-level WAF custom rule and a Workers-backed self-hosted Access
+application, and getting that ordering wrong could just as easily reopen the
+hole it's meant to close. Prefer the path-split code fix; treat WAF-layering
+as an unverified fallback only if that fix is delayed.)
+
+**Verify both halves after configuring Access** (the two curls the brief
+specifies remain the correct verification for `/errors`; the `/feedback`
+curl should be read as confirming the *current* state, not a target state,
+until the path split above ships):
+
+```bash
+# /errors: must now require login
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/errors
+# expect: 302 (redirect to the Access login)
+
+# POST /feedback: must NOT require login — this is every install's ingest path
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://relay.mydia.dev/feedback \
+  -H 'content-type: application/json' \
+  -d '{"type":"idea","message":"access check"}'
+# expect: 201
+
+# GET /feedback: today this is still open (see above) — confirm it is NOT
+# accidentally 302'd by an application scoped too broadly, and treat a bare
+# 200 here as the known, tracked gap, not a surprise
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/feedback
+```
+
+If the `/errors` curl ever comes back 200 instead of 302, or the `POST
+/feedback` curl ever comes back anything but 201, stop and re-check the
+Access application's path scope before proceeding with cutover — one of the
+two halves has regressed.
+
+### Step 2: contract diff — not wired into CI, on purpose
+
+`npm run test:contract` (see Testing above) is **not** part of the
+`deploy-worker` CI job. Two reasons:
+
+1. **There is nothing meaningful to diff against at Task 15's CI-job
+   deploy time.** The job deploys the Worker being tested; running the
+   contract diff immediately after would compare the freshly deployed Worker
+   against itself moments later, which (per Task 9's finding) proves the
+   harness mechanics and nothing about correctness of the change just
+   shipped.
+2. **An all-skipped run exits 0.** `CONTRACT_WORKER_URL` unset means the
+   entire suite is `describe.skipIf`-skipped, and Vitest's exit code cannot
+   distinguish that from every test passing. A CI job that ran this
+   unconditionally, without separately asserting the skip count, would be a
+   gate that can rubber-stamp a cutover having compared nothing — worse than
+   no gate, because it looks like one.
+
+**The real gate lives in Task 16, Step 1** — a human runs
+`CONTRACT_WORKER_URL=https://<staging>.workers.dev npm run test:contract`
+against a staging deploy before flipping any production route, watches the
+output, and does not proceed on a single mismatch. That manual supervision is
+deliberate: a person who runs the command and reads a "42 skipped" line
+notices something is wrong immediately; a CI badge does not.
+
+If this is ever automated, the job **must** fail when the skip count is
+nonzero (or, simpler, assert `CONTRACT_WORKER_URL` is set before invoking
+the suite at all) — never trust the bare exit code.
+
+### Step 3: real platform CPU measurement (subtitle download path)
+
+Task 6 shipped `src/proxy/subdl.ts`'s archive extraction (`extractSubtitle`)
+with a **local-only** CPU measurement: 0.1630ms mean / 0.3049ms p99 over a
+~10KB archive, measured with Node's `perf_hooks`, explicitly caveated in
+`task-6-report.md` as a different engine (V8 in Node vs. workerd) and
+different silicon than production. It was never validated against the real
+constraint — the Workers **free plan's 10ms CPU-time-per-invocation limit** —
+because that requires a deployed Worker, which did not exist when Task 6 ran.
+It still doesn't, as of this task.
+
+**Do this once the first real deploy exists** — i.e., after Step 0 above
+succeeds and `deploy-worker` has pushed to the Worker's `workers.dev`
+subdomain for the first time (this happens automatically; Task 16 is what
+later adds `relay.mydia.dev` routes, but the Worker is live on
+`*.workers.dev` from the very first successful CI deploy):
+
+1. Trigger a real request through the download path against a live SubDL
+   subtitle (needs a working `SUBDL_API_KEY` from Step 0):
+   ```bash
+   curl -sS "https://<worker>.workers.dev/api/v1/subtitles/download/<file_id>"
+   ```
+   Repeat several times, and include at least one request against a subtitle
+   archive near the top of the realistic size range (a large multi-file
+   archive), not just a minimal one — the 0.30ms p99 local figure came from a
+   ~10KB archive and the extraction cost scales with archive size.
+2. Read the **CPU time** metric for those invocations from the Cloudflare
+   dashboard (Workers & Pages → the Worker → Metrics → CPU time), not wall
+   time — wall time on this route includes network I/O to `dl.subdl.com`,
+   which the 10ms budget does not count.
+3. Compare against 10ms.
+   - **Under budget with headroom** (the local figure suggests this is
+     likely, but "likely" is exactly what this step exists to stop trusting):
+     no action needed, but record the real number somewhere durable (this
+     README, or a follow-up note) so the next person doesn't have to
+     re-derive it.
+   - **Close to or over 10ms:** do not ship this route further before
+     addressing it. Options in order of preference: (a) confirm the account
+     is actually on a paid plan with a higher/no CPU cap before assuming
+     free-plan limits apply, (b) profile `extractSubtitle` and
+     `readCapped`/`declaredContentLengthExceeds` (`src/proxy/subdl.ts`) for
+     the actual hot path on a large archive, (c) lower `MAX_ARCHIVE_BYTES`
+     (currently 20,000,000) if real-world archives never approach it, trading
+     rejected-but-legitimate edge cases for headroom.
+
+## Brief vs. reality
+
+This task's brief (`task-15-brief.md`) assumed several things that don't
+match this repository as it stands. Recorded here so the next person doesn't
+re-discover them the hard way:
+
+- **The Access path split as specified doesn't work.** See Step 1 above —
+  Access matches by path only, not method, and `/feedback` serves both the
+  public POST and the dashboard GET on the identical path. This is the
+  biggest gap; everything else below is comparatively minor.
+- **"The Cloudflare API token and zone id already exist in
+  `infra/config.yaml`; add them as repository secrets if they are not there
+  yet"** conflates three different things:
+  - `infra/config.yaml` is a **local, git-ignored** operator file consumed by
+    the `infra/deploy` Python tool. Nothing in it is automatically a GitHub
+    Actions secret; there is no sync between the two.
+  - Its `cloudflare_api_token` is scoped to **`Zone:DNS:Edit`** only (see
+    `infra/README.md`'s setup instructions), for `external-dns`. It has no
+    permission to deploy a Worker, write D1, or write KV — reusing it as-is
+    would make `wrangler deploy` fail with an authorization error.
+  - It stores a **zone ID**, not an account ID. `wrangler` needs
+    `CLOUDFLARE_ACCOUNT_ID` (an account identifier), a different Cloudflare
+    resource entirely; a zone ID doesn't work for that env var.
+  - Separately, `CLOUDFLARE_API_TOKEN` **does already exist** as a GitHub
+    Actions repository secret — but for `wrangler pages deploy` in
+    `deploy-site.yml`/`deploy-web-player.yml`, a different scope again (Pages
+    edit, not Workers/D1/KV edit).
+- **`d1_databases[0].database_id` and `kv_namespaces[0].id` are
+  placeholders**, not real Cloudflare resources — `wrangler.jsonc`'s own
+  comments say so. The brief's CI snippet assumes `wrangler d1 migrations
+  apply --remote` and `wrangler deploy` just work once secrets exist; they
+  don't, until the D1 database and KV namespace are actually created (Step 0
+  above) and the placeholder IDs are replaced.
+- **Action versions.** The brief's Step 2 snippet uses
+  `actions/checkout@v4` and `actions/setup-node@v4`. This repository's own
+  workflows (including the `docker` job already in this same file) use
+  `@v7` for both; the shipped workflow matches the repository's convention
+  instead.
+- **Adding a bare `paths:` filter to the existing tag-triggered push block
+  would have been a silent trap**, not the drop-in change Step 3 describes —
+  except it turns out fine, for a documented reason: GitHub Actions does not
+  evaluate `paths` filters on tag pushes at all, only on branch pushes. So
+  adding `paths: ["relay-worker/**"]` alongside the existing `tags:` trigger
+  doesn't gate the Docker job's tag trigger — but it does mean the workflow
+  now *also* fires on branch pushes, which it never did before. Without an
+  `if:` guard, that would make a relay-worker-only commit to `master` also
+  invoke the unrelated `docker` job, which parses a semver out of the ref and
+  would receive a branch ref instead of a tag — producing a broken Docker
+  build on every such commit. Both jobs in the shipped workflow carry
+  `if:` guards (`startsWith(github.ref, 'refs/tags/')` for `docker`,
+  `github.ref_type == 'branch'` for `deploy-worker`) to prevent this.
+- **No PR-time CI signal exists for `relay-worker/` yet.** Unlike
+  `metadata-relay/` (covered by `ci-relay.yml` on every push and PR), there
+  is no equivalent workflow running `npm test`/`npm run typecheck` against
+  `relay-worker/**` on pull requests. The `deploy-worker` job added here
+  only runs after a merge to `master`, and it is safe (a failing test/
+  typecheck step stops the job before `wrangler deploy` runs), but it means a
+  broken PR currently gets no automated feedback before merge — only after.
+  This wasn't in Task 15's authorized scope (CI/README only); flagging it as
+  a gap worth a small follow-up rather than fixing it here.
+- **The Step 6 CPU measurement was never performed**, for the reason stated
+  in Task 6's report: it needs a deployed Worker, which didn't exist yet.
+  See the runbook's Step 3 above.

--- a/relay-worker/migrations/0001_pairing.sql
+++ b/relay-worker/migrations/0001_pairing.sql
@@ -1,0 +1,9 @@
+-- The key carries its own version prefix ("pairing:" or "pairing:v2:"), which
+-- is what keeps the two keyspaces from colliding, exactly as the Redis keys did.
+CREATE TABLE pairing_claims (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  expires_at INTEGER NOT NULL
+);
+
+CREATE INDEX pairing_claims_expires_idx ON pairing_claims (expires_at);

--- a/relay-worker/migrations/0002_crash_reports.sql
+++ b/relay-worker/migrations/0002_crash_reports.sql
@@ -7,7 +7,15 @@ CREATE TABLE errors (
   status TEXT NOT NULL DEFAULT 'unresolved',
   first_seen_at INTEGER NOT NULL,
   last_seen_at INTEGER NOT NULL,
-  occurrence_count INTEGER NOT NULL DEFAULT 0
+  occurrence_count INTEGER NOT NULL DEFAULT 0,
+  -- Set to 1 (via `MAX(errors.count_is_floor, excluded.count_is_floor)` in
+  -- src/crashes/ingest.ts's upsert) the moment ANY of this fingerprint's
+  -- ingest_buckets rows ever reaches MAX_OCCURRENCE_ROWS_PER_BUCKET, and
+  -- NEVER reset back to 0 afterwards. See ingest_buckets.saturated below for
+  -- why this can't live on that table instead -- this column is the durable
+  -- half of that story. A dashboard must read THIS column, not
+  -- ingest_buckets.saturated, to decide whether occurrence_count is exact.
+  count_is_floor INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX errors_last_seen_idx ON errors (last_seen_at DESC);
@@ -51,10 +59,27 @@ CREATE INDEX occurrences_fingerprint_time_idx
 -- One consequence: once a bucket saturates, `errors.occurrence_count` stops
 -- advancing too (its upsert is part of what gets skipped), so it becomes a
 -- floor, not an exact count, for the rest of that hour. `saturated` records
--- exactly when that happened so a reader (e.g. a dashboard) can render the
--- count as "at least N in this hour, throttled" instead of presenting an
--- undercount as if it were exact. It resets to 0 whenever `hour_bucket`
--- rolls over, since a fresh hour gets a fresh budget.
+-- that this happened -- but ONLY for as long as this exact row's current
+-- hour window lasts. It resets to 0 the moment a fresh hour's write lands
+-- for the same (fingerprint, instance_key) pair (a fresh hour gets a fresh
+-- budget), and that reset is in-place: nothing preserves what `saturated`
+-- was a moment before.
+--
+-- That reset is exactly right for what THIS table is for -- deciding
+-- whether to admit the CURRENT hour's writes -- and exactly wrong for
+-- answering "is errors.occurrence_count exact?" for a fingerprint whose
+-- misbehaving install keeps crashing past the hour boundary: saturate hour
+-- H, then send one single further crash in hour H+1, and this row flips
+-- back to `saturated = 0` even though every crash dropped during H's
+-- throttling is gone forever and will never be counted -- the total is
+-- STILL a floor, permanently, regardless of what any later hour's traffic
+-- looks like. A dashboard reading `saturated` directly would show a
+-- precise-looking number at exactly the moment (some time after a storm)
+-- an operator is most likely to look. `errors.count_is_floor` is the fix:
+-- a separate, sticky, never-reset flag set the instant any bucket for that
+-- fingerprint ever saturates. Keep using `saturated` for what it's
+-- correctly used for (the live per-hour admission decision in
+-- src/crashes/ingest.ts); read `count_is_floor` for "is the total exact?".
 CREATE TABLE ingest_buckets (
   fingerprint TEXT NOT NULL,
   instance_key TEXT NOT NULL,

--- a/relay-worker/migrations/0002_crash_reports.sql
+++ b/relay-worker/migrations/0002_crash_reports.sql
@@ -27,14 +27,39 @@ CREATE TABLE occurrences (
 CREATE INDEX occurrences_fingerprint_time_idx
   ON occurrences (fingerprint, occurred_at DESC);
 
--- One row per fingerprint per instance per hour bucket. Its presence is what
--- tells ingest to count an occurrence without writing a new occurrence row,
--- which is what stops a single crash-looping install exhausting D1's daily
--- write budget for everyone.
+-- One row per (fingerprint, instance) -- NOT per hour. `hour_bucket` is a
+-- plain column here, not part of the key: ingest reads this row first, and
+-- when its stored hour_bucket differs from the current one it resets
+-- `written`/`saturated` back to a fresh count instead of inserting a new
+-- row. Keying on (fingerprint, instance, hour) instead would grow this table
+-- by one row per fingerprint/instance for every hour that has ever elapsed,
+-- forever, with nothing to evict it.
+--
+-- `written` is a write BUDGET, not a crash count: ingest checks this row
+-- BEFORE touching `errors` or `occurrences`, and once `written` reaches
+-- MAX_OCCURRENCE_ROWS_PER_BUCKET (3, in src/crashes/ingest.ts) for the
+-- current hour, it performs NO writes at all for the rest of that hour --
+-- not to `errors`, not to this table, not to `occurrences`. This is what
+-- actually bounds D1 writes: an `INSERT ... ON CONFLICT DO UPDATE` reports a
+-- write on every call whether it inserts or updates, so unconditionally
+-- upserting `errors` on every request (as an earlier version of this
+-- migration's comment implied was already the design) would have cost
+-- roughly 2 writes per request regardless of the cap -- a storm of N
+-- requests would still perform ~2N writes, only the `occurrences` insert
+-- among them was ever actually capped.
+--
+-- One consequence: once a bucket saturates, `errors.occurrence_count` stops
+-- advancing too (its upsert is part of what gets skipped), so it becomes a
+-- floor, not an exact count, for the rest of that hour. `saturated` records
+-- exactly when that happened so a reader (e.g. a dashboard) can render the
+-- count as "at least N in this hour, throttled" instead of presenting an
+-- undercount as if it were exact. It resets to 0 whenever `hour_bucket`
+-- rolls over, since a fresh hour gets a fresh budget.
 CREATE TABLE ingest_buckets (
   fingerprint TEXT NOT NULL,
   instance_key TEXT NOT NULL,
   hour_bucket INTEGER NOT NULL,
   written INTEGER NOT NULL DEFAULT 0,
-  PRIMARY KEY (fingerprint, instance_key, hour_bucket)
+  saturated INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (fingerprint, instance_key)
 );

--- a/relay-worker/migrations/0002_crash_reports.sql
+++ b/relay-worker/migrations/0002_crash_reports.sql
@@ -80,10 +80,30 @@ CREATE INDEX occurrences_fingerprint_time_idx
 -- fingerprint ever saturates. Keep using `saturated` for what it's
 -- correctly used for (the live per-hour admission decision in
 -- src/crashes/ingest.ts); read `count_is_floor` for "is the total exact?".
+-- `hits` (final review fix round): an UNCAPPED count of requests admitted
+-- past the burst-guard rate limiter for this (fingerprint, instance_key) in
+-- the current hour_bucket, advanced by ONE atomic
+-- `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` statement
+-- (src/crashes/ingest.ts) rather than by a separate SELECT-then-decide-then-
+-- write sequence. That collapse is what actually closes the concurrency
+-- race the original two-statement design had: D1 only guarantees ordering
+-- within a single statement (or a .batch()), not across two independent
+-- .prepare()/.run() calls, so a SELECT followed later by a separate INSERT
+-- left a window where N concurrent requests could all read the
+-- pre-increment state and all decide to write, defeating the cap entirely
+-- (measured: 20 concurrent identical crash reports produced 142 writes
+-- against a cap the sequential-only test suite asserted was always 23).
+-- `hits` being uncapped and monotonic within the hour is what makes the
+-- admission decision unambiguous from the RETURNED value alone: the Nth
+-- concurrent request to actually commit is guaranteed a unique hits = N
+-- (SQLite serialises writers to the same row even without an explicit
+-- transaction wrapper), so "admitted" is simply `hits <= cap`, no stale
+-- read involved.
 CREATE TABLE ingest_buckets (
   fingerprint TEXT NOT NULL,
   instance_key TEXT NOT NULL,
   hour_bucket INTEGER NOT NULL,
+  hits INTEGER NOT NULL DEFAULT 0,
   written INTEGER NOT NULL DEFAULT 0,
   saturated INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (fingerprint, instance_key)

--- a/relay-worker/migrations/0002_crash_reports.sql
+++ b/relay-worker/migrations/0002_crash_reports.sql
@@ -1,0 +1,40 @@
+CREATE TABLE errors (
+  fingerprint TEXT PRIMARY KEY,
+  kind TEXT NOT NULL,
+  message TEXT NOT NULL,
+  source_file TEXT,
+  source_line INTEGER,
+  status TEXT NOT NULL DEFAULT 'unresolved',
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  occurrence_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX errors_last_seen_idx ON errors (last_seen_at DESC);
+CREATE INDEX errors_status_last_seen_idx ON errors (status, last_seen_at DESC);
+
+CREATE TABLE occurrences (
+  id TEXT PRIMARY KEY,
+  fingerprint TEXT NOT NULL REFERENCES errors (fingerprint) ON DELETE CASCADE,
+  occurred_at INTEGER NOT NULL,
+  version TEXT,
+  environment TEXT,
+  instance_key TEXT,
+  context TEXT NOT NULL DEFAULT '{}',
+  stacktrace TEXT NOT NULL DEFAULT '[]'
+);
+
+CREATE INDEX occurrences_fingerprint_time_idx
+  ON occurrences (fingerprint, occurred_at DESC);
+
+-- One row per fingerprint per instance per hour bucket. Its presence is what
+-- tells ingest to count an occurrence without writing a new occurrence row,
+-- which is what stops a single crash-looping install exhausting D1's daily
+-- write budget for everyone.
+CREATE TABLE ingest_buckets (
+  fingerprint TEXT NOT NULL,
+  instance_key TEXT NOT NULL,
+  hour_bucket INTEGER NOT NULL,
+  written INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (fingerprint, instance_key, hour_bucket)
+);

--- a/relay-worker/migrations/0003_feedback.sql
+++ b/relay-worker/migrations/0003_feedback.sql
@@ -1,0 +1,16 @@
+CREATE TABLE feedback_submissions (
+  id TEXT PRIMARY KEY,
+  type TEXT NOT NULL,
+  message TEXT NOT NULL,
+  contact TEXT,
+  instance_id TEXT,
+  mydia_version TEXT,
+  source_ip TEXT,
+  state TEXT NOT NULL DEFAULT 'unread',
+  github_ref TEXT,
+  inserted_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX feedback_state_inserted_idx
+  ON feedback_submissions (state, inserted_at DESC);

--- a/relay-worker/migrations/0003_feedback.sql
+++ b/relay-worker/migrations/0003_feedback.sql
@@ -18,12 +18,25 @@ CREATE INDEX feedback_state_inserted_idx
 -- Backs POST /feedback's rate limiting (src/feedback/ingest.ts's
 -- checkFeedbackRateLimit), mirroring router.ex's handle_feedback/1: 5
 -- requests/hour, checked independently by client IP ("ip:<ip>") and by an
--- anti-collision-namespaced instance id ("instance:supplied:<value>" or
--- "instance:fallback:<ip>"), both gating before a submission is validated
--- or stored. hour_bucket is a resettable column, not part of the key, the
--- same fixed-window trade 0002_crash_reports.sql's ingest_buckets makes: one
--- row per distinct bucket_key, not one per key per hour that has ever
--- elapsed.
+-- anti-collision-namespaced instance id ("instance:supplied:<sha256 of
+-- value>" or "instance:fallback:<sha256 of ip>"), both gating before a
+-- submission is validated or stored.
+--
+-- Row SIZE is bounded by hashing the instance-derived key component
+-- (feedbackInstanceRateLimitKey): `instance_id` is an arbitrary
+-- client-supplied string with no length cap anywhere, and this check runs
+-- BEFORE validation, so an unhashed key would let a row's size be
+-- attacker-chosen. hour_bucket being a resettable column rather than part
+-- of the key does NOT by itself bound row COUNT the way
+-- 0002_crash_reports.sql's ingest_buckets is bounded -- that table's
+-- cardinality is capped by real crash/install diversity, but a caller can
+-- mint a fresh instance_id on every request at zero cost, so distinct
+-- bucket_key values are unbounded here even after hashing. Row count is
+-- instead bounded by src/obs/sweep.ts's sweepStaleFeedbackRateLimits,
+-- wired to an hourly Cron Trigger (wrangler.jsonc), which deletes any row
+-- whose hour_bucket has fallen behind the current one -- the D1 equivalent
+-- of the periodic cleaner Elixir's ETS-backed RateLimiter already has built
+-- in.
 CREATE TABLE feedback_rate_limits (
   bucket_key TEXT PRIMARY KEY,
   hour_bucket INTEGER NOT NULL,

--- a/relay-worker/migrations/0003_feedback.sql
+++ b/relay-worker/migrations/0003_feedback.sql
@@ -14,3 +14,18 @@ CREATE TABLE feedback_submissions (
 
 CREATE INDEX feedback_state_inserted_idx
   ON feedback_submissions (state, inserted_at DESC);
+
+-- Backs POST /feedback's rate limiting (src/feedback/ingest.ts's
+-- checkFeedbackRateLimit), mirroring router.ex's handle_feedback/1: 5
+-- requests/hour, checked independently by client IP ("ip:<ip>") and by an
+-- anti-collision-namespaced instance id ("instance:supplied:<value>" or
+-- "instance:fallback:<ip>"), both gating before a submission is validated
+-- or stored. hour_bucket is a resettable column, not part of the key, the
+-- same fixed-window trade 0002_crash_reports.sql's ingest_buckets makes: one
+-- row per distinct bucket_key, not one per key per hour that has ever
+-- elapsed.
+CREATE TABLE feedback_rate_limits (
+  bucket_key TEXT PRIMARY KEY,
+  hour_bucket INTEGER NOT NULL,
+  count INTEGER NOT NULL
+);

--- a/relay-worker/migrations/0003_feedback.sql
+++ b/relay-worker/migrations/0003_feedback.sql
@@ -37,6 +37,23 @@ CREATE INDEX feedback_state_inserted_idx
 -- whose hour_bucket has fallen behind the current one -- the D1 equivalent
 -- of the periodic cleaner Elixir's ETS-backed RateLimiter already has built
 -- in.
+--
+-- `count` (final review fix round): advanced by ONE atomic
+-- `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` per request
+-- (checkAndIncrementBucket), not by a separate SELECT-then-decide-then-write
+-- sequence -- that two-statement shape is exactly what let 20 concurrent
+-- identical-IP submissions all get admitted against this table's 5/hour cap
+-- in a real reproduction (D1 only guarantees ordering within one statement
+-- or a .batch(), not across two independent .prepare()/.run() calls). `count`
+-- is uncapped and monotonic within the hour so the admission decision is
+-- unambiguous from the RETURNED value alone (admitted iff `count <= 5`):
+-- SQLite serialises writers to the same row even without an explicit
+-- transaction wrapper, so the Nth request to actually commit is guaranteed a
+-- unique `count = N`, with no stale read in the decision path. A cheap
+-- read-only pre-check still runs first purely to avoid paying a write once a
+-- bucket is already solidly saturated for the hour (same optimisation the
+-- original design relied on) -- it is never the source of truth for whether
+-- a request is admitted.
 CREATE TABLE feedback_rate_limits (
   bucket_key TEXT PRIMARY KEY,
   hour_bucket INTEGER NOT NULL,

--- a/relay-worker/package-lock.json
+++ b/relay-worker/package-lock.json
@@ -10,119 +10,62 @@
         "hono": "^4.6.0"
       },
       "devDependencies": {
-        "@cloudflare/vitest-pool-workers": "^0.5.0",
-        "@cloudflare/workers-types": "^4.20250109.0",
+        "@cloudflare/vitest-pool-workers": "^0.12.0",
+        "@cloudflare/workers-types": "^4.20260310.1",
+        "@types/node": "^22.10.0",
         "typescript": "^5.7.0",
         "vitest": "~2.1.0",
-        "wrangler": "^3.99.0"
+        "wrangler": "4.72.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
-      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "mime": "^3.0.0"
-      },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.0.0"
       }
     },
-    "node_modules/@cloudflare/vitest-pool-workers": {
-      "version": "0.5.41",
-      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.5.41.tgz",
-      "integrity": "sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "birpc": "0.2.14",
-        "cjs-module-lexer": "^1.2.3",
-        "devalue": "^4.3.0",
-        "esbuild": "0.17.19",
-        "miniflare": "3.20241230.0",
-        "semver": "^7.5.1",
-        "wrangler": "3.100.0",
-        "zod": "^3.22.3"
-      },
-      "peerDependencies": {
-        "@vitest/runner": "2.0.x - 2.1.x",
-        "@vitest/snapshot": "2.0.x - 2.1.x",
-        "vitest": "2.0.x - 2.1.x"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/ohash": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
-      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
-      "name": "unenv-nightly",
-      "version": "2.0.0-20241218-183400-5d6aec3",
-      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241218-183400-5d6aec3.tgz",
-      "integrity": "sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defu": "^6.1.4",
-        "mlly": "^1.7.3",
-        "ohash": "^1.1.4",
-        "pathe": "^1.1.2",
-        "ufo": "^1.5.4"
-      }
-    },
-    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
-      "version": "3.100.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.100.0.tgz",
-      "integrity": "sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==",
-      "deprecated": "Downgrade to 3.99.0",
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
+      "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.3.4",
-        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
-        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
-        "blake3-wasm": "^2.1.5",
-        "chokidar": "^4.0.1",
-        "date-fns": "^4.1.0",
-        "esbuild": "0.17.19",
-        "itty-time": "^1.0.6",
-        "miniflare": "3.20241230.0",
-        "nanoid": "^3.3.3",
-        "path-to-regexp": "^6.3.0",
-        "resolve": "^1.22.8",
-        "selfsigned": "^2.0.1",
-        "source-map": "^0.6.1",
-        "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
-        "workerd": "1.20241230.0",
-        "xxhash-wasm": "^1.0.1"
-      },
-      "bin": {
-        "wrangler": "bin/wrangler.js",
-        "wrangler2": "bin/wrangler.js"
-      },
-      "engines": {
-        "node": ">=16.17.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20241230.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
-        "@cloudflare/workers-types": {
+        "workerd": {
           "optional": true
         }
       }
     },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.12.21",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.12.21.tgz",
+      "integrity": "sha512-xqvqVR+qAhekXWaTNY36UtFFmHrz13yGUoWVGOu6LDC2ABiQqI1E1lQ3eUZY8KVB+1FXY/mP5dB6oD07XUGnPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "^1.2.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260310.0",
+        "wrangler": "4.72.0"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 3.2.x",
+        "@vitest/snapshot": "2.0.x - 3.2.x",
+        "vitest": "2.0.x - 3.2.x"
+      }
+    },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20241230.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241230.0.tgz",
-      "integrity": "sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==",
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260310.1.tgz",
+      "integrity": "sha512-hF2VpoWaMb1fiGCQJqCY6M8I+2QQqjkyY4LiDYdTL5D/w6C1l5v1zhc0/jrjdD1DXfpJtpcSMSmEPjHse4p9Ig==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +80,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20241230.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241230.0.tgz",
-      "integrity": "sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==",
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260310.1.tgz",
+      "integrity": "sha512-h/Vl3XrYYPI6yFDE27XO1QPq/1G1lKIM8tzZGIWYpntK3IN5XtH3Ee/sLaegpJ49aIJoqhF2mVAZ6Yw+Vk2gJw==",
       "cpu": [
         "arm64"
       ],
@@ -154,9 +97,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20241230.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241230.0.tgz",
-      "integrity": "sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==",
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260310.1.tgz",
+      "integrity": "sha512-XzQ0GZ8G5P4d74bQYOIP2Su4CLdNPpYidrInaSOuSxMw+HamsHaFrjVsrV2mPy/yk2hi6SY2yMbgKFK9YjA7vw==",
       "cpu": [
         "x64"
       ],
@@ -171,9 +114,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20241230.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241230.0.tgz",
-      "integrity": "sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==",
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260310.1.tgz",
+      "integrity": "sha512-sxv4CxnN4ZR0uQGTFVGa0V4KTqwdej/czpIc5tYS86G8FQQoGIBiAIs2VvU7b8EROPcandxYHDBPTb+D9HIMPw==",
       "cpu": [
         "arm64"
       ],
@@ -188,9 +131,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20241230.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241230.0.tgz",
-      "integrity": "sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==",
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260310.1.tgz",
+      "integrity": "sha512-+1ZTViWKJypLfgH/luAHCqkent0DEBjAjvO40iAhOMHRLYP/SPphLvr4Jpi6lb+sIocS8Q1QZL4uM5Etg1Wskg==",
       "cpu": [
         "x64"
       ],
@@ -235,30 +178,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild-plugins/node-globals-polyfill": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
-      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
-      "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "esbuild": "*"
-      }
-    },
-    "node_modules/@esbuild-plugins/node-modules-polyfill": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
-      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "rollup-plugin-node-polyfills": "^0.2.1"
-      },
-      "peerDependencies": {
-        "esbuild": "*"
-      }
-    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -277,9 +196,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -290,13 +209,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -307,13 +226,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -324,13 +243,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -341,13 +260,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -358,13 +277,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -375,13 +294,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -392,13 +311,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -409,13 +328,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -426,13 +345,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -443,13 +362,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -460,13 +379,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -477,13 +396,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -494,13 +413,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -511,13 +430,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -528,13 +447,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -545,13 +464,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -562,13 +498,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -579,13 +532,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -596,13 +566,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -613,13 +583,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -630,13 +600,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -647,23 +617,23 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -680,13 +650,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -703,13 +673,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -724,9 +694,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -741,9 +711,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
@@ -761,9 +731,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
@@ -780,10 +750,50 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
@@ -801,9 +811,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
@@ -821,9 +831,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
@@ -841,9 +851,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
@@ -861,9 +871,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
@@ -883,13 +893,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
@@ -909,13 +919,65 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
@@ -935,13 +997,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
@@ -961,13 +1023,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
@@ -987,13 +1049,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
@@ -1013,13 +1075,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
@@ -1027,7 +1089,7 @@
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1036,10 +1098,30 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -1057,9 +1139,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -1123,6 +1205,35 @@
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
       }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.63.1",
@@ -1513,6 +1624,26 @@
         "win32"
       ]
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1521,23 +1652,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
-      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
-      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1653,42 +1774,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/as-table": {
-      "version": "1.0.55",
-      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
-      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "printable-characters": "^1.0.42"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1697,16 +1782,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/birpc": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
-      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/blake3-wasm": {
@@ -1724,17 +1799,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/capnp-ts": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
-      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "tslib": "^2.2.0"
       }
     },
     "node_modules/chai": {
@@ -1764,22 +1828,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -1787,88 +1835,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
-    "node_modules/confbox": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
-      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/date-fns": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
-      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
-      "dev": true,
-      "license": "MIT",
+        "node": ">=18"
+      },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/debug": {
@@ -1899,39 +1877,24 @@
         "node": ">=6"
       }
     },
-    "node_modules/defu": {
-      "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/devalue": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
-      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1942,9 +1905,9 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1952,44 +1915,52 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=18"
       }
     },
     "node_modules/estree-walker": {
@@ -2002,19 +1973,6 @@
         "@types/estree": "^1.0.0"
       }
     },
-    "node_modules/exit-hook": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2024,13 +1982,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/exsolve": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
-      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fflate": {
       "version": "0.8.3",
@@ -2053,47 +2004,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-source": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
-      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "data-uri-to-buffer": "^2.0.0",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/hono": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
@@ -2103,36 +2013,15 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
-      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.3"
-      },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=6"
       }
-    },
-    "node_modules/itty-time": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
-      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2151,65 +2040,26 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/miniflare": {
-      "version": "3.20241230.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.0.tgz",
-      "integrity": "sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==",
+      "version": "4.20260310.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260310.0.tgz",
+      "integrity": "sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "acorn": "^8.8.0",
-        "acorn-walk": "^8.2.0",
-        "capnp-ts": "^0.7.0",
-        "exit-hook": "^2.2.1",
-        "glob-to-regexp": "^0.4.1",
-        "stoppable": "^1.1.0",
-        "undici": "^5.28.4",
-        "workerd": "1.20241230.0",
-        "ws": "^8.18.0",
-        "youch": "^3.2.2",
-        "zod": "^3.22.3"
+        "sharp": "^0.34.5",
+        "undici": "7.18.2",
+        "workerd": "1.20260310.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
       },
       "bin": {
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.0.0"
       }
-    },
-    "node_modules/mlly": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
-      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "pathe": "^2.0.3",
-        "pkg-types": "^1.3.1",
-        "ufo": "^1.6.3"
-      }
-    },
-    "node_modules/mlly/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2217,16 +2067,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
@@ -2246,30 +2086,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
-      "dev": true,
-      "license": "(BSD-3-Clause OR GPL-2.0)",
-      "engines": {
-        "node": ">= 6.13.0"
-      }
-    },
-    "node_modules/ohash": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
-      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -2302,25 +2118,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/pkg-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
-      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confbox": "^0.1.8",
-        "mlly": "^1.7.4",
-        "pathe": "^2.0.1"
-      }
-    },
-    "node_modules/pkg-types/node_modules/pathe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/postcss": {
       "version": "8.5.28",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
@@ -2348,49 +2145,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/printable-characters": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
-      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-      "dev": true,
-      "license": "Unlicense"
-    },
-    "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/rollup": {
@@ -2439,77 +2193,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-inject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
-      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1",
-        "magic-string": "^0.25.3",
-        "rollup-pluginutils": "^2.8.1"
-      }
-    },
-    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/rollup-plugin-node-polyfills": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
-      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rollup-plugin-inject": "^3.0.0"
-      }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/selfsigned": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node-forge": "^1.3.0",
-        "node-forge": "^1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -2524,17 +2207,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -2543,25 +2225,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/siginfo": {
@@ -2570,27 +2257,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2602,31 +2268,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stacktracey": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
-      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "as-table": "^1.0.36",
-        "get-source": "^2.0.12"
-      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -2635,28 +2282,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/tinybench": {
@@ -2708,7 +2344,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2724,45 +2361,31 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ufo": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
-      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
-      "version": "2.0.0-rc.14",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
-      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.1",
-        "ohash": "^2.0.10",
-        "pathe": "^2.0.3",
-        "ufo": "^1.5.4"
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/unenv/node_modules/pathe": {
@@ -3352,9 +2975,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20241230.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241230.0.tgz",
-      "integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
+      "version": "1.20260310.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260310.1.tgz",
+      "integrity": "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3365,44 +2988,41 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20241230.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20241230.0",
-        "@cloudflare/workerd-linux-64": "1.20241230.0",
-        "@cloudflare/workerd-linux-arm64": "1.20241230.0",
-        "@cloudflare/workerd-windows-64": "1.20241230.0"
+        "@cloudflare/workerd-darwin-64": "1.20260310.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260310.1",
+        "@cloudflare/workerd-linux-64": "1.20260310.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260310.1",
+        "@cloudflare/workerd-windows-64": "1.20260310.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "3.114.17",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
-      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "version": "4.72.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.72.0.tgz",
+      "integrity": "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.3.4",
-        "@cloudflare/unenv-preset": "2.0.2",
-        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
-        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.15.0",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.17.19",
-        "miniflare": "3.20250718.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260310.0",
         "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.14",
-        "workerd": "1.20250718.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260310.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2",
-        "sharp": "^0.33.5"
+        "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250408.0"
+        "@cloudflare/workers-types": "^4.20260310.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -3410,178 +3030,7 @@
         }
       }
     },
-    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
-      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peerDependencies": {
-        "unenv": "2.0.0-rc.14",
-        "workerd": "^1.20250124.0"
-      },
-      "peerDependenciesMeta": {
-        "workerd": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
-      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
-      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
-      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
-      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
-      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/wrangler/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/wrangler/node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/wrangler/node_modules/miniflare": {
-      "version": "3.20250718.3",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
-      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "0.8.1",
-        "acorn": "8.14.0",
-        "acorn-walk": "8.3.2",
-        "exit-hook": "2.2.1",
-        "glob-to-regexp": "0.4.1",
-        "stoppable": "1.1.0",
-        "undici": "^5.28.5",
-        "workerd": "1.20250718.0",
-        "ws": "8.18.0",
-        "youch": "3.3.4",
-        "zod": "3.22.3"
-      },
-      "bin": {
-        "miniflare": "bootstrap.js"
-      },
-      "engines": {
-        "node": ">=16.13"
-      }
-    },
-    "node_modules/wrangler/node_modules/workerd": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
-      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "workerd": "bin/workerd"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250718.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
-        "@cloudflare/workerd-linux-64": "1.20250718.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
-        "@cloudflare/workerd-windows-64": "1.20250718.0"
-      }
-    },
-    "node_modules/wrangler/node_modules/ws": {
+    "node_modules/ws": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
@@ -3603,65 +3052,29 @@
         }
       }
     },
-    "node_modules/wrangler/node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.21.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
-      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/xxhash-wasm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
-      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/youch": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
-      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cookie": "^0.7.1",
-        "mustache": "^4.2.0",
-        "stacktracey": "^2.1.8"
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
       }
     },
-    "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/relay-worker/package-lock.json
+++ b/relay-worker/package-lock.json
@@ -1,0 +1,3661 @@
+{
+  "name": "mydia-relay-worker",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mydia-relay-worker",
+      "dependencies": {
+        "hono": "^4.6.0"
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.5.0",
+        "@cloudflare/workers-types": "^4.20250109.0",
+        "typescript": "^5.7.0",
+        "vitest": "~2.1.0",
+        "wrangler": "^3.99.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.5.41",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.5.41.tgz",
+      "integrity": "sha512-J0uYmOKJgyo/az5nV8QHlR6xQ+HHB6S65tOEutkvUPbuPDbFlBPRT+XHJhSTNNvZGeM1t2qZIzxp0WGmXLtNlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "birpc": "0.2.14",
+        "cjs-module-lexer": "^1.2.3",
+        "devalue": "^4.3.0",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20241230.0",
+        "semver": "^7.5.1",
+        "wrangler": "3.100.0",
+        "zod": "^3.22.3"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "2.0.x - 2.1.x",
+        "@vitest/snapshot": "2.0.x - 2.1.x",
+        "vitest": "2.0.x - 2.1.x"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/ohash": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.6.tgz",
+      "integrity": "sha512-TBu7PtV8YkAZn0tSxobKY2n2aAQva936lhRrj6957aDaCf9IEtqsKbgMzXE/F/sjqYOwmrukeORHNLe5glk7Cg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-20241218-183400-5d6aec3",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241218-183400-5d6aec3.tgz",
+      "integrity": "sha512-7Xpi29CJRbOV1/IrC03DawMJ0hloklDLq/cigSe+J2jkcC+iDres2Cy0r4ltj5f0x7DqsaGaB4/dLuCPPFZnZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "mlly": "^1.7.3",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
+      "version": "3.100.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.100.0.tgz",
+      "integrity": "sha512-+nsZK374Xnp2BEQQuB/18pnObgsOey0AHVlg75pAdwNaKAmB2aa0/E5rFb7i89DiiwFYoZMz3cARY1UKcm/WQQ==",
+      "deprecated": "Downgrade to 3.99.0",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^4.0.1",
+        "date-fns": "^4.1.0",
+        "esbuild": "0.17.19",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241230.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.3.0",
+        "resolve": "^1.22.8",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241218-183400-5d6aec3",
+        "workerd": "1.20241230.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241230.0.tgz",
+      "integrity": "sha512-BZHLg4bbhNQoaY1Uan81O3FV/zcmWueC55juhnaI7NAobiQth9RppadPNpxNAmS9fK2mR5z8xrwMQSQrHmztyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-lllxycj7EzYoJ0VOJh8M3palUgoonVrILnzGrgsworgWlIpgjfXGS7b41tEGCw6AxSxL9prmTIGtfSPUvn/rjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241230.0.tgz",
+      "integrity": "sha512-Y3mHcW0KghOmWdNZyHYpEOG4Ba/ga8tht5vj1a+WXfagEjMO8Y98XhZUlCaYa9yB7Wh5jVcK5LM2jlO/BLgqpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241230.0.tgz",
+      "integrity": "sha512-IAjhsWPlHzhhkJ6I49sDG6XfMnhPvv0szKGXxTWQK/IWMrbGdHm4RSfNKBSoLQm67jGMIzbmcrX9UIkms27Y1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241230.0.tgz",
+      "integrity": "sha512-y5SPIk9iOb2gz+yWtHxoeMnjPnkYQswiCJ480oHC6zexnJLlKTpcmBCjDH1nWCT4pQi8F25gaH8thgElf4NvXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
+      "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.14.tgz",
+      "integrity": "sha512-37FHE8rqsYM5JEKCnXFyHpBCzvgHEExwVVTq+nUmloInU7l8ezD1TpOhKpS8oe1DTYFqEK27rFZVKG43oTqXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devalue": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.3.tgz",
+      "integrity": "sha512-UH8EL6H2ifcY8TbD2QsxwCC/pr5xSwPvv85LrLXVihmHVC3T3YqTCIwnR5ak0yO1KYqlxrPVOA/JVZJYPy2ATg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/exsolve": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20241230.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241230.0.tgz",
+      "integrity": "sha512-ZtWNoNAIj5Q0Vb3B4SPEKr7DDmVG8a0Stsp/AuRkYXoJniA5hsbKjFNIGhTXGMIHVP5bvDrKJWt/POIDGfpiKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20241230.0",
+        "ws": "^8.18.0",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "dev": true,
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/ohash": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
+      "integrity": "sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stacktracey": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
+      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.14",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
+      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "exsolve": "^1.0.1",
+        "ohash": "^2.0.10",
+        "pathe": "^2.0.3",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/unenv/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20241230.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241230.0.tgz",
+      "integrity": "sha512-EgixXP0JGXGq6J9lz17TKIZtfNDUvJNG+cl9paPMfZuYWT920fFpBx+K04YmnbQRLnglsivF1GT9pxh1yrlWhg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20241230.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241230.0",
+        "@cloudflare/workerd-linux-64": "1.20241230.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241230.0",
+        "@cloudflare/workerd-windows-64": "1.20241230.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.114.17",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
+      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/unenv-preset": "2.0.2",
+        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.17.19",
+        "miniflare": "3.20250718.3",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.14",
+        "workerd": "1.20250718.0"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250408.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
+      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.14",
+        "workerd": "^1.20250124.0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
+      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
+      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
+      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
+      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/wrangler/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/miniflare": {
+      "version": "3.20250718.3",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
+      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "8.14.0",
+        "acorn-walk": "8.3.2",
+        "exit-hook": "2.2.1",
+        "glob-to-regexp": "0.4.1",
+        "stoppable": "1.1.0",
+        "undici": "^5.28.5",
+        "workerd": "1.20250718.0",
+        "ws": "8.18.0",
+        "youch": "3.3.4",
+        "zod": "3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      }
+    },
+    "node_modules/wrangler/node_modules/workerd": {
+      "version": "1.20250718.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
+      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20250718.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
+        "@cloudflare/workerd-linux-64": "1.20250718.0",
+        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
+        "@cloudflare/workerd-windows-64": "1.20250718.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/zod": {
+      "version": "3.22.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
+      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/relay-worker/package-lock.json
+++ b/relay-worker/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "mydia-relay-worker",
       "dependencies": {
+        "fflate": "^0.8.3",
         "hono": "^4.6.0"
       },
       "devDependencies": {
@@ -2029,6 +2030,12 @@
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
       "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/fsevents": {

--- a/relay-worker/package.json
+++ b/relay-worker/package.json
@@ -14,10 +14,11 @@
     "hono": "^4.6.0"
   },
   "devDependencies": {
-    "@cloudflare/vitest-pool-workers": "^0.5.0",
-    "@cloudflare/workers-types": "^4.20250109.0",
+    "@cloudflare/vitest-pool-workers": "^0.12.0",
+    "@cloudflare/workers-types": "^4.20260310.1",
+    "@types/node": "^22.10.0",
     "typescript": "^5.7.0",
     "vitest": "~2.1.0",
-    "wrangler": "^3.99.0"
+    "wrangler": "4.72.0"
   }
 }

--- a/relay-worker/package.json
+++ b/relay-worker/package.json
@@ -10,6 +10,7 @@
     "dev": "wrangler dev"
   },
   "dependencies": {
+    "fflate": "^0.8.3",
     "hono": "^4.6.0"
   },
   "devDependencies": {

--- a/relay-worker/package.json
+++ b/relay-worker/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:contract": "vitest run test/contract",
     "typecheck": "tsc --noEmit",
     "deploy": "wrangler deploy",
     "dev": "wrangler dev"

--- a/relay-worker/package.json
+++ b/relay-worker/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mydia-relay-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  },
+  "dependencies": {
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.5.0",
+    "@cloudflare/workers-types": "^4.20250109.0",
+    "typescript": "^5.7.0",
+    "vitest": "~2.1.0",
+    "wrangler": "^3.99.0"
+  }
+}

--- a/relay-worker/src/archive/zip.ts
+++ b/relay-worker/src/archive/zip.ts
@@ -1,0 +1,65 @@
+import { unzipSync } from "fflate";
+
+// Mirrors @path_pattern in subdl/file_id.ex. Anchored, and deliberately
+// excludes "/" inside the filename so no path segment can be smuggled in.
+const SUBTITLE_PATH_PATTERN = /^\/subtitle\/[A-Za-z0-9._-]+\.zip$/;
+
+const SUBTITLE_EXTENSIONS = [".srt", ".ass", ".ssa", ".sub", ".vtt"];
+
+// Mirrors FileId.encode/1's strip_query/1: SubDL appends the API key used for
+// the search onto every result url, and dropping the query string here is the
+// single point that keeps the relay's key out of the encoded id.
+function stripQuery(url: string): string {
+  const index = url.indexOf("?");
+  return index === -1 ? url : url.slice(0, index);
+}
+
+export function encodeFileId(url: string): string {
+  return btoa(stripQuery(url))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function decodeFileId(id: string): string | null {
+  try {
+    const base64 = id.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    const path = atob(padded);
+    return SUBTITLE_PATH_PATTERN.test(path) ? path : null;
+  } catch {
+    return null;
+  }
+}
+
+// Entry names are read from the archive as-is and rejected before the bytes
+// are used. This is the guard the Elixir version applies by reading names from
+// the central directory before OTP's unzip sanitises them; here nothing
+// sanitises anything, so the check is the only protection.
+function safeName(name: string): boolean {
+  if (name.startsWith("/")) return false;
+  if (name.split("/").includes("..")) return false;
+  return true;
+}
+
+export function extractSubtitle(zipBytes: Uint8Array): Uint8Array | null {
+  let entries: Record<string, Uint8Array>;
+  try {
+    entries = unzipSync(zipBytes);
+  } catch {
+    return null;
+  }
+
+  for (const name of Object.keys(entries)) {
+    if (!safeName(name)) return null;
+  }
+
+  for (const [name, bytes] of Object.entries(entries)) {
+    const lower = name.toLowerCase();
+    if (SUBTITLE_EXTENSIONS.some((ext) => lower.endsWith(ext))) {
+      return bytes;
+    }
+  }
+
+  return null;
+}

--- a/relay-worker/src/archive/zip.ts
+++ b/relay-worker/src/archive/zip.ts
@@ -1,10 +1,17 @@
-import { unzipSync } from "fflate";
+import { unzipSync, type UnzipFileInfo } from "fflate";
 
 // Mirrors @path_pattern in subdl/file_id.ex. Anchored, and deliberately
 // excludes "/" inside the filename so no path segment can be smuggled in.
 const SUBTITLE_PATH_PATTERN = /^\/subtitle\/[A-Za-z0-9._-]+\.zip$/;
 
 const SUBTITLE_EXTENSIONS = [".srt", ".ass", ".ssa", ".sub", ".vtt"];
+
+// Mirrors @max_total_bytes in metadata_relay/subtitles/archive.ex: 20MB
+// expanded is three orders of magnitude of headroom over a feature-length
+// subtitle (tens of KB) and still refuses a bomb. Exported so the download
+// route can apply the same ceiling to the compressed body before it is ever
+// handed to extractSubtitle.
+export const MAX_ARCHIVE_BYTES = 20_000_000;
 
 // Mirrors FileId.encode/1's strip_query/1: SubDL appends the API key used for
 // the search onto every result url, and dropping the query string here is the
@@ -43,16 +50,43 @@ function safeName(name: string): boolean {
 }
 
 export function extractSubtitle(zipBytes: Uint8Array): Uint8Array | null {
+  // Mirrors check_declared_size/1 in archive.ex: sum declared (uncompressed)
+  // sizes from the central directory, read via fflate's filter callback
+  // *before* that entry is inflated, and once the running total would reach
+  // or exceed the cap, stop decompressing anything else. A crafted archive
+  // can be a few KB on the wire and declare tens of megabytes per entry;
+  // checking this before inflate is what keeps that cheap for an attacker and
+  // expensive for us from ever happening. Once the cap trips, the whole
+  // archive is rejected below -- not just the entry that tipped it over --
+  // so nothing already decompressed by that point is ever returned.
+  let totalDeclared = 0;
+  let overCap = false;
+
   let entries: Record<string, Uint8Array>;
   try {
-    entries = unzipSync(zipBytes);
+    entries = unzipSync(zipBytes, {
+      filter(file: UnzipFileInfo): boolean {
+        totalDeclared += file.originalSize;
+        if (totalDeclared >= MAX_ARCHIVE_BYTES) overCap = true;
+        return !overCap;
+      },
+    });
   } catch {
     return null;
   }
 
+  if (overCap) return null;
+
   for (const name of Object.keys(entries)) {
     if (!safeName(name)) return null;
   }
+
+  // Post-decompression safety net, mirroring check_total_size/1: a crafted
+  // local file header can understate its declared size, so what actually
+  // came out is checked too, not just what the header claimed going in.
+  let actualTotal = 0;
+  for (const bytes of Object.values(entries)) actualTotal += bytes.length;
+  if (actualTotal >= MAX_ARCHIVE_BYTES) return null;
 
   for (const [name, bytes] of Object.entries(entries)) {
     const lower = name.toLowerCase();

--- a/relay-worker/src/cache/key.ts
+++ b/relay-worker/src/cache/key.ts
@@ -1,0 +1,68 @@
+// TTLs in seconds. Copied from metadata-relay/lib/metadata_relay/cache.ex:32-37.
+const IMAGES_TTL = 7776000; // 90 days
+const TRENDING_TTL = 3600; // 1 hour
+const SEARCH_TTL = 604800; // 7 days
+const DETAILS_TTL = 2592000; // 30 days
+const SEASON_TTL = 1209600; // 14 days
+const METADATA_TTL = 2592000; // 30 days
+
+export const SUBTITLE_WIRE_FORMAT_VERSION = 1;
+export const EMPTY_SUBTITLE_TTL_SECONDS = 3600;
+
+const CACHEABLE_POST_PATH = "/api/v1/subtitles/search";
+
+const DETAILS_PATTERN = /\/(movies|tv\/shows)\/\d+:(?!search)/;
+const MUSIC_DETAILS_PATTERN = /\/music\/(artist|release|release-group|recording)\//;
+const SEASON_PATTERN = /\/\d+\/\d+:/;
+
+export function buildKey(
+  method: string,
+  path: string,
+  queryString: string,
+): string {
+  return `${method}:${path}:${queryString}`;
+}
+
+// Order mirrors the `cond` in cache.ex exactly. Reordering changes which TTL
+// a path gets: /tv/shows/1399/images matches both the images and details
+// rules, and images must win.
+export function ttlSecondsFor(key: string): number {
+  if (key.includes("/images") || key.includes("/music/cover/")) return IMAGES_TTL;
+  if (key.includes("/trending")) return TRENDING_TTL;
+  if (key.includes("/search")) return SEARCH_TTL;
+  if (DETAILS_PATTERN.test(key)) return DETAILS_TTL;
+  if (MUSIC_DETAILS_PATTERN.test(key)) return DETAILS_TTL;
+  if (key.includes("/tv/shows/") && SEASON_PATTERN.test(key)) return SEASON_TTL;
+  return METADATA_TTL;
+}
+
+// Mirrors canonicalize/1 in plug/cache.ex: object keys stringified and sorted
+// so two installs asking the same question share an entry even when their JSON
+// serializers differ, list order preserved because it is meaningful in JSON.
+export function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([k, v]) => [String(k), canonicalize(v)] as const)
+      .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+  }
+  return value;
+}
+
+export async function bodyFingerprint(body: unknown): Promise<string> {
+  const canonical = JSON.stringify(canonicalize(body));
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonical),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export function subtitleSearchCacheKey(
+  fingerprint: string,
+  version: number = SUBTITLE_WIRE_FORMAT_VERSION,
+): string {
+  return buildKey("POST", CACHEABLE_POST_PATH, `v${version}:${fingerprint}`);
+}

--- a/relay-worker/src/cache/store.ts
+++ b/relay-worker/src/cache/store.ts
@@ -1,0 +1,87 @@
+import type { Env } from "../env";
+import { ttlSecondsFor } from "./key";
+
+// Mirrors filter_headers/1 in plug/cache.ex. content-disposition is here
+// because a cached response that drops it changes how the client handles the
+// body, and keeping it means a future file-serving route stays correct.
+export const CACHED_HEADER_ALLOWLIST = [
+  "content-type",
+  "content-disposition",
+  "cache-control",
+  "etag",
+] as const;
+
+export function filterHeaders(headers: Headers): Headers {
+  const out = new Headers();
+  for (const name of CACHED_HEADER_ALLOWLIST) {
+    const value = headers.get(name);
+    if (value !== null) out.set(name, value);
+  }
+  return out;
+}
+
+// The Cache API is URL-keyed, so a logical key becomes a synthetic URL on a
+// reserved host that never resolves. Encoding keeps a key containing "/" or
+// "?" from splitting into path and query.
+function cacheUrl(key: string): string {
+  return `https://cache.invalid/${encodeURIComponent(key)}`;
+}
+
+interface StoredEntry {
+  status: number;
+  headers: [string, string][];
+  body: string;
+}
+
+export async function cacheGet(
+  env: Env,
+  key: string,
+  opts: { kv?: boolean } = {},
+): Promise<Response | null> {
+  const edge = await caches.default.match(cacheUrl(key));
+  if (edge) return edge;
+
+  if (!opts.kv) return null;
+
+  const stored = await env.CACHE_KV.get<StoredEntry>(key, "json");
+  if (!stored) return null;
+
+  return new Response(stored.body, {
+    status: stored.status,
+    headers: new Headers(stored.headers),
+  });
+}
+
+export async function cachePut(
+  env: Env,
+  key: string,
+  res: Response,
+  opts: { ttlSeconds?: number; kv?: boolean } = {},
+): Promise<void> {
+  const ttlSeconds = opts.ttlSeconds ?? ttlSecondsFor(key);
+  const body = await res.clone().text();
+  const headers = filterHeaders(res.headers);
+
+  // Edge copy: fast, per-PoP, evictable. This is the whole cache for every
+  // route except SubDL search.
+  const edgeHeaders = new Headers(headers);
+  edgeHeaders.set("cache-control", `public, max-age=${ttlSeconds}`);
+  await caches.default.put(
+    cacheUrl(key),
+    new Response(body, { status: res.status, headers: edgeHeaders }),
+  );
+
+  if (!opts.kv) return;
+
+  // KV copy, opt-in. Only SubDL search asks for this: it spends a shared key
+  // with a 2000/day allowance, and a per-PoP cache would let each PoP spend it
+  // separately. Nothing else has a reason to pay for a second tier.
+  const entry: StoredEntry = {
+    status: res.status,
+    headers: [...headers.entries()],
+    body,
+  };
+  await env.CACHE_KV.put(key, JSON.stringify(entry), {
+    expirationTtl: Math.max(ttlSeconds, 60),
+  });
+}

--- a/relay-worker/src/cache/store.ts
+++ b/relay-worker/src/cache/store.ts
@@ -23,7 +23,13 @@ export function filterHeaders(headers: Headers): Headers {
 // The Cache API is URL-keyed, so a logical key becomes a synthetic URL on a
 // reserved host that never resolves. Encoding keeps a key containing "/" or
 // "?" from splitting into path and query.
-function cacheUrl(key: string): string {
+//
+// Exported so passthrough.ts can address the same edge-cache entries with its
+// own binary-safe get/put: cachePut below always round-trips the body through
+// `.text()`, which corrupts a JPEG (or anything else that isn't valid UTF-8)
+// on the way back out, so the music cover art route cannot reuse cacheGet/
+// cachePut and instead talks to `caches.default` directly, keyed the same way.
+export function cacheUrl(key: string): string {
   return `https://cache.invalid/${encodeURIComponent(key)}`;
 }
 

--- a/relay-worker/src/cache/store.ts
+++ b/relay-worker/src/cache/store.ts
@@ -39,7 +39,12 @@ export async function cacheGet(
   opts: { kv?: boolean } = {},
 ): Promise<Response | null> {
   const edge = await caches.default.match(cacheUrl(key));
-  if (edge) return edge;
+  // A Response read back from the Cache API has immutable headers. Every
+  // caller of cacheGet eventually wants to stamp something onto the
+  // response it gets back (x-relay-cache today, more later), so return a
+  // fresh Response here rather than letting each call site discover the
+  // "Can't modify immutable headers" TypeError on its own.
+  if (edge) return new Response(edge.body, edge);
 
   if (!opts.kv) return null;
 

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -1,0 +1,257 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+
+export interface CrashFrame {
+  module: string | null;
+  function: string | null;
+  file: string | null;
+  line: number | null;
+}
+
+export interface NormalizedCrash {
+  kind: string;
+  message: string;
+  stacktrace: CrashFrame[];
+  sourceFile: string | null;
+  sourceLine: number | null;
+  version: string | null;
+  environment: string | null;
+  occurredAt: number;
+  context: Record<string, unknown>;
+}
+
+export interface ErrorRow {
+  fingerprint: string;
+  kind: string;
+  message: string;
+  source_file: string | null;
+  source_line: number | null;
+  status: string;
+  first_seen_at: number;
+  last_seen_at: number;
+  occurrence_count: number;
+}
+
+export interface OccurrenceRow {
+  id: string;
+  fingerprint: string;
+  occurred_at: number;
+  version: string | null;
+  environment: string | null;
+  instance_key: string | null;
+  context: string;
+  stacktrace: string;
+}
+
+// Occurrence rows written per fingerprint per instance per hour. Beyond this
+// the crash is still counted, but no new row is written.
+const MAX_OCCURRENCE_ROWS_PER_BUCKET = 3;
+
+function frame(
+  module: unknown,
+  fn: unknown,
+  file: unknown,
+  line: unknown,
+): CrashFrame {
+  return {
+    module: typeof module === "string" ? module : null,
+    function: typeof fn === "string" ? fn : null,
+    file: typeof file === "string" ? file : null,
+    line: typeof line === "number" ? line : null,
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+// Mirrors Elixir truthiness (only nil/false are falsy -- 0 and "" are NOT),
+// since router.ex's `if file || line do` and `parse_stacktrace_entry`'s
+// required-key match are both Elixir-side checks this ports.
+function elixirTruthy(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== false;
+}
+
+// router.ex's parse_stacktrace_entry/1: `%{"file" => file, "line" => line} =
+// entry` requires BOTH keys to be present in the entry (any value, including
+// null, satisfies the match) -- an entry missing either key is dropped
+// entirely rather than kept with nulls filled in. Mydia.CrashReporter's own
+// format_stacktrace/1 always emits both keys (possibly null) for every
+// frame, so this never actually fires against real traffic, but a stray
+// third-party client sending a bare {module, function} entry should not
+// silently keep a frame router.ex would have discarded.
+function parseStacktraceEntry(entry: unknown): CrashFrame | null {
+  if (!isPlainObject(entry)) return null;
+  if (!("file" in entry) || !("line" in entry)) return null;
+  return frame(entry.module, entry.function, entry.file, entry.line);
+}
+
+// router.ex's metadata_stack_frame/1: builds a frame from `metadata` only
+// when `file` or `line` is present (Elixir truthy), not when only
+// module/function are given. Getting this backwards was the brief's own bug
+// (it gated on module || function || file): a report describing only which
+// function crashed, with no file/line, would otherwise still fingerprint
+// distinctly from another report with genuinely no metadata at all, or
+// worse, a report with only module/function would collapse into one bucket
+// with every other module/function-less report instead of being dropped to
+// the safe "no-frame" case router.ex uses.
+function metadataStackFrame(metadata: unknown): CrashFrame | null {
+  if (!isPlainObject(metadata)) return null;
+  const file = metadata.file;
+  const line = metadata.line;
+  if (!elixirTruthy(file) && !elixirTruthy(line)) return null;
+  return frame(metadata.module, metadata.function, file, line);
+}
+
+// Mydia.CrashReporter.build_report/3 sends `occurred_at` via
+// `DateTime.to_iso8601/1` -- always a string, never a Unix number. Accepting
+// only `typeof === "number"` (the brief's original check) would silently
+// discard this field on every real report and substitute ingestion time
+// instead. A Unix-seconds number is still accepted for callers other than
+// the Elixir producer (e.g. direct API use, tests).
+function parseOccurredAt(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.floor(value);
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return Math.floor(parsed / 1000);
+  }
+  return Math.floor(Date.now() / 1000);
+}
+
+export function normalizeCrashReport(
+  body: Record<string, unknown>,
+): NormalizedCrash {
+  const kind =
+    typeof body.error_type === "string" ? body.error_type : "RuntimeError";
+  const message =
+    typeof body.error_message === "string" ? body.error_message : "Unknown error";
+
+  const rawStack = Array.isArray(body.stacktrace) ? body.stacktrace : [];
+  let stacktrace = rawStack
+    .map(parseStacktraceEntry)
+    .filter((f): f is CrashFrame => f !== null);
+
+  // Without any source info every report derives the same fingerprint and
+  // collapses into one useless group, so metadata stands in for a frame.
+  if (stacktrace.length === 0) {
+    const synthesized = metadataStackFrame(body.metadata);
+    if (synthesized) stacktrace = [synthesized];
+  }
+
+  const top = stacktrace[0];
+
+  return {
+    kind,
+    message,
+    stacktrace,
+    sourceFile: top?.file ?? null,
+    sourceLine: top?.line ?? null,
+    version: typeof body.version === "string" ? body.version : null,
+    environment: typeof body.environment === "string" ? body.environment : null,
+    occurredAt: parseOccurredAt(body.occurred_at),
+    context: isPlainObject(body.metadata) ? body.metadata : {},
+  };
+}
+
+export async function fingerprintOf(
+  kind: string,
+  topFrame: string,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${kind}|${topFrame}`),
+  );
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 32);
+}
+
+export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
+  app.post("/crashes/report", async (c) => {
+    const body = (await c.req.json().catch(() => null)) as Record<
+      string,
+      unknown
+    > | null;
+    if (!body) return c.json({ error: "Invalid JSON body" }, 400);
+
+    const crash = normalizeCrashReport(body);
+    const top = crash.stacktrace[0];
+    const topKey = top
+      ? `${top.module ?? ""}:${top.function ?? ""}:${top.file ?? ""}:${top.line ?? ""}`
+      : "no-frame";
+    const fingerprint = await fingerprintOf(crash.kind, topKey);
+
+    const instanceKey =
+      c.req.header("cf-connecting-ip") ?? crash.version ?? "unknown";
+    const hourBucket = Math.floor(crash.occurredAt / 3600);
+
+    // Always count. This is one small upsert regardless of storm volume.
+    await c.env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
+                           status, first_seen_at, last_seen_at, occurrence_count)
+       VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1)
+       ON CONFLICT(fingerprint) DO UPDATE SET
+         last_seen_at = excluded.last_seen_at,
+         occurrence_count = errors.occurrence_count + 1,
+         message = excluded.message`,
+    )
+      .bind(
+        fingerprint,
+        crash.kind,
+        crash.message,
+        crash.sourceFile,
+        crash.sourceLine,
+        crash.occurredAt,
+        crash.occurredAt,
+      )
+      .run();
+
+    // Write a full occurrence row only while this fingerprint/instance/hour
+    // is under budget. A crash-looping install keeps being counted but stops
+    // consuming D1's daily write allowance for everybody else.
+    const bucket = await c.env.DB.prepare(
+      `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, written)
+       VALUES (?, ?, ?, 1)
+       ON CONFLICT(fingerprint, instance_key, hour_bucket) DO UPDATE SET
+         written = ingest_buckets.written + 1
+       RETURNING written`,
+    )
+      .bind(fingerprint, instanceKey, hourBucket)
+      .first<{ written: number }>();
+
+    if ((bucket?.written ?? 0) <= MAX_OCCURRENCE_ROWS_PER_BUCKET) {
+      await c.env.DB.prepare(
+        `INSERT INTO occurrences
+           (id, fingerprint, occurred_at, version, environment, instance_key, context, stacktrace)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+        .bind(
+          crypto.randomUUID(),
+          fingerprint,
+          crash.occurredAt,
+          crash.version,
+          crash.environment,
+          instanceKey,
+          JSON.stringify(crash.context),
+          JSON.stringify(crash.stacktrace),
+        )
+        .run();
+    }
+
+    // Mydia.CrashReporter.Sender.send_http_request/2 pattern-matches on
+    // exactly {status: 201, body: response} as its only success case (see
+    // lib/mydia/crash_reporter/sender.ex). Any other status -- including a
+    // plausible-looking 202 Accepted -- falls into its catch-all branch,
+    // which logs the send as failed and hands it to Queue for exponential
+    // backoff retry, eventually discarding it after 10 attempts or 24 hours.
+    // Returning 201 here is load-bearing, not cosmetic parity with the old
+    // Elixir relay.
+    return c.json(
+      { status: "created", message: "Crash report received", id: fingerprint },
+      201,
+    );
+  });
+}

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -92,8 +92,8 @@ function parseStacktraceEntry(entry: unknown): CrashFrame | null {
 
 // router.ex's metadata_stack_frame/1: builds a frame from `metadata` only
 // when `file` or `line` is present (Elixir truthy), not when only
-// module/function are given. Getting this backwards was the brief's own bug
-// (it gated on module || function || file): a report describing only which
+// module/function are given. An earlier version of this port got it backwards
+// by gating on module || function || file: a report describing only which
 // function crashed, with no file/line, would otherwise still fingerprint
 // distinctly from another report with genuinely no metadata at all, or
 // worse, a report with only module/function would collapse into one bucket
@@ -109,7 +109,7 @@ function metadataStackFrame(metadata: unknown): CrashFrame | null {
 
 // Mydia.CrashReporter.build_report/3 sends `occurred_at` via
 // `DateTime.to_iso8601/1` -- always a string, never a Unix number. Accepting
-// only `typeof === "number"` (the brief's original check) would silently
+// only `typeof === "number"`, as this first did, would silently
 // discard this field on every real report and substitute ingestion time
 // instead. A Unix-seconds number is still accepted for callers other than
 // the Elixir producer (e.g. direct API use, tests).

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -30,6 +30,10 @@ export interface ErrorRow {
   first_seen_at: number;
   last_seen_at: number;
   occurrence_count: number;
+  // Sticky: set to 1 the moment any bucket for this fingerprint ever
+  // saturates, never reset back to 0. See 0002_crash_reports.sql for why
+  // this can't be answered from ingest_buckets.saturated alone.
+  count_is_floor: number;
 }
 
 export interface OccurrenceRow {
@@ -273,14 +277,24 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
     const saturated = written >= MAX_OCCURRENCE_ROWS_PER_BUCKET ? 1 : 0;
     let writes = 0;
 
+    // count_is_floor is bound to the SAME `saturated` value computed above
+    // for THIS write's bucket -- the moment this write is the one that pushes
+    // the bucket to the cap. ON CONFLICT's `MAX(errors.count_is_floor,
+    // excluded.count_is_floor)` is what makes it sticky: once a prior write
+    // has set it to 1, a later write binding 0 (an ordinary, unsaturated
+    // crash from a *different* hour or instance) can never flip it back.
+    // Unlike ingest_buckets.saturated, this column is never told to reset --
+    // see 0002_crash_reports.sql for why that distinction is load-bearing.
     const errorsResult = await c.env.DB.prepare(
       `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
-                           status, first_seen_at, last_seen_at, occurrence_count)
-       VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1)
+                           status, first_seen_at, last_seen_at, occurrence_count,
+                           count_is_floor)
+       VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1, ?)
        ON CONFLICT(fingerprint) DO UPDATE SET
          last_seen_at = excluded.last_seen_at,
          occurrence_count = errors.occurrence_count + 1,
-         message = excluded.message`,
+         message = excluded.message,
+         count_is_floor = MAX(errors.count_is_floor, excluded.count_is_floor)`,
     )
       .bind(
         fingerprint,
@@ -290,6 +304,7 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
         crash.sourceLine,
         crash.occurredAt,
         crash.occurredAt,
+        saturated,
       )
       .run();
     writes += errorsResult.meta.rows_written;

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -202,6 +202,108 @@ interface BucketRow {
   saturated: number;
 }
 
+interface AtomicBucketRow {
+  hits: number;
+  written: number;
+  saturated: number;
+  writes: number;
+}
+
+const ALREADY_HANDLED = {
+  status: "created",
+  message: "Crash report received",
+} as const;
+
+// Final-review fix round: the burst guard in front of the D1 accounting
+// below. See wrangler.jsonc's CRASH_INGEST_LIMITER comment for the numbers
+// and rationale. This binding is atomic and costs no D1 access at all, so a
+// flood that never gets past it never touches the racy path below -- but its
+// 10s window is a genuine behaviour divergence from the original design: a
+// request rejected here still returns 201 with zero writes, identical to the
+// "already saturated" response below, so the producer (which only retries on
+// a non-201 status) is never told anything went wrong.
+async function admittedByBurstGuard(
+  env: Env,
+  fingerprint: string,
+  instanceKey: string,
+): Promise<boolean> {
+  const { success } = await env.CRASH_INGEST_LIMITER.limit({
+    key: `crash:${fingerprint}:${instanceKey}`,
+  });
+  return success;
+}
+
+// Final-review fix round: replaces the old read-then-separate-write shape
+// that let concurrent requests race. THE key fix is one atomic
+// `INSERT ... ON CONFLICT DO UPDATE ... RETURNING` statement per request --
+// D1 only guarantees ordering within a single statement (or a .batch()), not
+// across two independent .prepare()/.run() calls, so a SELECT followed later
+// by a separate write left a window where N concurrent requests could all
+// read the pre-increment state and all decide to write. Measured, before this
+// fix: 20 concurrent identical crash reports produced 142 D1 writes against a
+// cap the sequential-only test suite asserted was always 23.
+//
+// `hits` is an UNCAPPED, monotonic-within-the-hour counter advanced by this
+// one statement; SQLite serialises writers to the same row even without an
+// explicit transaction wrapper, so the Nth request to actually commit is
+// guaranteed a unique `hits = N` -- "admitted" is simply `hits <= cap`,
+// decided from the RETURNED value, with no stale read involved. `written`
+// (MIN(hits, cap)) and `saturated` are still maintained for the existing
+// dashboard-facing meaning of those columns (an exact write BUDGET, capped),
+// computed from the same CASE expression as `hits` inside this one
+// statement -- not from a separate read.
+//
+// A cheap read-only pre-check still runs BEFORE this (see registerCrashRoutes
+// below) purely to skip the write entirely once a bucket is already solidly
+// saturated for the hour -- the same optimisation the original design relied
+// on to keep a saturating storm's total write cost roughly constant instead
+// of scaling with request count. That pre-check is never the source of truth
+// for admission; a stale read there can only cause a few extra calls to
+// reach this statement, never let more than `cap` actually get admitted.
+async function incrementBucketAtomically(
+  db: D1Database,
+  fingerprint: string,
+  instanceKey: string,
+  hourBucket: number,
+  cap: number,
+): Promise<AtomicBucketRow> {
+  const result = await db
+    .prepare(
+      `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, hits, written, saturated)
+       VALUES (?, ?, ?, 1, 1, 0)
+       ON CONFLICT(fingerprint, instance_key) DO UPDATE SET
+         hits = CASE
+           WHEN ingest_buckets.hour_bucket != excluded.hour_bucket THEN 1
+           ELSE ingest_buckets.hits + 1
+         END,
+         hour_bucket = excluded.hour_bucket,
+         written = MIN(
+           CASE
+             WHEN ingest_buckets.hour_bucket != excluded.hour_bucket THEN 1
+             ELSE ingest_buckets.hits + 1
+           END,
+           ?
+         ),
+         saturated = CASE
+           WHEN ingest_buckets.hour_bucket != excluded.hour_bucket THEN 0
+           WHEN (ingest_buckets.hits + 1) >= ? THEN 1
+           ELSE ingest_buckets.saturated
+         END
+       RETURNING hits, written, saturated`,
+    )
+    .bind(fingerprint, instanceKey, hourBucket, cap, cap)
+    .run<Pick<AtomicBucketRow, "hits" | "written" | "saturated">>();
+
+  const row = result.results[0];
+  if (!row) {
+    // RETURNING always yields exactly one row for a single-row upsert; this
+    // is unreachable in practice and exists only so the return type doesn't
+    // need a nullable escape hatch at every call site.
+    throw new Error("ingest_buckets upsert returned no row");
+  }
+  return { ...row, writes: result.meta.rows_written };
+}
+
 export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
   app.post("/crashes/report", async (c) => {
     const body = (await c.req.json().catch(() => null)) as Record<
@@ -226,77 +328,89 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
       c.req.header("cf-connecting-ip") ?? crash.version ?? "unknown";
     const hourBucket = Math.floor(crash.occurredAt / 3600);
 
-    // READ the bucket first. This is the fix for fix round 1's critical
-    // finding: the original version upserted `errors` and `ingest_buckets`
-    // UNCONDITIONALLY on every request, before ever checking the cap -- only
-    // the `occurrences` insert was actually throttled. D1 counts an
-    // `INSERT ... ON CONFLICT DO UPDATE` as a write on every call whether it
-    // inserts or updates, so a storm of N requests performed ~2N writes
-    // regardless of the cap: the install that could exhaust the daily
-    // budget before this fix could still exhaust it after, needing only the
-    // same order of magnitude of requests.
-    //
-    // A read is roughly a fiftieth the cost of a write on D1's free tier (5M
-    // row reads/day vs. 100k row writes/day), so paying for one read per
-    // request to decide whether to write at all is the trade that actually
-    // bounds writes: once a bucket is saturated, this request performs NO
-    // further D1 access at all -- no errors upsert, no bucket write, no
-    // occurrence insert.
+    // Layer 1: the atomic, D1-free burst guard. A rejection here means this
+    // exact (fingerprint, instance) pair has already sent CRASH_INGEST_LIMITER's
+    // worth of requests in the last 10 seconds -- far more than the client-side
+    // throttle (Mydia.CrashReporter.Throttle, 10/min per instance across ALL
+    // fingerprints) could produce legitimately. No D1 access happens at all.
+    if (!(await admittedByBurstGuard(c.env, fingerprint, instanceKey))) {
+      return c.json({ ...ALREADY_HANDLED, id: fingerprint }, 201, {
+        "x-relay-d1-writes": "0",
+      });
+    }
+
+    // Layer 2: a cheap, non-authoritative pre-check. Once a bucket is
+    // solidly saturated for the current hour, this skips the atomic write
+    // entirely (0 further D1 access) -- the same trade fix round 1 made,
+    // preserved here so a long-running storm's total write cost still stays
+    // roughly constant instead of growing with however many requests the
+    // burst guard admits over the storm's full duration. A stale read here
+    // is harmless: it can only let a few extra requests reach layer 3, never
+    // let more than the cap actually get admitted, since layer 3 is what
+    // makes the real decision.
     const existing = await c.env.DB.prepare(
       "SELECT hour_bucket, written, saturated FROM ingest_buckets WHERE fingerprint = ? AND instance_key = ?",
     )
       .bind(fingerprint, instanceKey)
       .first<BucketRow>();
 
-    // A stored hour_bucket different from the current one (including no row
-    // at all) means this is a fresh budget window: reset to a clean count
-    // rather than carrying the previous hour's total forward. This is also
-    // what keeps ingest_buckets bounded by distinct (fingerprint,
-    // instance_key) pairs instead of growing by one row per pair for every
-    // hour that has ever elapsed -- the table's primary key no longer
-    // includes hour_bucket at all (migrations/0002_crash_reports.sql).
-    const isFreshWindow = !existing || existing.hour_bucket !== hourBucket;
-    const priorWritten = isFreshWindow ? 0 : existing!.written;
+    const solidlySaturated =
+      existing &&
+      existing.hour_bucket === hourBucket &&
+      existing.written >= MAX_OCCURRENCE_ROWS_PER_BUCKET;
 
-    if (!isFreshWindow && priorWritten >= MAX_OCCURRENCE_ROWS_PER_BUCKET) {
-      // Already saturated for this hour: perform no writes at all. The
-      // producer still gets the 201 it expects (Sender only retries on a
-      // non-201 status); the crash is simply not reflected in
-      // occurrence_count or a new occurrences row. ingest_buckets.saturated
-      // (set below, on the write that reached the cap) is what tells a
-      // reader this count is a floor, not an exact total, for the rest of
-      // this hour.
-      return c.json(
-        { status: "created", message: "Crash report received", id: fingerprint },
-        201,
-        { "x-relay-d1-writes": "0" },
-      );
+    if (solidlySaturated) {
+      return c.json({ ...ALREADY_HANDLED, id: fingerprint }, 201, {
+        "x-relay-d1-writes": "0",
+      });
     }
 
-    const written = priorWritten + 1;
-    const saturated = written >= MAX_OCCURRENCE_ROWS_PER_BUCKET ? 1 : 0;
-    let writes = 0;
+    // Layer 3: the atomic admission decision. See incrementBucketAtomically's
+    // own comment for why this -- not the read above -- is what actually
+    // bounds occurrence_count exactly, even under real concurrency.
+    const bucket = await incrementBucketAtomically(
+      c.env.DB,
+      fingerprint,
+      instanceKey,
+      hourBucket,
+      MAX_OCCURRENCE_ROWS_PER_BUCKET,
+    );
+    const admitted = bucket.hits <= MAX_OCCURRENCE_ROWS_PER_BUCKET;
 
-    // count_is_floor is bound to the SAME `saturated` value computed above
-    // for THIS write's bucket -- the moment this write is the one that pushes
-    // the bucket to the cap. ON CONFLICT's `MAX(errors.count_is_floor,
-    // excluded.count_is_floor)` is what makes it sticky: once a prior write
-    // has set it to 1, a later write binding 0 (an ordinary, unsaturated
-    // crash from a *different* hour or instance) can never flip it back.
-    // Unlike ingest_buckets.saturated, this column is never told to reset --
-    // see 0002_crash_reports.sql for why that distinction is load-bearing.
-    const errorsResult = await c.env.DB.prepare(
-      `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
-                           status, first_seen_at, last_seen_at, occurrence_count,
-                           count_is_floor)
-       VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1, ?)
-       ON CONFLICT(fingerprint) DO UPDATE SET
-         last_seen_at = excluded.last_seen_at,
-         occurrence_count = errors.occurrence_count + 1,
-         message = excluded.message,
-         count_is_floor = MAX(errors.count_is_floor, excluded.count_is_floor)`,
-    )
-      .bind(
+    if (!admitted) {
+      return c.json({ ...ALREADY_HANDLED, id: fingerprint }, 201, {
+        "x-relay-d1-writes": String(bucket.writes),
+      });
+    }
+
+    // count_is_floor is bound to the SAME `saturated` value the atomic
+    // upsert above just computed for THIS bucket -- the moment this write is
+    // the one that pushes the bucket to the cap. ON CONFLICT's
+    // `MAX(errors.count_is_floor, excluded.count_is_floor)` is what makes it
+    // sticky: once a prior write has set it to 1, a later write binding 0
+    // (an ordinary, unsaturated crash from a *different* hour or instance)
+    // can never flip it back. Unlike ingest_buckets.saturated, this column
+    // is never told to reset -- see 0002_crash_reports.sql for why that
+    // distinction is load-bearing.
+    //
+    // Batched together (not two separate .run() calls) so the error-group
+    // upsert and the occurrence row it describes always land as one unit --
+    // each statement is individually safe under concurrency on its own
+    // (both are plain atomic upserts/inserts), but batching removes any
+    // possibility of another concurrent request's statements interleaving
+    // between these two specifically.
+    const [errorsResult, occurrenceResult] = await c.env.DB.batch([
+      c.env.DB.prepare(
+        `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
+                             status, first_seen_at, last_seen_at, occurrence_count,
+                             count_is_floor)
+         VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1, ?)
+         ON CONFLICT(fingerprint) DO UPDATE SET
+           last_seen_at = excluded.last_seen_at,
+           occurrence_count = errors.occurrence_count + 1,
+           message = excluded.message,
+           count_is_floor = MAX(errors.count_is_floor, excluded.count_is_floor)`,
+      ).bind(
         fingerprint,
         crash.kind,
         crash.message,
@@ -304,29 +418,13 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
         crash.sourceLine,
         crash.occurredAt,
         crash.occurredAt,
-        saturated,
-      )
-      .run();
-    writes += errorsResult.meta.rows_written;
-
-    const bucketResult = await c.env.DB.prepare(
-      `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, written, saturated)
-       VALUES (?, ?, ?, ?, ?)
-       ON CONFLICT(fingerprint, instance_key) DO UPDATE SET
-         hour_bucket = excluded.hour_bucket,
-         written = excluded.written,
-         saturated = excluded.saturated`,
-    )
-      .bind(fingerprint, instanceKey, hourBucket, written, saturated)
-      .run();
-    writes += bucketResult.meta.rows_written;
-
-    const occurrenceResult = await c.env.DB.prepare(
-      `INSERT INTO occurrences
-         (id, fingerprint, occurred_at, version, environment, instance_key, context, stacktrace)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-    )
-      .bind(
+        bucket.saturated,
+      ),
+      c.env.DB.prepare(
+        `INSERT INTO occurrences
+           (id, fingerprint, occurred_at, version, environment, instance_key, context, stacktrace)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).bind(
         crypto.randomUUID(),
         fingerprint,
         crash.occurredAt,
@@ -335,9 +433,9 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
         instanceKey,
         JSON.stringify(crash.context),
         JSON.stringify(crash.stacktrace),
-      )
-      .run();
-    writes += occurrenceResult.meta.rows_written;
+      ),
+    ]);
+    const writes = bucket.writes + errorsResult.meta.rows_written + occurrenceResult.meta.rows_written;
 
     // Mydia.CrashReporter.Sender.send_http_request/2 pattern-matches on
     // exactly {status: 201, body: response} as its only success case (see

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -45,7 +45,7 @@ export interface OccurrenceRow {
 
 // Occurrence rows written per fingerprint per instance per hour. Beyond this
 // the crash is still counted, but no new row is written.
-const MAX_OCCURRENCE_ROWS_PER_BUCKET = 3;
+export const MAX_OCCURRENCE_ROWS_PER_BUCKET = 3;
 
 function frame(
   module: unknown,
@@ -169,6 +169,35 @@ export async function fingerprintOf(
     .slice(0, 32);
 }
 
+// router.ex's validate_crash_report/1: these three keys must be PRESENT
+// (Map.has_key?; any value, including null, satisfies it) or the request is
+// rejected with 400 before anything is stored. normalizeCrashReport's
+// lenient defaulting is correct for the pure function -- the Elixir also
+// normalises leniently once past this gate -- so this replicates the GATE
+// itself, run at the route, strictly before any D1 access. A well-formed but
+// empty `{}` always maps to the same fingerprint, and that fingerprint's
+// first-ever request is never throttled (there's no bucket row yet), so
+// without this gate, repeated anonymous POSTs of `{}` to this
+// unauthenticated endpoint would be an easier route to budget exhaustion
+// than an actual crash loop.
+const REQUIRED_FIELDS = ["error_type", "error_message", "stacktrace"] as const;
+
+function validateCrashReportShape(body: Record<string, unknown>): string[] {
+  const errors = REQUIRED_FIELDS.filter((field) => !(field in body)).map(
+    (field) => `Missing required field: ${field}`,
+  );
+  if ("stacktrace" in body && !Array.isArray(body.stacktrace)) {
+    errors.push("stacktrace must be a list");
+  }
+  return errors;
+}
+
+interface BucketRow {
+  hour_bucket: number;
+  written: number;
+  saturated: number;
+}
+
 export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
   app.post("/crashes/report", async (c) => {
     const body = (await c.req.json().catch(() => null)) as Record<
@@ -176,6 +205,11 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
       unknown
     > | null;
     if (!body) return c.json({ error: "Invalid JSON body" }, 400);
+
+    const validationErrors = validateCrashReportShape(body);
+    if (validationErrors.length > 0) {
+      return c.json({ error: "Validation failed", errors: validationErrors }, 400);
+    }
 
     const crash = normalizeCrashReport(body);
     const top = crash.stacktrace[0];
@@ -188,8 +222,58 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
       c.req.header("cf-connecting-ip") ?? crash.version ?? "unknown";
     const hourBucket = Math.floor(crash.occurredAt / 3600);
 
-    // Always count. This is one small upsert regardless of storm volume.
-    await c.env.DB.prepare(
+    // READ the bucket first. This is the fix for fix round 1's critical
+    // finding: the original version upserted `errors` and `ingest_buckets`
+    // UNCONDITIONALLY on every request, before ever checking the cap -- only
+    // the `occurrences` insert was actually throttled. D1 counts an
+    // `INSERT ... ON CONFLICT DO UPDATE` as a write on every call whether it
+    // inserts or updates, so a storm of N requests performed ~2N writes
+    // regardless of the cap: the install that could exhaust the daily
+    // budget before this fix could still exhaust it after, needing only the
+    // same order of magnitude of requests.
+    //
+    // A read is roughly a fiftieth the cost of a write on D1's free tier (5M
+    // row reads/day vs. 100k row writes/day), so paying for one read per
+    // request to decide whether to write at all is the trade that actually
+    // bounds writes: once a bucket is saturated, this request performs NO
+    // further D1 access at all -- no errors upsert, no bucket write, no
+    // occurrence insert.
+    const existing = await c.env.DB.prepare(
+      "SELECT hour_bucket, written, saturated FROM ingest_buckets WHERE fingerprint = ? AND instance_key = ?",
+    )
+      .bind(fingerprint, instanceKey)
+      .first<BucketRow>();
+
+    // A stored hour_bucket different from the current one (including no row
+    // at all) means this is a fresh budget window: reset to a clean count
+    // rather than carrying the previous hour's total forward. This is also
+    // what keeps ingest_buckets bounded by distinct (fingerprint,
+    // instance_key) pairs instead of growing by one row per pair for every
+    // hour that has ever elapsed -- the table's primary key no longer
+    // includes hour_bucket at all (migrations/0002_crash_reports.sql).
+    const isFreshWindow = !existing || existing.hour_bucket !== hourBucket;
+    const priorWritten = isFreshWindow ? 0 : existing!.written;
+
+    if (!isFreshWindow && priorWritten >= MAX_OCCURRENCE_ROWS_PER_BUCKET) {
+      // Already saturated for this hour: perform no writes at all. The
+      // producer still gets the 201 it expects (Sender only retries on a
+      // non-201 status); the crash is simply not reflected in
+      // occurrence_count or a new occurrences row. ingest_buckets.saturated
+      // (set below, on the write that reached the cap) is what tells a
+      // reader this count is a floor, not an exact total, for the rest of
+      // this hour.
+      return c.json(
+        { status: "created", message: "Crash report received", id: fingerprint },
+        201,
+        { "x-relay-d1-writes": "0" },
+      );
+    }
+
+    const written = priorWritten + 1;
+    const saturated = written >= MAX_OCCURRENCE_ROWS_PER_BUCKET ? 1 : 0;
+    let writes = 0;
+
+    const errorsResult = await c.env.DB.prepare(
       `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
                            status, first_seen_at, last_seen_at, occurrence_count)
        VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1)
@@ -208,38 +292,37 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
         crash.occurredAt,
       )
       .run();
+    writes += errorsResult.meta.rows_written;
 
-    // Write a full occurrence row only while this fingerprint/instance/hour
-    // is under budget. A crash-looping install keeps being counted but stops
-    // consuming D1's daily write allowance for everybody else.
-    const bucket = await c.env.DB.prepare(
-      `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, written)
-       VALUES (?, ?, ?, 1)
-       ON CONFLICT(fingerprint, instance_key, hour_bucket) DO UPDATE SET
-         written = ingest_buckets.written + 1
-       RETURNING written`,
+    const bucketResult = await c.env.DB.prepare(
+      `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, written, saturated)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(fingerprint, instance_key) DO UPDATE SET
+         hour_bucket = excluded.hour_bucket,
+         written = excluded.written,
+         saturated = excluded.saturated`,
     )
-      .bind(fingerprint, instanceKey, hourBucket)
-      .first<{ written: number }>();
+      .bind(fingerprint, instanceKey, hourBucket, written, saturated)
+      .run();
+    writes += bucketResult.meta.rows_written;
 
-    if ((bucket?.written ?? 0) <= MAX_OCCURRENCE_ROWS_PER_BUCKET) {
-      await c.env.DB.prepare(
-        `INSERT INTO occurrences
-           (id, fingerprint, occurred_at, version, environment, instance_key, context, stacktrace)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    const occurrenceResult = await c.env.DB.prepare(
+      `INSERT INTO occurrences
+         (id, fingerprint, occurred_at, version, environment, instance_key, context, stacktrace)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        crypto.randomUUID(),
+        fingerprint,
+        crash.occurredAt,
+        crash.version,
+        crash.environment,
+        instanceKey,
+        JSON.stringify(crash.context),
+        JSON.stringify(crash.stacktrace),
       )
-        .bind(
-          crypto.randomUUID(),
-          fingerprint,
-          crash.occurredAt,
-          crash.version,
-          crash.environment,
-          instanceKey,
-          JSON.stringify(crash.context),
-          JSON.stringify(crash.stacktrace),
-        )
-        .run();
-    }
+      .run();
+    writes += occurrenceResult.meta.rows_written;
 
     // Mydia.CrashReporter.Sender.send_http_request/2 pattern-matches on
     // exactly {status: 201, body: response} as its only success case (see
@@ -249,9 +332,18 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
     // backoff retry, eventually discarding it after 10 attempts or 24 hours.
     // Returning 201 here is load-bearing, not cosmetic parity with the old
     // Elixir relay.
+    //
+    // x-relay-d1-writes exposes the actual write count this request
+    // performed. It's not part of the producer's contract (Sender only
+    // checks the status code), but it's the only way to observe
+    // meta.rows_written from outside the Worker's own request handling, and
+    // is what test/crashes/ingest.test.ts's write-bounding regression test
+    // asserts on -- table row counts can't distinguish a skipped write from
+    // an unconditional UPDATE that happens not to change a row count.
     return c.json(
       { status: "created", message: "Crash report received", id: fingerprint },
       201,
+      { "x-relay-d1-writes": String(writes) },
     );
   });
 }

--- a/relay-worker/src/crashes/queries.ts
+++ b/relay-worker/src/crashes/queries.ts
@@ -47,35 +47,11 @@ export async function setErrorStatus(
     .run();
 }
 
-// ingest.ts's throttle (MAX_OCCURRENCE_ROWS_PER_BUCKET) stops both writing
-// new occurrences AND advancing errors.occurrence_count once a
-// fingerprint/instance/hour bucket saturates -- from that point on,
-// occurrence_count is a FLOOR for the rest of that hour, not an exact total.
-// ingest_buckets.saturated is set on the write that reached the cap and is
-// never cleared retroactively for that hour (it only resets to 0 the next
-// time a *fresh* hour's write lands for the same fingerprint/instance pair,
-// per 0002_crash_reports.sql's schema comment), so a lingering saturated=1
-// row is exactly the record that some of this fingerprint's crashes were
-// dropped rather than counted -- permanently, since the count is never
-// backfilled once the hour has passed.
-//
-// A fingerprint can have multiple instance_key buckets (different installs,
-// or the same install across IP changes); ANY of them ever saturating means
-// the fingerprint's total occurrence_count is not exact, so this checks
-// across all of a fingerprint's buckets rather than a single one.
-export async function getSaturatedFingerprints(
-  env: Env,
-  fingerprints: string[],
-): Promise<Set<string>> {
-  if (fingerprints.length === 0) return new Set();
-
-  const placeholders = fingerprints.map(() => "?").join(",");
-  const { results } = await env.DB.prepare(
-    `SELECT DISTINCT fingerprint FROM ingest_buckets
-     WHERE saturated = 1 AND fingerprint IN (${placeholders})`,
-  )
-    .bind(...fingerprints)
-    .all<{ fingerprint: string }>();
-
-  return new Set(results.map((row) => row.fingerprint));
-}
+// Whether occurrence_count is exact lives on errors.count_is_floor itself
+// (a sticky flag ingest.ts sets and never clears -- see
+// 0002_crash_reports.sql), not on ingest_buckets.saturated (a transient,
+// per-hour flag that resets the moment a fresh hour's crash arrives, even
+// though the total it left behind is still permanently short). Because
+// count_is_floor already comes back on every `SELECT *` in listErrors and
+// getError above, no separate query is needed here -- a caller reads
+// `row.count_is_floor` directly off the ErrorRow.

--- a/relay-worker/src/crashes/queries.ts
+++ b/relay-worker/src/crashes/queries.ts
@@ -1,0 +1,48 @@
+import type { Env } from "../env";
+import type { ErrorRow, OccurrenceRow } from "./ingest";
+
+export async function listErrors(
+  env: Env,
+  opts: { status?: string; limit: number; offset: number },
+): Promise<ErrorRow[]> {
+  const stmt = opts.status
+    ? env.DB.prepare(
+        `SELECT * FROM errors WHERE status = ?
+         ORDER BY last_seen_at DESC LIMIT ? OFFSET ?`,
+      ).bind(opts.status, opts.limit, opts.offset)
+    : env.DB.prepare(
+        `SELECT * FROM errors ORDER BY last_seen_at DESC LIMIT ? OFFSET ?`,
+      ).bind(opts.limit, opts.offset);
+
+  const { results } = await stmt.all<ErrorRow>();
+  return results;
+}
+
+export async function getError(
+  env: Env,
+  fingerprint: string,
+): Promise<{ error: ErrorRow; occurrences: OccurrenceRow[] } | null> {
+  const error = await env.DB.prepare("SELECT * FROM errors WHERE fingerprint = ?")
+    .bind(fingerprint)
+    .first<ErrorRow>();
+  if (!error) return null;
+
+  const { results } = await env.DB.prepare(
+    `SELECT * FROM occurrences WHERE fingerprint = ?
+     ORDER BY occurred_at DESC LIMIT 50`,
+  )
+    .bind(fingerprint)
+    .all<OccurrenceRow>();
+
+  return { error, occurrences: results };
+}
+
+export async function setErrorStatus(
+  env: Env,
+  fingerprint: string,
+  status: "unresolved" | "resolved",
+): Promise<void> {
+  await env.DB.prepare("UPDATE errors SET status = ? WHERE fingerprint = ?")
+    .bind(status, fingerprint)
+    .run();
+}

--- a/relay-worker/src/crashes/queries.ts
+++ b/relay-worker/src/crashes/queries.ts
@@ -46,3 +46,36 @@ export async function setErrorStatus(
     .bind(status, fingerprint)
     .run();
 }
+
+// ingest.ts's throttle (MAX_OCCURRENCE_ROWS_PER_BUCKET) stops both writing
+// new occurrences AND advancing errors.occurrence_count once a
+// fingerprint/instance/hour bucket saturates -- from that point on,
+// occurrence_count is a FLOOR for the rest of that hour, not an exact total.
+// ingest_buckets.saturated is set on the write that reached the cap and is
+// never cleared retroactively for that hour (it only resets to 0 the next
+// time a *fresh* hour's write lands for the same fingerprint/instance pair,
+// per 0002_crash_reports.sql's schema comment), so a lingering saturated=1
+// row is exactly the record that some of this fingerprint's crashes were
+// dropped rather than counted -- permanently, since the count is never
+// backfilled once the hour has passed.
+//
+// A fingerprint can have multiple instance_key buckets (different installs,
+// or the same install across IP changes); ANY of them ever saturating means
+// the fingerprint's total occurrence_count is not exact, so this checks
+// across all of a fingerprint's buckets rather than a single one.
+export async function getSaturatedFingerprints(
+  env: Env,
+  fingerprints: string[],
+): Promise<Set<string>> {
+  if (fingerprints.length === 0) return new Set();
+
+  const placeholders = fingerprints.map(() => "?").join(",");
+  const { results } = await env.DB.prepare(
+    `SELECT DISTINCT fingerprint FROM ingest_buckets
+     WHERE saturated = 1 AND fingerprint IN (${placeholders})`,
+  )
+    .bind(...fingerprints)
+    .all<{ fingerprint: string }>();
+
+  return new Set(results.map((row) => row.fingerprint));
+}

--- a/relay-worker/src/dashboards/errors.ts
+++ b/relay-worker/src/dashboards/errors.ts
@@ -1,0 +1,115 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+import { listErrors, getError, setErrorStatus, getSaturatedFingerprints } from "../crashes/queries";
+import { layout, escapeHtml } from "./layout";
+
+const PAGE_SIZE = 50;
+
+function when(unix: number): string {
+  return new Date(unix * 1000).toISOString().replace("T", " ").slice(0, 19);
+}
+
+function formatInteger(n: number): string {
+  return Math.trunc(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+// The single place a raw occurrence_count is turned into markup. When the
+// ingest throttle has ever saturated one of this fingerprint's buckets,
+// occurrence_count is a FLOOR, not an exact total (see queries.ts's
+// getSaturatedFingerprints) -- rendering it as a bare number would present a
+// throttled undercount as if it were precise, worst exactly during the crash
+// storm an operator is trying to understand. "&ge;" plus a visible
+// "throttled" badge is the distinguishing signal; nothing here is
+// attacker-controlled (occurrence_count is an integer column, the label
+// text is a fixed string) but it is still routed through escapeHtml for the
+// same reason every other interpolated value in this file is: never special
+// case a value here just because it looks safe today.
+function renderCount(count: number, saturated: boolean): string {
+  const value = escapeHtml(formatInteger(count));
+  if (!saturated) return value;
+  return `<span class="floor">&ge;&nbsp;${value}<span class="badge" title="The ingest throttle saturated at least one hourly bucket for this error. Crashes beyond the per-hour cap were accepted but not counted, so this total is a floor, not an exact count.">throttled</span></span>`;
+}
+
+export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
+  app.get("/errors", async (c) => {
+    const status = c.req.query("status") ?? undefined;
+    const page = Number(c.req.query("page") ?? "0");
+    const rows = await listErrors(c.env, {
+      status,
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    });
+    const saturated = await getSaturatedFingerprints(
+      c.env,
+      rows.map((r) => r.fingerprint),
+    );
+
+    const body = `
+<p class="muted">
+  <a href="/errors">all</a>
+  <a href="/errors?status=unresolved">unresolved</a>
+  <a href="/errors?status=resolved">resolved</a>
+</p>
+<table>
+  <thead><tr><th>Kind</th><th>Message</th><th>Source</th><th>Count</th><th>Last seen</th><th>Status</th></tr></thead>
+  <tbody>
+    ${rows
+      .map(
+        (r) => `<tr>
+      <td><a href="/errors/${escapeHtml(r.fingerprint)}">${escapeHtml(r.kind)}</a></td>
+      <td>${escapeHtml(r.message)}</td>
+      <td class="muted">${escapeHtml(r.source_file ?? "")}${r.source_line ? `:${escapeHtml(r.source_line)}` : ""}</td>
+      <td>${renderCount(r.occurrence_count, saturated.has(r.fingerprint))}</td>
+      <td class="muted">${escapeHtml(when(r.last_seen_at))}</td>
+      <td>${escapeHtml(r.status)}</td>
+    </tr>`,
+      )
+      .join("")}
+  </tbody>
+</table>
+${rows.length === PAGE_SIZE ? `<p><a href="/errors?page=${page + 1}${status ? `&status=${escapeHtml(status)}` : ""}">Next</a></p>` : ""}`;
+
+    return c.html(layout("Errors", body));
+  });
+
+  app.get("/errors/:fingerprint", async (c) => {
+    const found = await getError(c.env, c.req.param("fingerprint"));
+    if (!found) return c.html(layout("Not found", "<p>No such error group.</p>"), 404);
+
+    const { error, occurrences } = found;
+    const saturated = (await getSaturatedFingerprints(c.env, [error.fingerprint])).has(
+      error.fingerprint,
+    );
+
+    const body = `
+<p>
+  <strong>${escapeHtml(error.kind)}</strong>: ${escapeHtml(error.message)}<br>
+  <span class="muted">${renderCount(error.occurrence_count, saturated)} occurrences, first ${escapeHtml(when(error.first_seen_at))}, last ${escapeHtml(when(error.last_seen_at))}</span>
+</p>
+<form method="post" action="/errors/${escapeHtml(error.fingerprint)}/${error.status === "resolved" ? "unresolve" : "resolve"}">
+  <button type="submit">${error.status === "resolved" ? "Reopen" : "Resolve"}</button>
+</form>
+<h2>Recent occurrences</h2>
+${occurrences
+  .map(
+    (o) => `<details>
+  <summary>${escapeHtml(when(o.occurred_at))} &middot; ${escapeHtml(o.version ?? "unknown")} &middot; ${escapeHtml(o.environment ?? "")}</summary>
+  <pre>${escapeHtml(o.stacktrace)}</pre>
+  <pre>${escapeHtml(o.context)}</pre>
+</details>`,
+  )
+  .join("")}`;
+
+    return c.html(layout(error.kind, body));
+  });
+
+  app.post("/errors/:fingerprint/resolve", async (c) => {
+    await setErrorStatus(c.env, c.req.param("fingerprint"), "resolved");
+    return c.redirect(`/errors/${c.req.param("fingerprint")}`, 303);
+  });
+
+  app.post("/errors/:fingerprint/unresolve", async (c) => {
+    await setErrorStatus(c.env, c.req.param("fingerprint"), "unresolved");
+    return c.redirect(`/errors/${c.req.param("fingerprint")}`, 303);
+  });
+}

--- a/relay-worker/src/dashboards/errors.ts
+++ b/relay-worker/src/dashboards/errors.ts
@@ -1,15 +1,9 @@
 import type { Hono } from "hono";
 import type { Env } from "../env";
 import { listErrors, getError, setErrorStatus } from "../crashes/queries";
-import { layout, escapeHtml } from "./layout";
+import { layout, escapeHtml, parsePage, when } from "./layout";
 
 const PAGE_SIZE = 50;
-
-// A page number past this is almost certainly hostile rather than a real
-// operator paging through results; clamping here (rather than merely
-// rejecting) keeps GET /errors always answering 200 regardless of what a
-// caller sends -- this route is unauthenticated until Task 15.
-const MAX_PAGE = 100_000;
 
 // fingerprintOf (src/crashes/ingest.ts) always produces exactly 32 lowercase
 // hex characters (the first 32 hex chars of a SHA-256 digest). Anything else
@@ -20,27 +14,8 @@ function isValidFingerprintShape(value: string): boolean {
   return FINGERPRINT_SHAPE.test(value);
 }
 
-function when(unix: number): string {
-  return new Date(unix * 1000).toISOString().replace("T", " ").slice(0, 19);
-}
-
 function formatInteger(n: number): string {
   return Math.trunc(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-}
-
-// `?page=` arrives as arbitrary caller-supplied text on an unauthenticated
-// route. `Number(...)` alone turns "abc"/"NaN" into NaN, "Infinity" into
-// Infinity, and "1e300"/"99999999999999999999" into finite-but-astronomical
-// floats -- every one of those reaches D1 as an OFFSET value D1 rejects with
-// `D1_ERROR: datatype mismatch`, which Hono surfaces as an unhandled 500.
-// Reject anything that isn't a small non-negative safe integer by falling
-// back to page 0, and clamp anything absurdly large (but technically a safe
-// integer) to MAX_PAGE rather than trusting it straight into the query.
-function parsePage(raw: string | undefined): number {
-  if (raw === undefined) return 0;
-  const n = Number(raw);
-  if (!Number.isSafeInteger(n) || n < 0) return 0;
-  return Math.min(n, MAX_PAGE);
 }
 
 // The single place a raw occurrence_count is turned into markup. When

--- a/relay-worker/src/dashboards/errors.ts
+++ b/relay-worker/src/dashboards/errors.ts
@@ -1,9 +1,24 @@
 import type { Hono } from "hono";
 import type { Env } from "../env";
-import { listErrors, getError, setErrorStatus, getSaturatedFingerprints } from "../crashes/queries";
+import { listErrors, getError, setErrorStatus } from "../crashes/queries";
 import { layout, escapeHtml } from "./layout";
 
 const PAGE_SIZE = 50;
+
+// A page number past this is almost certainly hostile rather than a real
+// operator paging through results; clamping here (rather than merely
+// rejecting) keeps GET /errors always answering 200 regardless of what a
+// caller sends -- this route is unauthenticated until Task 15.
+const MAX_PAGE = 100_000;
+
+// fingerprintOf (src/crashes/ingest.ts) always produces exactly 32 lowercase
+// hex characters (the first 32 hex chars of a SHA-256 digest). Anything else
+// in the :fingerprint path segment cannot be a real error group.
+const FINGERPRINT_SHAPE = /^[0-9a-f]{32}$/;
+
+function isValidFingerprintShape(value: string): boolean {
+  return FINGERPRINT_SHAPE.test(value);
+}
 
 function when(unix: number): string {
   return new Date(unix * 1000).toISOString().replace("T", " ").slice(0, 19);
@@ -13,36 +28,48 @@ function formatInteger(n: number): string {
   return Math.trunc(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
-// The single place a raw occurrence_count is turned into markup. When the
-// ingest throttle has ever saturated one of this fingerprint's buckets,
-// occurrence_count is a FLOOR, not an exact total (see queries.ts's
-// getSaturatedFingerprints) -- rendering it as a bare number would present a
-// throttled undercount as if it were precise, worst exactly during the crash
-// storm an operator is trying to understand. "&ge;" plus a visible
-// "throttled" badge is the distinguishing signal; nothing here is
-// attacker-controlled (occurrence_count is an integer column, the label
-// text is a fixed string) but it is still routed through escapeHtml for the
-// same reason every other interpolated value in this file is: never special
-// case a value here just because it looks safe today.
-function renderCount(count: number, saturated: boolean): string {
+// `?page=` arrives as arbitrary caller-supplied text on an unauthenticated
+// route. `Number(...)` alone turns "abc"/"NaN" into NaN, "Infinity" into
+// Infinity, and "1e300"/"99999999999999999999" into finite-but-astronomical
+// floats -- every one of those reaches D1 as an OFFSET value D1 rejects with
+// `D1_ERROR: datatype mismatch`, which Hono surfaces as an unhandled 500.
+// Reject anything that isn't a small non-negative safe integer by falling
+// back to page 0, and clamp anything absurdly large (but technically a safe
+// integer) to MAX_PAGE rather than trusting it straight into the query.
+function parsePage(raw: string | undefined): number {
+  if (raw === undefined) return 0;
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n) || n < 0) return 0;
+  return Math.min(n, MAX_PAGE);
+}
+
+// The single place a raw occurrence_count is turned into markup. When
+// errors.count_is_floor is set (ingest.ts sets it the moment any of this
+// fingerprint's buckets ever saturates, and never clears it -- see
+// 0002_crash_reports.sql), occurrence_count is a FLOOR, not an exact total:
+// rendering it as a bare number would present a throttled undercount as if
+// it were precise, worst exactly during the crash storm an operator is
+// trying to understand. "&ge;" plus a visible "throttled" badge is the
+// distinguishing signal; nothing here is attacker-controlled (occurrence_count
+// is an integer column, the label text is a fixed string) but it is still
+// routed through escapeHtml for the same reason every other interpolated
+// value in this file is: never special case a value here just because it
+// looks safe today.
+function renderCount(count: number, isFloor: boolean): string {
   const value = escapeHtml(formatInteger(count));
-  if (!saturated) return value;
-  return `<span class="floor">&ge;&nbsp;${value}<span class="badge" title="The ingest throttle saturated at least one hourly bucket for this error. Crashes beyond the per-hour cap were accepted but not counted, so this total is a floor, not an exact count.">throttled</span></span>`;
+  if (!isFloor) return value;
+  return `<span class="floor">&ge;&nbsp;${value}<span class="badge" title="The ingest throttle saturated at least one hourly bucket for this error at some point. Crashes beyond the per-hour cap were accepted but not counted, so this total is a permanent floor, not an exact count.">throttled</span></span>`;
 }
 
 export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
   app.get("/errors", async (c) => {
     const status = c.req.query("status") ?? undefined;
-    const page = Number(c.req.query("page") ?? "0");
+    const page = parsePage(c.req.query("page"));
     const rows = await listErrors(c.env, {
       status,
       limit: PAGE_SIZE,
       offset: page * PAGE_SIZE,
     });
-    const saturated = await getSaturatedFingerprints(
-      c.env,
-      rows.map((r) => r.fingerprint),
-    );
 
     const body = `
 <p class="muted">
@@ -53,13 +80,22 @@ export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
 <table>
   <thead><tr><th>Kind</th><th>Message</th><th>Source</th><th>Count</th><th>Last seen</th><th>Status</th></tr></thead>
   <tbody>
-    ${rows
-      .map(
-        (r) => `<tr>
+    ${
+      // escapeHtml(r.fingerprint) below (in the <a href>) is defense in
+      // depth, NOT what makes that href safe -- escapeHtml only neutralises
+      // HTML metacharacters, not URL-structural ones (a slash, "?", "#", a
+      // raw CRLF). What actually makes it safe is that the surrounding path
+      // is the fixed literal "/errors/" and fingerprintOf's output is
+      // constrained to 32 lowercase hex characters. If fingerprint
+      // generation ever allows arbitrary bytes, this href needs its own
+      // encodeURIComponent, not just escapeHtml.
+      rows
+        .map(
+          (r) => `<tr>
       <td><a href="/errors/${escapeHtml(r.fingerprint)}">${escapeHtml(r.kind)}</a></td>
       <td>${escapeHtml(r.message)}</td>
       <td class="muted">${escapeHtml(r.source_file ?? "")}${r.source_line ? `:${escapeHtml(r.source_line)}` : ""}</td>
-      <td>${renderCount(r.occurrence_count, saturated.has(r.fingerprint))}</td>
+      <td>${renderCount(r.occurrence_count, r.count_is_floor === 1)}</td>
       <td class="muted">${escapeHtml(when(r.last_seen_at))}</td>
       <td>${escapeHtml(r.status)}</td>
     </tr>`,
@@ -77,14 +113,15 @@ ${rows.length === PAGE_SIZE ? `<p><a href="/errors?page=${page + 1}${status ? `&
     if (!found) return c.html(layout("Not found", "<p>No such error group.</p>"), 404);
 
     const { error, occurrences } = found;
-    const saturated = (await getSaturatedFingerprints(c.env, [error.fingerprint])).has(
-      error.fingerprint,
-    );
 
+    // escapeHtml(error.fingerprint) in the <form action> below is the same
+    // defense-in-depth as the list page's <a href> (see the comment there);
+    // the fixed "/errors/" prefix plus fingerprintOf's 32-hex-char output is
+    // what actually makes it safe, not the escaping itself.
     const body = `
 <p>
   <strong>${escapeHtml(error.kind)}</strong>: ${escapeHtml(error.message)}<br>
-  <span class="muted">${renderCount(error.occurrence_count, saturated)} occurrences, first ${escapeHtml(when(error.first_seen_at))}, last ${escapeHtml(when(error.last_seen_at))}</span>
+  <span class="muted">${renderCount(error.occurrence_count, error.count_is_floor === 1)} occurrences, first ${escapeHtml(when(error.first_seen_at))}, last ${escapeHtml(when(error.last_seen_at))}</span>
 </p>
 <form method="post" action="/errors/${escapeHtml(error.fingerprint)}/${error.status === "resolved" ? "unresolve" : "resolve"}">
   <button type="submit">${error.status === "resolved" ? "Reopen" : "Resolve"}</button>
@@ -103,13 +140,30 @@ ${occurrences
     return c.html(layout(error.kind, body));
   });
 
+  // Both mutation routes validate the fingerprint's shape BEFORE touching D1
+  // or building the redirect. A malformed segment here isn't hypothetical:
+  // Hono's redirect() builds the Location header directly from the decoded
+  // param, and a value containing a CRLF sequence (delivered URL-encoded,
+  // e.g. `%0D%0A`) makes the underlying Headers implementation throw --
+  // fails safe (no header injection actually lands), but as an unhandled
+  // 500, not a clean 404, on an unauthenticated route. Rejecting anything
+  // that isn't a real fingerprint's shape up front avoids both the wasted D1
+  // round trip for garbage input and the 500.
   app.post("/errors/:fingerprint/resolve", async (c) => {
-    await setErrorStatus(c.env, c.req.param("fingerprint"), "resolved");
-    return c.redirect(`/errors/${c.req.param("fingerprint")}`, 303);
+    const fingerprint = c.req.param("fingerprint");
+    if (!isValidFingerprintShape(fingerprint)) {
+      return c.html(layout("Not found", "<p>No such error group.</p>"), 404);
+    }
+    await setErrorStatus(c.env, fingerprint, "resolved");
+    return c.redirect(`/errors/${fingerprint}`, 303);
   });
 
   app.post("/errors/:fingerprint/unresolve", async (c) => {
-    await setErrorStatus(c.env, c.req.param("fingerprint"), "unresolved");
-    return c.redirect(`/errors/${c.req.param("fingerprint")}`, 303);
+    const fingerprint = c.req.param("fingerprint");
+    if (!isValidFingerprintShape(fingerprint)) {
+      return c.html(layout("Not found", "<p>No such error group.</p>"), 404);
+    }
+    await setErrorStatus(c.env, fingerprint, "unresolved");
+    return c.redirect(`/errors/${fingerprint}`, 303);
   });
 }

--- a/relay-worker/src/dashboards/errors.ts
+++ b/relay-worker/src/dashboards/errors.ts
@@ -37,7 +37,7 @@ function renderCount(count: number, isFloor: boolean): string {
 }
 
 export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
-  app.get("/errors", async (c) => {
+  app.get("/admin/errors", async (c) => {
     const status = c.req.query("status") ?? undefined;
     const page = parsePage(c.req.query("page"));
     const rows = await listErrors(c.env, {
@@ -48,9 +48,9 @@ export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
 
     const body = `
 <p class="muted">
-  <a href="/errors">all</a>
-  <a href="/errors?status=unresolved">unresolved</a>
-  <a href="/errors?status=resolved">resolved</a>
+  <a href="/admin/errors">all</a>
+  <a href="/admin/errors?status=unresolved">unresolved</a>
+  <a href="/admin/errors?status=resolved">resolved</a>
 </p>
 <table>
   <thead><tr><th>Kind</th><th>Message</th><th>Source</th><th>Count</th><th>Last seen</th><th>Status</th></tr></thead>
@@ -60,14 +60,14 @@ export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
       // depth, NOT what makes that href safe -- escapeHtml only neutralises
       // HTML metacharacters, not URL-structural ones (a slash, "?", "#", a
       // raw CRLF). What actually makes it safe is that the surrounding path
-      // is the fixed literal "/errors/" and fingerprintOf's output is
+      // is the fixed literal "/admin/errors/" and fingerprintOf's output is
       // constrained to 32 lowercase hex characters. If fingerprint
       // generation ever allows arbitrary bytes, this href needs its own
       // encodeURIComponent, not just escapeHtml.
       rows
         .map(
           (r) => `<tr>
-      <td><a href="/errors/${escapeHtml(r.fingerprint)}">${escapeHtml(r.kind)}</a></td>
+      <td><a href="/admin/errors/${escapeHtml(r.fingerprint)}">${escapeHtml(r.kind)}</a></td>
       <td>${escapeHtml(r.message)}</td>
       <td class="muted">${escapeHtml(r.source_file ?? "")}${r.source_line ? `:${escapeHtml(r.source_line)}` : ""}</td>
       <td>${renderCount(r.occurrence_count, r.count_is_floor === 1)}</td>
@@ -78,12 +78,12 @@ export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
       .join("")}
   </tbody>
 </table>
-${rows.length === PAGE_SIZE ? `<p><a href="/errors?page=${page + 1}${status ? `&status=${escapeHtml(status)}` : ""}">Next</a></p>` : ""}`;
+${rows.length === PAGE_SIZE ? `<p><a href="/admin/errors?page=${page + 1}${status ? `&status=${escapeHtml(status)}` : ""}">Next</a></p>` : ""}`;
 
     return c.html(layout("Errors", body));
   });
 
-  app.get("/errors/:fingerprint", async (c) => {
+  app.get("/admin/errors/:fingerprint", async (c) => {
     const found = await getError(c.env, c.req.param("fingerprint"));
     if (!found) return c.html(layout("Not found", "<p>No such error group.</p>"), 404);
 
@@ -91,14 +91,14 @@ ${rows.length === PAGE_SIZE ? `<p><a href="/errors?page=${page + 1}${status ? `&
 
     // escapeHtml(error.fingerprint) in the <form action> below is the same
     // defense-in-depth as the list page's <a href> (see the comment there);
-    // the fixed "/errors/" prefix plus fingerprintOf's 32-hex-char output is
+    // the fixed "/admin/errors/" prefix plus fingerprintOf's 32-hex-char output is
     // what actually makes it safe, not the escaping itself.
     const body = `
 <p>
   <strong>${escapeHtml(error.kind)}</strong>: ${escapeHtml(error.message)}<br>
   <span class="muted">${renderCount(error.occurrence_count, error.count_is_floor === 1)} occurrences, first ${escapeHtml(when(error.first_seen_at))}, last ${escapeHtml(when(error.last_seen_at))}</span>
 </p>
-<form method="post" action="/errors/${escapeHtml(error.fingerprint)}/${error.status === "resolved" ? "unresolve" : "resolve"}">
+<form method="post" action="/admin/errors/${escapeHtml(error.fingerprint)}/${error.status === "resolved" ? "unresolve" : "resolve"}">
   <button type="submit">${error.status === "resolved" ? "Reopen" : "Resolve"}</button>
 </form>
 <h2>Recent occurrences</h2>
@@ -124,21 +124,21 @@ ${occurrences
   // 500, not a clean 404, on an unauthenticated route. Rejecting anything
   // that isn't a real fingerprint's shape up front avoids both the wasted D1
   // round trip for garbage input and the 500.
-  app.post("/errors/:fingerprint/resolve", async (c) => {
+  app.post("/admin/errors/:fingerprint/resolve", async (c) => {
     const fingerprint = c.req.param("fingerprint");
     if (!isValidFingerprintShape(fingerprint)) {
       return c.html(layout("Not found", "<p>No such error group.</p>"), 404);
     }
     await setErrorStatus(c.env, fingerprint, "resolved");
-    return c.redirect(`/errors/${fingerprint}`, 303);
+    return c.redirect(`/admin/errors/${fingerprint}`, 303);
   });
 
-  app.post("/errors/:fingerprint/unresolve", async (c) => {
+  app.post("/admin/errors/:fingerprint/unresolve", async (c) => {
     const fingerprint = c.req.param("fingerprint");
     if (!isValidFingerprintShape(fingerprint)) {
       return c.html(layout("Not found", "<p>No such error group.</p>"), 404);
     }
     await setErrorStatus(c.env, fingerprint, "unresolved");
-    return c.redirect(`/errors/${fingerprint}`, 303);
+    return c.redirect(`/admin/errors/${fingerprint}`, 303);
   });
 }

--- a/relay-worker/src/dashboards/feedback.ts
+++ b/relay-worker/src/dashboards/feedback.ts
@@ -1,0 +1,162 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+import { listFeedback, setFeedbackState, setGithubRef } from "../feedback/queries";
+import { layout, escapeHtml } from "./layout";
+
+const PAGE_SIZE = 50;
+
+// Mirrors Submission.@states (metadata-relay/lib/metadata_relay/feedback/submission.ex)
+// and state_changeset/2's validate_inclusion -- these three are the only
+// values D1's UPDATE below (via setFeedbackState) is allowed to write.
+const STATES = ["unread", "read", "archived"] as const;
+type FeedbackState = (typeof STATES)[number];
+
+function isValidState(value: string): value is FeedbackState {
+  return (STATES as readonly string[]).includes(value);
+}
+
+// Mirrors FeedbackLive.Index's mount/3: landing on the dashboard with no
+// explicit filter shows the unread queue first, not the entire history. The
+// literal "all" (queries.ts's listFeedback, matching
+// Feedback.list_submissions/1's maybe_filter/3) is what turns the filter
+// off entirely.
+const DEFAULT_STATE_FILTER: FeedbackState = "unread";
+
+// Same reasoning as dashboards/errors.ts's MAX_PAGE / parsePage: ?page= is
+// arbitrary caller-supplied text on an unauthenticated route.
+// `Number("abc")`/`Number("NaN")`/`Number("Infinity")`/`Number("1e300")`
+// each produce a value that reaches D1 as an OFFSET and throws
+// `D1_ERROR: datatype mismatch`, surfaced as an unhandled Hono 500.
+const MAX_PAGE = 100_000;
+
+function parsePage(raw: string | undefined): number {
+  if (raw === undefined) return 0;
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n) || n < 0) return 0;
+  return Math.min(n, MAX_PAGE);
+}
+
+// Every real feedback id is crypto.randomUUID() output (validateSubmission
+// in feedback/ingest.ts), the same shape Ecto.UUID.cast/1 requires of
+// Feedback.get_submission/1's :id argument on the Elixir side. Anything
+// else in the :id path segment cannot be a real submission, and letting it
+// through to c.redirect() risks the same CRLF -> unhandled-500-in-Headers
+// failure dashboards/errors.ts already hit for :fingerprint. Validate
+// before touching D1 or building a redirect.
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidIdShape(value: string): boolean {
+  return UUID_SHAPE.test(value);
+}
+
+function when(unix: number): string {
+  return new Date(unix * 1000).toISOString().replace("T", " ").slice(0, 19);
+}
+
+const NOT_FOUND_BODY = "<p>No such feedback submission.</p>";
+
+export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
+  app.get("/feedback", async (c) => {
+    const rawState = c.req.query("state");
+    // Mirrors normalize_state_filter/1: no param at all defaults to
+    // "unread"; a recognised value (including the literal "all") is used
+    // as-is; anything unrecognised falls back to "all" rather than
+    // rejecting a bookmarked or hand-edited URL outright.
+    const state: FeedbackState | "all" =
+      rawState === undefined
+        ? DEFAULT_STATE_FILTER
+        : rawState === "all" || isValidState(rawState)
+          ? rawState
+          : "all";
+    const page = parsePage(c.req.query("page"));
+
+    const rows = await listFeedback(c.env, {
+      state,
+      limit: PAGE_SIZE,
+      offset: page * PAGE_SIZE,
+    });
+
+    const body = `
+<p class="muted">
+  <a href="/feedback">unread</a>
+  <a href="/feedback?state=read">read</a>
+  <a href="/feedback?state=archived">archived</a>
+  <a href="/feedback?state=all">all</a>
+</p>
+<table>
+  <thead><tr><th>When</th><th>Type</th><th>Message</th><th>Version</th><th>Contact</th><th>Instance</th><th>State</th><th>GitHub</th></tr></thead>
+  <tbody>
+    ${rows
+      .map((r) => {
+        // Mirrors index.html.heex's contextual buttons: "Mark read" only
+        // shows for an unread row, "Archive" only for a not-yet-archived
+        // row -- neither the Elixir dashboard nor this one exposes a
+        // generic "switch to any other state" control per row.
+        const markReadForm = `<form method="post" action="/feedback/${escapeHtml(r.id)}/state">
+              <input type="hidden" name="state" value="read">
+              <button type="submit">mark read</button>
+            </form>`;
+        const archiveForm = `<form method="post" action="/feedback/${escapeHtml(r.id)}/state">
+              <input type="hidden" name="state" value="archived">
+              <button type="submit">archive</button>
+            </form>`;
+
+        return `<tr>
+      <td class="muted">${escapeHtml(when(r.inserted_at))}</td>
+      <td>${escapeHtml(r.type)}</td>
+      <td>${escapeHtml(r.message)}</td>
+      <td class="muted">${escapeHtml(r.mydia_version ?? "")}</td>
+      <td class="muted">${escapeHtml(r.contact ?? "")}</td>
+      <td class="muted">${escapeHtml(r.instance_id ?? "")}</td>
+      <td>
+        ${escapeHtml(r.state)}
+        ${r.state === "unread" ? markReadForm : ""}
+        ${r.state !== "archived" ? archiveForm : ""}
+      </td>
+      <td>
+        <form method="post" action="/feedback/${escapeHtml(r.id)}/github">
+          <input name="github_ref" placeholder="owner/repo#123" value="${escapeHtml(r.github_ref ?? "")}" size="16">
+          <button type="submit">save</button>
+        </form>
+      </td>
+    </tr>`;
+      })
+      .join("")}
+  </tbody>
+</table>
+${rows.length === PAGE_SIZE ? `<p><a href="/feedback?page=${page + 1}&state=${escapeHtml(state)}">Next</a></p>` : ""}`;
+
+    return c.html(layout("Feedback", body));
+  });
+
+  app.post("/feedback/:id/state", async (c) => {
+    const id = c.req.param("id");
+    if (!isValidIdShape(id)) {
+      return c.html(layout("Not found", NOT_FOUND_BODY), 404);
+    }
+
+    const form = await c.req.formData();
+    const rawState = String(form.get("state") ?? "");
+    if (!isValidState(rawState)) {
+      return c.json({ errors: [`state must be one of ${STATES.join(", ")}`] }, 422);
+    }
+
+    await setFeedbackState(c.env, id, rawState);
+    return c.redirect("/feedback", 303);
+  });
+
+  app.post("/feedback/:id/github", async (c) => {
+    const id = c.req.param("id");
+    if (!isValidIdShape(id)) {
+      return c.html(layout("Not found", NOT_FOUND_BODY), 404);
+    }
+
+    const form = await c.req.formData();
+    // Mirrors Submission.github_ref_changeset/2: no validate_required, so a
+    // blank value is accepted and stored as-is (clearing a previously
+    // attached ref), not rejected with a 422 the Elixir side never had.
+    const ref = String(form.get("github_ref") ?? "");
+    await setGithubRef(c.env, id, ref);
+    return c.redirect("/feedback", 303);
+  });
+}

--- a/relay-worker/src/dashboards/feedback.ts
+++ b/relay-worker/src/dashboards/feedback.ts
@@ -1,7 +1,7 @@
 import type { Hono } from "hono";
 import type { Env } from "../env";
 import { listFeedback, setFeedbackState, setGithubRef } from "../feedback/queries";
-import { layout, escapeHtml } from "./layout";
+import { layout, escapeHtml, parsePage, when } from "./layout";
 
 const PAGE_SIZE = 50;
 
@@ -22,20 +22,6 @@ function isValidState(value: string): value is FeedbackState {
 // off entirely.
 const DEFAULT_STATE_FILTER: FeedbackState = "unread";
 
-// Same reasoning as dashboards/errors.ts's MAX_PAGE / parsePage: ?page= is
-// arbitrary caller-supplied text on an unauthenticated route.
-// `Number("abc")`/`Number("NaN")`/`Number("Infinity")`/`Number("1e300")`
-// each produce a value that reaches D1 as an OFFSET and throws
-// `D1_ERROR: datatype mismatch`, surfaced as an unhandled Hono 500.
-const MAX_PAGE = 100_000;
-
-function parsePage(raw: string | undefined): number {
-  if (raw === undefined) return 0;
-  const n = Number(raw);
-  if (!Number.isSafeInteger(n) || n < 0) return 0;
-  return Math.min(n, MAX_PAGE);
-}
-
 // Every real feedback id is crypto.randomUUID() output (validateSubmission
 // in feedback/ingest.ts), the same shape Ecto.UUID.cast/1 requires of
 // Feedback.get_submission/1's :id argument on the Elixir side. Anything
@@ -47,10 +33,6 @@ const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 function isValidIdShape(value: string): boolean {
   return UUID_SHAPE.test(value);
-}
-
-function when(unix: number): string {
-  return new Date(unix * 1000).toISOString().replace("T", " ").slice(0, 19);
 }
 
 const NOT_FOUND_BODY = "<p>No such feedback submission.</p>";
@@ -84,7 +66,7 @@ export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
   <a href="/feedback?state=all">all</a>
 </p>
 <table>
-  <thead><tr><th>When</th><th>Type</th><th>Message</th><th>Version</th><th>Contact</th><th>Instance</th><th>State</th><th>GitHub</th></tr></thead>
+  <thead><tr><th>When</th><th>Type</th><th>Message</th><th>Version</th><th>Contact</th><th>Instance</th><th>Source IP</th><th>State</th><th>GitHub</th></tr></thead>
   <tbody>
     ${rows
       .map((r) => {
@@ -104,10 +86,11 @@ export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
         return `<tr>
       <td class="muted">${escapeHtml(when(r.inserted_at))}</td>
       <td>${escapeHtml(r.type)}</td>
-      <td>${escapeHtml(r.message)}</td>
+      <td class="wrap">${escapeHtml(r.message)}</td>
       <td class="muted">${escapeHtml(r.mydia_version ?? "")}</td>
       <td class="muted">${escapeHtml(r.contact ?? "")}</td>
       <td class="muted">${escapeHtml(r.instance_id ?? "")}</td>
+      <td class="muted">${escapeHtml(r.source_ip ?? "")}</td>
       <td>
         ${escapeHtml(r.state)}
         ${r.state === "unread" ? markReadForm : ""}
@@ -153,8 +136,10 @@ ${rows.length === PAGE_SIZE ? `<p><a href="/feedback?page=${page + 1}&state=${es
 
     const form = await c.req.formData();
     // Mirrors Submission.github_ref_changeset/2: no validate_required, so a
-    // blank value is accepted and stored as-is (clearing a previously
-    // attached ref), not rejected with a 422 the Elixir side never had.
+    // blank value is accepted (clearing a previously attached ref), not
+    // rejected with a 422 the Elixir side never had. setGithubRef itself
+    // normalizes a blank/whitespace-only value to NULL, matching what
+    // Ecto.Changeset.cast/4's default empty_values does on the Elixir side.
     const ref = String(form.get("github_ref") ?? "");
     await setGithubRef(c.env, id, ref);
     return c.redirect("/feedback", 303);

--- a/relay-worker/src/dashboards/feedback.ts
+++ b/relay-worker/src/dashboards/feedback.ts
@@ -38,7 +38,7 @@ function isValidIdShape(value: string): boolean {
 const NOT_FOUND_BODY = "<p>No such feedback submission.</p>";
 
 export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
-  app.get("/feedback", async (c) => {
+  app.get("/admin/feedback", async (c) => {
     const rawState = c.req.query("state");
     // Mirrors normalize_state_filter/1: no param at all defaults to
     // "unread"; a recognised value (including the literal "all") is used
@@ -60,10 +60,10 @@ export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
 
     const body = `
 <p class="muted">
-  <a href="/feedback">unread</a>
-  <a href="/feedback?state=read">read</a>
-  <a href="/feedback?state=archived">archived</a>
-  <a href="/feedback?state=all">all</a>
+  <a href="/admin/feedback">unread</a>
+  <a href="/admin/feedback?state=read">read</a>
+  <a href="/admin/feedback?state=archived">archived</a>
+  <a href="/admin/feedback?state=all">all</a>
 </p>
 <table>
   <thead><tr><th>When</th><th>Type</th><th>Message</th><th>Version</th><th>Contact</th><th>Instance</th><th>Source IP</th><th>State</th><th>GitHub</th></tr></thead>
@@ -74,11 +74,11 @@ export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
         // shows for an unread row, "Archive" only for a not-yet-archived
         // row -- neither the Elixir dashboard nor this one exposes a
         // generic "switch to any other state" control per row.
-        const markReadForm = `<form method="post" action="/feedback/${escapeHtml(r.id)}/state">
+        const markReadForm = `<form method="post" action="/admin/feedback/${escapeHtml(r.id)}/state">
               <input type="hidden" name="state" value="read">
               <button type="submit">mark read</button>
             </form>`;
-        const archiveForm = `<form method="post" action="/feedback/${escapeHtml(r.id)}/state">
+        const archiveForm = `<form method="post" action="/admin/feedback/${escapeHtml(r.id)}/state">
               <input type="hidden" name="state" value="archived">
               <button type="submit">archive</button>
             </form>`;
@@ -97,7 +97,7 @@ export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
         ${r.state !== "archived" ? archiveForm : ""}
       </td>
       <td>
-        <form method="post" action="/feedback/${escapeHtml(r.id)}/github">
+        <form method="post" action="/admin/feedback/${escapeHtml(r.id)}/github">
           <input name="github_ref" placeholder="owner/repo#123" value="${escapeHtml(r.github_ref ?? "")}" size="16">
           <button type="submit">save</button>
         </form>
@@ -107,12 +107,12 @@ export function registerFeedbackDashboard(app: Hono<{ Bindings: Env }>): void {
       .join("")}
   </tbody>
 </table>
-${rows.length === PAGE_SIZE ? `<p><a href="/feedback?page=${page + 1}&state=${escapeHtml(state)}">Next</a></p>` : ""}`;
+${rows.length === PAGE_SIZE ? `<p><a href="/admin/feedback?page=${page + 1}&state=${escapeHtml(state)}">Next</a></p>` : ""}`;
 
     return c.html(layout("Feedback", body));
   });
 
-  app.post("/feedback/:id/state", async (c) => {
+  app.post("/admin/feedback/:id/state", async (c) => {
     const id = c.req.param("id");
     if (!isValidIdShape(id)) {
       return c.html(layout("Not found", NOT_FOUND_BODY), 404);
@@ -125,10 +125,10 @@ ${rows.length === PAGE_SIZE ? `<p><a href="/feedback?page=${page + 1}&state=${es
     }
 
     await setFeedbackState(c.env, id, rawState);
-    return c.redirect("/feedback", 303);
+    return c.redirect("/admin/feedback", 303);
   });
 
-  app.post("/feedback/:id/github", async (c) => {
+  app.post("/admin/feedback/:id/github", async (c) => {
     const id = c.req.param("id");
     if (!isValidIdShape(id)) {
       return c.html(layout("Not found", NOT_FOUND_BODY), 404);
@@ -142,6 +142,6 @@ ${rows.length === PAGE_SIZE ? `<p><a href="/feedback?page=${page + 1}&state=${es
     // Ecto.Changeset.cast/4's default empty_values does on the Elixir side.
     const ref = String(form.get("github_ref") ?? "");
     await setGithubRef(c.env, id, ref);
-    return c.redirect("/feedback", 303);
+    return c.redirect("/admin/feedback", 303);
   });
 }

--- a/relay-worker/src/dashboards/layout.ts
+++ b/relay-worker/src/dashboards/layout.ts
@@ -32,8 +32,8 @@ export function escapeHtml(value: unknown): string {
 // Hono 500. Reject anything that isn't a small non-negative safe integer by
 // falling back to page 0, and clamp anything absurdly large (but technically
 // a safe integer) to MAX_PAGE rather than trusting it straight into the
-// query. Originated in dashboards/errors.ts (Task 13) and was duplicated
-// verbatim into dashboards/feedback.ts (Task 14) before being extracted
+// query. Originated in dashboards/errors.ts and was duplicated
+// verbatim into dashboards/feedback.ts before being extracted
 // here -- one copy, so a future fix to this guard can't land in one
 // dashboard and not the other.
 export const MAX_PAGE = 100_000;

--- a/relay-worker/src/dashboards/layout.ts
+++ b/relay-worker/src/dashboards/layout.ts
@@ -1,8 +1,13 @@
-// Shared chrome for the maintainer dashboards (errors, feedback). This
-// dashboard is UNAUTHENTICATED until Task 15 puts Cloudflare Access in front
-// of it -- do not add ad-hoc auth here, but also do not add anything (an
-// inline API key, a bypassable query param, etc.) that would make it harder
-// for Task 15 to gate this route entirely at the edge.
+// Shared chrome for the maintainer dashboards (errors, feedback). Both live
+// under the /admin/* prefix specifically so a single Cloudflare Access
+// application scoped to /admin* covers both today and any future
+// maintainer-only route by construction, without a per-route decision. The
+// Worker holds no in-code auth for these routes -- Access enforces at the
+// edge before a request ever reaches the Worker -- so do not add ad-hoc auth
+// here (an inline API key, a bypassable query param, etc.); that would
+// duplicate or conflict with the edge gate. Do not move a route out of
+// /admin/* without also updating the Access application's path scope --
+// see relay-worker/README.md's runbook.
 
 // Every value rendered into one of these pages can originate from an
 // unauthenticated remote install (POST /crashes/report, POST /feedback are
@@ -74,7 +79,7 @@ export function layout(title: string, body: string): string {
 </style>
 </head>
 <body>
-<nav><a href="/errors">Errors</a><a href="/feedback">Feedback</a></nav>
+<nav><a href="/admin/errors">Errors</a><a href="/admin/feedback">Feedback</a></nav>
 <h1>${escapeHtml(title)}</h1>
 ${body}
 </body>

--- a/relay-worker/src/dashboards/layout.ts
+++ b/relay-worker/src/dashboards/layout.ts
@@ -1,0 +1,54 @@
+// Shared chrome for the maintainer dashboards (errors, feedback). This
+// dashboard is UNAUTHENTICATED until Task 15 puts Cloudflare Access in front
+// of it -- do not add ad-hoc auth here, but also do not add anything (an
+// inline API key, a bypassable query param, etc.) that would make it harder
+// for Task 15 to gate this route entirely at the edge.
+
+// Every value rendered into one of these pages can originate from an
+// unauthenticated remote install (POST /crashes/report, POST /feedback are
+// both open). escapeHtml is the one and only sanctioned way to interpolate
+// dynamic text into a template string here -- never interpolate a
+// crash/feedback-derived value without it, including values that "look safe"
+// like a hex fingerprint or an integer count.
+export function escapeHtml(value: unknown): string {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function layout(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; margin: 0; padding: 2rem; }
+  h1 { font-size: 1.25rem; }
+  nav a { margin-right: 1rem; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { text-align: left; padding: .5rem .75rem; border-bottom: 1px solid #8883; vertical-align: top; }
+  th { font-weight: 600; }
+  pre { overflow-x: auto; background: #8881; padding: .75rem; border-radius: .375rem; }
+  .muted { opacity: .65; }
+  .floor { white-space: nowrap; }
+  .floor .badge {
+    display: inline-block; margin-left: .35rem; padding: .05rem .4rem;
+    border-radius: .25rem; font-size: .75rem; background: #f59e0b3d; color: inherit;
+  }
+  form { display: inline; }
+  button { font: inherit; padding: .25rem .6rem; cursor: pointer; }
+</style>
+</head>
+<body>
+<nav><a href="/errors">Errors</a><a href="/feedback">Feedback</a></nav>
+<h1>${escapeHtml(title)}</h1>
+${body}
+</body>
+</html>`;
+}

--- a/relay-worker/src/dashboards/layout.ts
+++ b/relay-worker/src/dashboards/layout.ts
@@ -19,6 +19,33 @@ export function escapeHtml(value: unknown): string {
     .replace(/'/g, "&#39;");
 }
 
+// Shared pagination guard for both dashboards' ?page= query param. It is
+// arbitrary caller-supplied text on an unauthenticated route, and
+// `Number("abc")`/`Number("NaN")`/`Number("Infinity")`/`Number("1e300")`/an
+// oversized numeric string each produce a value that reaches D1 as an
+// OFFSET and throws `D1_ERROR: datatype mismatch`, surfaced as an unhandled
+// Hono 500. Reject anything that isn't a small non-negative safe integer by
+// falling back to page 0, and clamp anything absurdly large (but technically
+// a safe integer) to MAX_PAGE rather than trusting it straight into the
+// query. Originated in dashboards/errors.ts (Task 13) and was duplicated
+// verbatim into dashboards/feedback.ts (Task 14) before being extracted
+// here -- one copy, so a future fix to this guard can't land in one
+// dashboard and not the other.
+export const MAX_PAGE = 100_000;
+
+export function parsePage(raw: string | undefined): number {
+  if (raw === undefined) return 0;
+  const n = Number(raw);
+  if (!Number.isSafeInteger(n) || n < 0) return 0;
+  return Math.min(n, MAX_PAGE);
+}
+
+// Shared "unix seconds -> readable UTC timestamp" formatter for both
+// dashboards' list tables. Same extraction reasoning as parsePage above.
+export function when(unix: number): string {
+  return new Date(unix * 1000).toISOString().replace("T", " ").slice(0, 19);
+}
+
 export function layout(title: string, body: string): string {
   return `<!doctype html>
 <html lang="en">
@@ -36,6 +63,7 @@ export function layout(title: string, body: string): string {
   th { font-weight: 600; }
   pre { overflow-x: auto; background: #8881; padding: .75rem; border-radius: .375rem; }
   .muted { opacity: .65; }
+  .wrap { white-space: pre-wrap; }
   .floor { white-space: nowrap; }
   .floor .badge {
     display: inline-block; margin-left: .35rem; padding: .05rem .4rem;

--- a/relay-worker/src/env.ts
+++ b/relay-worker/src/env.ts
@@ -9,4 +9,7 @@ export interface Env {
   RELAY_VERSION: string;
   FEEDBACK_FROM: string;
   FEEDBACK_TO: string;
+
+  // Bindings
+  CACHE_KV: KVNamespace;
 }

--- a/relay-worker/src/env.ts
+++ b/relay-worker/src/env.ts
@@ -16,4 +16,10 @@ export interface Env {
   PROXY_LIMITER: RateLimit;
   PAIRING_CREATE_LIMITER: RateLimit;
   PAIRING_READ_LIMITER: RateLimit;
+  // Burst guards in front of the two D1-backed hourly budgets (crash ingest,
+  // feedback ingest). See src/crashes/ingest.ts and src/feedback/ingest.ts
+  // for why a D1 read-then-write sequence needs an atomic gate ahead of it
+  // that a `ratelimit` binding's 10s/60s period can't itself replace.
+  CRASH_INGEST_LIMITER: RateLimit;
+  FEEDBACK_INGEST_LIMITER: RateLimit;
 }

--- a/relay-worker/src/env.ts
+++ b/relay-worker/src/env.ts
@@ -12,6 +12,7 @@ export interface Env {
 
   // Bindings
   CACHE_KV: KVNamespace;
+  DB: D1Database;
   PROXY_LIMITER: RateLimit;
   PAIRING_CREATE_LIMITER: RateLimit;
   PAIRING_READ_LIMITER: RateLimit;

--- a/relay-worker/src/env.ts
+++ b/relay-worker/src/env.ts
@@ -1,0 +1,12 @@
+export interface Env {
+  // Secrets (set with `wrangler secret put`)
+  TMDB_API_KEY?: string;
+  TVDB_API_KEY?: string;
+  SUBDL_API_KEY?: string;
+  RESEND_API_KEY?: string;
+
+  // Vars
+  RELAY_VERSION: string;
+  FEEDBACK_FROM: string;
+  FEEDBACK_TO: string;
+}

--- a/relay-worker/src/env.ts
+++ b/relay-worker/src/env.ts
@@ -12,4 +12,7 @@ export interface Env {
 
   // Bindings
   CACHE_KV: KVNamespace;
+  PROXY_LIMITER: RateLimit;
+  PAIRING_CREATE_LIMITER: RateLimit;
+  PAIRING_READ_LIMITER: RateLimit;
 }

--- a/relay-worker/src/feedback/ingest.ts
+++ b/relay-worker/src/feedback/ingest.ts
@@ -196,20 +196,47 @@ interface RateLimitBucketRow {
   count: number;
 }
 
-// Mirrors router.ex's feedback_rate_limit_instance_id/2 exactly, including
-// its T-236 anti-collision namespacing: the supplied and fallback cases are
-// tagged with fixed, disjoint literal prefixes applied BEFORE the
+// SHA-256 hex digest, same primitive crashes/ingest.ts's fingerprintOf uses.
+// Bounds every bucket_key to a fixed size regardless of what a client sends
+// -- see feedbackInstanceRateLimitKey below for why that matters.
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// Mirrors router.ex's feedback_rate_limit_instance_id/2's T-236
+// anti-collision namespacing: the supplied and fallback cases are tagged
+// with fixed, disjoint literal prefixes applied BEFORE the
 // caller-controlled or IP-derived value, not interpolated together into one
 // string a caller could reproduce. A caller sending
 // instance_id: "fallback:<victim ip>" therefore produces
-// "instance:supplied:fallback:<victim ip>", which can never equal another
-// caller's real fallback key "instance:fallback:<their ip>" -- only the
-// fallback path can ever produce a key with that prefix.
-export function feedbackInstanceRateLimitKey(rawInstanceId: unknown, ip: string): string {
+// "instance:supplied:<hash of that literal string>", which can never equal
+// another caller's real fallback key "instance:fallback:<hash of their
+// ip>" -- only the fallback path can ever produce a key with that prefix,
+// and hashing doesn't change that: the prefix, not the hash, is what
+// prevents the collision.
+//
+// The value is hashed (not used raw) because, unlike an IP address --
+// bounded in size and cardinality by Cloudflare's own edge, which sets
+// cf-connecting-ip and isn't something an attacker can cheaply manufacture
+// more of -- `instance_id` is an arbitrary client-supplied JSON string with
+// no length cap anywhere (validateSubmission only bounds `message`), and
+// this check runs BEFORE validation. Without hashing, one row lands in
+// feedback_rate_limits per distinct instance_id ever sent, sized by
+// whatever the attacker chose to send, at zero attacker cost and no upper
+// bound -- unlike crashes/ingest.ts's ingest_buckets, whose cardinality is
+// bounded by real crash/install diversity, not attacker-paced. Hashing
+// makes every row a fixed ~90 bytes regardless of input; sweepStale
+// FeedbackRateLimits (src/obs/sweep.ts) bounds the row *count* the same way
+// Elixir's ETS-backed RateLimiter self-evicts via its own periodic cleaner.
+export async function feedbackInstanceRateLimitKey(
+  rawInstanceId: unknown,
+  ip: string,
+): Promise<string> {
   if (typeof rawInstanceId === "string" && rawInstanceId !== "") {
-    return `instance:supplied:${rawInstanceId}`;
+    return `instance:supplied:${await sha256Hex(rawInstanceId)}`;
   }
-  return `instance:fallback:${ip}`;
+  return `instance:fallback:${await sha256Hex(ip)}`;
 }
 
 export interface FeedbackRateLimitResult {
@@ -275,7 +302,7 @@ export async function checkFeedbackRateLimit(
   const ipResult = await checkAndIncrementBucket(db, `ip:${ip}`, hourBucket);
   if (!ipResult.allowed) return ipResult;
 
-  const instanceKey = feedbackInstanceRateLimitKey(rawInstanceId, ip);
+  const instanceKey = await feedbackInstanceRateLimitKey(rawInstanceId, ip);
   const instanceResult = await checkAndIncrementBucket(db, instanceKey, hourBucket);
 
   return {

--- a/relay-worker/src/feedback/ingest.ts
+++ b/relay-worker/src/feedback/ingest.ts
@@ -317,9 +317,15 @@ const RATE_LIMITED_BODY = {
 } as const;
 
 export function registerFeedbackRoutes(app: Hono<{ Bindings: Env }>): void {
-  // A method-specific route (app.post, not app.all) so the Task 14 dashboard
-  // can later register app.get("/feedback", ...) without either route
-  // swallowing the other -- Hono matches on path AND method.
+  // This is the public ingest endpoint every mydia install calls -- a wire
+  // contract that must never move. It stays at bare /feedback; the
+  // maintainer dashboard (src/dashboards/feedback.ts) lives at the separate
+  // /admin/feedback path specifically so the two can be governed
+  // independently by Cloudflare Access, which -- like Hono's router --
+  // matches on path only and cannot gate one HTTP method on a shared path
+  // while leaving another method on that same path alone. Keeping this an
+  // app.post (not app.all) is still correct in its own right: nothing else
+  // should ever answer other methods at this exact path.
   app.post("/feedback", async (c) => {
     // undefined here means the body wasn't parseable JSON *at all* -- this
     // is the one case that never reaches Elixir's controller action, since

--- a/relay-worker/src/feedback/ingest.ts
+++ b/relay-worker/src/feedback/ingest.ts
@@ -244,16 +244,23 @@ export interface FeedbackRateLimitResult {
   writes: number;
 }
 
-// Read-before-write, the exact trade crashes/ingest.ts's fix round mandated
-// for ingest_buckets: an INSERT ... ON CONFLICT DO UPDATE bills a write on
-// every call whether it inserts or updates, so a storm of requests against
-// an already-saturated bucket would otherwise cost a write per request
-// regardless of the cap. Reading first means a saturated bucket costs
-// exactly one read and zero writes; the write only happens on the branch
-// that actually admits the request. hour_bucket is a resettable column
-// (not part of the key), same as ingest_buckets, so this table is bounded
-// by distinct bucket_key values rather than growing by one row per key for
-// every hour that has ever elapsed.
+// Final-review fix round: the two-statement read-then-write shape this
+// function used to have (a SELECT, decide in JS, then a SEPARATE INSERT) is
+// exactly what let 20 concurrent identical-IP submissions all get admitted
+// against this table's 5/hour cap in a real reproduction -- D1 only
+// guarantees ordering within a single statement (or a .batch()), not across
+// two independent .prepare()/.run() calls, so concurrent requests could all
+// read the same pre-increment state and all decide to admit.
+//
+// The fix keeps the cheap read as a non-authoritative pre-check (once a
+// bucket is solidly saturated for the hour, this still costs exactly one
+// read and zero writes, same as before), but the actual admission decision
+// now comes from ONE atomic `INSERT ... ON CONFLICT DO UPDATE ... RETURNING`
+// statement: `count` is an uncapped, monotonic-within-the-hour counter, and
+// SQLite serialises writers to the same row even without an explicit
+// transaction wrapper, so the Nth request to actually commit is guaranteed a
+// unique `count = N` -- "admitted" is simply `count <= FEEDBACK_RATE_LIMIT`,
+// decided from the RETURNED value, with no stale read in the decision path.
 async function checkAndIncrementBucket(
   db: D1Database,
   bucketKey: string,
@@ -264,25 +271,27 @@ async function checkAndIncrementBucket(
     .bind(bucketKey)
     .first<RateLimitBucketRow>();
 
-  const isFreshWindow = !existing || existing.hour_bucket !== hourBucket;
-  const priorCount = isFreshWindow ? 0 : existing!.count;
-
-  if (priorCount >= FEEDBACK_RATE_LIMIT) {
+  if (existing && existing.hour_bucket === hourBucket && existing.count >= FEEDBACK_RATE_LIMIT) {
     return { allowed: false, writes: 0 };
   }
 
   const result = await db
     .prepare(
       `INSERT INTO feedback_rate_limits (bucket_key, hour_bucket, count)
-       VALUES (?, ?, ?)
+       VALUES (?, ?, 1)
        ON CONFLICT(bucket_key) DO UPDATE SET
-         hour_bucket = excluded.hour_bucket,
-         count = excluded.count`,
+         count = CASE
+           WHEN feedback_rate_limits.hour_bucket != excluded.hour_bucket THEN 1
+           ELSE feedback_rate_limits.count + 1
+         END,
+         hour_bucket = excluded.hour_bucket
+       RETURNING count`,
     )
-    .bind(bucketKey, hourBucket, priorCount + 1)
-    .run();
+    .bind(bucketKey, hourBucket)
+    .run<{ count: number }>();
 
-  return { allowed: true, writes: result.meta.rows_written };
+  const count = result.results[0]?.count ?? 0;
+  return { allowed: count <= FEEDBACK_RATE_LIMIT, writes: result.meta.rows_written };
 }
 
 // Mirrors router.ex's `with {:ok, _} <- check(ip), {:ok, _} <- check(instance)
@@ -341,6 +350,24 @@ export function registerFeedbackRoutes(app: Hono<{ Bindings: Env }>): void {
 
     const ip = c.req.header("cf-connecting-ip") ?? "unknown";
     const hourBucket = Math.floor(Date.now() / 3_600_000);
+
+    // Final-review fix round: the atomic, D1-free burst guard in front of
+    // checkFeedbackRateLimit below. See wrangler.jsonc's
+    // FEEDBACK_INGEST_LIMITER comment for the numbers and rationale. Keyed
+    // on IP -- the identity the demonstrated race actually exploited (20
+    // concurrent identical-IP submissions, all 20 admitted against the
+    // 5/hour cap) -- and checked before D1 is touched at all, same ordering
+    // as the D1-backed check it guards (both run before validation, matching
+    // router.ex's handle_feedback/1).
+    const { success: burstOk } = await c.env.FEEDBACK_INGEST_LIMITER.limit({
+      key: `feedback:${ip}`,
+    });
+    if (!burstOk) {
+      return c.json(RATE_LIMITED_BODY, 429, {
+        "retry-after": "10",
+        "x-relay-d1-writes": "0",
+      });
+    }
 
     // router.ex checks both rate limits BEFORE process_feedback/2 runs at
     // all -- before it even checks whether the body decoded to a proper

--- a/relay-worker/src/feedback/ingest.ts
+++ b/relay-worker/src/feedback/ingest.ts
@@ -172,31 +172,171 @@ export async function notify(env: Env, submission: Submission): Promise<void> {
   });
 }
 
+// -- Rate limiting -------------------------------------------------------
+//
+// router.ex's handle_feedback/1: two independent checks -- 5 requests/hour
+// by client IP, and 5 requests/hour by an anti-collision-namespaced
+// instance id -- both gating BEFORE process_feedback/2 (validation and the
+// D1 insert) ever runs. This endpoint is public and unauthenticated with no
+// per-identity cap otherwise, sharing D1's 100k-row-writes/day free-tier
+// budget with crash ingest, so leaving it unthrottled risks the same class
+// of exhaustion Task 11 spent two rounds bounding for /crashes/report --
+// except here every accepted row also fires an unthrottled outbound Resend
+// call.
+//
+// Cloudflare's `ratelimit` binding (PROXY_LIMITER etc.) cannot express this:
+// its `simple.period` only supports 10 or 60 seconds (confirmed against
+// node_modules/wrangler/config-schema.json), so "5 per hour" needs a D1
+// bucket instead, structured like crashes/ingest.ts's ingest_buckets.
+
+export const FEEDBACK_RATE_LIMIT = 5;
+
+interface RateLimitBucketRow {
+  hour_bucket: number;
+  count: number;
+}
+
+// Mirrors router.ex's feedback_rate_limit_instance_id/2 exactly, including
+// its T-236 anti-collision namespacing: the supplied and fallback cases are
+// tagged with fixed, disjoint literal prefixes applied BEFORE the
+// caller-controlled or IP-derived value, not interpolated together into one
+// string a caller could reproduce. A caller sending
+// instance_id: "fallback:<victim ip>" therefore produces
+// "instance:supplied:fallback:<victim ip>", which can never equal another
+// caller's real fallback key "instance:fallback:<their ip>" -- only the
+// fallback path can ever produce a key with that prefix.
+export function feedbackInstanceRateLimitKey(rawInstanceId: unknown, ip: string): string {
+  if (typeof rawInstanceId === "string" && rawInstanceId !== "") {
+    return `instance:supplied:${rawInstanceId}`;
+  }
+  return `instance:fallback:${ip}`;
+}
+
+export interface FeedbackRateLimitResult {
+  allowed: boolean;
+  writes: number;
+}
+
+// Read-before-write, the exact trade crashes/ingest.ts's fix round mandated
+// for ingest_buckets: an INSERT ... ON CONFLICT DO UPDATE bills a write on
+// every call whether it inserts or updates, so a storm of requests against
+// an already-saturated bucket would otherwise cost a write per request
+// regardless of the cap. Reading first means a saturated bucket costs
+// exactly one read and zero writes; the write only happens on the branch
+// that actually admits the request. hour_bucket is a resettable column
+// (not part of the key), same as ingest_buckets, so this table is bounded
+// by distinct bucket_key values rather than growing by one row per key for
+// every hour that has ever elapsed.
+async function checkAndIncrementBucket(
+  db: D1Database,
+  bucketKey: string,
+  hourBucket: number,
+): Promise<FeedbackRateLimitResult> {
+  const existing = await db
+    .prepare("SELECT hour_bucket, count FROM feedback_rate_limits WHERE bucket_key = ?")
+    .bind(bucketKey)
+    .first<RateLimitBucketRow>();
+
+  const isFreshWindow = !existing || existing.hour_bucket !== hourBucket;
+  const priorCount = isFreshWindow ? 0 : existing!.count;
+
+  if (priorCount >= FEEDBACK_RATE_LIMIT) {
+    return { allowed: false, writes: 0 };
+  }
+
+  const result = await db
+    .prepare(
+      `INSERT INTO feedback_rate_limits (bucket_key, hour_bucket, count)
+       VALUES (?, ?, ?)
+       ON CONFLICT(bucket_key) DO UPDATE SET
+         hour_bucket = excluded.hour_bucket,
+         count = excluded.count`,
+    )
+    .bind(bucketKey, hourBucket, priorCount + 1)
+    .run();
+
+  return { allowed: true, writes: result.meta.rows_written };
+}
+
+// Mirrors router.ex's `with {:ok, _} <- check(ip), {:ok, _} <- check(instance)
+// do process_feedback(...) end`. The IP check runs first; same as the
+// Elixir's ETS-backed RateLimiter (which inserts the request into a bucket
+// the moment that bucket's own check passes), its write happens whenever it
+// INDIVIDUALLY passes -- independent of whether the instance check that
+// follows then rejects the request. The instance check is never reached at
+// all once the IP check itself rejects (a `with` short-circuits), so a
+// fully-saturated-on-IP request costs one read and zero writes total.
+export async function checkFeedbackRateLimit(
+  db: D1Database,
+  ip: string,
+  rawInstanceId: unknown,
+  hourBucket: number,
+): Promise<FeedbackRateLimitResult> {
+  const ipResult = await checkAndIncrementBucket(db, `ip:${ip}`, hourBucket);
+  if (!ipResult.allowed) return ipResult;
+
+  const instanceKey = feedbackInstanceRateLimitKey(rawInstanceId, ip);
+  const instanceResult = await checkAndIncrementBucket(db, instanceKey, hourBucket);
+
+  return {
+    allowed: instanceResult.allowed,
+    writes: ipResult.writes + instanceResult.writes,
+  };
+}
+
+const RATE_LIMITED_BODY = {
+  error: "Too many requests",
+  message: "Rate limit exceeded. Please try again later.",
+} as const;
+
 export function registerFeedbackRoutes(app: Hono<{ Bindings: Env }>): void {
   // A method-specific route (app.post, not app.all) so the Task 14 dashboard
   // can later register app.get("/feedback", ...) without either route
   // swallowing the other -- Hono matches on path AND method.
   app.post("/feedback", async (c) => {
-    const parsed: unknown = await c.req.json().catch(() => null);
+    // undefined here means the body wasn't parseable JSON *at all* -- this
+    // is the one case that never reaches Elixir's controller action, since
+    // Plug.Parsers rejects genuinely malformed syntax before routing, so it
+    // is also the one case that bypasses rate limiting entirely.
+    const parsed: unknown = await c.req.json().catch(() => undefined);
+    if (parsed === undefined) {
+      return c.json({ error: "Invalid JSON", message: "Request body must be valid JSON" }, 400);
+    }
+
+    const isObject = parsed !== null && typeof parsed === "object" && !Array.isArray(parsed);
+    const body = isObject ? (parsed as Record<string, unknown>) : {};
+
+    const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+    const hourBucket = Math.floor(Date.now() / 3_600_000);
+
+    // router.ex checks both rate limits BEFORE process_feedback/2 runs at
+    // all -- before it even checks whether the body decoded to a proper
+    // JSON object -- so a parseable-but-non-object body, or one that will
+    // go on to fail field validation, still spends a rate-limit slot.
+    const rateLimit = await checkFeedbackRateLimit(c.env.DB, ip, body.instance_id, hourBucket);
+    if (!rateLimit.allowed) {
+      return c.json(RATE_LIMITED_BODY, 429, {
+        "retry-after": "3600",
+        "x-relay-d1-writes": String(rateLimit.writes),
+      });
+    }
 
     // router.ex's validate_feedback(_) catch-all: params must be a JSON
     // object (a map on the Elixir side), not an array, string, number, or
     // null.
-    if (
-      parsed === null ||
-      typeof parsed !== "object" ||
-      Array.isArray(parsed)
-    ) {
+    if (!isObject) {
       return c.json(
         { error: "Invalid JSON", message: "Request body must be valid JSON" },
         400,
+        { "x-relay-d1-writes": String(rateLimit.writes) },
       );
     }
 
-    const body = parsed as Record<string, unknown>;
     const result = validateSubmission(body);
     if (!result.ok) {
-      return c.json({ error: "Validation failed", errors: result.errors }, 400);
+      return c.json({ error: "Validation failed", errors: result.errors }, 400, {
+        "x-relay-d1-writes": String(rateLimit.writes),
+      });
     }
 
     // Only checked once the other validations pass, matching router.ex's
@@ -205,7 +345,11 @@ export function registerFeedbackRoutes(app: Hono<{ Bindings: Env }>): void {
     // byte_size(message) does on the Elixir side.
     const messageBytes = new TextEncoder().encode(result.value.message).length;
     if (messageBytes > MESSAGE_MAX_BYTES) {
-      return c.json({ error: "Message too long", limit_bytes: MESSAGE_MAX_BYTES }, 400);
+      return c.json(
+        { error: "Message too long", limit_bytes: MESSAGE_MAX_BYTES },
+        400,
+        { "x-relay-d1-writes": String(rateLimit.writes) },
+      );
     }
 
     const now = Math.floor(Date.now() / 1000);
@@ -214,7 +358,7 @@ export function registerFeedbackRoutes(app: Hono<{ Bindings: Env }>): void {
       source_ip: c.req.header("cf-connecting-ip") ?? null,
     };
 
-    await c.env.DB.prepare(
+    const insertResult = await c.env.DB.prepare(
       `INSERT INTO feedback_submissions
          (id, type, message, contact, instance_id, mydia_version, source_ip,
           state, github_ref, inserted_at, updated_at)
@@ -240,6 +384,8 @@ export function registerFeedbackRoutes(app: Hono<{ Bindings: Env }>): void {
     // and duplicate it -- Sender only recognises 201 as success.
     c.executionCtx.waitUntil(notify(c.env, submission).catch(() => undefined));
 
-    return c.json({ status: "created", id: submission.id }, 201);
+    return c.json({ status: "created", id: submission.id }, 201, {
+      "x-relay-d1-writes": String(rateLimit.writes + insertResult.meta.rows_written),
+    });
   });
 }

--- a/relay-worker/src/feedback/ingest.ts
+++ b/relay-worker/src/feedback/ingest.ts
@@ -180,7 +180,7 @@ export async function notify(env: Env, submission: Submission): Promise<void> {
 // D1 insert) ever runs. This endpoint is public and unauthenticated with no
 // per-identity cap otherwise, sharing D1's 100k-row-writes/day free-tier
 // budget with crash ingest, so leaving it unthrottled risks the same class
-// of exhaustion Task 11 spent two rounds bounding for /crashes/report --
+// of exhaustion that /crashes/report took two rounds to bound --
 // except here every accepted row also fires an unthrottled outbound Resend
 // call.
 //

--- a/relay-worker/src/feedback/ingest.ts
+++ b/relay-worker/src/feedback/ingest.ts
@@ -1,0 +1,245 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+
+// router.ex's validate_feedback_type/2: only these three are accepted.
+const TYPES = ["bug", "idea", "question"] as const;
+
+// router.ex's `process_feedback/2` never reads a `state` from the request at
+// all (get_feedback_param only reads type/message/contact/instance_id/
+// mydia_version) -- every submission is created via Submission's schema
+// default. A client-supplied `state` is silently ignored, not merely
+// rejected, matching the producer exactly: it must not be a way to bypass
+// triage by posting straight to "archived".
+const DEFAULT_STATE = "unread";
+
+export const MESSAGE_MAX_BYTES = 4096;
+
+export interface Submission {
+  id: string;
+  type: string;
+  message: string;
+  contact: string | null;
+  instance_id: string | null;
+  mydia_version: string | null;
+  source_ip: string | null;
+  state: string;
+  github_ref: string | null;
+}
+
+export interface FeedbackRow extends Submission {
+  inserted_at: number;
+  updated_at: number;
+}
+
+// Mirrors router.ex's require_feedback_field/3: is_binary(value) &&
+// String.trim(value) != "" -- a value only counts as present when it is a
+// string that isn't empty once whitespace is trimmed.
+function isRequiredFieldPresent(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+// Mirrors router.ex's validate_feedback_type/2's own binary/non-empty guard,
+// which runs independently of require_feedback_field/3 above (not gated on
+// it) -- a whitespace-only type can produce BOTH "Missing required field:
+// type" and "Invalid type: <raw value>" at once, same as router.ex.
+function isNonEmptyBinary(value: unknown): value is string {
+  return typeof value === "string" && value !== "";
+}
+
+// Mirrors router.ex's validate_optional_feedback_field/3: nil/absent is
+// fine, any string (including "") is fine, anything else (a number, array,
+// object, boolean) is rejected outright rather than silently coerced.
+function isValidOptionalField(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+// Mirrors router.ex's normalize_optional_feedback_field/1: trims, then
+// turns an empty result into nil. Unlike type/message, the stored value IS
+// the trimmed string, not the raw one.
+function normalizeOptional(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+export function validateSubmission(
+  body: Record<string, unknown>,
+): { ok: true; value: Submission } | { ok: false; errors: string[] } {
+  const errors: string[] = [];
+
+  const type = body.type;
+  const message = body.message;
+
+  if (!isRequiredFieldPresent(type)) errors.push("Missing required field: type");
+  if (!isRequiredFieldPresent(message)) errors.push("Missing required field: message");
+
+  if (isNonEmptyBinary(type) && !TYPES.includes(type as (typeof TYPES)[number])) {
+    errors.push(`Invalid type: ${type}`);
+  }
+
+  if (!isValidOptionalField(body.contact)) errors.push("Invalid field: contact");
+  if (!isValidOptionalField(body.instance_id)) errors.push("Invalid field: instance_id");
+  if (!isValidOptionalField(body.mydia_version)) errors.push("Invalid field: mydia_version");
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    value: {
+      id: crypto.randomUUID(),
+      // isRequiredFieldPresent narrowed these to `string` above; errors would
+      // have been non-empty otherwise and we would have returned already.
+      type: type as string,
+      message: message as string,
+      contact: normalizeOptional(body.contact),
+      instance_id: normalizeOptional(body.instance_id),
+      mydia_version: normalizeOptional(body.mydia_version),
+      source_ip: null,
+      state: DEFAULT_STATE,
+      github_ref: null,
+    },
+  };
+}
+
+// Mirrors the guard in feedback/notifier.ex's @contact_address: strips CR
+// and LF so a crafted contact or message excerpt cannot inject additional
+// mail headers into the subject or reply-to fields sent to Resend's API.
+export function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]/g, " ").trim();
+}
+
+// Mirrors notifier.ex's @contact_address: `\A[^\s@,;:<>"]+@[^\s@,;:<>"]+\.[^\s@,;:<>"]+\z`.
+// Deliberately whole-string anchored (JS's `^`/`$` without the `m` flag
+// already behave like Elixir's `\A`/`\z`, unlike Elixir's own `^`/`$`, which
+// are per-line anchors -- this is the exact case that comment warns about),
+// so an embedded CR/LF can never sneak an extra "line" past the check.
+const CONTACT_ADDRESS = /^[^\s@,;:<>"]+@[^\s@,;:<>"]+\.[^\s@,;:<>"]+$/;
+
+function contactAsReplyTo(contact: string | null): string | null {
+  if (contact === null) return null;
+  return CONTACT_ADDRESS.test(contact) ? contact : null;
+}
+
+// notifier.ex's subject_preview/1: collapse all whitespace runs (not just
+// CR/LF) to a single space, trim, then cap at 80 characters.
+function subjectPreview(message: string): string {
+  return message.replace(/\s+/g, " ").trim().slice(0, 80);
+}
+
+function optionalValue(value: string | null): string {
+  return value ?? "-";
+}
+
+// Mirrors notifier.ex's deliver_new_submission/1 via Resend's HTTP API --
+// Workers cannot open the SMTP connections Swoosh used. Called only after
+// the row has already committed to D1 (see registerFeedbackRoutes below), so
+// a Resend outage can never turn a stored submission into a client-visible
+// error.
+export async function notify(env: Env, submission: Submission): Promise<void> {
+  if (!env.RESEND_API_KEY) return;
+
+  const replyTo = contactAsReplyTo(submission.contact);
+
+  const payload: Record<string, unknown> = {
+    from: env.FEEDBACK_FROM,
+    to: [env.FEEDBACK_TO],
+    subject: sanitizeHeaderValue(
+      `[Mydia feedback] ${submission.type}: ${subjectPreview(submission.message)}`,
+    ),
+    text: [
+      "New Mydia feedback received.",
+      "",
+      `Type: ${submission.type}`,
+      `Contact: ${optionalValue(submission.contact)}`,
+      `Instance: ${optionalValue(submission.instance_id)}`,
+      `Mydia version: ${optionalValue(submission.mydia_version)}`,
+      `Source IP: ${optionalValue(submission.source_ip)}`,
+      "",
+      "Message:",
+      submission.message,
+    ].join("\n"),
+  };
+
+  if (replyTo) payload.reply_to = sanitizeHeaderValue(replyTo);
+
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function registerFeedbackRoutes(app: Hono<{ Bindings: Env }>): void {
+  // A method-specific route (app.post, not app.all) so the Task 14 dashboard
+  // can later register app.get("/feedback", ...) without either route
+  // swallowing the other -- Hono matches on path AND method.
+  app.post("/feedback", async (c) => {
+    const parsed: unknown = await c.req.json().catch(() => null);
+
+    // router.ex's validate_feedback(_) catch-all: params must be a JSON
+    // object (a map on the Elixir side), not an array, string, number, or
+    // null.
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return c.json(
+        { error: "Invalid JSON", message: "Request body must be valid JSON" },
+        400,
+      );
+    }
+
+    const body = parsed as Record<string, unknown>;
+    const result = validateSubmission(body);
+    if (!result.ok) {
+      return c.json({ error: "Validation failed", errors: result.errors }, 400);
+    }
+
+    // Only checked once the other validations pass, matching router.ex's
+    // `cond` ordering: errors != [] short-circuits before the byte-length
+    // check ever runs. Uses the RAW (untrimmed) message, same as
+    // byte_size(message) does on the Elixir side.
+    const messageBytes = new TextEncoder().encode(result.value.message).length;
+    if (messageBytes > MESSAGE_MAX_BYTES) {
+      return c.json({ error: "Message too long", limit_bytes: MESSAGE_MAX_BYTES }, 400);
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const submission: Submission = {
+      ...result.value,
+      source_ip: c.req.header("cf-connecting-ip") ?? null,
+    };
+
+    await c.env.DB.prepare(
+      `INSERT INTO feedback_submissions
+         (id, type, message, contact, instance_id, mydia_version, source_ip,
+          state, github_ref, inserted_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        submission.id,
+        submission.type,
+        submission.message,
+        submission.contact,
+        submission.instance_id,
+        submission.mydia_version,
+        submission.source_ip,
+        submission.state,
+        submission.github_ref,
+        now,
+        now,
+      )
+      .run();
+
+    // The row is already committed above. A Resend outage must never turn a
+    // stored submission into a 500 that makes Mydia.Feedback.Sender retry
+    // and duplicate it -- Sender only recognises 201 as success.
+    c.executionCtx.waitUntil(notify(c.env, submission).catch(() => undefined));
+
+    return c.json({ status: "created", id: submission.id }, 201);
+  });
+}

--- a/relay-worker/src/feedback/queries.ts
+++ b/relay-worker/src/feedback/queries.ts
@@ -43,9 +43,20 @@ export async function setFeedbackState(
 }
 
 export async function setGithubRef(env: Env, id: string, ref: string): Promise<void> {
+  // Mirrors Submission.github_ref_changeset/2: Ecto.Changeset.cast/4's
+  // default `empty_values` (which includes "") normalizes a blank change
+  // away entirely, so the Elixir side never persists "" -- a blank
+  // submission leaves the struct's `nil` default in place. Trim first so a
+  // whitespace-only submission is treated the same way (the Elixir cast
+  // only special-cases the exact string "", but nothing here should ever
+  // want to persist "   " as if it were a real reference either). A
+  // non-blank ref is stored exactly as submitted, uninspected -- same as
+  // the Elixir side, which never trims real content.
+  const normalized = ref.trim() === "" ? null : ref;
+
   await env.DB.prepare(
     "UPDATE feedback_submissions SET github_ref = ?, updated_at = ? WHERE id = ?",
   )
-    .bind(ref, Math.floor(Date.now() / 1000), id)
+    .bind(normalized, Math.floor(Date.now() / 1000), id)
     .run();
 }

--- a/relay-worker/src/feedback/queries.ts
+++ b/relay-worker/src/feedback/queries.ts
@@ -1,0 +1,51 @@
+import type { Env } from "../env";
+import type { FeedbackRow } from "./ingest";
+
+export interface ListFeedbackOptions {
+  state?: string;
+  limit: number;
+  offset: number;
+}
+
+export async function listFeedback(
+  env: Env,
+  opts: ListFeedbackOptions,
+): Promise<FeedbackRow[]> {
+  // Mirrors MetadataRelay.Feedback.list_submissions/1's maybe_filter/3: nil
+  // and the literal "all" both mean "no filter", not a value to match
+  // against the state column.
+  const state = opts.state && opts.state !== "all" ? opts.state : undefined;
+
+  const stmt = state
+    ? env.DB.prepare(
+        `SELECT * FROM feedback_submissions WHERE state = ?
+         ORDER BY inserted_at DESC LIMIT ? OFFSET ?`,
+      ).bind(state, opts.limit, opts.offset)
+    : env.DB.prepare(
+        `SELECT * FROM feedback_submissions
+         ORDER BY inserted_at DESC LIMIT ? OFFSET ?`,
+      ).bind(opts.limit, opts.offset);
+
+  const { results } = await stmt.all<FeedbackRow>();
+  return results;
+}
+
+export async function setFeedbackState(
+  env: Env,
+  id: string,
+  state: "unread" | "read" | "archived",
+): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE feedback_submissions SET state = ?, updated_at = ? WHERE id = ?",
+  )
+    .bind(state, Math.floor(Date.now() / 1000), id)
+    .run();
+}
+
+export async function setGithubRef(env: Env, id: string, ref: string): Promise<void> {
+  await env.DB.prepare(
+    "UPDATE feedback_submissions SET github_ref = ?, updated_at = ? WHERE id = ?",
+  )
+    .bind(ref, Math.floor(Date.now() / 1000), id)
+    .run();
+}

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -9,19 +9,28 @@ import { logRequest } from "./obs/log";
 
 export const app = new Hono<{ Bindings: Env }>();
 
-// Registered before every route (including /health and /stats below) so the
-// EXEMPT set inside rateLimitMiddleware is what actually protects those
+// Both registered before every route (including /health and /stats below) so
+// the EXEMPT set inside rateLimitMiddleware is what actually protects those
 // routes, not an accident of Hono's registration-order middleware
 // composition -- app.use() only wraps routes registered after it, so a
 // health-check route defined ahead of this would otherwise never reach
 // either middleware at all.
-app.use("*", rateLimitMiddleware());
-
+//
+// Order between the two matters, and it is the OPPOSITE of what it looks
+// like it should be: Hono composes middleware as an onion, so whichever is
+// registered SECOND runs as the INNER layer, closer to the route. The
+// logging middleware must be outermost (registered first) so its
+// `await next()` only returns once rateLimitMiddleware has had its own turn
+// to replace c.res with a 429 -- otherwise the log line records the route's
+// pre-throttle status (e.g. a plain 200/404) instead of what the client
+// actually received.
 app.use("*", async (c, next) => {
   await next();
   const cache = c.res.headers.get("x-relay-cache") === "HIT" ? "HIT" : "MISS";
   logRequest(new URL(c.req.url).pathname, c.res.status, cache);
 });
+
+app.use("*", rateLimitMiddleware());
 
 app.get("/health", (c) =>
   c.json({

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -9,6 +9,7 @@ import { registerCrashRoutes } from "./crashes/ingest";
 import { registerFeedbackRoutes } from "./feedback/ingest";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
+import { runScheduledSweep } from "./obs/sweep";
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -73,4 +74,14 @@ registerFeedbackRoutes(app);
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));
 
-export default app;
+export default {
+  fetch: app.fetch,
+  // Cron Trigger (wrangler.jsonc's triggers.crons), never the request path.
+  // Sweeps two tables that grow without an eviction path otherwise:
+  // feedback_rate_limits (src/obs/sweep.ts's justification for why this is
+  // required, not optional, for that table specifically) and
+  // pairing_claims via pairing/store.ts's purgeExpiredClaims.
+  async scheduled(_controller: ScheduledController, env: Env, _ctx: ExecutionContext): Promise<void> {
+    await runScheduledSweep(env);
+  },
+} satisfies ExportedHandler<Env>;

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "./env";
 import { registerTmdbRoutes } from "./proxy/tmdb";
+import { registerTvdbRoutes } from "./proxy/tvdb";
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -26,6 +27,7 @@ app.get("/stats", (c) =>
 );
 
 registerTmdbRoutes(app);
+registerTvdbRoutes(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import type { Env } from "./env";
 import { registerTmdbRoutes } from "./proxy/tmdb";
 import { registerTvdbRoutes } from "./proxy/tvdb";
+import { registerSubdlRoutes, subdlApiKey } from "./proxy/subdl";
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -10,7 +11,10 @@ app.get("/health", (c) =>
     status: "ok",
     service: "metadata-relay",
     version: c.env.RELAY_VERSION ?? "0.0.0",
-    subtitles_configured: Boolean(c.env.SUBDL_API_KEY),
+    // subdlApiKey treats a blank/whitespace-only key as absent, same as the
+    // search route does, so this can't report "configured" for a value that
+    // would 503 on the first real search.
+    subtitles_configured: Boolean(subdlApiKey(c.env)),
   }),
 );
 
@@ -28,6 +32,7 @@ app.get("/stats", (c) =>
 
 registerTmdbRoutes(app);
 registerTvdbRoutes(app);
+registerSubdlRoutes(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -94,7 +94,13 @@ registerFeedbackRoutes(app);
 // exists (runbook, relay-worker/README.md) would expose maintainer data.
 registerFeedbackDashboard(app);
 
-// 404 catch-all, matching the Elixir router's behaviour.
+// 404 catch-all. Deliberately NOT a match for the Elixir router's own
+// behaviour here: router.ex's fallback returns a plain-text 404 body, this
+// returns JSON -- a considered divergence, not an oversight, kept because
+// every other error path in this Worker (validation failures, rate limits,
+// crash/feedback ingest) already answers JSON, and a mixed-format 404 would
+// be the odd one out for no benefit. Do not "fix" this to match the Elixir;
+// that would be introducing a regression, not correcting one.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));
 
 export default {

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -5,6 +5,7 @@ import { registerTvdbRoutes } from "./proxy/tvdb";
 import { registerSubdlRoutes, subdlApiKey } from "./proxy/subdl";
 import { registerPassthroughRoutes } from "./proxy/passthrough";
 import { registerPairingRoutes } from "./pairing/routes";
+import { registerCrashRoutes } from "./crashes/ingest";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
 
@@ -62,6 +63,7 @@ registerTvdbRoutes(app);
 registerSubdlRoutes(app);
 registerPassthroughRoutes(app);
 registerPairingRoutes(app);
+registerCrashRoutes(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -8,6 +8,7 @@ import { registerPairingRoutes } from "./pairing/routes";
 import { registerCrashRoutes } from "./crashes/ingest";
 import { registerErrorDashboard } from "./dashboards/errors";
 import { registerFeedbackRoutes } from "./feedback/ingest";
+import { registerFeedbackDashboard } from "./dashboards/feedback";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
 import { runScheduledSweep } from "./obs/sweep";
@@ -72,10 +73,15 @@ registerCrashRoutes(app);
 // Cloudflare Access in front of it; do not deploy this to a public hostname
 // before that lands.
 registerErrorDashboard(app);
-// POST only -- Task 14 adds GET /feedback (the maintainer dashboard) as a
-// separate route registration, and Hono matches by path AND method, so the
-// two coexist without either swallowing the other.
+// POST only -- registerFeedbackDashboard below adds GET /feedback (the
+// maintainer dashboard replacing FeedbackLive.Index) as a separate route
+// registration, and Hono matches by path AND method, so the two coexist
+// without either swallowing the other.
 registerFeedbackRoutes(app);
+// GET /feedback plus the state/github mutation routes. Unauthenticated
+// until Task 15 puts Cloudflare Access in front of it; do not deploy this
+// to a public hostname before that lands.
+registerFeedbackDashboard(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -6,6 +6,7 @@ import { registerSubdlRoutes, subdlApiKey } from "./proxy/subdl";
 import { registerPassthroughRoutes } from "./proxy/passthrough";
 import { registerPairingRoutes } from "./pairing/routes";
 import { registerCrashRoutes } from "./crashes/ingest";
+import { registerErrorDashboard } from "./dashboards/errors";
 import { registerFeedbackRoutes } from "./feedback/ingest";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
@@ -66,6 +67,11 @@ registerSubdlRoutes(app);
 registerPassthroughRoutes(app);
 registerPairingRoutes(app);
 registerCrashRoutes(app);
+// GET/POST /errors and /errors/:fingerprint -- the maintainer dashboard
+// replacing error_tracker's LiveView UI. Unauthenticated until Task 15 puts
+// Cloudflare Access in front of it; do not deploy this to a public hostname
+// before that lands.
+registerErrorDashboard(app);
 // POST only -- Task 14 adds GET /feedback (the maintainer dashboard) as a
 // separate route registration, and Hono matches by path AND method, so the
 // two coexist without either swallowing the other.

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -1,0 +1,30 @@
+import { Hono } from "hono";
+import type { Env } from "./env";
+
+export const app = new Hono<{ Bindings: Env }>();
+
+app.get("/health", (c) =>
+  c.json({
+    status: "ok",
+    service: "metadata-relay",
+    version: c.env.RELAY_VERSION ?? "0.0.0",
+    subtitles_configured: Boolean(c.env.SUBDL_API_KEY),
+  }),
+);
+
+// The Elixir /stats reported ETS cache counters that reset on every restart.
+// The Worker has no equivalent in-process counter, and Workers Logs plus the
+// dashboard hold the real history, so this reports what the edge can answer
+// cheaply and keeps the route alive for anything already polling it.
+app.get("/stats", (c) =>
+  c.json({
+    service: "metadata-relay",
+    version: c.env.RELAY_VERSION ?? "0.0.0",
+    cache: { backend: "cloudflare-cache-api+kv" },
+  }),
+);
+
+// 404 catch-all, matching the Elixir router's behaviour.
+app.all("*", (c) => c.json({ error: "Not found" }, 404));
+
+export default app;

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -6,6 +6,7 @@ import { registerSubdlRoutes, subdlApiKey } from "./proxy/subdl";
 import { registerPassthroughRoutes } from "./proxy/passthrough";
 import { registerPairingRoutes } from "./pairing/routes";
 import { registerCrashRoutes } from "./crashes/ingest";
+import { registerFeedbackRoutes } from "./feedback/ingest";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
 
@@ -64,6 +65,10 @@ registerSubdlRoutes(app);
 registerPassthroughRoutes(app);
 registerPairingRoutes(app);
 registerCrashRoutes(app);
+// POST only -- Task 14 adds GET /feedback (the maintainer dashboard) as a
+// separate route registration, and Hono matches by path AND method, so the
+// two coexist without either swallowing the other.
+registerFeedbackRoutes(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -68,19 +68,30 @@ registerSubdlRoutes(app);
 registerPassthroughRoutes(app);
 registerPairingRoutes(app);
 registerCrashRoutes(app);
-// GET/POST /errors and /errors/:fingerprint -- the maintainer dashboard
-// replacing error_tracker's LiveView UI. Unauthenticated until Task 15 puts
-// Cloudflare Access in front of it; do not deploy this to a public hostname
-// before that lands.
+// GET/POST /admin/errors and /admin/errors/:fingerprint -- the maintainer
+// dashboard replacing error_tracker's LiveView UI. Deliberately under
+// /admin/* (not the bare /errors a naive port would use) so one Cloudflare
+// Access application scoped to /admin* covers this AND the feedback
+// dashboard below with no per-route decision -- see
+// relay-worker/README.md's runbook for why that matters: Access, like a
+// Worker route, matches on path only, with no HTTP-method dimension, so a
+// dashboard sharing a path with a public endpoint could never be gated
+// without also gating the public one. Creating that Access application is
+// still a manual step; until it exists, this route has no auth at all.
 registerErrorDashboard(app);
-// POST only -- registerFeedbackDashboard below adds GET /feedback (the
-// maintainer dashboard replacing FeedbackLive.Index) as a separate route
-// registration, and Hono matches by path AND method, so the two coexist
-// without either swallowing the other.
+// POST /feedback is the public ingest endpoint every mydia install calls --
+// a wire contract that must never move. registerFeedbackDashboard below
+// registers the maintainer dashboard's GET at the entirely separate
+// /admin/feedback path, not at /feedback, precisely so the two can be
+// governed independently: Access can cover /admin/feedback without ever
+// seeing a POST /feedback request, since Access (like Hono's router) has no
+// way to gate one HTTP method on a path while leaving another method on
+// that same path alone.
 registerFeedbackRoutes(app);
-// GET /feedback plus the state/github mutation routes. Unauthenticated
-// until Task 15 puts Cloudflare Access in front of it; do not deploy this
-// to a public hostname before that lands.
+// GET /admin/feedback plus the state/github mutation routes. See the
+// registerErrorDashboard comment above: /admin/* is deliberate, and
+// deploying this to a public hostname before the /admin* Access application
+// exists (runbook, relay-worker/README.md) would expose maintainer data.
 registerFeedbackDashboard(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -4,6 +4,7 @@ import { registerTmdbRoutes } from "./proxy/tmdb";
 import { registerTvdbRoutes } from "./proxy/tvdb";
 import { registerSubdlRoutes, subdlApiKey } from "./proxy/subdl";
 import { registerPassthroughRoutes } from "./proxy/passthrough";
+import { registerPairingRoutes } from "./pairing/routes";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
 
@@ -60,6 +61,7 @@ registerTmdbRoutes(app);
 registerTvdbRoutes(app);
 registerSubdlRoutes(app);
 registerPassthroughRoutes(app);
+registerPairingRoutes(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "./env";
+import { registerTmdbRoutes } from "./proxy/tmdb";
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -23,6 +24,8 @@ app.get("/stats", (c) =>
     cache: { backend: "cloudflare-cache-api+kv" },
   }),
 );
+
+registerTmdbRoutes(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -4,8 +4,24 @@ import { registerTmdbRoutes } from "./proxy/tmdb";
 import { registerTvdbRoutes } from "./proxy/tvdb";
 import { registerSubdlRoutes, subdlApiKey } from "./proxy/subdl";
 import { registerPassthroughRoutes } from "./proxy/passthrough";
+import { rateLimitMiddleware } from "./obs/ratelimit";
+import { logRequest } from "./obs/log";
 
 export const app = new Hono<{ Bindings: Env }>();
+
+// Registered before every route (including /health and /stats below) so the
+// EXEMPT set inside rateLimitMiddleware is what actually protects those
+// routes, not an accident of Hono's registration-order middleware
+// composition -- app.use() only wraps routes registered after it, so a
+// health-check route defined ahead of this would otherwise never reach
+// either middleware at all.
+app.use("*", rateLimitMiddleware());
+
+app.use("*", async (c, next) => {
+  await next();
+  const cache = c.res.headers.get("x-relay-cache") === "HIT" ? "HIT" : "MISS";
+  logRequest(new URL(c.req.url).pathname, c.res.status, cache);
+});
 
 app.get("/health", (c) =>
   c.json({

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -3,6 +3,7 @@ import type { Env } from "./env";
 import { registerTmdbRoutes } from "./proxy/tmdb";
 import { registerTvdbRoutes } from "./proxy/tvdb";
 import { registerSubdlRoutes, subdlApiKey } from "./proxy/subdl";
+import { registerPassthroughRoutes } from "./proxy/passthrough";
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -33,6 +34,7 @@ app.get("/stats", (c) =>
 registerTmdbRoutes(app);
 registerTvdbRoutes(app);
 registerSubdlRoutes(app);
+registerPassthroughRoutes(app);
 
 // 404 catch-all, matching the Elixir router's behaviour.
 app.all("*", (c) => c.json({ error: "Not found" }, 404));

--- a/relay-worker/src/obs/log.ts
+++ b/relay-worker/src/obs/log.ts
@@ -1,0 +1,29 @@
+// Mirrors service_from_path/1 in plug/cache.ex.
+export function serviceFromPath(path: string): string | null {
+  if (path.startsWith("/tmdb/")) return "tmdb";
+  if (path.startsWith("/tvdb/")) return "tvdb";
+  if (path.startsWith("/music/")) return "music";
+  if (path.startsWith("/openlibrary/")) return "openlibrary";
+  if (path.startsWith("/api/v1/subtitles/")) return "subdl";
+  return null;
+}
+
+// One structured line per request, retained by Workers Logs. The old
+// metadata_relay_requests_total{status="ok"|"error"} counter was dominated by
+// benign upstream 404s for TMDB ids that do not exist, which read as a 61%
+// error rate while the pod logged nothing. Recording the real status code lets
+// a query bucket by it instead of trusting a misleading binary.
+export function logRequest(
+  path: string,
+  status: number,
+  cache: "HIT" | "MISS",
+): void {
+  console.log(
+    JSON.stringify({
+      service: serviceFromPath(path) ?? "other",
+      path,
+      status,
+      cache,
+    }),
+  );
+}

--- a/relay-worker/src/obs/ratelimit.ts
+++ b/relay-worker/src/obs/ratelimit.ts
@@ -14,7 +14,38 @@ const EXEMPT = new Set(["/health", "/stats"]);
 // write-bounding. Charging any of these against the proxy budget too would
 // let a normal flow exhaust that budget for the same IP and break metadata
 // for that install.
-const EXEMPT_PREFIXES = ["/pairing/", "/crashes/", "/feedback", "/errors"];
+//
+// "/feedback" here is deliberately the bare public POST ingest path only --
+// it does NOT match "/admin/feedback" (a prefix check is a literal string
+// match; "/admin/feedback" does not start with "/feedback"), so it has no
+// bearing on the dashboard below.
+//
+// "/admin/" covers both maintainer dashboards (dashboards/errors.ts,
+// dashboards/feedback.ts, and any future /admin/* route by construction --
+// see dashboards/layout.ts). These proxy nothing upstream -- they only read
+// or write D1 -- so charging them against a budget that exists to protect
+// shared upstream provider quota (TMDB/TVDB/etc.) wouldn't serve this
+// limiter's purpose even before considering that they're Access-gated,
+// low-volume maintainer traffic. This is a relocation of the exemption that
+// used to be spelled out as "/errors" (bare) before both dashboards moved
+// under /admin/*, not new behaviour.
+const EXEMPT_PREFIXES = ["/pairing/", "/crashes/", "/feedback", "/admin/"];
+
+// Exported so this decision is unit-testable directly, on bare path strings,
+// rather than only observable by driving several hundred real requests
+// through SELF.fetch() to approach PROXY_LIMITER's actual 300/min threshold
+// -- test/obs/ratelimit.test.ts's other tests already need PROXY_LIMIT
+// _ITERATION_CAP-sized loops for THAT limiter's own behaviour, and that
+// file's own extensive comments document a real, wall-clock-dependent flake
+// in miniflare's rate-limit simulator. A prefix-matching predicate needs
+// none of that: it is pure, and testing it directly costs microseconds
+// instead of a few hundred HTTP+D1 round trips, without weakening coverage
+// of the actual regression this guards (an exempt path silently falling out
+// of this list, e.g. when a dashboard's route moves).
+export function isExemptFromProxyLimit(path: string): boolean {
+  if (EXEMPT.has(path)) return true;
+  return EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
 
 // Applied on a cache miss only, matching ProxyRateLimit's placement after the
 // cache plug. A cache hit costs no upstream quota, so throttling one buys
@@ -22,8 +53,7 @@ const EXEMPT_PREFIXES = ["/pairing/", "/crashes/", "/feedback", "/errors"];
 export function rateLimitMiddleware(): MiddlewareHandler<{ Bindings: Env }> {
   return async (c, next) => {
     const path = new URL(c.req.url).pathname;
-    if (EXEMPT.has(path)) return next();
-    if (EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix))) return next();
+    if (isExemptFromProxyLimit(path)) return next();
 
     await next();
 

--- a/relay-worker/src/obs/ratelimit.ts
+++ b/relay-worker/src/obs/ratelimit.ts
@@ -47,17 +47,36 @@ export function isExemptFromProxyLimit(path: string): boolean {
   return EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 
-// Applied on a cache miss only, matching ProxyRateLimit's placement after the
-// cache plug. A cache hit costs no upstream quota, so throttling one buys
-// nothing and hurts a legitimate "refresh all metadata" pass.
+// Final-review fix round: checked BEFORE `next()`, not after. The original
+// shape here called `await next()` first -- running the real handler and its
+// real upstream `fetch()` to TMDB/TVDB/SubDL/MusicBrainz/OpenLibrary -- and
+// only THEN checked the limiter, swapping in a 429 after the fact. That is a
+// halting-Plug-pipeline shape (the Elixir this ports is Cache then
+// ProxyRateLimit then the handler, so a throttled request never reaches the
+// code that calls upstream) that the check-after shape cannot actually
+// replicate: probed at 320 cache-busted requests from one IP, all 320 -
+// including the 20 that got a 429 back - still produced a real upstream
+// call. That defeated the limiter's entire purpose, worst for
+// /api/v1/subtitles/search, whose SubDL key carries a shared 2000/day
+// allowance a sustained flood could exhaust in minutes.
+//
+// Checking first means a cache HIT is now also charged against the budget --
+// this endpoint used to inspect x-relay-cache after the fact specifically to
+// exempt hits, on the theory that a cache hit costs no upstream quota and
+// throttling one buys nothing. That's still true in isolation, but knowing a
+// request will hit cache requires either running it (defeating the point) or
+// probing the cache a second time from inside this middleware (a duplicate
+// lookup on every single request, to save nothing on the common path). Given
+// that choice, this accepts the stricter, fail-closed direction: a bulk
+// "refresh all metadata" pass that would previously have been served
+// entirely from cache can now consume rate-limit budget it didn't before
+// (recorded in README.md's "what this migration changed"). Protecting
+// upstream quota -- this limiter's actual purpose -- only works if the check
+// runs before the fetch that spends that quota, not after.
 export function rateLimitMiddleware(): MiddlewareHandler<{ Bindings: Env }> {
   return async (c, next) => {
     const path = new URL(c.req.url).pathname;
     if (isExemptFromProxyLimit(path)) return next();
-
-    await next();
-
-    if (c.res.headers.get("x-relay-cache") === "HIT") return;
 
     const ip = c.req.header("cf-connecting-ip") ?? "unknown";
     const { success } = await c.env.PROXY_LIMITER.limit({ key: `proxy:${ip}` });
@@ -84,6 +103,9 @@ export function rateLimitMiddleware(): MiddlewareHandler<{ Bindings: Env }> {
           },
         },
       );
+      return;
     }
+
+    await next();
   };
 }

--- a/relay-worker/src/obs/ratelimit.ts
+++ b/relay-worker/src/obs/ratelimit.ts
@@ -1,0 +1,55 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../env";
+
+// Paths that are never throttled here. /health and /stats are polled by
+// deployed monitoring, and throttling those would turn a busy relay into an
+// apparently dead one.
+const EXEMPT = new Set(["/health", "/stats"]);
+
+// Prefixes that carry their own, tighter limiter and must not also be charged
+// against the 300/min proxy budget. Pairing uses 10/min create and 30/min read;
+// charging both would let a normal pairing flow exhaust the proxy budget for
+// the same IP and break metadata for that install.
+const EXEMPT_PREFIXES = ["/pairing/", "/crashes/", "/feedback", "/errors"];
+
+// Applied on a cache miss only, matching ProxyRateLimit's placement after the
+// cache plug. A cache hit costs no upstream quota, so throttling one buys
+// nothing and hurts a legitimate "refresh all metadata" pass.
+export function rateLimitMiddleware(): MiddlewareHandler<{ Bindings: Env }> {
+  return async (c, next) => {
+    const path = new URL(c.req.url).pathname;
+    if (EXEMPT.has(path)) return next();
+    if (EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix))) return next();
+
+    await next();
+
+    if (c.res.headers.get("x-relay-cache") === "HIT") return;
+
+    const ip = c.req.header("cf-connecting-ip") ?? "unknown";
+    const { success } = await c.env.PROXY_LIMITER.limit({ key: `proxy:${ip}` });
+
+    if (!success) {
+      // Exact parity with metadata_relay/plug/proxy_rate_limit.ex's enforce/1:
+      // {"error": "Too many requests", "message": "Rate limit exceeded. Please
+      // try again later."}, retry-after 60 (window_ms / 1000). This is
+      // deliberately NOT router.ex's separate send_rate_limited/2 helper (used
+      // by pairing/feedback/crash-report routes), which answers with a
+      // differently-cased "rate_limited" error string -- the two are
+      // different limiters in the Elixir codebase with different response
+      // bodies, and this one replaces ProxyRateLimit specifically.
+      c.res = new Response(
+        JSON.stringify({
+          error: "Too many requests",
+          message: "Rate limit exceeded. Please try again later.",
+        }),
+        {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "60",
+          },
+        },
+      );
+    }
+  };
+}

--- a/relay-worker/src/obs/ratelimit.ts
+++ b/relay-worker/src/obs/ratelimit.ts
@@ -7,9 +7,13 @@ import type { Env } from "../env";
 const EXEMPT = new Set(["/health", "/stats"]);
 
 // Prefixes that carry their own, tighter limiter and must not also be charged
-// against the 300/min proxy budget. Pairing uses 10/min create and 30/min read;
-// charging both would let a normal pairing flow exhaust the proxy budget for
-// the same IP and break metadata for that install.
+// against the 300/min proxy budget. Pairing uses 10/min create and 30/min
+// read; feedback uses feedback/ingest.ts's checkFeedbackRateLimit (5/hour by
+// IP and by instance id, a D1-backed mirror of router.ex's
+// handle_feedback/1); crashes uses crashes/ingest.ts's own per-hour
+// write-bounding. Charging any of these against the proxy budget too would
+// let a normal flow exhaust that budget for the same IP and break metadata
+// for that install.
 const EXEMPT_PREFIXES = ["/pairing/", "/crashes/", "/feedback", "/errors"];
 
 // Applied on a cache miss only, matching ProxyRateLimit's placement after the

--- a/relay-worker/src/obs/sweep.ts
+++ b/relay-worker/src/obs/sweep.ts
@@ -26,9 +26,10 @@ export async function sweepStaleFeedbackRateLimits(env: Env): Promise<number> {
 }
 
 // Runs both sweeps under one Cron Trigger. pairing/store.ts's
-// purgeExpiredClaims was written in Task 10 and never wired to anything --
-// the identical defect (a table with no eviction path) in a different
-// table, closed here in the same commit rather than left for a third round.
+// purgeExpiredClaims was written when pairing landed and then never wired to
+// anything -- the identical defect (a table with no eviction path) in a
+// different table, closed here in the same commit rather than left to be
+// rediscovered a third time.
 // readClaim already refuses an expired row on read, so this, like the
 // feedback sweep above, is housekeeping (bounding table growth), not a
 // correctness fix.

--- a/relay-worker/src/obs/sweep.ts
+++ b/relay-worker/src/obs/sweep.ts
@@ -1,0 +1,37 @@
+import type { Env } from "../env";
+import { purgeExpiredClaims } from "../pairing/store";
+
+// Elixir's MetadataRelay.RateLimiter is an ETS table with its own periodic
+// cleaner, so it self-evicts; D1 has no equivalent, so a Worker port has to
+// supply eviction explicitly rather than inherit it. Run on a Cron Trigger
+// (wrangler.jsonc's triggers.crons), never on the request path.
+//
+// hour_bucket < currentHour - 1 (not <= currentHour) deliberately keeps the
+// PREVIOUS hour's rows around for one extra sweep cycle rather than cutting
+// exactly at the current hour: checkAndIncrementBucket (feedback/ingest.ts)
+// already treats any row whose hour_bucket doesn't match the CURRENT hour
+// as fully stale regardless of its count, so this can never delete a row a
+// live request still depends on -- it only widens the margin between "no
+// longer relevant" and "actually deleted" by one hour, which costs nothing
+// and avoids a sweep landing exactly on an hour boundary racing a request
+// in the window it's currently rolling out of.
+export async function sweepStaleFeedbackRateLimits(env: Env): Promise<number> {
+  const currentHour = Math.floor(Date.now() / 3_600_000);
+  const result = await env.DB.prepare(
+    "DELETE FROM feedback_rate_limits WHERE hour_bucket < ?",
+  )
+    .bind(currentHour - 1)
+    .run();
+  return result.meta.changes;
+}
+
+// Runs both sweeps under one Cron Trigger. pairing/store.ts's
+// purgeExpiredClaims was written in Task 10 and never wired to anything --
+// the identical defect (a table with no eviction path) in a different
+// table, closed here in the same commit rather than left for a third round.
+// readClaim already refuses an expired row on read, so this, like the
+// feedback sweep above, is housekeeping (bounding table growth), not a
+// correctness fix.
+export async function runScheduledSweep(env: Env): Promise<void> {
+  await Promise.all([sweepStaleFeedbackRateLimits(env), purgeExpiredClaims(env)]);
+}

--- a/relay-worker/src/pairing/routes.ts
+++ b/relay-worker/src/pairing/routes.ts
@@ -1,0 +1,250 @@
+import type { Context, Hono } from "hono";
+import type { Env } from "../env";
+import { storeClaim, readClaim, deleteClaim } from "./store";
+
+// @default_ttl_seconds in metadata_relay/pairing.ex
+const TTL_SECONDS = 300;
+const V1_PREFIX = "pairing:";
+const V2_PREFIX = "pairing:v2:";
+
+const LOOKUP_KEY_PATTERN = /^[0-9a-f]{64}$/;
+// Matches Pairing.Handler's @max_sealed_bytes: a real payload is a few
+// hundred bytes, the cap stops the store being used as free blob hosting.
+const MAX_SEALED_BYTES = 8192;
+
+// Matches Pairing.generate_code/1's alphabet exactly: excludes 0, O, I, 1 AND
+// L (easy to misread as 1) so a code read aloud or typed by hand is
+// unambiguous. Length 6, also matching the Elixir default.
+const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+const CODE_LENGTH = 6;
+
+type PairingContext = Context<{ Bindings: Env }>;
+type ErrorBody = { error: string; message: string };
+
+function generateCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(CODE_LENGTH));
+  return [...bytes].map((b) => CODE_ALPHABET[b % CODE_ALPHABET.length]).join("");
+}
+
+// Mirrors Pairing.normalize_code/1, applied by the Elixir context to every
+// GET/DELETE lookup (never to create): uppercases and strips the dashes or
+// spaces a person introduces reading a 6-character code aloud or typing it
+// from memory. The stored key itself is always the code exactly as
+// generated, so lookups must normalize to match it.
+function normalizeCode(code: string): string {
+  return code.toUpperCase().replace(/[-\s]/g, "");
+}
+
+// router.ex's allow_web_player/1, verbatim: origin only. The Elixir router
+// never sends access-control-allow-headers, even on the OPTIONS preflight
+// below -- don't add one here even though a browser client with custom
+// headers would want it; that's a latent gap in the Elixir this task is not
+// scoped to fix.
+function corsOrigin(extra: Record<string, string> = {}): Record<string, string> {
+  return { ...extra, "access-control-allow-origin": "*" };
+}
+
+function validationError(message: string): ErrorBody {
+  return { error: "Validation error", message };
+}
+
+function notFoundError(): ErrorBody {
+  return { error: "Not found", message: "Claim code not found or expired" };
+}
+
+// Exact parity with router.ex's send_rate_limited/2: {"error": "rate_limited",
+// "message": "Too many requests. Please try again later.", "retry_after": N}.
+// This is deliberately NOT ratelimit.ts's rateLimitMiddleware body (which
+// mirrors the separate ProxyRateLimit plug's differently-cased "Too many
+// requests" error string and has no retry_after field) -- pairing uses the
+// router's own helper in the Elixir, not the proxy plug.
+//
+// `withCors` is true only for the GET/DELETE routes, where the Elixir conn
+// already carries the access-control-allow-origin header (set by
+// allow_web_player/1 before the rate-limit check runs) by the time
+// send_rate_limited/2 sends the 429. The POST create routes never call
+// allow_web_player, so their 429 carries no CORS header either.
+function rateLimitedResponse(withCors: boolean): Response {
+  return new Response(
+    JSON.stringify({
+      error: "rate_limited",
+      message: "Too many requests. Please try again later.",
+      retry_after: 60,
+    }),
+    {
+      status: 429,
+      headers: {
+        "content-type": "application/json",
+        "retry-after": "60",
+        ...(withCors ? corsOrigin() : {}),
+      },
+    },
+  );
+}
+
+async function limited(limiter: RateLimit, ip: string): Promise<boolean> {
+  // check_pairing_rate_limit/2 keys every pairing route on "pairing:<ip>";
+  // create vs. read/delete is separated by which Cloudflare Rate Limiting
+  // binding is passed in (PAIRING_CREATE_LIMITER 10/min, PAIRING_READ_LIMITER
+  // 30/min -- wrangler.jsonc), not by a key prefix, since each binding is
+  // already its own independent counter namespace.
+  const { success } = await limiter.limit({ key: `pairing:${ip}` });
+  return !success;
+}
+
+function ipOf(c: PairingContext): string {
+  return c.req.header("cf-connecting-ip") ?? "unknown";
+}
+
+// Handler.validate_node_addr/1: required, must be a string, and must itself
+// be valid JSON (it's an opaque iroh EndpointAddr the relay never inspects
+// beyond that).
+function validateNodeAddr(nodeAddr: unknown): ErrorBody | null {
+  if (nodeAddr === undefined || nodeAddr === null || nodeAddr === "") {
+    return validationError("node_addr is required");
+  }
+  if (typeof nodeAddr !== "string") {
+    return validationError("node_addr must be a string");
+  }
+  try {
+    JSON.parse(nodeAddr);
+  } catch {
+    return validationError("node_addr must be valid JSON");
+  }
+  return null;
+}
+
+// Handler.validate_lookup_key/1.
+function validateLookupKey(lookupKey: unknown): ErrorBody | null {
+  if (typeof lookupKey !== "string") {
+    return validationError("lookup_key is required");
+  }
+  if (!LOOKUP_KEY_PATTERN.test(lookupKey)) {
+    return validationError("lookup_key must be 64 lowercase hex characters");
+  }
+  return null;
+}
+
+// Handler.validate_sealed/1. Uses UTF-8 byte length (like Elixir's
+// byte_size/1 on a binary), not JS string length, since sealed is base64url
+// text that could in principle contain multi-byte characters.
+function validateSealed(sealed: unknown): ErrorBody | null {
+  if (typeof sealed !== "string" || sealed.length === 0) {
+    return validationError("sealed is required");
+  }
+  if (new TextEncoder().encode(sealed).length > MAX_SEALED_BYTES) {
+    return validationError(`sealed exceeds ${MAX_SEALED_BYTES} bytes`);
+  }
+  return null;
+}
+
+export function registerPairingRoutes(app: Hono<{ Bindings: Env }>): void {
+  // Create claim code for node_addr (v1). Handler.create_claim/1 + router.ex
+  // POST /pairing/claim. Response is {"claim_code": "..."} -- NOT {"code",
+  // "expires_in"}; the Elixir never returns an expires_in field at all.
+  app.post("/pairing/claim", async (c) => {
+    if (await limited(c.env.PAIRING_CREATE_LIMITER, ipOf(c))) {
+      return rateLimitedResponse(false);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as { node_addr?: unknown } | null;
+    const invalid = validateNodeAddr(body?.node_addr);
+    if (invalid) return c.json(invalid, 400);
+
+    const code = generateCode();
+    await storeClaim(c.env, V1_PREFIX + code, body!.node_addr as string, TTL_SECONDS);
+
+    return c.json({ claim_code: code }, 200);
+  });
+
+  // Get node_addr for claim code (v1). router.ex applies allow_web_player/1
+  // before the rate-limit check, so every response below -- 200, 404, and a
+  // 429 from the limiter -- carries the CORS origin header.
+  app.get("/pairing/claim/:code", async (c) => {
+    if (await limited(c.env.PAIRING_READ_LIMITER, ipOf(c))) {
+      return rateLimitedResponse(true);
+    }
+
+    const key = V1_PREFIX + normalizeCode(c.req.param("code"));
+    const value = await readClaim(c.env, key);
+    if (!value) return c.json(notFoundError(), 404, corsOrigin());
+    return c.json({ node_addr: value }, 200, corsOrigin());
+  });
+
+  // Preflight for the claim lookup. Elixir sets allow-methods but never
+  // allow-headers, even here.
+  app.options("/pairing/claim/:code", (c) =>
+    c.body(null, 204, corsOrigin({ "access-control-allow-methods": "GET, DELETE" })),
+  );
+
+  // Delete claim code after successful pairing. Idempotent in the Elixir
+  // (delete_claim/1 never distinguishes "existed" from "didn't"), so this
+  // always answers 204, never 404.
+  app.delete("/pairing/claim/:code", async (c) => {
+    if (await limited(c.env.PAIRING_READ_LIMITER, ipOf(c))) {
+      return rateLimitedResponse(true);
+    }
+    const key = V1_PREFIX + normalizeCode(c.req.param("code"));
+    await deleteClaim(c.env, key);
+    return c.body(null, 204, corsOrigin());
+  });
+
+  // v2: the relay stores a blinded lookup key against a sealed blob and can
+  // read neither the claim code nor the server's node address. This is the
+  // only pairing surface the Elixir backend itself calls
+  // (lib/mydia/remote_access.ex) -- the v1 routes above exist for the
+  // Flutter player's fallback path only.
+  app.post("/pairing/v2/claim", async (c) => {
+    if (await limited(c.env.PAIRING_CREATE_LIMITER, ipOf(c))) {
+      return rateLimitedResponse(false);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as
+      | { lookup_key?: unknown; sealed?: unknown }
+      | null;
+
+    const keyError = validateLookupKey(body?.lookup_key);
+    if (keyError) return c.json(keyError, 400);
+    const sealedError = validateSealed(body?.sealed);
+    if (sealedError) return c.json(sealedError, 400);
+
+    await storeClaim(
+      c.env,
+      V2_PREFIX + (body!.lookup_key as string),
+      body!.sealed as string,
+      TTL_SECONDS,
+    );
+    return c.body(null, 204);
+  });
+
+  app.get("/pairing/v2/claim/:lookup_key", async (c) => {
+    if (await limited(c.env.PAIRING_READ_LIMITER, ipOf(c))) {
+      return rateLimitedResponse(true);
+    }
+
+    const lookupKey = c.req.param("lookup_key");
+    const keyError = validateLookupKey(lookupKey);
+    if (keyError) return c.json(keyError, 400, corsOrigin());
+
+    const value = await readClaim(c.env, V2_PREFIX + lookupKey);
+    if (!value) return c.json(notFoundError(), 404, corsOrigin());
+    return c.json({ sealed: value }, 200, corsOrigin());
+  });
+
+  app.options("/pairing/v2/claim/:lookup_key", (c) =>
+    c.body(null, 204, corsOrigin({ "access-control-allow-methods": "GET, DELETE" })),
+  );
+
+  app.delete("/pairing/v2/claim/:lookup_key", async (c) => {
+    if (await limited(c.env.PAIRING_READ_LIMITER, ipOf(c))) {
+      return rateLimitedResponse(true);
+    }
+
+    const lookupKey = c.req.param("lookup_key");
+    const keyError = validateLookupKey(lookupKey);
+    if (keyError) return c.json(keyError, 400, corsOrigin());
+
+    await deleteClaim(c.env, V2_PREFIX + lookupKey);
+    return c.body(null, 204, corsOrigin());
+  });
+}

--- a/relay-worker/src/pairing/routes.ts
+++ b/relay-worker/src/pairing/routes.ts
@@ -35,13 +35,62 @@ function normalizeCode(code: string): string {
   return code.toUpperCase().replace(/[-\s]/g, "");
 }
 
-// router.ex's allow_web_player/1, verbatim: origin only. The Elixir router
-// never sends access-control-allow-headers, even on the OPTIONS preflight
-// below -- don't add one here even though a browser client with custom
-// headers would want it; that's a latent gap in the Elixir this task is not
-// scoped to fix.
+// router.ex's allow_web_player/1, verbatim: origin only, no allow-headers.
+// This is correct ONLY for a non-preflight request (a plain GET/DELETE/404,
+// or an OPTIONS that isn't a genuine CORS preflight) -- see
+// isGenuinePreflight/corsicaPreflightResponse below for the case this does
+// NOT cover. A first pass at this file concluded router.ex's missing
+// allow-headers was a production gap; it is not, because router.ex is not
+// the whole picture in production (see below).
 function corsOrigin(extra: Record<string, string> = {}): Record<string, string> {
   return { ...extra, "access-control-allow-origin": "*" };
+}
+
+// metadata_relay_web/endpoint.ex plugs Corsica GLOBALLY, in front of the
+// router: `plug Corsica, origins: "*", allow_headers: ["content-type",
+// "authorization", "x-request-id"], allow_methods: ["GET", "POST", "PUT",
+// "DELETE", "OPTIONS"]`. Corsica's own preflight_req?/1 (verified against
+// its v2.1.3 source) treats a request as a genuine preflight only when it is
+// OPTIONS AND carries both an Origin header and an
+// Access-Control-Request-Method header; when both are present it halts the
+// plug pipeline and answers directly with send_preflight_resp/4 -- the
+// router's own `options "/pairing/claim/:code"` handler (the one
+// corsOrigin() above serves) is never reached at all. A bare OPTIONS missing
+// either header is not a CORS request to Corsica and falls through to that
+// router handler unmodified, which is what corsOrigin() continues to model.
+//
+// This is why send_rate_limited-style parity wasn't enough: for a genuine
+// preflight, production never even reaches router.ex, so router.ex's own
+// CORS gaps (no allow-headers, "GET, DELETE" methods scoped to one route)
+// are irrelevant -- Corsica answers first, with its own STATIC, app-wide
+// configuration, regardless of which path or which methods that specific
+// route actually supports.
+function isGenuinePreflight(c: PairingContext): boolean {
+  return (
+    c.req.header("origin") !== undefined &&
+    c.req.header("access-control-request-method") !== undefined
+  );
+}
+
+// Mirrors Corsica.send_preflight_resp/4 exactly for this app's static
+// config, confirmed against the v2.1.3 source:
+// - status 200 (Corsica's default), not the router's own 204.
+// - access-control-allow-origin: "*" (origins: "*", allow_credentials not
+//   set so send_wildcard_origin?/1 is true -- literal "*", no Vary header).
+// - access-control-allow-methods / -headers: Enum.join(list, ",") -- a bare
+//   comma, NOT ", " -- over the endpoint's full configured list, not just
+//   the methods this one route supports.
+// - body "" (empty), no max-age (option not configured, so Corsica never
+//   sends the header at all -- there is no default value to fall back to).
+function corsicaPreflightResponse(): Response {
+  return new Response("", {
+    status: 200,
+    headers: {
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET,POST,PUT,DELETE,OPTIONS",
+      "access-control-allow-headers": "content-type,authorization,x-request-id",
+    },
+  });
 }
 
 function validationError(message: string): ErrorBody {
@@ -171,10 +220,16 @@ export function registerPairingRoutes(app: Hono<{ Bindings: Env }>): void {
     return c.json({ node_addr: value }, 200, corsOrigin());
   });
 
-  // Preflight for the claim lookup. Elixir sets allow-methods but never
-  // allow-headers, even here.
+  // Preflight for the claim lookup. A GENUINE preflight (Origin +
+  // Access-Control-Request-Method) never reaches router.ex in production --
+  // Corsica answers it first, globally -- so that case is served by
+  // corsicaPreflightResponse() instead of this route's own 204. Anything
+  // else (a bare OPTIONS probe, or one missing either header) falls through
+  // to router.ex's own handler, which this models faithfully.
   app.options("/pairing/claim/:code", (c) =>
-    c.body(null, 204, corsOrigin({ "access-control-allow-methods": "GET, DELETE" })),
+    isGenuinePreflight(c)
+      ? corsicaPreflightResponse()
+      : c.body(null, 204, corsOrigin({ "access-control-allow-methods": "GET, DELETE" })),
   );
 
   // Delete claim code after successful pairing. Idempotent in the Elixir
@@ -231,8 +286,11 @@ export function registerPairingRoutes(app: Hono<{ Bindings: Env }>): void {
     return c.json({ sealed: value }, 200, corsOrigin());
   });
 
+  // Same Corsica-vs-router split as the v1 OPTIONS handler above.
   app.options("/pairing/v2/claim/:lookup_key", (c) =>
-    c.body(null, 204, corsOrigin({ "access-control-allow-methods": "GET, DELETE" })),
+    isGenuinePreflight(c)
+      ? corsicaPreflightResponse()
+      : c.body(null, 204, corsOrigin({ "access-control-allow-methods": "GET, DELETE" })),
   );
 
   app.delete("/pairing/v2/claim/:lookup_key", async (c) => {

--- a/relay-worker/src/pairing/store.ts
+++ b/relay-worker/src/pairing/store.ts
@@ -1,0 +1,44 @@
+import type { Env } from "../env";
+
+export async function storeClaim(
+  env: Env,
+  key: string,
+  value: string,
+  ttlSeconds: number,
+): Promise<void> {
+  const expiresAt = Math.floor(Date.now() / 1000) + ttlSeconds;
+  await env.DB.prepare(
+    `INSERT INTO pairing_claims (key, value, expires_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET
+       value = excluded.value, expires_at = excluded.expires_at`,
+  )
+    .bind(key, value, expiresAt)
+    .run();
+}
+
+// Expiry is enforced on read rather than by a background sweeper, so an expired
+// row can never be served even if nothing has cleaned it up yet. A periodic
+// delete of expired rows is a housekeeping concern, not a correctness one.
+export async function readClaim(env: Env, key: string): Promise<string | null> {
+  const row = await env.DB.prepare(
+    "SELECT value FROM pairing_claims WHERE key = ? AND expires_at > ?",
+  )
+    .bind(key, Math.floor(Date.now() / 1000))
+    .first<{ value: string }>();
+
+  return row?.value ?? null;
+}
+
+export async function deleteClaim(env: Env, key: string): Promise<void> {
+  await env.DB.prepare("DELETE FROM pairing_claims WHERE key = ?").bind(key).run();
+}
+
+// Not wired to a scheduled trigger yet -- no cron handler exists in this
+// Worker as of this task. Kept as the obvious hook for one later, exactly as
+// the module-level comment above says: housekeeping, not correctness, since
+// readClaim already refuses an expired row on its own.
+export async function purgeExpiredClaims(env: Env): Promise<void> {
+  await env.DB.prepare("DELETE FROM pairing_claims WHERE expires_at <= ?")
+    .bind(Math.floor(Date.now() / 1000))
+    .run();
+}

--- a/relay-worker/src/proxy/forward.ts
+++ b/relay-worker/src/proxy/forward.ts
@@ -12,7 +12,7 @@ export function forwardParams(
 ): URLSearchParams {
   const out = new URLSearchParams();
   for (const [key, value] of incoming.entries()) {
-    if (key in inject) continue;
+    if (Object.hasOwn(inject, key)) continue;
     out.append(key, value);
   }
   for (const [key, value] of Object.entries(inject)) {

--- a/relay-worker/src/proxy/forward.ts
+++ b/relay-worker/src/proxy/forward.ts
@@ -1,0 +1,69 @@
+import type { Env } from "../env";
+import { cacheGet, cachePut } from "../cache/store";
+import { ttlSecondsFor } from "../cache/key";
+
+// No allowlist, deliberately. TMDB handlers forward caller params straight
+// through, which is the only reason append_to_response works for credits,
+// keywords, images, videos, recommendations, release_dates and
+// content_ratings. Adding an allowlist here silently breaks enrichment.
+export function forwardParams(
+  incoming: URLSearchParams,
+  inject: Record<string, string>,
+): URLSearchParams {
+  const out = new URLSearchParams();
+  for (const [key, value] of incoming.entries()) {
+    if (key in inject) continue;
+    out.append(key, value);
+  }
+  for (const [key, value] of Object.entries(inject)) {
+    out.append(key, value);
+  }
+  return out;
+}
+
+export async function proxyJson(
+  env: Env,
+  upstreamUrl: string,
+  cacheKey: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const hit = await cacheGet(env, cacheKey);
+  if (hit) {
+    // A Response read back from the Cache API has immutable headers, so
+    // `hit.headers.set(...)` throws "Can't modify immutable headers." Build a
+    // fresh Response around the same body/status/headers to get a mutable
+    // Headers instance before stamping the cache-status header.
+    const res = new Response(hit.body, hit);
+    res.headers.set("x-relay-cache", "HIT");
+    return res;
+  }
+
+  const upstream = await fetch(upstreamUrl, init);
+  const body = await upstream.text();
+
+  const res = new Response(body, {
+    status: upstream.status,
+    headers: {
+      "content-type":
+        upstream.headers.get("content-type") ?? "application/json",
+      // Real edge-cacheable headers. The Elixir relay sent
+      // "max-age=0, private, must-revalidate", which is why Cloudflare
+      // reported cf-cache-status: DYNAMIC on every route and nothing was
+      // ever cached at the edge.
+      "cache-control": cacheableHeader(cacheKey),
+    },
+  });
+
+  // Only successful responses are cached, matching plug/cache.ex.
+  if (upstream.status >= 200 && upstream.status < 300) {
+    await cachePut(env, cacheKey, res.clone());
+  }
+
+  res.headers.set("x-relay-cache", "MISS");
+  return res;
+}
+
+function cacheableHeader(cacheKey: string): string {
+  const ttl = ttlSecondsFor(cacheKey);
+  return `public, s-maxage=${ttl}, stale-while-revalidate=86400, stale-if-error=604800`;
+}

--- a/relay-worker/src/proxy/passthrough.ts
+++ b/relay-worker/src/proxy/passthrough.ts
@@ -1,0 +1,276 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+import { buildKey, ttlSecondsFor } from "../cache/key";
+import { cacheUrl } from "../cache/store";
+import { proxyJson } from "./forward";
+
+// Source of truth: metadata-relay/lib/metadata_relay/music/client.ex and
+// metadata-relay/lib/metadata_relay/open_library/client.ex. Music and Books
+// are deprecated product areas -- installs in the field still call these,
+// there is no origin left to send them to once the Elixir relay retires, and
+// they need no credentials, so this is a faithful port, not a redesign.
+
+const MUSICBRAINZ_BASE = "https://musicbrainz.org/ws/2";
+const COVERART_BASE = "https://coverartarchive.org";
+const OPENLIBRARY_BASE = "https://openlibrary.org";
+
+// Exact value from music/client.ex:9. MusicBrainz rejects requests with no
+// User-Agent and keys its rate limiting on the string, so this is copied
+// verbatim (including the internal spacing) rather than reworded.
+const MUSICBRAINZ_USER_AGENT =
+  "MetadataRelay/1.0 ( https://github.com/mydia-org/mydia )";
+
+// Exact value from open_library/client.ex:17. Deliberately a different
+// string from MusicBrainz's -- the two Elixir clients never shared one.
+const OPENLIBRARY_USER_AGENT =
+  "MetadataRelay/1.0 (https://github.com/my-org/metadata-relay)";
+
+// get_mb/2 in music/client.ex sends both of these on every MusicBrainz call.
+const MUSICBRAINZ_HEADERS = {
+  "user-agent": MUSICBRAINZ_USER_AGENT,
+  accept: "application/json",
+};
+
+// get_caa/1 in music/client.ex sends only a User-Agent -- no accept header,
+// unlike the MusicBrainz JSON client above.
+const COVERART_HEADERS = { "user-agent": MUSICBRAINZ_USER_AGENT };
+
+// Client.new/0 in open_library/client.ex sends both of these on every call.
+const OPENLIBRARY_HEADERS = {
+  "user-agent": OPENLIBRARY_USER_AGENT,
+  accept: "application/json",
+};
+
+function cacheKeyFor(url: URL): string {
+  return buildKey("GET", url.pathname, url.searchParams.toString());
+}
+
+// -- MusicBrainz ----------------------------------------------------------
+
+// music/handler.ex's search/1 requires both params and picks the upstream
+// resource straight from the caller's `type` (Client.get_mb("/#{type}",
+// ...)) -- there is no fixed search endpoint, and no whitelist of `type`
+// values on the Elixir side either.
+function registerMusicSearch(app: Hono<{ Bindings: Env }>): void {
+  app.get("/music/search", async (c) => {
+    const url = new URL(c.req.url);
+    // is_nil/1 in the Elixir, not a truthiness check: an explicit empty
+    // string is "present" there and must be here too.
+    const query = url.searchParams.get("query");
+    const type = url.searchParams.get("type");
+    if (query === null || type === null) {
+      return c.json(
+        { error: "Missing required parameters: query, type" },
+        400,
+      );
+    }
+
+    const cacheKey = cacheKeyFor(url);
+    const upstreamQuery = new URLSearchParams({ query, fmt: "json" });
+    const upstream = `${MUSICBRAINZ_BASE}/${encodeURIComponent(type)}?${upstreamQuery.toString()}`;
+
+    return proxyJson(c.env, upstream, cacheKey, {
+      headers: MUSICBRAINZ_HEADERS,
+    });
+  });
+}
+
+interface MbDetailRoute {
+  path: string;
+  resource: string;
+  // The exact `inc=` comment value from the matching handler.ex function.
+  inc: string;
+}
+
+// get_artist/2, get_release/2, get_release_group/2 and get_recording/2 in
+// music/handler.ex all declare `_params` -- the caller's query string is
+// never forwarded -- and each injects its own fixed `inc=` value instead.
+const MB_DETAIL_ROUTES: MbDetailRoute[] = [
+  {
+    path: "/music/artist/:id",
+    resource: "artist",
+    inc: "url-rels+genres+release-groups",
+  },
+  {
+    path: "/music/release/:id",
+    resource: "release",
+    inc: "recordings+artist-credits+labels+release-groups+genres",
+  },
+  {
+    path: "/music/release-group/:id",
+    resource: "release-group",
+    inc: "releases+artist-credits+genres",
+  },
+  {
+    path: "/music/recording/:id",
+    resource: "recording",
+    inc: "releases+artist-credits+genres",
+  },
+];
+
+function registerMbDetailRoutes(app: Hono<{ Bindings: Env }>): void {
+  for (const route of MB_DETAIL_ROUTES) {
+    app.get(route.path, async (c) => {
+      const params: Record<string, string> = c.req.param();
+      const id = params.id;
+      const url = new URL(c.req.url);
+      const cacheKey = cacheKeyFor(url);
+      const upstreamQuery = new URLSearchParams({
+        fmt: "json",
+        inc: route.inc,
+      });
+      const upstream = `${MUSICBRAINZ_BASE}/${route.resource}/${encodeURIComponent(id)}?${upstreamQuery.toString()}`;
+
+      return proxyJson(c.env, upstream, cacheKey, {
+        headers: MUSICBRAINZ_HEADERS,
+      });
+    });
+  }
+}
+
+// -- Cover Art Archive ------------------------------------------------------
+//
+// get_cover_art/1 in music/handler.ex tries the 500px cover first and falls
+// back to the full-size cover only on a 404 from the 500px request; any
+// other error short-circuits without a second request. router.ex's
+// handle_image_request/2 then answers with a fixed "image/jpeg" content
+// type regardless of what the upstream actually sent.
+//
+// This can't reuse proxyJson/cachePut: both read the upstream body with
+// `.text()`, which corrupts binary image bytes that aren't valid UTF-8 on
+// the way back out. This route reads and caches raw bytes instead.
+
+async function fetchCoverArt(id: string): Promise<Response> {
+  const primary = await fetch(
+    `${COVERART_BASE}/release/${encodeURIComponent(id)}/front-500`,
+    { headers: COVERART_HEADERS },
+  );
+  if (primary.status !== 404) return primary;
+
+  return fetch(`${COVERART_BASE}/release/${encodeURIComponent(id)}/front`, {
+    headers: COVERART_HEADERS,
+  });
+}
+
+function registerCoverArt(app: Hono<{ Bindings: Env }>): void {
+  app.get("/music/cover/:id", async (c) => {
+    const id = c.req.param("id");
+    const url = new URL(c.req.url);
+    const cacheKey = cacheKeyFor(url);
+
+    const cached = await caches.default.match(cacheUrl(cacheKey));
+    if (cached) {
+      const res = new Response(cached.body, cached);
+      res.headers.set("x-relay-cache", "HIT");
+      return res;
+    }
+
+    let upstream: Response;
+    try {
+      upstream = await fetchCoverArt(id);
+    } catch (err) {
+      // Mirrors router.ex's `{:error, reason} -> send_resp(conn, 500, inspect(reason))`.
+      return new Response(err instanceof Error ? err.message : String(err), {
+        status: 500,
+      });
+    }
+
+    if (upstream.status === 404) {
+      return new Response("Not found", { status: 404 });
+    }
+    if (upstream.status < 200 || upstream.status >= 300) {
+      return new Response("Upstream error", { status: upstream.status });
+    }
+
+    const bytes = await upstream.arrayBuffer();
+    const ttl = ttlSecondsFor(cacheKey);
+    const res = new Response(bytes, {
+      status: 200,
+      headers: {
+        "content-type": "image/jpeg",
+        "cache-control": `public, s-maxage=${ttl}, stale-while-revalidate=86400, stale-if-error=604800`,
+      },
+    });
+
+    await caches.default.put(cacheUrl(cacheKey), res.clone());
+    res.headers.set("x-relay-cache", "MISS");
+    return res;
+  });
+}
+
+// -- OpenLibrary ------------------------------------------------------------
+
+// get_by_isbn/2 in open_library/handler.ex does not hit an /isbn/*.json
+// path (Open Library has no such endpoint) -- it calls the Books API at
+// /api/books with bibkeys=ISBN:<isbn>, jscmd=data and format=json. The
+// caller's own query string (`_params`) is ignored.
+function registerOpenLibraryIsbn(app: Hono<{ Bindings: Env }>): void {
+  app.get("/openlibrary/isbn/:isbn", async (c) => {
+    const isbn = c.req.param("isbn");
+    const url = new URL(c.req.url);
+    const cacheKey = cacheKeyFor(url);
+    const upstreamQuery = new URLSearchParams({
+      bibkeys: `ISBN:${isbn}`,
+      jscmd: "data",
+      format: "json",
+    });
+    const upstream = `${OPENLIBRARY_BASE}/api/books?${upstreamQuery.toString()}`;
+
+    return proxyJson(c.env, upstream, cacheKey, {
+      headers: OPENLIBRARY_HEADERS,
+    });
+  });
+}
+
+// search/1 in open_library/handler.ex forwards the caller's params
+// untouched: `Client.get("/search.json", params: params)`.
+function registerOpenLibrarySearch(app: Hono<{ Bindings: Env }>): void {
+  app.get("/openlibrary/search", async (c) => {
+    const url = new URL(c.req.url);
+    const cacheKey = cacheKeyFor(url);
+    const upstream = `${OPENLIBRARY_BASE}/search.json?${url.searchParams.toString()}`;
+
+    return proxyJson(c.env, upstream, cacheKey, {
+      headers: OPENLIBRARY_HEADERS,
+    });
+  });
+}
+
+// get_work/2 and get_author/2 in open_library/handler.ex both declare
+// `_params` and call Client.get/1 with no :params option -- the caller's
+// query string is never forwarded.
+function registerOpenLibraryWorks(app: Hono<{ Bindings: Env }>): void {
+  app.get("/openlibrary/works/:id", async (c) => {
+    const id = c.req.param("id");
+    const url = new URL(c.req.url);
+    const cacheKey = cacheKeyFor(url);
+    const upstream = `${OPENLIBRARY_BASE}/works/${encodeURIComponent(id)}.json`;
+
+    return proxyJson(c.env, upstream, cacheKey, {
+      headers: OPENLIBRARY_HEADERS,
+    });
+  });
+}
+
+function registerOpenLibraryAuthors(app: Hono<{ Bindings: Env }>): void {
+  app.get("/openlibrary/authors/:id", async (c) => {
+    const id = c.req.param("id");
+    const url = new URL(c.req.url);
+    const cacheKey = cacheKeyFor(url);
+    const upstream = `${OPENLIBRARY_BASE}/authors/${encodeURIComponent(id)}.json`;
+
+    return proxyJson(c.env, upstream, cacheKey, {
+      headers: OPENLIBRARY_HEADERS,
+    });
+  });
+}
+
+export function registerPassthroughRoutes(app: Hono<{ Bindings: Env }>): void {
+  registerMusicSearch(app);
+  registerMbDetailRoutes(app);
+  registerCoverArt(app);
+  registerOpenLibraryIsbn(app);
+  registerOpenLibrarySearch(app);
+  registerOpenLibraryWorks(app);
+  registerOpenLibraryAuthors(app);
+}

--- a/relay-worker/src/proxy/subdl.ts
+++ b/relay-worker/src/proxy/subdl.ts
@@ -1,0 +1,382 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+import {
+  bodyFingerprint,
+  subtitleSearchCacheKey,
+  EMPTY_SUBTITLE_TTL_SECONDS,
+} from "../cache/key";
+import { cacheGet, cachePut } from "../cache/store";
+import { encodeFileId, decodeFileId, extractSubtitle } from "../archive/zip";
+
+const SEARCH_URL = "https://api.subdl.com/api/v1/subtitles";
+const DOWNLOAD_HOST = "https://dl.subdl.com";
+const SUBS_PER_PAGE = "30";
+
+// -- Search query construction ------------------------------------------
+//
+// Ported from build_query/1, identity/1, type_params/1 and languages/1 in
+// metadata-relay/lib/metadata_relay/subdl/handler.ex. The relay's JSON body
+// keys (query, imdb_id, tmdb_id, media_type, season_number, episode_number,
+// languages) are NOT the same names SubDL's own query string wants
+// (film_name, imdb_id-with-"tt"-prefix, tmdb_id, type, season_number,
+// episode_number, upper-cased comma-joined languages) -- this section is the
+// translation between the two.
+
+interface SearchBody {
+  tmdb_id?: unknown;
+  imdb_id?: unknown;
+  query?: unknown;
+  media_type?: unknown;
+  season_number?: unknown;
+  episode_number?: unknown;
+  languages?: unknown;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asSearchBody(body: unknown): SearchBody {
+  return isPlainObject(body) ? (body as SearchBody) : {};
+}
+
+// Elixir's present?/1: not nil and not "". A JSON 0 or false is present.
+function present(value: unknown): value is string | number {
+  return value !== null && value !== undefined && value !== "";
+}
+
+function imdbWithPrefix(id: string | number): string {
+  const asString = String(id);
+  return asString.startsWith("tt") ? asString : `tt${asString}`;
+}
+
+// SubDL accepts one identity per search: tmdb_id is preferred because it is
+// unambiguous for both films and series, imdb_id next, and a free-text query
+// (sent to SubDL as "film_name") is the last resort. Returns null when none
+// of the three are present, matching identity/1 returning nil.
+function buildIdentity(body: SearchBody): [string, string] | null {
+  if (present(body.tmdb_id)) return ["tmdb_id", String(body.tmdb_id)];
+  if (present(body.imdb_id)) return ["imdb_id", imdbWithPrefix(body.imdb_id)];
+  if (present(body.query)) return ["film_name", String(body.query)];
+  return null;
+}
+
+function buildTypeParams(body: SearchBody): Array<[string, string]> {
+  if (body.media_type === "episode") {
+    const params: Array<[string, string]> = [["type", "tv"]];
+    if (present(body.season_number)) {
+      params.push(["season_number", String(body.season_number)]);
+    }
+    if (present(body.episode_number)) {
+      params.push(["episode_number", String(body.episode_number)]);
+    }
+    return params;
+  }
+  if (body.media_type === "movie") return [["type", "movie"]];
+  return [];
+}
+
+// SubDL expects uppercase two-letter codes, comma joined. Defaults to "en"
+// when absent, matching Map.get(params, "languages", "en").
+function buildLanguages(value: unknown): string {
+  const raw = Array.isArray(value) ? value.join(",") : String(value ?? "en");
+  return raw
+    .split(",")
+    .map((code) => code.trim())
+    .filter((code) => code.length > 0)
+    .map((code) => code.toUpperCase())
+    .join(",");
+}
+
+// -- transform_subtitle/2 port -------------------------------------------
+
+// Shaped like handler.ex's feature map: feature_type, title, year, imdb_id,
+// tmdb_id, each nullable. Kept as Record<string, unknown> (rather than a named
+// interface) so it composes with transformSubtitle's own Record-typed feature
+// parameter without a cast that TS's structural checker flags as unsound.
+function emptyFeature(): Record<string, unknown> {
+  return {
+    feature_type: null,
+    title: null,
+    year: null,
+    imdb_id: null,
+    tmdb_id: null,
+  };
+}
+
+// Ported from feature_context/1 in handler.ex: the first entry of the
+// upstream response's "results" array describes the film/show the search
+// matched, independent of which subtitle is being transformed. Any shape
+// other than a non-empty array whose first element is an object falls back
+// to all-null, matching every non-matching clause in the Elixir falling
+// through to empty_feature/0.
+function featureContext(results: unknown): Record<string, unknown> {
+  if (Array.isArray(results) && results.length > 0) {
+    const first: unknown = results[0];
+    if (first !== null && typeof first === "object" && !Array.isArray(first)) {
+      const r = first as Record<string, unknown>;
+      return {
+        feature_type: r.type ?? null,
+        title: r.name ?? null,
+        year: r.year ?? null,
+        imdb_id: r.imdb_id ?? null,
+        tmdb_id: r.tmdb_id ?? null,
+      };
+    }
+  }
+  return emptyFeature();
+}
+
+// Elixir's `||`: falls through to `fallback` only when `value` is nil or
+// false, otherwise returns `value` unchanged (even if it is not the type one
+// might expect, e.g. a truthy non-boolean "hi" flag).
+function elixirOr(value: unknown, fallback: unknown): unknown {
+  return value === null || value === undefined || value === false
+    ? fallback
+    : value;
+}
+
+function normalizeLanguage(value: unknown): string {
+  if (value === null || value === undefined) return "en";
+  return String(value).slice(0, 2).toLowerCase();
+}
+
+// Ported field for field from transform_subtitle/2 in
+// metadata-relay/lib/metadata_relay/subdl/handler.ex:175-199, including the
+// keys always set to null. Mydia's Provider.Relay consumes "moviehash_match",
+// "season", "episode" and the feature_* keys directly (see
+// lib/mydia/subtitles/provider/relay.ex), so dropping any of them silently
+// breaks a client already relying on their presence.
+export function transformSubtitle(
+  subtitle: Record<string, unknown>,
+  feature: unknown,
+): Record<string, unknown> {
+  const f: Record<string, unknown> = isPlainObject(feature)
+    ? feature
+    : emptyFeature();
+
+  return {
+    source: "SubDL",
+    id: encodeFileId(String(elixirOr(subtitle.url, ""))),
+    language: normalizeLanguage(elixirOr(subtitle.language, subtitle.lang)),
+    format: "srt",
+    rating: null,
+    download_count: null,
+    release: elixirOr(subtitle.release_name, ""),
+    uploader: elixirOr(subtitle.author, ""),
+    hearing_impaired: elixirOr(subtitle.hi, false),
+    foreign_parts_only: false,
+    moviehash_match: false,
+    season: subtitle.season ?? null,
+    episode: subtitle.episode ?? null,
+    feature_type: f.feature_type ?? null,
+    title: f.title ?? null,
+    year: f.year ?? null,
+    imdb_id: f.imdb_id ?? null,
+    tmdb_id: f.tmdb_id ?? null,
+  };
+}
+
+// A rejected key is the relay's problem, not the caller's: reporting 401
+// would tell every install its own credentials failed. Anything else keeps
+// its upstream status when that status is already a client-facing one.
+// Ported from client_status/1 in router.ex.
+function clientStatus(status: number): number {
+  if (status === 401 || status === 403) return 502;
+  if (status >= 400 && status <= 599) return status;
+  return 502;
+}
+
+function errorJson(message: string, status: number, extraHeaders?: HeadersInit): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "content-type": "application/json", ...extraHeaders },
+  });
+}
+
+// Ported from Client.api_key/0 in metadata-relay/lib/metadata_relay/subdl/
+// client.ex: a blank or whitespace-only key is a common deployment accident
+// and is treated as absent, same as an unset one, rather than being sent to
+// SubDL and getting back an opaque rejection. Exported standalone (mirroring
+// tvdb-auth.ts's getTvdbToken) because Hono's request context can't be
+// constructed directly in a test -- this is what a "key absent" test exercises.
+export function subdlApiKey(env: Env): string | null {
+  const key = env.SUBDL_API_KEY;
+  if (key === undefined || key === null) return null;
+  return key.trim() === "" ? null : key;
+}
+
+export function registerSubdlRoutes(app: Hono<{ Bindings: Env }>): void {
+  app.post("/api/v1/subtitles/search", async (c) => {
+    const apiKey = subdlApiKey(c.env);
+    if (!apiKey) {
+      return c.json(
+        {
+          error: "Service not configured",
+          message:
+            "SubDL integration is not configured. Please set the SUBDL_API_KEY environment variable.",
+        },
+        503,
+      );
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      return c.json({ error: "Invalid JSON body" }, 400);
+    }
+
+    const body = asSearchBody(rawBody);
+    const identity = buildIdentity(body);
+    if (!identity) {
+      return c.json({ error: "Insufficient search criteria" }, 400);
+    }
+
+    const cacheKey = subtitleSearchCacheKey(await bodyFingerprint(rawBody));
+    const hit = await cacheGet(c.env, cacheKey, { kv: true });
+    if (hit) return hit;
+
+    const query = new URLSearchParams();
+    query.set("api_key", apiKey);
+    query.set("languages", buildLanguages(body.languages));
+    query.set("subs_per_page", SUBS_PER_PAGE);
+    query.set(identity[0], identity[1]);
+    for (const [key, value] of buildTypeParams(body)) query.set(key, value);
+
+    const upstream = await fetch(`${SEARCH_URL}?${query.toString()}`);
+
+    if (upstream.status === 429) {
+      const retryAfter = upstream.headers.get("retry-after") ?? "60";
+      return errorJson("Too many requests", 429, { "retry-after": retryAfter });
+    }
+
+    if (!upstream.ok) {
+      // api.subdl.com is the one host the relay's shared key is sent to, so
+      // its error text is the one place that key could come back echoed.
+      // Never forwarded; a fixed message only.
+      return errorJson("Subtitle provider error", clientStatus(upstream.status));
+    }
+
+    const rawText = await upstream.text();
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawText);
+    } catch {
+      // A binary or HTML body (captcha, CDN block) rather than JSON.
+      return errorJson("Unexpected upstream response", 502);
+    }
+
+    if (!isPlainObject(payload)) {
+      return errorJson("Unexpected upstream response", 502);
+    }
+
+    let subtitles: unknown[];
+    if (Array.isArray(payload.subtitles)) {
+      const feature = featureContext(payload.results);
+      subtitles = (payload.subtitles as Record<string, unknown>[]).map((s) =>
+        transformSubtitle(s, feature),
+      );
+    } else if (payload.status === false) {
+      // A miss, not an anomaly. SubDL answers a miss with status:false plus
+      // an error string rather than an empty list.
+      subtitles = [];
+    } else {
+      // Anything else is an upstream anomaly, not a search that found
+      // nothing, and the two must not answer alike: caching an anomaly as
+      // empty would pin "this title has no subtitles" on every install for
+      // the full search TTL, with nothing to invalidate it.
+      return errorJson("Unexpected upstream response", 502);
+    }
+
+    const result = { subtitles };
+    const res = new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    // An empty result is a claim about today, and subtitles for a new
+    // release land within hours. Holding it for the full search TTL would
+    // hide a fresh upload from every install for as long as the entry lives.
+    const ttlSeconds =
+      subtitles.length === 0 ? EMPTY_SUBTITLE_TTL_SECONDS : undefined;
+    await cachePut(c.env, cacheKey, res.clone(), { ttlSeconds, kv: true });
+
+    return res;
+  });
+
+  app.get("/api/v1/subtitles/download-url/:id", (c) => {
+    const path = decodeFileId(c.req.param("id"));
+    if (!path) return c.json({ error: "Invalid subtitle id" }, 400);
+
+    const fileName =
+      path
+        .split("/")
+        .pop()
+        ?.replace(/\.zip$/, ".srt") ?? "subtitle.srt";
+
+    // Points back at this relay, not at SubDL: clients expect plain
+    // subtitle bytes and do no archive handling of their own.
+    return c.json({
+      download_url: `${new URL(c.req.url).origin}/api/v1/subtitles/download/${c.req.param("id")}`,
+      file_name: fileName,
+      // SubDL publishes no quota headers. Reporting null is honest;
+      // reporting a number would be invention.
+      requests_used: null,
+      requests_remaining: null,
+    });
+  });
+
+  app.get("/api/v1/subtitles/download/:id", async (c) => {
+    const path = decodeFileId(c.req.param("id"));
+    if (!path) return c.json({ error: "Invalid subtitle id" }, 400);
+
+    const upstream = await fetch(`${DOWNLOAD_HOST}${path}`);
+
+    if (upstream.status === 404) {
+      // A subtitle pulled from SubDL after it was indexed. "Gone" is a
+      // different answer from "the relay is broken", and only a 404 lets
+      // the client tell them apart.
+      return c.json(
+        {
+          error: "Subtitle not found",
+          message: "This subtitle is no longer available from the provider.",
+        },
+        404,
+      );
+    }
+
+    if (!upstream.ok) {
+      // No upstream body is forwarded here, ever. dl.subdl.com is fetched
+      // unauthenticated, but its error body is still never this relay's to
+      // hand back verbatim.
+      return c.json(
+        {
+          error: "Subtitle unavailable",
+          message: "The subtitle could not be retrieved from the provider.",
+        },
+        502,
+      );
+    }
+
+    const bytes = new Uint8Array(await upstream.arrayBuffer());
+    const subtitle = extractSubtitle(bytes);
+    if (!subtitle) {
+      return c.json(
+        {
+          error: "Subtitle unavailable",
+          message: "The subtitle could not be retrieved from the provider.",
+        },
+        502,
+      );
+    }
+
+    return new Response(subtitle, {
+      status: 200,
+      headers: {
+        "content-type": "application/octet-stream",
+        "content-disposition": 'attachment; filename="subtitle.srt"',
+      },
+    });
+  });
+}

--- a/relay-worker/src/proxy/subdl.ts
+++ b/relay-worker/src/proxy/subdl.ts
@@ -6,16 +6,21 @@ import {
   EMPTY_SUBTITLE_TTL_SECONDS,
 } from "../cache/key";
 import { cacheGet, cachePut } from "../cache/store";
-import {
-  encodeFileId,
-  decodeFileId,
-  extractSubtitle,
-  MAX_ARCHIVE_BYTES,
-} from "../archive/zip";
+import { encodeFileId, decodeFileId, extractSubtitle } from "../archive/zip";
 
 const SEARCH_URL = "https://api.subdl.com/api/v1/subtitles";
 const DOWNLOAD_HOST = "https://dl.subdl.com";
 const SUBS_PER_PAGE = "30";
+
+// Bounds the compressed transfer, a different concern from
+// extractSubtitle's MAX_ARCHIVE_BYTES (the expanded-content cap). This one
+// exists purely to stop an HTTP body from being buffered at all before ZIP
+// parsing ever gets a chance to run. Real SubDL archives are tens of KB;
+// 2,000,000 bytes (2MB) is already two orders of magnitude of slack for
+// anything legitimate, deliberately far tighter than the 20MB expansion cap
+// -- a compressed subtitle archive should never need to approach the size of
+// the most content this relay would ever accept expanded.
+const MAX_DOWNLOAD_BYTES = 2_000_000;
 
 // -- Search query construction ------------------------------------------
 //
@@ -224,6 +229,64 @@ function subtitleUnavailable(c: Context<{ Bindings: Env }>): Response {
   );
 }
 
+// Content-Length is a cheap early-out for an honest server that has already
+// declared a body too large to bother reading -- it is NOT a bound. It can be
+// absent, non-numeric, or simply a lie (workerd does not enforce it against
+// the real byte count), so the actual limit is enforced by readCapped below
+// regardless of what this header claims.
+function declaredContentLengthExceeds(
+  response: Response,
+  maxBytes: number,
+): boolean {
+  const raw = response.headers.get("content-length");
+  if (raw === null) return false;
+  const declared = Number(raw);
+  return Number.isFinite(declared) && declared >= maxBytes;
+}
+
+// Reads a response body up to maxBytes, streaming chunk by chunk and
+// rejecting (null) the instant the running total would reach or exceed the
+// cap -- discarding whatever was buffered so far and cancelling the stream so
+// the underlying connection isn't left draining. Unlike a Content-Length
+// check this does not trust the server: it counts real bytes as they arrive,
+// so an absent, wrong, or lying header changes nothing about the outcome.
+async function readCapped(
+  response: Response,
+  maxBytes: number,
+): Promise<Uint8Array | null> {
+  const body = response.body;
+  if (!body) return new Uint8Array(0);
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    total += value.length;
+    if (total >= maxBytes) {
+      try {
+        await reader.cancel();
+      } catch {
+        // Already closed or errored; nothing more to clean up.
+      }
+      return null;
+    }
+    chunks.push(value);
+  }
+
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
 export function registerSubdlRoutes(app: Hono<{ Bindings: Env }>): void {
   app.post("/api/v1/subtitles/search", async (c) => {
     const apiKey = subdlApiKey(c.env);
@@ -371,19 +434,19 @@ export function registerSubdlRoutes(app: Hono<{ Bindings: Env }>): void {
       return subtitleUnavailable(c);
     }
 
-    // Defence in depth, ahead of extractSubtitle's own declared-size cap: the
-    // compressed body itself is unbounded before any ZIP parsing happens at
-    // all, so a huge Content-Length is rejected before `.arrayBuffer()` ever
-    // buffers it into memory. Same ceiling as the expanded-content cap
-    // (MAX_ARCHIVE_BYTES) -- nothing legitimate needs a compressed subtitle
-    // archive anywhere near as large as the most we'd ever accept expanded,
-    // and real archives are tens of KB, three orders of magnitude under this.
-    const contentLength = Number(upstream.headers.get("content-length"));
-    if (Number.isFinite(contentLength) && contentLength >= MAX_ARCHIVE_BYTES) {
+    // Cheap early-out for an honest server that already declared its body
+    // too large -- saves the read below, but is not itself the bound: see
+    // readCapped, which enforces the real limit against actual bytes
+    // regardless of what (or whether) this header says.
+    if (declaredContentLengthExceeds(upstream, MAX_DOWNLOAD_BYTES)) {
       return subtitleUnavailable(c);
     }
 
-    const bytes = new Uint8Array(await upstream.arrayBuffer());
+    const bytes = await readCapped(upstream, MAX_DOWNLOAD_BYTES);
+    if (!bytes) {
+      return subtitleUnavailable(c);
+    }
+
     const subtitle = extractSubtitle(bytes);
     if (!subtitle) {
       return subtitleUnavailable(c);

--- a/relay-worker/src/proxy/subdl.ts
+++ b/relay-worker/src/proxy/subdl.ts
@@ -1,4 +1,4 @@
-import type { Hono } from "hono";
+import type { Context, Hono } from "hono";
 import type { Env } from "../env";
 import {
   bodyFingerprint,
@@ -6,7 +6,12 @@ import {
   EMPTY_SUBTITLE_TTL_SECONDS,
 } from "../cache/key";
 import { cacheGet, cachePut } from "../cache/store";
-import { encodeFileId, decodeFileId, extractSubtitle } from "../archive/zip";
+import {
+  encodeFileId,
+  decodeFileId,
+  extractSubtitle,
+  MAX_ARCHIVE_BYTES,
+} from "../archive/zip";
 
 const SEARCH_URL = "https://api.subdl.com/api/v1/subtitles";
 const DOWNLOAD_HOST = "https://dl.subdl.com";
@@ -206,6 +211,19 @@ export function subdlApiKey(env: Env): string | null {
   return key.trim() === "" ? null : key;
 }
 
+// Shared by every branch of the download route that must not echo an
+// upstream detail: a fixed body regardless of why the fetch, size check, or
+// extraction failed.
+function subtitleUnavailable(c: Context<{ Bindings: Env }>): Response {
+  return c.json(
+    {
+      error: "Subtitle unavailable",
+      message: "The subtitle could not be retrieved from the provider.",
+    },
+    502,
+  );
+}
+
 export function registerSubdlRoutes(app: Hono<{ Bindings: Env }>): void {
   app.post("/api/v1/subtitles/search", async (c) => {
     const apiKey = subdlApiKey(c.env);
@@ -350,25 +368,25 @@ export function registerSubdlRoutes(app: Hono<{ Bindings: Env }>): void {
       // No upstream body is forwarded here, ever. dl.subdl.com is fetched
       // unauthenticated, but its error body is still never this relay's to
       // hand back verbatim.
-      return c.json(
-        {
-          error: "Subtitle unavailable",
-          message: "The subtitle could not be retrieved from the provider.",
-        },
-        502,
-      );
+      return subtitleUnavailable(c);
+    }
+
+    // Defence in depth, ahead of extractSubtitle's own declared-size cap: the
+    // compressed body itself is unbounded before any ZIP parsing happens at
+    // all, so a huge Content-Length is rejected before `.arrayBuffer()` ever
+    // buffers it into memory. Same ceiling as the expanded-content cap
+    // (MAX_ARCHIVE_BYTES) -- nothing legitimate needs a compressed subtitle
+    // archive anywhere near as large as the most we'd ever accept expanded,
+    // and real archives are tens of KB, three orders of magnitude under this.
+    const contentLength = Number(upstream.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength >= MAX_ARCHIVE_BYTES) {
+      return subtitleUnavailable(c);
     }
 
     const bytes = new Uint8Array(await upstream.arrayBuffer());
     const subtitle = extractSubtitle(bytes);
     if (!subtitle) {
-      return c.json(
-        {
-          error: "Subtitle unavailable",
-          message: "The subtitle could not be retrieved from the provider.",
-        },
-        502,
-      );
+      return subtitleUnavailable(c);
     }
 
     return new Response(subtitle, {

--- a/relay-worker/src/proxy/tmdb.ts
+++ b/relay-worker/src/proxy/tmdb.ts
@@ -1,0 +1,54 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+import { buildKey } from "../cache/key";
+import { forwardParams, proxyJson } from "./forward";
+
+const TMDB_BASE = "https://api.themoviedb.org/3";
+
+// Relay path -> TMDB path. Keys with :id use the Hono param of the same name.
+// Source of truth: metadata-relay/lib/metadata_relay/tmdb/handler.ex.
+const ROUTES: Array<[string, (p: Record<string, string>) => string]> = [
+  ["/configuration", () => "/configuration"],
+  ["/tmdb/movies/search", () => "/search/movie"],
+  ["/tmdb/tv/search", () => "/search/tv"],
+  ["/tmdb/movies/trending", () => "/trending/movie/week"],
+  ["/tmdb/movies/popular", () => "/movie/popular"],
+  ["/tmdb/movies/upcoming", () => "/movie/upcoming"],
+  ["/tmdb/movies/now_playing", () => "/movie/now_playing"],
+  ["/tmdb/tv/trending", () => "/trending/tv/week"],
+  ["/tmdb/tv/popular", () => "/tv/popular"],
+  ["/tmdb/tv/on_the_air", () => "/tv/on_the_air"],
+  ["/tmdb/tv/airing_today", () => "/tv/airing_today"],
+  ["/tmdb/movies/discover", () => "/discover/movie"],
+  ["/tmdb/tv/discover", () => "/discover/tv"],
+  ["/tmdb/genre/movie", () => "/genre/movie/list"],
+  ["/tmdb/genre/tv", () => "/genre/tv/list"],
+  ["/tmdb/list/:id", (p) => `/list/${p.id}`],
+  ["/tmdb/collections/:id", (p) => `/collection/${p.id}`],
+  ["/tmdb/movies/:id", (p) => `/movie/${p.id}`],
+  ["/tmdb/tv/shows/:id", (p) => `/tv/${p.id}`],
+  ["/tmdb/movies/:id/images", (p) => `/movie/${p.id}/images`],
+  ["/tmdb/tv/shows/:id/images", (p) => `/tv/${p.id}/images`],
+  ["/tmdb/tv/shows/:id/:season", (p) => `/tv/${p.id}/season/${p.season}`],
+];
+
+export function registerTmdbRoutes(app: Hono<{ Bindings: Env }>): void {
+  for (const [relayPath, toUpstream] of ROUTES) {
+    app.get(relayPath, async (c) => {
+      const apiKey = c.env.TMDB_API_KEY;
+      if (!apiKey) return c.json({ error: "TMDB not configured" }, 503);
+
+      const url = new URL(c.req.url);
+      const params = forwardParams(url.searchParams, { api_key: apiKey });
+
+      // The cache key uses the caller-facing path and the caller's query
+      // string, never the injected key, so the key never lands in KV.
+      const callerQuery = new URLSearchParams(url.searchParams);
+      callerQuery.delete("api_key");
+      const cacheKey = buildKey("GET", url.pathname, callerQuery.toString());
+
+      const upstream = `${TMDB_BASE}${toUpstream(c.req.param())}?${params}`;
+      return proxyJson(c.env, upstream, cacheKey);
+    });
+  }
+}

--- a/relay-worker/src/proxy/tvdb-auth.ts
+++ b/relay-worker/src/proxy/tvdb-auth.ts
@@ -1,0 +1,69 @@
+import type { Env } from "../env";
+
+const LOGIN_URL = "https://api4.thetvdb.com/v4/login";
+const KV_KEY = "tvdb:jwt";
+const REFRESH_BEFORE_EXPIRY_SECONDS = 3600; // matches @refresh_before_expiry
+const FALLBACK_LIFETIME_SECONDS = 30 * 86400;
+
+interface StoredToken {
+  token: string;
+  exp: number;
+}
+
+export function parseJwtExpiry(token: string): number {
+  const fallback = Math.floor(Date.now() / 1000) + FALLBACK_LIFETIME_SECONDS;
+  const parts = token.split(".");
+  if (parts.length !== 3) return fallback;
+
+  try {
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    const payload = JSON.parse(atob(padded)) as { exp?: number };
+    return typeof payload.exp === "number" ? payload.exp : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function login(env: Env): Promise<StoredToken> {
+  const apiKey = env.TVDB_API_KEY;
+  if (!apiKey) throw new Error("TVDB_API_KEY is not set");
+
+  const res = await fetch(LOGIN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ apikey: apiKey }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`TVDB authentication failed with status ${res.status}`);
+  }
+
+  const body = (await res.json()) as { data?: { token?: string } };
+  const token = body.data?.token;
+  if (!token) throw new Error("TVDB login returned no token");
+
+  return { token, exp: parseJwtExpiry(token) };
+}
+
+// No proactive refresh timer exists in a Worker, so this refreshes lazily.
+// Several requests racing an expiry may each log in; TVDB login is cheap and
+// idempotent and the window is an hour wide, so that is accepted. If duplicate
+// logins show up in the logs, serialise the refresh through a D1 row used as
+// a lock rather than reaching for a new primitive.
+export async function getTvdbToken(env: Env): Promise<string> {
+  if (!env.TVDB_API_KEY) throw new Error("TVDB_API_KEY is not set");
+
+  const stored = await env.CACHE_KV.get<StoredToken>(KV_KEY, "json");
+  const now = Math.floor(Date.now() / 1000);
+
+  if (stored && stored.exp - now > REFRESH_BEFORE_EXPIRY_SECONDS) {
+    return stored.token;
+  }
+
+  const fresh = await login(env);
+  await env.CACHE_KV.put(KV_KEY, JSON.stringify(fresh), {
+    expirationTtl: Math.max(fresh.exp - now, 60),
+  });
+  return fresh.token;
+}

--- a/relay-worker/src/proxy/tvdb.ts
+++ b/relay-worker/src/proxy/tvdb.ts
@@ -1,0 +1,106 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+import { buildKey } from "../cache/key";
+import { forwardParams, proxyJson } from "./forward";
+import { getTvdbToken } from "./tvdb-auth";
+
+const TVDB_BASE = "https://api4.thetvdb.com/v4";
+
+type UpstreamPath = (
+  params: Record<string, string>,
+  query: URLSearchParams,
+) => string;
+
+interface TvdbRoute {
+  path: string;
+  toUpstream: UpstreamPath;
+  // handler.ex's plain lookups (get_series/2, get_season/2, get_episode/2,
+  // get_artwork/2, get_series_episodes/2) declare `_params \\ []` (or, for
+  // episodes, consume `page` into the path) and call Client.get(path) with no
+  // :params option, so nothing forwards upstream. Only search and the
+  // *_extended handlers pass `params: params` through to Client.get.
+  forwardQuery: boolean;
+}
+
+// Source of truth: metadata-relay/lib/metadata_relay/tvdb/handler.ex.
+const ROUTES: TvdbRoute[] = [
+  { path: "/tvdb/search", toUpstream: () => "/search", forwardQuery: true },
+  {
+    path: "/tvdb/series/:id",
+    toUpstream: (p) => `/series/${p.id}`,
+    forwardQuery: false,
+  },
+  {
+    path: "/tvdb/series/:id/extended",
+    toUpstream: (p) => `/series/${p.id}/extended`,
+    forwardQuery: true,
+  },
+  // get_series_episodes/2 reads `page` (default 0) out of the params map and
+  // bakes it into the path as .../episodes/default/page/N — not simply
+  // /series/{id}/episodes, and the page number is never also sent as a query
+  // parameter.
+  {
+    path: "/tvdb/series/:id/episodes",
+    toUpstream: (p, query) =>
+      `/series/${p.id}/episodes/default/page/${query.get("page") ?? "0"}`,
+    forwardQuery: false,
+  },
+  {
+    path: "/tvdb/seasons/:id",
+    toUpstream: (p) => `/seasons/${p.id}`,
+    forwardQuery: false,
+  },
+  {
+    path: "/tvdb/seasons/:id/extended",
+    toUpstream: (p) => `/seasons/${p.id}/extended`,
+    forwardQuery: true,
+  },
+  {
+    path: "/tvdb/episodes/:id",
+    toUpstream: (p) => `/episodes/${p.id}`,
+    forwardQuery: false,
+  },
+  {
+    path: "/tvdb/episodes/:id/extended",
+    toUpstream: (p) => `/episodes/${p.id}/extended`,
+    forwardQuery: true,
+  },
+  {
+    path: "/tvdb/artwork/:id",
+    toUpstream: (p) => `/artwork/${p.id}`,
+    forwardQuery: false,
+  },
+];
+
+export function registerTvdbRoutes(app: Hono<{ Bindings: Env }>): void {
+  for (const route of ROUTES) {
+    app.get(route.path, async (c) => {
+      if (!c.env.TVDB_API_KEY) {
+        return c.json({ error: "TVDB not configured" }, 503);
+      }
+
+      let token: string;
+      try {
+        token = await getTvdbToken(c.env);
+      } catch {
+        return c.json({ error: "TVDB authentication failed" }, 502);
+      }
+
+      const url = new URL(c.req.url);
+      const cacheKey = buildKey(
+        "GET",
+        url.pathname,
+        url.searchParams.toString(),
+      );
+      const upstreamPath = route.toUpstream(c.req.param(), url.searchParams);
+      const query = route.forwardQuery
+        ? forwardParams(url.searchParams, {}).toString()
+        : "";
+      const upstream = `${TVDB_BASE}${upstreamPath}${query ? `?${query}` : ""}`;
+
+      return proxyJson(c.env, upstream, cacheKey, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+    });
+  }
+}

--- a/relay-worker/test/archive/zip.test.ts
+++ b/relay-worker/test/archive/zip.test.ts
@@ -46,9 +46,9 @@ describe("extractSubtitle", () => {
 
   // Mirrors archive.ex's check_declared_size/1 + check_total_size/1: a small
   // download must not be allowed to expand into an unbounded write. These
-  // three tests were run against the pre-fix, uncapped extractSubtitle before
-  // this cap existed; see task-6-report.md's fix round 1 section for that
-  // "before" output. The zip-bomb test in particular is written so it fails
+  // three tests were run against the uncapped extractSubtitle before this cap
+  // existed, and all three failed there, so they are known to have teeth.
+  // The zip-bomb test in particular is written so it fails
   // against an implementation that fully decompresses before checking size.
   describe("size cap", () => {
     it("rejects an archive whose declared size is exactly at the cap", () => {

--- a/relay-worker/test/archive/zip.test.ts
+++ b/relay-worker/test/archive/zip.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { zipSync, strToU8 } from "fflate";
+import { extractSubtitle, encodeFileId, decodeFileId } from "../../src/archive/zip";
+
+describe("extractSubtitle", () => {
+  it("returns the subtitle bytes from a single-entry archive", () => {
+    const zip = zipSync({ "sub.srt": strToU8("1\n00:00:01,000 --> 00:00:02,000\nhi\n") });
+    const out = extractSubtitle(zip);
+    expect(out).not.toBeNull();
+    expect(new TextDecoder().decode(out!)).toContain("00:00:01,000");
+  });
+
+  it("picks the subtitle entry when the archive also holds junk", () => {
+    const zip = zipSync({
+      "readme.txt": strToU8("ignore me"),
+      "movie.srt": strToU8("1\n00:00:01,000 --> 00:00:02,000\nreal\n"),
+    });
+    expect(new TextDecoder().decode(extractSubtitle(zip)!)).toContain("real");
+  });
+
+  it("rejects an entry whose name escapes the archive root", () => {
+    // Path traversal guard: names are checked before use, because a crafted
+    // name is the whole attack here.
+    const zip = zipSync({ "../../etc/passwd.srt": strToU8("nope") });
+    expect(extractSubtitle(zip)).toBeNull();
+  });
+
+  it("rejects an absolute entry name", () => {
+    const zip = zipSync({ "/etc/passwd.srt": strToU8("nope") });
+    expect(extractSubtitle(zip)).toBeNull();
+  });
+
+  it("returns null for an archive with no subtitle entry", () => {
+    const zip = zipSync({ "cover.jpg": strToU8("binary") });
+    expect(extractSubtitle(zip)).toBeNull();
+  });
+
+  it("returns null for bytes that are not a zip at all", () => {
+    expect(extractSubtitle(strToU8("<html>captcha</html>"))).toBeNull();
+  });
+});
+
+describe("file id encoding", () => {
+  it("round trips a valid subtitle path", () => {
+    const id = encodeFileId("/subtitle/abc-123.zip");
+    expect(decodeFileId(id)).toBe("/subtitle/abc-123.zip");
+  });
+
+  it("uses unpadded url-safe base64, matching FileId.encode", () => {
+    expect(encodeFileId("/subtitle/a.zip")).not.toContain("=");
+    expect(encodeFileId("/subtitle/a.zip")).not.toContain("+");
+    expect(encodeFileId("/subtitle/a.zip")).not.toContain("/");
+  });
+
+  it("strips a query string before encoding, matching FileId.encode's strip_query", () => {
+    // SubDL appends the API key used for the search onto every result url.
+    // Dropping the query string here is the single point that keeps the
+    // relay's key out of the encoded id.
+    const withQuery = encodeFileId("/subtitle/abc-123.zip?api_key=SUPERSECRET");
+    const withoutQuery = encodeFileId("/subtitle/abc-123.zip");
+    expect(withQuery).toBe(withoutQuery);
+    expect(decodeFileId(withQuery)).toBe("/subtitle/abc-123.zip");
+  });
+
+  it("rejects a decoded path that is not a subtitle zip", () => {
+    const hostile = btoa("/etc/passwd").replace(/=+$/, "");
+    expect(decodeFileId(hostile)).toBeNull();
+  });
+
+  it("rejects a decoded path with traversal segments", () => {
+    const hostile = btoa("/subtitle/../../x.zip").replace(/=+$/, "");
+    expect(decodeFileId(hostile)).toBeNull();
+  });
+
+  it("rejects input that is not valid base64", () => {
+    expect(decodeFileId("!!!not base64!!!")).toBeNull();
+  });
+});

--- a/relay-worker/test/archive/zip.test.ts
+++ b/relay-worker/test/archive/zip.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { zipSync, strToU8 } from "fflate";
-import { extractSubtitle, encodeFileId, decodeFileId } from "../../src/archive/zip";
+import {
+  extractSubtitle,
+  encodeFileId,
+  decodeFileId,
+  MAX_ARCHIVE_BYTES,
+} from "../../src/archive/zip";
 
 describe("extractSubtitle", () => {
   it("returns the subtitle bytes from a single-entry archive", () => {
@@ -37,6 +42,39 @@ describe("extractSubtitle", () => {
 
   it("returns null for bytes that are not a zip at all", () => {
     expect(extractSubtitle(strToU8("<html>captcha</html>"))).toBeNull();
+  });
+
+  // Mirrors archive.ex's check_declared_size/1 + check_total_size/1: a small
+  // download must not be allowed to expand into an unbounded write. These
+  // three tests were run against the pre-fix, uncapped extractSubtitle before
+  // this cap existed; see task-6-report.md's fix round 1 section for that
+  // "before" output. The zip-bomb test in particular is written so it fails
+  // against an implementation that fully decompresses before checking size.
+  describe("size cap", () => {
+    it("rejects an archive whose declared size is exactly at the cap", () => {
+      const zip = zipSync({ "big.srt": new Uint8Array(MAX_ARCHIVE_BYTES) });
+      expect(extractSubtitle(zip)).toBeNull();
+    });
+
+    it("accepts an archive whose declared size is just under the cap", () => {
+      const payload = new Uint8Array(MAX_ARCHIVE_BYTES - 1000).fill(1);
+      const zip = zipSync({ "big.srt": payload });
+      const out = extractSubtitle(zip);
+      expect(out).not.toBeNull();
+      expect(out!.length).toBe(payload.length);
+    });
+
+    it("rejects a zip-bomb shape (tiny on the wire, huge declared size) without materialising it", () => {
+      // 30MB of zeros compresses to well under 1KB via deflate: small
+      // compressed size, huge originalSize -- exactly the shape
+      // check_declared_size/1 exists to catch before any bytes are produced.
+      const bomb = new Uint8Array(30_000_000);
+      const zip = zipSync({ "bomb.srt": bomb });
+      // ~1000x compression ratio: comfortably "tiny on the wire" relative to
+      // the 30MB declared size, without pinning an exact byte count.
+      expect(zip.length).toBeLessThan(50_000);
+      expect(extractSubtitle(zip)).toBeNull();
+    });
   });
 });
 

--- a/relay-worker/test/cache/key.test.ts
+++ b/relay-worker/test/cache/key.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildKey,
+  ttlSecondsFor,
+  canonicalize,
+  bodyFingerprint,
+  subtitleSearchCacheKey,
+} from "../../src/cache/key";
+
+describe("buildKey", () => {
+  it("matches the Elixir format method:path:query", () => {
+    expect(buildKey("GET", "/tmdb/movies/550", "language=en")).toBe(
+      "GET:/tmdb/movies/550:language=en",
+    );
+  });
+
+  it("keeps an empty query string as an empty segment", () => {
+    expect(buildKey("GET", "/configuration", "")).toBe("GET:/configuration:");
+  });
+});
+
+describe("ttlSecondsFor", () => {
+  it("gives images 90 days", () => {
+    expect(ttlSecondsFor("GET:/tmdb/movies/550/images:")).toBe(7776000);
+  });
+
+  it("gives music cover art 90 days", () => {
+    expect(ttlSecondsFor("GET:/music/cover/abc:")).toBe(7776000);
+  });
+
+  it("gives trending 1 hour", () => {
+    expect(ttlSecondsFor("GET:/tmdb/movies/trending:")).toBe(3600);
+  });
+
+  it("gives search 7 days", () => {
+    expect(ttlSecondsFor("GET:/tmdb/movies/search:query=x")).toBe(604800);
+  });
+
+  it("gives movie details 30 days", () => {
+    expect(ttlSecondsFor("GET:/tmdb/movies/550:")).toBe(2592000);
+  });
+
+  it("gives tv show details 30 days", () => {
+    expect(ttlSecondsFor("GET:/tmdb/tv/shows/1399:")).toBe(2592000);
+  });
+
+  it("gives music details 30 days", () => {
+    expect(ttlSecondsFor("GET:/music/artist/abc:")).toBe(2592000);
+  });
+
+  it("gives season data 14 days", () => {
+    expect(ttlSecondsFor("GET:/tmdb/tv/shows/1399/2:")).toBe(1209600);
+  });
+
+  it("defaults to 30 days", () => {
+    expect(ttlSecondsFor("GET:/tvdb/series/331753/extended:")).toBe(2592000);
+  });
+
+  it("prefers images over details when both could match", () => {
+    // Elixir's cond checks images first, so a details path ending in
+    // /images must not fall through to details_ttl.
+    expect(ttlSecondsFor("GET:/tmdb/tv/shows/1399/images:")).toBe(7776000);
+  });
+
+  it("prefers trending over search for a trending path", () => {
+    expect(ttlSecondsFor("GET:/tmdb/tv/trending:")).toBe(3600);
+  });
+});
+
+describe("canonicalize", () => {
+  it("sorts object keys so serializer order does not split the cache", () => {
+    expect(canonicalize({ b: 1, a: 2 })).toEqual([
+      ["a", 2],
+      ["b", 1],
+    ]);
+  });
+
+  it("preserves list order because JSON list order is meaningful", () => {
+    expect(canonicalize([3, 1, 2])).toEqual([3, 1, 2]);
+  });
+
+  it("recurses into nested structures", () => {
+    expect(canonicalize({ z: { y: 1, x: 2 } })).toEqual([
+      ["z", [["x", 2], ["y", 1]]],
+    ]);
+  });
+});
+
+describe("bodyFingerprint", () => {
+  it("gives the same digest regardless of key order", async () => {
+    const a = await bodyFingerprint({ film_name: "x", languages: ["en"] });
+    const b = await bodyFingerprint({ languages: ["en"], film_name: "x" });
+    expect(a).toBe(b);
+  });
+
+  it("gives a different digest for different list order", async () => {
+    const a = await bodyFingerprint({ languages: ["en", "fr"] });
+    const b = await bodyFingerprint({ languages: ["fr", "en"] });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns lowercase hex", async () => {
+    const digest = await bodyFingerprint({ a: 1 });
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("subtitleSearchCacheKey", () => {
+  it("folds the wire format version into the key", () => {
+    expect(subtitleSearchCacheKey("abc")).toBe(
+      "POST:/api/v1/subtitles/search:v1:abc",
+    );
+  });
+
+  it("changes when the version changes, so a shape change self-invalidates", () => {
+    expect(subtitleSearchCacheKey("abc", 2)).not.toBe(
+      subtitleSearchCacheKey("abc", 1),
+    );
+  });
+});

--- a/relay-worker/test/cache/store.test.ts
+++ b/relay-worker/test/cache/store.test.ts
@@ -1,0 +1,83 @@
+import { env } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import { cacheGet, cachePut, filterHeaders } from "../../src/cache/store";
+
+describe("filterHeaders", () => {
+  it("keeps only the four allowed headers", () => {
+    const input = new Headers({
+      "content-type": "application/json",
+      "content-disposition": "attachment",
+      "cache-control": "public, max-age=60",
+      etag: '"abc"',
+      "set-cookie": "session=leak",
+      "x-request-id": "noise",
+      authorization: "Bearer secret",
+    });
+
+    const out = filterHeaders(input);
+
+    expect(out.get("content-type")).toBe("application/json");
+    expect(out.get("content-disposition")).toBe("attachment");
+    expect(out.get("cache-control")).toBe("public, max-age=60");
+    expect(out.get("etag")).toBe('"abc"');
+    expect(out.get("set-cookie")).toBeNull();
+    expect(out.get("x-request-id")).toBeNull();
+    expect(out.get("authorization")).toBeNull();
+  });
+});
+
+describe("cache round trip", () => {
+  it("returns null for a key never written", async () => {
+    expect(await cacheGet(env, "GET:/tmdb/movies/1:")).toBeNull();
+  });
+
+  it("returns a stored response body and status", async () => {
+    const key = "GET:/tmdb/movies/550:";
+    await cachePut(
+      env,
+      key,
+      new Response(JSON.stringify({ id: 550 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const hit = await cacheGet(env, key);
+    expect(hit).not.toBeNull();
+    expect(hit!.status).toBe(200);
+    expect(await hit!.json<{ id: number }>()).toEqual({ id: 550 });
+  });
+
+  it("does not leak headers outside the allowlist through the cache", async () => {
+    const key = "GET:/tmdb/movies/551:";
+    await cachePut(
+      env,
+      key,
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json", "set-cookie": "x=1" },
+      }),
+    );
+
+    const hit = await cacheGet(env, key);
+    expect(hit!.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("keeps entries for distinct keys separate", async () => {
+    await cachePut(env, "GET:/a:", new Response("A"));
+    await cachePut(env, "GET:/b:", new Response("B"));
+
+    expect(await (await cacheGet(env, "GET:/a:"))!.text()).toBe("A");
+    expect(await (await cacheGet(env, "GET:/b:"))!.text()).toBe("B");
+  });
+
+  it("does not write to KV unless asked", async () => {
+    await cachePut(env, "GET:/kvless:", new Response("no kv"));
+    expect(await env.CACHE_KV.get("GET:/kvless:")).toBeNull();
+  });
+
+  it("writes to KV when the caller opts in", async () => {
+    await cachePut(env, "POST:/subs:v1:abc", new Response("subs"), { kv: true });
+    expect(await env.CACHE_KV.get("POST:/subs:v1:abc")).not.toBeNull();
+  });
+});

--- a/relay-worker/test/contract/contract.test.ts
+++ b/relay-worker/test/contract/contract.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import rawRoutes from "./routes.json";
+
+// Replays a fixed request list against a deployed Worker and the live Elixir
+// relay, diffing status and body. This is the gate that proves the port
+// before Task 16 cuts the production hostname over -- see
+// .superpowers/sdd/2026-09-05-metadata-relay-on-cloudflare-workers/task-9-report.md
+// for what has (and has not) actually been exercised through it.
+//
+// This file runs as the separate "contract" Vitest project (see
+// vitest.workspace.ts), under plain Node rather than workerd: it treats both
+// services as opaque HTTP endpoints reached by URL, needs no Workers-specific
+// runtime capability, and workerd's self-contained root CA store does not
+// necessarily trust every network's TLS-intercepting proxy the way the host
+// OS's trust store does (observed directly: identical fetch() calls succeed
+// under Node and fail with a cert-trust error under workerd, in a sandbox
+// that proxies outbound HTTPS). Plain `process.env` therefore works
+// normally here, unlike inside a workerd test.
+//
+// CONTRACT_WORKER_URL is unset by default, so this whole suite is skipped in
+// ordinary `npm run test` / CI runs -- there is no staging Worker to compare
+// against until one is deployed (Step 4 of the brief). Point both env vars at
+// the live relay to self-compare instead: every route then diffs against
+// itself, which proves the harness mechanics, the cache-buster, and the
+// volatile-key stripping, and -- most valuable -- that every path in
+// routes.json is a real route on the live service.
+const WORKER = process.env.CONTRACT_WORKER_URL;
+const RELAY = process.env.CONTRACT_RELAY_URL ?? "https://relay.mydia.dev";
+
+interface ContractRoute {
+  method: string;
+  path: string;
+  // Present only for routes that need a JSON request body (SubDL search).
+  body?: Record<string, unknown>;
+}
+
+const routes = rawRoutes as ContractRoute[];
+
+// Keys whose values legitimately differ between the two services.
+const VOLATILE_TOP_LEVEL = new Set(["version"]);
+
+function stripVolatile(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripVolatile);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([k]) => !VOLATILE_TOP_LEVEL.has(k))
+        .map(([k, v]) => [k, stripVolatile(v)]),
+    );
+  }
+  return value;
+}
+
+function requestInit(route: ContractRoute): RequestInit {
+  if (route.body === undefined) return { method: route.method };
+  return {
+    method: route.method,
+    body: JSON.stringify(route.body),
+    headers: { "content-type": "application/json" },
+  };
+}
+
+describe.skipIf(!WORKER)("Worker matches the live relay", () => {
+  for (const route of routes) {
+    it(`${route.method} ${route.path}`, async () => {
+      // Cache-buster, because Cloudflare will otherwise serve your own earlier
+      // request back to you and the diff will pass against itself.
+      const bust = `_cb=${crypto.randomUUID()}`;
+      const sep = route.path.includes("?") ? "&" : "?";
+      const suffix = `${route.path}${sep}${bust}`;
+
+      const init = requestInit(route);
+      const [workerRes, relayRes] = await Promise.all([
+        fetch(`${WORKER}${suffix}`, init),
+        fetch(`${RELAY}${suffix}`, init),
+      ]);
+
+      expect(workerRes.status, "status code").toBe(relayRes.status);
+
+      const workerBody = await workerRes.text();
+      const relayBody = await relayRes.text();
+
+      let workerJson: unknown;
+      let relayJson: unknown;
+      try {
+        workerJson = JSON.parse(workerBody) as unknown;
+        relayJson = JSON.parse(relayBody) as unknown;
+      } catch {
+        expect(workerBody).toBe(relayBody);
+        return;
+      }
+
+      expect(stripVolatile(workerJson)).toEqual(stripVolatile(relayJson));
+    });
+  }
+});

--- a/relay-worker/test/contract/contract.test.ts
+++ b/relay-worker/test/contract/contract.test.ts
@@ -24,6 +24,14 @@ import rawRoutes from "./routes.json";
 // itself, which proves the harness mechanics, the cache-buster, and the
 // volatile-key stripping, and -- most valuable -- that every path in
 // routes.json is a real route on the live service.
+//
+// IMPORTANT for whoever wires this into the Task 16 cutover gate: Vitest
+// exits 0 for a run that is entirely `describe.skipIf`-skipped, same as a
+// run where every test genuinely passed. A gate that only checks the exit
+// code would rubber-stamp a cutover having compared nothing, which is the
+// single worst failure mode this harness could have. Assert the skip count
+// is zero (or, simpler, that CONTRACT_WORKER_URL is actually set) before
+// trusting a green `test:contract` run as a real gate pass.
 const WORKER = process.env.CONTRACT_WORKER_URL;
 const RELAY = process.env.CONTRACT_RELAY_URL ?? "https://relay.mydia.dev";
 
@@ -32,19 +40,65 @@ interface ContractRoute {
   path: string;
   // Present only for routes that need a JSON request body (SubDL search).
   body?: Record<string, unknown>;
+  // Human-readable-only. Documents why a specific route is in this list
+  // despite not being a clean positive check (e.g. a route both services
+  // are expected to fail on identically), or a caveat about what the diff
+  // against it does and doesn't prove. Never read by the test logic below.
+  note?: string;
 }
 
 const routes = rawRoutes as ContractRoute[];
 
+// The SubDL search route (POST /api/v1/subtitles/search) keys its cache on
+// a SHA-256 of the JSON request body (subtitleSearchCacheKey/bodyFingerprint
+// in src/cache/key.ts), not on the URL or query string at all -- so the
+// `_cb` cache-buster appended below is a genuine no-op for that one route.
+// Harmless for this self-comparison (relay.mydia.dev's own cache-control is
+// `private, must-revalidate`, so it is never edge-cached regardless), but it
+// matters once CONTRACT_WORKER_URL points at a real deployed staging Worker:
+// that Worker's KV-backed cache (cachePut/cacheGet with {kv: true}) WILL
+// serve a stale transform for an identical body across separate contract
+// runs. Task 16 should deploy staging with a fresh KV namespace (or purge
+// CACHE_KV) before trusting this route's result, or a stale cached response
+// could be compared instead of a fresh one.
+function bytesEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  const av = new Uint8Array(a);
+  const bv = new Uint8Array(b);
+  for (let i = 0; i < av.length; i++) {
+    if (av[i] !== bv[i]) return false;
+  }
+  return true;
+}
+
 // Keys whose values legitimately differ between the two services.
 const VOLATILE_TOP_LEVEL = new Set(["version"]);
+
+// `created` needs shape-aware handling, not a blanket name match: found live
+// on GET /music/search, whose upstream (MusicBrainz) stamps a bare ISO-8601
+// string set to "now" on every single search -- confirmed empirically, this
+// self-comparison failed on it even though both sides hit the identical
+// live relay milliseconds apart. But the same key name also appears, in a
+// completely different shape, on the OpenLibrary works/authors routes:
+// `created: { type: "/type/datetime", value: "..." }`, a stable catalog
+// record timestamp that is exactly the kind of real content this diff
+// should keep comparing. Stripping by name alone would blind those two
+// routes to a genuine mismatch for no reason -- so only a bare *string*
+// `created` is treated as volatile; the OpenLibrary object shape is left to
+// recurse into (and its `value` string survives too, since the key there is
+// "value", not "created").
+function isVolatile(key: string, value: unknown): boolean {
+  if (VOLATILE_TOP_LEVEL.has(key)) return true;
+  if (key === "created" && typeof value === "string") return true;
+  return false;
+}
 
 function stripVolatile(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripVolatile);
   if (value !== null && typeof value === "object") {
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>)
-        .filter(([k]) => !VOLATILE_TOP_LEVEL.has(k))
+        .filter(([k, v]) => !isVolatile(k, v))
         .map(([k, v]) => [k, stripVolatile(v)]),
     );
   }
@@ -77,16 +131,25 @@ describe.skipIf(!WORKER)("Worker matches the live relay", () => {
 
       expect(workerRes.status, "status code").toBe(relayRes.status);
 
-      const workerBody = await workerRes.text();
-      const relayBody = await relayRes.text();
+      // Read as raw bytes, not text: /music/cover/:id returns a JPEG, and
+      // decoding arbitrary binary as UTF-8 replaces invalid byte sequences
+      // with U+FFFD, so two genuinely different images can decode to the
+      // same lossy string -- a text-based comparison would silently pass a
+      // real corruption. JSON bodies are still compared semantically below;
+      // only the "not JSON" fallback needs to be byte-exact rather than
+      // text-exact.
+      const workerBytes = await workerRes.arrayBuffer();
+      const relayBytes = await relayRes.arrayBuffer();
 
       let workerJson: unknown;
       let relayJson: unknown;
       try {
-        workerJson = JSON.parse(workerBody) as unknown;
-        relayJson = JSON.parse(relayBody) as unknown;
+        workerJson = JSON.parse(new TextDecoder().decode(workerBytes)) as unknown;
+        relayJson = JSON.parse(new TextDecoder().decode(relayBytes)) as unknown;
       } catch {
-        expect(workerBody).toBe(relayBody);
+        expect(bytesEqual(workerBytes, relayBytes), "byte-for-byte body").toBe(
+          true,
+        );
         return;
       }
 

--- a/relay-worker/test/contract/contract.test.ts
+++ b/relay-worker/test/contract/contract.test.ts
@@ -3,9 +3,10 @@ import rawRoutes from "./routes.json";
 
 // Replays a fixed request list against a deployed Worker and the live Elixir
 // relay, diffing status and body. This is the gate that proves the port
-// before Task 16 cuts the production hostname over -- see
-// .superpowers/sdd/2026-09-05-metadata-relay-on-cloudflare-workers/task-9-report.md
-// for what has (and has not) actually been exercised through it.
+// before the production cutover moves the hostname over. Note what it has
+// NOT exercised: no run has ever compared a real deployed Worker against the
+// relay, only the relay against itself (see below), so the harness mechanics
+// are proven and the actual port parity is not.
 //
 // This file runs as the separate "contract" Vitest project (see
 // vitest.workspace.ts), under plain Node rather than workerd: it treats both
@@ -19,13 +20,13 @@ import rawRoutes from "./routes.json";
 //
 // CONTRACT_WORKER_URL is unset by default, so this whole suite is skipped in
 // ordinary `npm run test` / CI runs -- there is no staging Worker to compare
-// against until one is deployed (Step 4 of the brief). Point both env vars at
+// against until one is deployed. Point both env vars at
 // the live relay to self-compare instead: every route then diffs against
 // itself, which proves the harness mechanics, the cache-buster, and the
 // volatile-key stripping, and -- most valuable -- that every path in
 // routes.json is a real route on the live service.
 //
-// IMPORTANT for whoever wires this into the Task 16 cutover gate: Vitest
+// IMPORTANT for whoever wires this into the cutover gate: Vitest
 // exits 0 for a run that is entirely `describe.skipIf`-skipped, same as a
 // run where every test genuinely passed. A gate that only checks the exit
 // code would rubber-stamp a cutover having compared nothing, which is the
@@ -58,7 +59,7 @@ const routes = rawRoutes as ContractRoute[];
 // matters once CONTRACT_WORKER_URL points at a real deployed staging Worker:
 // that Worker's KV-backed cache (cachePut/cacheGet with {kv: true}) WILL
 // serve a stale transform for an identical body across separate contract
-// runs. Task 16 should deploy staging with a fresh KV namespace (or purge
+// runs. Deploy staging with a fresh KV namespace (or purge
 // CACHE_KV) before trusting this route's result, or a stale cached response
 // could be compared instead of a fresh one.
 function bytesEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {

--- a/relay-worker/test/contract/routes.json
+++ b/relay-worker/test/contract/routes.json
@@ -24,13 +24,39 @@
   { "method": "GET", "path": "/tvdb/search?query=Glass%20Meridian" },
   { "method": "GET", "path": "/tvdb/series/331753" },
   { "method": "GET", "path": "/tvdb/series/331753/extended" },
-  { "method": "GET", "path": "/tvdb/series/331753/episodes" },
+  {
+    "method": "GET",
+    "path": "/tvdb/series/331753/episodes",
+    "note": "Both sides currently 400. TVDB's own OpenAPI spec defines this endpoint as GET /series/{id}/episodes/{season-type} with `page` as a QUERY parameter, but handler.ex bakes the page number into the path instead (.../episodes/default/page/{N}), which has never been a valid TVDB path -- confirmed against TVDB's spec, not guessed. mydia's own client never calls this route (it gets episodes from the *_extended endpoints), so the bug went unnoticed. Do NOT fix the Worker to work around this: it is deliberately bug-compatible with the Elixir during the port. This entry proves the two sides fail identically, not that the route works -- see task-9-report.md."
+  },
   { "method": "GET", "path": "/tvdb/series/999999999" },
+  { "method": "GET", "path": "/tvdb/seasons/720595" },
+  { "method": "GET", "path": "/tvdb/seasons/720595/extended" },
+  { "method": "GET", "path": "/tvdb/episodes/6279071" },
+  { "method": "GET", "path": "/tvdb/episodes/6279071/extended" },
+  { "method": "GET", "path": "/tvdb/artwork/62278912" },
   { "method": "GET", "path": "/openlibrary/search?q=Invented%20Book" },
+  { "method": "GET", "path": "/openlibrary/works/OL2618680W" },
+  { "method": "GET", "path": "/openlibrary/authors/OL381465A" },
+  { "method": "GET", "path": "/openlibrary/isbn/9780140328721" },
+  { "method": "GET", "path": "/music/search?query=Nebula%20Wraithcoil&type=artist" },
+  { "method": "GET", "path": "/music/artist/5b11f4ce-a62d-471e-81fc-a69a8278c7da" },
+  { "method": "GET", "path": "/music/release/eccae410-7577-4daa-b602-92d305828331" },
+  {
+    "method": "GET",
+    "path": "/music/release-group/1b022e01-4da6-387b-8658-8678046e4cef"
+  },
+  { "method": "GET", "path": "/music/recording/5fb524f1-8cc8-4c04-a921-e34c0a911ea7" },
+  {
+    "method": "GET",
+    "path": "/music/cover/eccae410-7577-4daa-b602-92d305828331",
+    "note": "Binary route (image/jpeg). Compared byte-for-byte in contract.test.ts, not as decoded text -- see the comment there on why a text/UTF-8 comparison cannot be trusted for binary bodies."
+  },
   {
     "method": "POST",
     "path": "/api/v1/subtitles/search",
-    "body": { "tmdb_id": 550, "media_type": "movie" }
+    "body": { "tmdb_id": 550, "media_type": "movie" },
+    "note": "This route's cache key is a SHA-256 of the request body (bodyFingerprint in cache/key.ts), not the URL, so the _cb cache-buster below is a no-op here -- see the comment in contract.test.ts for the Task 16 implication."
   },
   { "method": "POST", "path": "/api/v1/subtitles/search", "body": {} },
   {

--- a/relay-worker/test/contract/routes.json
+++ b/relay-worker/test/contract/routes.json
@@ -1,0 +1,46 @@
+[
+  { "method": "GET", "path": "/health" },
+  { "method": "GET", "path": "/configuration" },
+  { "method": "GET", "path": "/tmdb/genre/movie" },
+  { "method": "GET", "path": "/tmdb/genre/tv" },
+  { "method": "GET", "path": "/tmdb/movies/popular" },
+  { "method": "GET", "path": "/tmdb/tv/popular" },
+  { "method": "GET", "path": "/tmdb/movies/search?query=Quantum%20Harbour" },
+  { "method": "GET", "path": "/tmdb/tv/search?query=Glass%20Meridian" },
+  { "method": "GET", "path": "/tmdb/movies/550" },
+  {
+    "method": "GET",
+    "path": "/tmdb/movies/550?append_to_response=credits,keywords,images,videos,recommendations,release_dates"
+  },
+  { "method": "GET", "path": "/tmdb/tv/shows/1399" },
+  {
+    "method": "GET",
+    "path": "/tmdb/tv/shows/1399?append_to_response=credits,content_ratings"
+  },
+  { "method": "GET", "path": "/tmdb/tv/shows/1399/images" },
+  { "method": "GET", "path": "/tmdb/tv/shows/1399/2" },
+  { "method": "GET", "path": "/tmdb/movies/550/images" },
+  { "method": "GET", "path": "/tmdb/collections/131296" },
+  { "method": "GET", "path": "/tvdb/search?query=Glass%20Meridian" },
+  { "method": "GET", "path": "/tvdb/series/331753" },
+  { "method": "GET", "path": "/tvdb/series/331753/extended" },
+  { "method": "GET", "path": "/tvdb/series/331753/episodes" },
+  { "method": "GET", "path": "/tvdb/series/999999999" },
+  { "method": "GET", "path": "/openlibrary/search?q=Invented%20Book" },
+  {
+    "method": "POST",
+    "path": "/api/v1/subtitles/search",
+    "body": { "tmdb_id": 550, "media_type": "movie" }
+  },
+  { "method": "POST", "path": "/api/v1/subtitles/search", "body": {} },
+  {
+    "method": "GET",
+    "path": "/api/v1/subtitles/download-url/bm90LWEtcmVhbC1maWxl"
+  },
+  {
+    "method": "GET",
+    "path": "/api/v1/subtitles/download/bm90LWEtcmVhbC1maWxl"
+  },
+  { "method": "GET", "path": "/tmdb/movies/999999999" },
+  { "method": "GET", "path": "/nope/not/a/route" }
+]

--- a/relay-worker/test/contract/routes.json
+++ b/relay-worker/test/contract/routes.json
@@ -27,7 +27,7 @@
   {
     "method": "GET",
     "path": "/tvdb/series/331753/episodes",
-    "note": "Both sides currently 400. TVDB's own OpenAPI spec defines this endpoint as GET /series/{id}/episodes/{season-type} with `page` as a QUERY parameter, but handler.ex bakes the page number into the path instead (.../episodes/default/page/{N}), which has never been a valid TVDB path -- confirmed against TVDB's spec, not guessed. mydia's own client never calls this route (it gets episodes from the *_extended endpoints), so the bug went unnoticed. Do NOT fix the Worker to work around this: it is deliberately bug-compatible with the Elixir during the port. This entry proves the two sides fail identically, not that the route works -- see task-9-report.md."
+    "note": "Both sides currently 400. TVDB's own OpenAPI spec defines this endpoint as GET /series/{id}/episodes/{season-type} with `page` as a QUERY parameter, but handler.ex bakes the page number into the path instead (.../episodes/default/page/{N}), which has never been a valid TVDB path -- confirmed against TVDB's spec, not guessed. mydia's own client never calls this route (it gets episodes from the *_extended endpoints), so the bug went unnoticed. Do NOT fix the Worker to work around this: it is deliberately bug-compatible with the Elixir during the port. This entry proves the two sides fail identically, not that the route works."
   },
   { "method": "GET", "path": "/tvdb/series/999999999" },
   { "method": "GET", "path": "/tvdb/seasons/720595" },
@@ -42,7 +42,7 @@
   {
     "method": "GET",
     "path": "/music/search?query=Nebula%20Wraithcoil&type=artist",
-    "note": "Fuzzy-ranked full-text search over MusicBrainz's live index, not an exact-id lookup. Result order, per-entry `score`, and the top-level `count` can all differ between two near-simultaneous identical requests -- observed directly: one live contract run failed here with a shifted `count` and reordered/rescored artist entries, then passed 552ms later in isolation and 42/42 on the next full run. A single failure on this route is not by itself evidence the Worker's music port regressed -- retry it alone before concluding that. See task-9-report.md's non-determinism section."
+    "note": "Fuzzy-ranked full-text search over MusicBrainz's live index, not an exact-id lookup. Result order, per-entry `score`, and the top-level `count` can all differ between two near-simultaneous identical requests -- observed directly: one live contract run failed here with a shifted `count` and reordered/rescored artist entries, then passed 552ms later in isolation and 42/42 on the next full run. A single failure on this route is not by itself evidence the Worker's music port regressed -- retry it alone before concluding that."
   },
   { "method": "GET", "path": "/music/artist/5b11f4ce-a62d-471e-81fc-a69a8278c7da" },
   { "method": "GET", "path": "/music/release/eccae410-7577-4daa-b602-92d305828331" },
@@ -60,7 +60,7 @@
     "method": "POST",
     "path": "/api/v1/subtitles/search",
     "body": { "tmdb_id": 550, "media_type": "movie" },
-    "note": "This route's cache key is a SHA-256 of the request body (bodyFingerprint in cache/key.ts), not the URL, so the _cb cache-buster below is a no-op here -- see the comment in contract.test.ts for the Task 16 implication."
+    "note": "This route's cache key is a SHA-256 of the request body (bodyFingerprint in cache/key.ts), not the URL, so the _cb cache-buster below is a no-op here -- see the comment in contract.test.ts for what that means when comparing against a real deployed Worker."
   },
   { "method": "POST", "path": "/api/v1/subtitles/search", "body": {} },
   {

--- a/relay-worker/test/contract/routes.json
+++ b/relay-worker/test/contract/routes.json
@@ -39,7 +39,11 @@
   { "method": "GET", "path": "/openlibrary/works/OL2618680W" },
   { "method": "GET", "path": "/openlibrary/authors/OL381465A" },
   { "method": "GET", "path": "/openlibrary/isbn/9780140328721" },
-  { "method": "GET", "path": "/music/search?query=Nebula%20Wraithcoil&type=artist" },
+  {
+    "method": "GET",
+    "path": "/music/search?query=Nebula%20Wraithcoil&type=artist",
+    "note": "Fuzzy-ranked full-text search over MusicBrainz's live index, not an exact-id lookup. Result order, per-entry `score`, and the top-level `count` can all differ between two near-simultaneous identical requests -- observed directly: one live contract run failed here with a shifted `count` and reordered/rescored artist entries, then passed 552ms later in isolation and 42/42 on the next full run. A single failure on this route is not by itself evidence the Worker's music port regressed -- retry it alone before concluding that. See task-9-report.md's non-determinism section."
+  },
   { "method": "GET", "path": "/music/artist/5b11f4ce-a62d-471e-81fc-a69a8278c7da" },
   { "method": "GET", "path": "/music/release/eccae410-7577-4daa-b602-92d305828331" },
   {

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -397,4 +397,71 @@ describe("POST /crashes/report", () => {
     });
     expect(res.status).toBe(400);
   });
+
+  // Final-review CRITICAL: every test above drives requests sequentially,
+  // which is structurally blind to a defect that only appears under
+  // concurrency. The original read-then-separate-write shape (SELECT the
+  // bucket, decide in JS, then issue independent INSERT ... ON CONFLICT DO
+  // UPDATE statements) is not a transaction -- D1 only guarantees ordering
+  // within one statement or a .batch(), not across two independent
+  // .prepare()/.run() calls -- so concurrent identical requests could all
+  // read the same pre-increment state and all decide to admit. Measured
+  // against the pre-fix code: 20 concurrent identical crash reports produced
+  // 142 total D1 writes and an occurrence_count nowhere near the 3-per-hour
+  // cap. Promise.all (not a for loop) is what actually exercises the race;
+  // a for loop with awaited iterations is sequential in disguise.
+  it("bounds occurrence_count and total writes under REAL concurrency (Promise.all), not just sequentially", async () => {
+    const kind = "ConcurrentStorm";
+    const ip = "198.51.100.201";
+    const payload = {
+      error_type: kind,
+      error_message: "concurrent boom",
+      stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 5 }],
+    };
+
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        SELF.fetch(REPORT_URL, {
+          method: "POST",
+          headers: { ...json, "cf-connecting-ip": ip },
+          body: JSON.stringify(payload),
+        }),
+      ),
+    );
+
+    // The producer contract holds regardless of admission: every one of the
+    // 20 concurrent requests still gets 201 (Sender only retries on a
+    // non-201 status), whether or not this particular request's crash was
+    // actually counted.
+    for (const res of responses) {
+      expect(res.status).toBe(201);
+    }
+
+    const error = await env.DB.prepare(
+      "SELECT fingerprint, occurrence_count FROM errors WHERE kind = ?",
+    )
+      .bind(kind)
+      .first<{ fingerprint: string; occurrence_count: number }>();
+
+    // The atomic admission decision (a single INSERT ... ON CONFLICT DO
+    // UPDATE ... RETURNING per request) guarantees the SAME exact cap holds
+    // under concurrency as under the sequential test above -- not merely "a
+    // smaller number than before".
+    expect(error!.occurrence_count).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
+
+    const occurrences = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM occurrences WHERE fingerprint = ?",
+    )
+      .bind(error!.fingerprint)
+      .first<{ n: number }>();
+    expect(occurrences!.n).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
+
+    const bucket = await env.DB.prepare(
+      "SELECT written, saturated FROM ingest_buckets WHERE fingerprint = ? AND instance_key = ?",
+    )
+      .bind(error!.fingerprint, ip)
+      .first<{ written: number; saturated: number }>();
+    expect(bucket!.written).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
+    expect(bucket!.saturated).toBe(1);
+  });
 });

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -1,13 +1,45 @@
 import { env, SELF, applyD1Migrations } from "cloudflare:test";
 import { describe, it, expect, beforeAll } from "vitest";
-import { normalizeCrashReport } from "../../src/crashes/ingest";
+import { normalizeCrashReport, MAX_OCCURRENCE_ROWS_PER_BUCKET } from "../../src/crashes/ingest";
 
 const json = { "content-type": "application/json" };
+const REPORT_URL = "https://relay.mydia.dev/crashes/report";
 
 interface ReportResponse {
   status: string;
   message: string;
   id: string;
+}
+
+interface ValidationErrorResponse {
+  error: string;
+  errors: string[];
+}
+
+interface TableCounts {
+  errors: number;
+  occurrences: number;
+  buckets: number;
+}
+
+// Table ROW COUNTS are the wrong instrument for proving writes are bounded --
+// an INSERT ... ON CONFLICT DO UPDATE against an existing row doesn't change
+// COUNT(*), even though D1 bills it as a write every time (confirmed against
+// D1's own `meta.rows_written` during fix round 1's review). This is exactly
+// why the original storm test's `occurrences.n < 10` assertion missed the
+// real defect: the `errors` and `ingest_buckets` rows were being upserted on
+// every single request, and COUNT(*) on either table stayed at 1 the whole
+// time regardless. Used below only for the "nothing was written at all"
+// (validation-rejected) and "exactly one row landed" (happy path) cases,
+// where the before/after DELTA in row count is the right signal; the
+// write-bounding test itself sums `x-relay-d1-writes` instead.
+async function tableCounts(): Promise<TableCounts> {
+  const [errors, occurrences, buckets] = await Promise.all([
+    env.DB.prepare("SELECT COUNT(*) AS n FROM errors").first<{ n: number }>(),
+    env.DB.prepare("SELECT COUNT(*) AS n FROM occurrences").first<{ n: number }>(),
+    env.DB.prepare("SELECT COUNT(*) AS n FROM ingest_buckets").first<{ n: number }>(),
+  ]);
+  return { errors: errors!.n, occurrences: occurrences!.n, buckets: buckets!.n };
 }
 
 beforeAll(async () => {
@@ -82,8 +114,10 @@ describe("normalizeCrashReport", () => {
 });
 
 describe("POST /crashes/report", () => {
-  it("accepts a report and creates the error group", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+  it("accepts a report, creates the error group, and writes exactly one row per table", async () => {
+    const before = await tableCounts();
+
+    const res = await SELF.fetch(REPORT_URL, {
       method: "POST",
       headers: json,
       body: JSON.stringify({
@@ -111,6 +145,13 @@ describe("POST /crashes/report", () => {
       .bind("RuntimeError")
       .first();
     expect(row).toMatchObject({ kind: "RuntimeError", occurrence_count: 1 });
+
+    const after = await tableCounts();
+    expect(after).toEqual({
+      errors: before.errors + 1,
+      occurrences: before.occurrences + 1,
+      buckets: before.buckets + 1,
+    });
   });
 
   it("groups two identical crashes under one fingerprint", async () => {
@@ -121,7 +162,7 @@ describe("POST /crashes/report", () => {
     };
 
     for (let i = 0; i < 2; i++) {
-      await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+      await SELF.fetch(REPORT_URL, {
         method: "POST",
         headers: json,
         body: JSON.stringify(payload),
@@ -138,42 +179,218 @@ describe("POST /crashes/report", () => {
     expect(results[0].occurrence_count).toBe(2);
   });
 
-  it("counts a crash storm but stops writing occurrence rows for it", async () => {
+  // Fix round 1's critical finding: the original implementation upserted
+  // `errors` and `ingest_buckets` UNCONDITIONALLY on every request, before
+  // even checking the cap -- only the `occurrences` insert was actually
+  // throttled. D1 counts an `ON CONFLICT DO UPDATE` as a write on every call
+  // whether it inserts or updates, so a storm of N requests performed ~2N
+  // writes: the install that could exhaust the daily budget before this fix
+  // could still exhaust it after, needing only the same order of magnitude
+  // of requests.
+  //
+  // This sums the actual D1 writes each request performs (exposed via the
+  // x-relay-d1-writes response header, since the test has no other way to
+  // observe meta.rows_written from inside the Worker's own request handling)
+  // rather than inspecting table row counts, which can't tell an
+  // unconditional UPDATE from a skipped one.
+  //
+  // It deliberately does NOT assert an exact write total: a single INSERT
+  // touches its table's own B-tree plus one per index (including the
+  // implicit autoindex a non-INTEGER PRIMARY KEY creates), so the true
+  // per-request cost is a small implementation detail of the schema, not a
+  // clean constant -- measured at 9, 7, and 7 writes for the three requests
+  // that actually write, once for each of errors/ingest_buckets/occurrences
+  // in this schema. What must hold regardless of that detail is the actual
+  // invariant this task cares about: a storm 10x larger performs the SAME
+  // total writes, not 10x more, because writes stop entirely once the
+  // bucket saturates.
+  it("performs the same total D1 writes for a small and a large crash storm", async () => {
+    async function totalWritesFor(kind: string, ip: string, count: number): Promise<number> {
+      let total = 0;
+      for (let i = 0; i < count; i++) {
+        const res = await SELF.fetch(REPORT_URL, {
+          method: "POST",
+          headers: { ...json, "cf-connecting-ip": ip },
+          body: JSON.stringify({
+            error_type: kind,
+            error_message: "loop",
+            stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 11 }],
+          }),
+        });
+        expect(res.status).toBe(201);
+        total += Number(res.headers.get("x-relay-d1-writes") ?? "0");
+      }
+      return total;
+    }
+
+    // Both counts exceed MAX_OCCURRENCE_ROWS_PER_BUCKET, so both storms
+    // saturate partway through -- different fingerprints/instances so they
+    // can't share (and thus contaminate) a bucket.
+    const smallStorm = await totalWritesFor("WriteBoundSmall", "198.51.100.61", 5);
+    const bigStorm = await totalWritesFor("WriteBoundBig", "198.51.100.63", 50);
+
+    expect(bigStorm).toBe(smallStorm);
+    // Sanity bound well under what unconditional per-request upserts (the
+    // pre-fix behaviour) would cost 50 requests: observed 23, asserted <50
+    // to avoid coupling this test to the schema's exact index count.
+    expect(bigStorm).toBeLessThan(50);
+  });
+
+  it("caps occurrence_count and marks the bucket saturated once a storm exceeds the per-hour budget", async () => {
     const payload = {
       error_type: "StormError",
       error_message: "loop",
       stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 9 }],
     };
+    const ip = "198.51.100.7";
 
     for (let i = 0; i < 50; i++) {
-      await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+      await SELF.fetch(REPORT_URL, {
         method: "POST",
-        headers: { ...json, "cf-connecting-ip": "198.51.100.7" },
+        headers: { ...json, "cf-connecting-ip": ip },
         body: JSON.stringify(payload),
       });
     }
 
     const error = await env.DB.prepare(
-      "SELECT occurrence_count FROM errors WHERE kind = ?",
+      "SELECT fingerprint, occurrence_count FROM errors WHERE kind = ?",
     )
       .bind("StormError")
-      .first<{ occurrence_count: number }>();
+      .first<{ fingerprint: string; occurrence_count: number }>();
 
     const occurrences = await env.DB.prepare(
-      `SELECT COUNT(*) AS n FROM occurrences
-       WHERE fingerprint = (SELECT fingerprint FROM errors WHERE kind = ?)`,
+      "SELECT COUNT(*) AS n FROM occurrences WHERE fingerprint = ?",
     )
-      .bind("StormError")
+      .bind(error!.fingerprint)
       .first<{ n: number }>();
 
-    // Every crash is counted.
-    expect(error!.occurrence_count).toBe(50);
-    // But the write budget is bounded: far fewer rows than reports.
-    expect(occurrences!.n).toBeLessThan(10);
+    const bucket = await env.DB.prepare(
+      "SELECT written, saturated FROM ingest_buckets WHERE fingerprint = ? AND instance_key = ?",
+    )
+      .bind(error!.fingerprint, ip)
+      .first<{ written: number; saturated: number }>();
+
+    // occurrence_count is now a FLOOR once saturated, not an exact count of
+    // every crash received -- this is the deliberate trade-off fix round 1
+    // mandated in exchange for bounding writes (superseding this task's
+    // original "every crash is still counted" goal). `saturated` is what
+    // lets a reader tell the two apart instead of silently presenting an
+    // undercount as exact.
+    expect(error!.occurrence_count).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
+    expect(occurrences!.n).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
+    expect(bucket!.written).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
+    expect(bucket!.saturated).toBe(1);
+  });
+
+  // router.ex's validate_crash_report/1 requires error_type, error_message
+  // and stacktrace to be PRESENT KEYS (Map.has_key?, any value including
+  // null satisfies it) before it stores anything, returning 400 with no
+  // write when they're missing. The Worker had no equivalent gate: since a
+  // bare `{}` always normalises to the same kind/topKey and the errors
+  // upsert was unthrottled, this was a second, EASIER route to budget
+  // exhaustion than a crash loop -- no throttling applies to a fingerprint
+  // that's never been seen before, so repeated anonymous POSTs of `{}` to
+  // this unauthenticated endpoint could each mint a fresh write.
+  describe("required-field validation (matches router.ex's Map.has_key? gate)", () => {
+    it("rejects an empty object with zero rows written anywhere", async () => {
+      const before = await tableCounts();
+
+      const res = await SELF.fetch(REPORT_URL, {
+        method: "POST",
+        headers: json,
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json<ValidationErrorResponse>();
+      expect(body.error).toBe("Validation failed");
+      expect(body.errors).toEqual(
+        expect.arrayContaining([
+          "Missing required field: error_type",
+          "Missing required field: error_message",
+          "Missing required field: stacktrace",
+        ]),
+      );
+
+      expect(await tableCounts()).toEqual(before);
+    });
+
+    it("rejects a payload missing only stacktrace, with zero rows written", async () => {
+      const before = await tableCounts();
+
+      const res = await SELF.fetch(REPORT_URL, {
+        method: "POST",
+        headers: json,
+        body: JSON.stringify({
+          error_type: "SomeError",
+          error_message: "no stacktrace field at all",
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json<ValidationErrorResponse>();
+      expect(body.errors).toEqual(["Missing required field: stacktrace"]);
+
+      expect(await tableCounts()).toEqual(before);
+    });
+
+    it("rejects a non-list stacktrace even when the key is present", async () => {
+      const res = await SELF.fetch(REPORT_URL, {
+        method: "POST",
+        headers: json,
+        body: JSON.stringify({
+          error_type: "SomeError",
+          error_message: "stacktrace is a string, not a list",
+          stacktrace: "not-a-list",
+        }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json<ValidationErrorResponse>();
+      expect(body.errors).toContain("stacktrace must be a list");
+    });
+  });
+
+  // Prior schema keyed ingest_buckets on (fingerprint, instance_key,
+  // hour_bucket), so this table grew by one row per fingerprint/instance for
+  // every hour that ever elapsed, forever -- unbounded by anything but
+  // wall-clock time. The fixed schema keys on (fingerprint, instance_key)
+  // alone and treats hour_bucket as a column that gets reset in place.
+  it("does not multiply bucket rows across hour boundaries for the same fingerprint/instance", async () => {
+    const ip = "198.51.100.62";
+    const reportAt = (occurredAt: string) =>
+      SELF.fetch(REPORT_URL, {
+        method: "POST",
+        headers: { ...json, "cf-connecting-ip": ip },
+        body: JSON.stringify({
+          error_type: "HourRollover",
+          error_message: "boom",
+          stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 42 }],
+          occurred_at: occurredAt,
+        }),
+      });
+
+    await reportAt("2026-01-01T00:10:00.000Z");
+    await reportAt("2026-01-01T05:45:00.000Z"); // a different hour bucket entirely
+
+    const error = await env.DB.prepare("SELECT fingerprint FROM errors WHERE kind = ?")
+      .bind("HourRollover")
+      .first<{ fingerprint: string }>();
+
+    const { results } = await env.DB.prepare(
+      "SELECT hour_bucket, written FROM ingest_buckets WHERE fingerprint = ? AND instance_key = ?",
+    )
+      .bind(error!.fingerprint, ip)
+      .all<{ hour_bucket: number; written: number }>();
+
+    expect(results).toHaveLength(1);
+    // The stored hour_bucket tracks the most recent request's hour, and its
+    // budget was reset for that hour rather than carried over.
+    expect(results[0].written).toBe(1);
   });
 
   it("rejects a body that is not JSON", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+    const res = await SELF.fetch(REPORT_URL, {
       method: "POST",
       headers: json,
       body: "not json",

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -1,0 +1,183 @@
+import { env, SELF, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { normalizeCrashReport } from "../../src/crashes/ingest";
+
+const json = { "content-type": "application/json" };
+
+interface ReportResponse {
+  status: string;
+  message: string;
+  id: string;
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+describe("normalizeCrashReport", () => {
+  it("uses the reported error type as the kind", () => {
+    const out = normalizeCrashReport({
+      error_type: "Ecto.NoResultsError",
+      error_message: "expected at least one result",
+      stacktrace: [{ module: "Mydia.Media", function: "get!/1", file: "media.ex", line: 12 }],
+    });
+
+    expect(out.kind).toBe("Ecto.NoResultsError");
+    expect(out.message).toBe("expected at least one result");
+  });
+
+  it("defaults kind and message when the payload omits them", () => {
+    const out = normalizeCrashReport({});
+    expect(out.kind).toBe("RuntimeError");
+    expect(out.message).toBe("Unknown error");
+  });
+
+  it("synthesises a frame from metadata when no stacktrace is supplied", () => {
+    // Without any source info every report would derive the same fingerprint
+    // and collapse into one useless group.
+    const out = normalizeCrashReport({
+      error_type: "ArgumentError",
+      error_message: "bad arg",
+      metadata: { module: "Mydia.Library", function: "scan/1", file: "library.ex", line: 88 },
+    });
+
+    expect(out.stacktrace).toHaveLength(1);
+    expect(out.sourceFile).toBe("library.ex");
+    expect(out.sourceLine).toBe(88);
+  });
+
+  // router.ex's metadata_stack_frame/1 only synthesises a frame when metadata
+  // carries `file` or `line` -- module/function alone are not enough (they
+  // get folded into the frame if a frame is built, but they don't trigger
+  // building one). Getting this backwards would mean a report that names a
+  // module/function but has no location either loses its distinguishing
+  // frame (falls back to "no-frame", the same group as every other
+  // location-less report) or, worse, incorrectly keeps location-less reports
+  // apart when router.ex would have grouped them.
+  it("does not synthesise a frame from metadata that has no file or line", () => {
+    const out = normalizeCrashReport({
+      error_type: "ArgumentError",
+      error_message: "bad arg",
+      metadata: { module: "Mydia.Library", function: "scan/1" },
+    });
+
+    expect(out.stacktrace).toHaveLength(0);
+    expect(out.sourceFile).toBeNull();
+    expect(out.sourceLine).toBeNull();
+  });
+
+  // Mydia.CrashReporter.build_report/3 sends `occurred_at` as
+  // `DateTime.to_iso8601/1` -- a string, never a Unix number. A check that
+  // only accepts `typeof === "number"` silently discards this field on every
+  // real report and substitutes ingestion time instead.
+  it("parses an ISO8601 occurred_at as sent by Mydia.CrashReporter", () => {
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      occurred_at: "2026-01-15T10:30:00.000000Z",
+    });
+
+    expect(out.occurredAt).toBe(Math.floor(Date.parse("2026-01-15T10:30:00.000000Z") / 1000));
+  });
+});
+
+describe("POST /crashes/report", () => {
+  it("accepts a report and creates the error group", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({
+        error_type: "RuntimeError",
+        error_message: "boom",
+        version: "1.2.3",
+        environment: "prod",
+        stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 1 }],
+      }),
+    });
+
+    // Mydia.CrashReporter.Sender.send_http_request/2 pattern-matches on
+    // exactly {status: 201, body: response} as its success case; anything
+    // else (including a plausible-looking 202) falls through to the
+    // catch-all "unexpected HTTP status" branch, which is logged as a
+    // failure and retried by Queue until it is discarded. 201 is not
+    // cosmetic here.
+    expect(res.status).toBe(201);
+    const resBody = await res.json<ReportResponse>();
+    expect(resBody.status).toBe("created");
+
+    const row = await env.DB.prepare(
+      "SELECT kind, occurrence_count FROM errors WHERE kind = ?",
+    )
+      .bind("RuntimeError")
+      .first();
+    expect(row).toMatchObject({ kind: "RuntimeError", occurrence_count: 1 });
+  });
+
+  it("groups two identical crashes under one fingerprint", async () => {
+    const payload = {
+      error_type: "GroupMe",
+      error_message: "same",
+      stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 7 }],
+    };
+
+    for (let i = 0; i < 2; i++) {
+      await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+        method: "POST",
+        headers: json,
+        body: JSON.stringify(payload),
+      });
+    }
+
+    const { results } = await env.DB.prepare(
+      "SELECT occurrence_count FROM errors WHERE kind = ?",
+    )
+      .bind("GroupMe")
+      .all();
+
+    expect(results).toHaveLength(1);
+    expect(results[0].occurrence_count).toBe(2);
+  });
+
+  it("counts a crash storm but stops writing occurrence rows for it", async () => {
+    const payload = {
+      error_type: "StormError",
+      error_message: "loop",
+      stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 9 }],
+    };
+
+    for (let i = 0; i < 50; i++) {
+      await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+        method: "POST",
+        headers: { ...json, "cf-connecting-ip": "198.51.100.7" },
+        body: JSON.stringify(payload),
+      });
+    }
+
+    const error = await env.DB.prepare(
+      "SELECT occurrence_count FROM errors WHERE kind = ?",
+    )
+      .bind("StormError")
+      .first<{ occurrence_count: number }>();
+
+    const occurrences = await env.DB.prepare(
+      `SELECT COUNT(*) AS n FROM occurrences
+       WHERE fingerprint = (SELECT fingerprint FROM errors WHERE kind = ?)`,
+    )
+      .bind("StormError")
+      .first<{ n: number }>();
+
+    // Every crash is counted.
+    expect(error!.occurrence_count).toBe(50);
+    // But the write budget is bounded: far fewer rows than reports.
+    expect(occurrences!.n).toBeLessThan(10);
+  });
+
+  it("rejects a body that is not JSON", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/crashes/report", {
+      method: "POST",
+      headers: json,
+      body: "not json",
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/relay-worker/test/dashboards/errors.test.ts
+++ b/relay-worker/test/dashboards/errors.test.ts
@@ -138,6 +138,20 @@ describe("GET /admin/errors", () => {
     const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
     expect(html).toContain(`href="/admin/errors/${FP1}"`);
   });
+
+  // Mirrors dashboards/feedback.test.ts's identical regression guard: GET
+  // /errors must not be a second, unauthenticated way to reach maintainer
+  // crash data now that the real dashboard lives at /admin/errors --
+  // whatever this returns, it must not be the dashboard.
+  // registerErrorDashboard only registers routes under /admin/errors, so
+  // this falls through to the app-wide 404 catch-all in src/index.ts.
+  it("no longer serves the dashboard at the old /errors path", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/errors");
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    expect(body).not.toContain("RuntimeError");
+    expect(body).not.toContain("<table");
+  });
 });
 
 // IMPORTANT-1 fix-round-1 finding: `Number(c.req.query("page") ?? "0")` fed

--- a/relay-worker/test/dashboards/errors.test.ts
+++ b/relay-worker/test/dashboards/errors.test.ts
@@ -212,9 +212,9 @@ describe("POST /admin/errors/:fingerprint/resolve validates the fingerprint shap
   });
 });
 
-// Task 11's ingest throttle stops counting (and stops writing new rows) once
+// The ingest throttle stops counting (and stops writing new rows) once
 // a fingerprint/instance/hour bucket saturates. errors.count_is_floor
-// (fix-round-1) is the durable record of that, distinct from
+// is the durable record of that, distinct from
 // ingest_buckets.saturated, which resets the moment a fresh hour's write
 // lands for the same fingerprint/instance -- see 0002_crash_reports.sql.
 describe("GET /admin/errors occurrence count vs. ingest throttling", () => {

--- a/relay-worker/test/dashboards/errors.test.ts
+++ b/relay-worker/test/dashboards/errors.test.ts
@@ -1,6 +1,16 @@
 import { env, SELF, applyD1Migrations } from "cloudflare:test";
 import { describe, it, expect, beforeAll } from "vitest";
 import { escapeHtml } from "../../src/dashboards/layout";
+import { MAX_OCCURRENCE_ROWS_PER_BUCKET } from "../../src/crashes/ingest";
+
+// Resolve/unresolve now validate the :fingerprint path segment against
+// fingerprintOf's real shape (32 lowercase hex chars) before touching D1 or
+// building a redirect, so every fixture exercised through those two routes
+// needs a realistic-looking fingerprint rather than a short mnemonic string.
+// GET routes never validate shape (D1 handles an arbitrary string safely and
+// simply returns no row), so list/detail/escaping-only tests keep their
+// short fixture names below.
+const FP1 = "a1b2c3d4e5f60718293a4b5c6d7e8f90";
 
 beforeAll(async () => {
   await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
@@ -8,9 +18,9 @@ beforeAll(async () => {
   await env.DB.prepare(
     `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
                          status, first_seen_at, last_seen_at, occurrence_count)
-     VALUES ('fp1', 'RuntimeError', 'boom', 'm.ex', 3, 'unresolved', ?, ?, 7)`,
+     VALUES (?, 'RuntimeError', 'boom', 'm.ex', 3, 'unresolved', ?, ?, 7)`,
   )
-    .bind(now, now)
+    .bind(FP1, now, now)
     .run();
 });
 
@@ -35,7 +45,7 @@ describe("GET /errors", () => {
   });
 
   it("shows a single error group with its occurrences", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/errors/fp1");
+    const res = await SELF.fetch(`https://relay.mydia.dev/errors/${FP1}`);
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("RuntimeError");
   });
@@ -49,16 +59,41 @@ describe("GET /errors", () => {
     // fetch()'s default `redirect: "follow"` would otherwise chase the 303
     // and hand back the followed page's 200, hiding the redirect status this
     // assertion cares about.
-    const res = await SELF.fetch("https://relay.mydia.dev/errors/fp1/resolve", {
+    const res = await SELF.fetch(`https://relay.mydia.dev/errors/${FP1}/resolve`, {
       method: "POST",
       redirect: "manual",
     });
     expect(res.status).toBe(303);
 
     const row = await env.DB.prepare(
-      "SELECT status FROM errors WHERE fingerprint = 'fp1'",
-    ).first<{ status: string }>();
+      "SELECT status FROM errors WHERE fingerprint = ?",
+    )
+      .bind(FP1)
+      .first<{ status: string }>();
     expect(row!.status).toBe("resolved");
+  });
+
+  // MINOR fix-round-1 gap: only resolve had a test; unresolve is the other
+  // half of the same write-mutating pair and got none.
+  it("unresolves a group and reflects the new status", async () => {
+    const resolveRes = await SELF.fetch(`https://relay.mydia.dev/errors/${FP1}/resolve`, {
+      method: "POST",
+      redirect: "manual",
+    });
+    expect(resolveRes.status).toBe(303);
+
+    const unresolveRes = await SELF.fetch(
+      `https://relay.mydia.dev/errors/${FP1}/unresolve`,
+      { method: "POST", redirect: "manual" },
+    );
+    expect(unresolveRes.status).toBe(303);
+
+    const row = await env.DB.prepare(
+      "SELECT status FROM errors WHERE fingerprint = ?",
+    )
+      .bind(FP1)
+      .first<{ status: string }>();
+    expect(row!.status).toBe("unresolved");
   });
 
   it("never renders a crash message as raw HTML", async () => {
@@ -100,21 +135,74 @@ describe("GET /errors", () => {
   // be escaped defensively rather than trusted because "the input happens to
   // be safe today".
   it("escapes the fingerprint used to build occurrence links", async () => {
-    const found = await env.DB.prepare(
-      "SELECT fingerprint FROM errors WHERE kind = 'RuntimeError' AND message = 'boom'",
-    ).first<{ fingerprint: string }>();
-
     const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
-    expect(html).toContain(`href="/errors/${found!.fingerprint}"`);
+    expect(html).toContain(`href="/errors/${FP1}"`);
+  });
+});
+
+// IMPORTANT-1 fix-round-1 finding: `Number(c.req.query("page") ?? "0")` fed
+// straight into a D1 OFFSET with no guard. Each of these five inputs was
+// confirmed to throw `D1_ERROR: datatype mismatch`, surfaced as an unhandled
+// Hono 500, before the fix -- on an endpoint that is unauthenticated today.
+describe("GET /errors?page= guards against hostile input", () => {
+  const hostileValues = ["abc", "NaN", "Infinity", "1e300", "99999999999999999999"];
+
+  it.each(hostileValues)("does not 500 for page=%s", async (value) => {
+    const res = await SELF.fetch(
+      `https://relay.mydia.dev/errors?page=${encodeURIComponent(value)}`,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("still paginates normally for an ordinary page number", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/errors?page=1");
+    expect(res.status).toBe(200);
+  });
+
+  it("clamps a negative page to the first page instead of erroring", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/errors?page=-5");
+    expect(res.status).toBe(200);
+  });
+});
+
+// IMPORTANT-2 fix-round-1 finding: c.redirect() builds the Location header
+// from the raw, decoded :fingerprint param. A value containing a CRLF
+// sequence made the underlying Headers implementation throw -- fails safe
+// (no header injection actually lands; the runtime itself rejects the
+// control characters, and the fixed "/errors/" prefix rules out an open
+// redirect either way) but still surfaced as an unhandled 500 rather than a
+// clean 404, on an endpoint that is unauthenticated today.
+describe("POST /errors/:fingerprint/resolve validates the fingerprint shape first", () => {
+  it("returns 404, not a 500, for a CRLF-injected fingerprint segment", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/errors/abc%0D%0AInjected/resolve",
+      { method: "POST", redirect: "manual" },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a non-hex fingerprint", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/errors/not-a-real-fingerprint/resolve",
+      { method: "POST", redirect: "manual" },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("also validates on the unresolve route", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/errors/abc%0D%0AInjected/unresolve",
+      { method: "POST", redirect: "manual" },
+    );
+    expect(res.status).toBe(404);
   });
 });
 
 // Task 11's ingest throttle stops counting (and stops writing new rows) once
-// a fingerprint/instance/hour bucket saturates: ingest_buckets.saturated
-// records that occurrence_count is a FLOOR, not an exact total, for the rest
-// of that hour. A dashboard that prints occurrence_count as a plain number
-// presents a throttled undercount as if it were precise -- worst exactly
-// when an operator most needs the real number, during a crash storm.
+// a fingerprint/instance/hour bucket saturates. errors.count_is_floor
+// (fix-round-1) is the durable record of that, distinct from
+// ingest_buckets.saturated, which resets the moment a fresh hour's write
+// lands for the same fingerprint/instance -- see 0002_crash_reports.sql.
 describe("GET /errors occurrence count vs. ingest throttling", () => {
   const SATURATED_FP = "fpsaturated";
 
@@ -122,16 +210,10 @@ describe("GET /errors occurrence count vs. ingest throttling", () => {
     const now = Math.floor(Date.now() / 1000);
     await env.DB.prepare(
       `INSERT INTO errors (fingerprint, kind, message, status,
-                           first_seen_at, last_seen_at, occurrence_count)
-       VALUES (?, 'StormError', 'storm', 'unresolved', ?, ?, 3)`,
+                           first_seen_at, last_seen_at, occurrence_count, count_is_floor)
+       VALUES (?, 'StormError', 'storm', 'unresolved', ?, ?, 3, 1)`,
     )
       .bind(SATURATED_FP, now, now)
-      .run();
-    await env.DB.prepare(
-      `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, written, saturated)
-       VALUES (?, 'some-instance', ?, 3, 1)`,
-    )
-      .bind(SATURATED_FP, Math.floor(now / 3600))
       .run();
   });
 
@@ -147,9 +229,9 @@ describe("GET /errors occurrence count vs. ingest throttling", () => {
 
   it("does not mark an unsaturated fingerprint's count as a floor", async () => {
     const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
-    // fp1's own row (found via its detail link), bounded to just that <tr>
+    // FP1's own row (found via its detail link), bounded to just that <tr>
     // so a neighbouring saturated row's markup can't leak into the slice.
-    const linkIndex = html.indexOf('href="/errors/fp1"');
+    const linkIndex = html.indexOf(`href="/errors/${FP1}"`);
     expect(linkIndex).toBeGreaterThan(-1);
     const rowEnd = html.indexOf("</tr>", linkIndex);
     const rowSlice = html.slice(linkIndex, rowEnd);
@@ -161,5 +243,150 @@ describe("GET /errors occurrence count vs. ingest throttling", () => {
       await SELF.fetch(`https://relay.mydia.dev/errors/${SATURATED_FP}`)
     ).text();
     expect(html).toMatch(/&ge;|≥|throttled|at least/i);
+  });
+});
+
+// The critical fix-round-1 finding, reproduced end-to-end through the real
+// ingest route rather than by hand-inserting rows: a bucket saturates, the
+// hour rolls over, and the same misbehaving install sends exactly one more
+// crash. Before this fix that one further request reset
+// ingest_buckets.saturated back to 0 in place, and the dashboard (which used
+// to read that live flag) started rendering a bare, precise-looking number
+// again -- permanently wrong, since the crashes dropped during the
+// saturated hour are gone forever.
+describe("the floor marker survives an hour rollover", () => {
+  function postCrash(kind: string, ip: string, occurredAtSeconds: number) {
+    return SELF.fetch("https://relay.mydia.dev/crashes/report", {
+      method: "POST",
+      headers: { "content-type": "application/json", "cf-connecting-ip": ip },
+      body: JSON.stringify({
+        error_type: kind,
+        error_message: "loop",
+        stacktrace: [{ module: "M", function: "f/0", file: "m.ex", line: 42 }],
+        occurred_at: new Date(occurredAtSeconds * 1000).toISOString(),
+      }),
+    });
+  }
+
+  it("keeps rendering the floor after the hour rolls over and one more crash arrives from the same instance", async () => {
+    const ip = "203.0.113.50";
+    const kind = "RolloverStorm";
+    const hourStart = 500_000 * 3600; // arbitrary hour, far from "now"
+
+    // Saturate the bucket within the first hour.
+    for (let i = 0; i < MAX_OCCURRENCE_ROWS_PER_BUCKET + 2; i++) {
+      await postCrash(kind, ip, hourStart + 10);
+    }
+
+    const fingerprintRow = await env.DB.prepare(
+      "SELECT fingerprint FROM errors WHERE kind = ?",
+    )
+      .bind(kind)
+      .first<{ fingerprint: string }>();
+    const fingerprint = fingerprintRow!.fingerprint;
+
+    const beforeRollover = await env.DB.prepare(
+      "SELECT count_is_floor, occurrence_count FROM errors WHERE fingerprint = ?",
+    )
+      .bind(fingerprint)
+      .first<{ count_is_floor: number; occurrence_count: number }>();
+    expect(beforeRollover!.count_is_floor).toBe(1);
+    expect(beforeRollover!.occurrence_count).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
+
+    // Roll the hour forward and send exactly ONE more crash from the SAME
+    // fingerprint and instance.
+    await postCrash(kind, ip, hourStart + 3600 + 10);
+
+    // Sanity: the transient per-hour flag really did reset -- this is
+    // precisely the scenario that used to erase the floor signal.
+    const bucket = await env.DB.prepare(
+      "SELECT hour_bucket, written, saturated FROM ingest_buckets WHERE fingerprint = ? AND instance_key = ?",
+    )
+      .bind(fingerprint, ip)
+      .first<{ hour_bucket: number; written: number; saturated: number }>();
+    expect(bucket!.saturated).toBe(0);
+    expect(bucket!.written).toBe(1);
+
+    const afterRollover = await env.DB.prepare(
+      "SELECT count_is_floor, occurrence_count FROM errors WHERE fingerprint = ?",
+    )
+      .bind(fingerprint)
+      .first<{ count_is_floor: number; occurrence_count: number }>();
+    // The durable flag must NOT reset, and the count keeps advancing on top
+    // of the floor it was already at.
+    expect(afterRollover!.count_is_floor).toBe(1);
+    expect(afterRollover!.occurrence_count).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET + 1);
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const rowStart = html.indexOf(kind);
+    expect(rowStart).toBeGreaterThan(-1);
+    const rowEnd = html.indexOf("</tr>", rowStart);
+    expect(html.slice(rowStart, rowEnd)).toMatch(/&ge;|≥|throttled|at least/i);
+  });
+
+  it("keeps rendering a plain exact count for a fingerprint that never saturates, across many hours", async () => {
+    const ip = "203.0.113.51";
+    const kind = "NeverSaturates";
+    const baseHour = 600_000;
+
+    // One crash per hour for several hours -- never enough in any single
+    // hour to reach MAX_OCCURRENCE_ROWS_PER_BUCKET.
+    for (let h = 0; h < 5; h++) {
+      await postCrash(kind, ip, (baseHour + h) * 3600 + 10);
+    }
+
+    const row = await env.DB.prepare(
+      "SELECT count_is_floor, occurrence_count FROM errors WHERE kind = ?",
+    )
+      .bind(kind)
+      .first<{ count_is_floor: number; occurrence_count: number }>();
+    expect(row!.count_is_floor).toBe(0);
+    expect(row!.occurrence_count).toBe(5);
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const rowStart = html.indexOf(kind);
+    expect(rowStart).toBeGreaterThan(-1);
+    const rowEnd = html.indexOf("</tr>", rowStart);
+    expect(html.slice(rowStart, rowEnd)).not.toMatch(/throttled/i);
+  });
+
+  it("keeps the floor marker across a resolve/unresolve cycle", async () => {
+    const ip = "203.0.113.52";
+    const kind = "ResolveCycleStorm";
+    const occurredAt = 700_000 * 3600 + 10;
+
+    for (let i = 0; i < MAX_OCCURRENCE_ROWS_PER_BUCKET + 1; i++) {
+      await postCrash(kind, ip, occurredAt);
+    }
+
+    const fingerprintRow = await env.DB.prepare(
+      "SELECT fingerprint FROM errors WHERE kind = ?",
+    )
+      .bind(kind)
+      .first<{ fingerprint: string }>();
+    const fingerprint = fingerprintRow!.fingerprint;
+
+    const hasFloorMarker = async (): Promise<boolean> => {
+      const html = await (
+        await SELF.fetch(`https://relay.mydia.dev/errors/${fingerprint}`)
+      ).text();
+      return /&ge;|≥|throttled|at least/i.test(html);
+    };
+
+    expect(await hasFloorMarker()).toBe(true);
+
+    const resolveRes = await SELF.fetch(
+      `https://relay.mydia.dev/errors/${fingerprint}/resolve`,
+      { method: "POST", redirect: "manual" },
+    );
+    expect(resolveRes.status).toBe(303);
+    expect(await hasFloorMarker()).toBe(true);
+
+    const unresolveRes = await SELF.fetch(
+      `https://relay.mydia.dev/errors/${fingerprint}/unresolve`,
+      { method: "POST", redirect: "manual" },
+    );
+    expect(unresolveRes.status).toBe(303);
+    expect(await hasFloorMarker()).toBe(true);
   });
 });

--- a/relay-worker/test/dashboards/errors.test.ts
+++ b/relay-worker/test/dashboards/errors.test.ts
@@ -32,9 +32,9 @@ describe("escapeHtml", () => {
   });
 });
 
-describe("GET /errors", () => {
+describe("GET /admin/errors", () => {
   it("lists error groups with their occurrence counts", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/errors");
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/errors");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
 
@@ -45,13 +45,13 @@ describe("GET /errors", () => {
   });
 
   it("shows a single error group with its occurrences", async () => {
-    const res = await SELF.fetch(`https://relay.mydia.dev/errors/${FP1}`);
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/errors/${FP1}`);
     expect(res.status).toBe(200);
     expect(await res.text()).toContain("RuntimeError");
   });
 
   it("returns 404 for an unknown fingerprint", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/errors/nosuchfp");
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/errors/nosuchfp");
     expect(res.status).toBe(404);
   });
 
@@ -59,7 +59,7 @@ describe("GET /errors", () => {
     // fetch()'s default `redirect: "follow"` would otherwise chase the 303
     // and hand back the followed page's 200, hiding the redirect status this
     // assertion cares about.
-    const res = await SELF.fetch(`https://relay.mydia.dev/errors/${FP1}/resolve`, {
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/errors/${FP1}/resolve`, {
       method: "POST",
       redirect: "manual",
     });
@@ -76,14 +76,14 @@ describe("GET /errors", () => {
   // MINOR fix-round-1 gap: only resolve had a test; unresolve is the other
   // half of the same write-mutating pair and got none.
   it("unresolves a group and reflects the new status", async () => {
-    const resolveRes = await SELF.fetch(`https://relay.mydia.dev/errors/${FP1}/resolve`, {
+    const resolveRes = await SELF.fetch(`https://relay.mydia.dev/admin/errors/${FP1}/resolve`, {
       method: "POST",
       redirect: "manual",
     });
     expect(resolveRes.status).toBe(303);
 
     const unresolveRes = await SELF.fetch(
-      `https://relay.mydia.dev/errors/${FP1}/unresolve`,
+      `https://relay.mydia.dev/admin/errors/${FP1}/unresolve`,
       { method: "POST", redirect: "manual" },
     );
     expect(unresolveRes.status).toBe(303);
@@ -106,7 +106,7 @@ describe("GET /errors", () => {
       .bind(now, now)
       .run();
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
     expect(html).not.toContain("<script>alert(1)</script>");
   });
 
@@ -125,7 +125,7 @@ describe("GET /errors", () => {
       .bind(now, now)
       .run();
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
     expect(html).not.toContain('"><svg onload=alert(1)>');
     expect(html).not.toContain("<svg onload=alert(1)>");
   });
@@ -135,8 +135,8 @@ describe("GET /errors", () => {
   // be escaped defensively rather than trusted because "the input happens to
   // be safe today".
   it("escapes the fingerprint used to build occurrence links", async () => {
-    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
-    expect(html).toContain(`href="/errors/${FP1}"`);
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
+    expect(html).toContain(`href="/admin/errors/${FP1}"`);
   });
 });
 
@@ -144,23 +144,23 @@ describe("GET /errors", () => {
 // straight into a D1 OFFSET with no guard. Each of these five inputs was
 // confirmed to throw `D1_ERROR: datatype mismatch`, surfaced as an unhandled
 // Hono 500, before the fix -- on an endpoint that is unauthenticated today.
-describe("GET /errors?page= guards against hostile input", () => {
+describe("GET /admin/errors?page= guards against hostile input", () => {
   const hostileValues = ["abc", "NaN", "Infinity", "1e300", "99999999999999999999"];
 
   it.each(hostileValues)("does not 500 for page=%s", async (value) => {
     const res = await SELF.fetch(
-      `https://relay.mydia.dev/errors?page=${encodeURIComponent(value)}`,
+      `https://relay.mydia.dev/admin/errors?page=${encodeURIComponent(value)}`,
     );
     expect(res.status).toBe(200);
   });
 
   it("still paginates normally for an ordinary page number", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/errors?page=1");
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/errors?page=1");
     expect(res.status).toBe(200);
   });
 
   it("clamps a negative page to the first page instead of erroring", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/errors?page=-5");
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/errors?page=-5");
     expect(res.status).toBe(200);
   });
 });
@@ -169,13 +169,13 @@ describe("GET /errors?page= guards against hostile input", () => {
 // from the raw, decoded :fingerprint param. A value containing a CRLF
 // sequence made the underlying Headers implementation throw -- fails safe
 // (no header injection actually lands; the runtime itself rejects the
-// control characters, and the fixed "/errors/" prefix rules out an open
+// control characters, and the fixed "/admin/errors/" prefix rules out an open
 // redirect either way) but still surfaced as an unhandled 500 rather than a
 // clean 404, on an endpoint that is unauthenticated today.
-describe("POST /errors/:fingerprint/resolve validates the fingerprint shape first", () => {
+describe("POST /admin/errors/:fingerprint/resolve validates the fingerprint shape first", () => {
   it("returns 404, not a 500, for a CRLF-injected fingerprint segment", async () => {
     const res = await SELF.fetch(
-      "https://relay.mydia.dev/errors/abc%0D%0AInjected/resolve",
+      "https://relay.mydia.dev/admin/errors/abc%0D%0AInjected/resolve",
       { method: "POST", redirect: "manual" },
     );
     expect(res.status).toBe(404);
@@ -183,7 +183,7 @@ describe("POST /errors/:fingerprint/resolve validates the fingerprint shape firs
 
   it("returns 404 for a non-hex fingerprint", async () => {
     const res = await SELF.fetch(
-      "https://relay.mydia.dev/errors/not-a-real-fingerprint/resolve",
+      "https://relay.mydia.dev/admin/errors/not-a-real-fingerprint/resolve",
       { method: "POST", redirect: "manual" },
     );
     expect(res.status).toBe(404);
@@ -191,7 +191,7 @@ describe("POST /errors/:fingerprint/resolve validates the fingerprint shape firs
 
   it("also validates on the unresolve route", async () => {
     const res = await SELF.fetch(
-      "https://relay.mydia.dev/errors/abc%0D%0AInjected/unresolve",
+      "https://relay.mydia.dev/admin/errors/abc%0D%0AInjected/unresolve",
       { method: "POST", redirect: "manual" },
     );
     expect(res.status).toBe(404);
@@ -203,7 +203,7 @@ describe("POST /errors/:fingerprint/resolve validates the fingerprint shape firs
 // (fix-round-1) is the durable record of that, distinct from
 // ingest_buckets.saturated, which resets the moment a fresh hour's write
 // lands for the same fingerprint/instance -- see 0002_crash_reports.sql.
-describe("GET /errors occurrence count vs. ingest throttling", () => {
+describe("GET /admin/errors occurrence count vs. ingest throttling", () => {
   const SATURATED_FP = "fpsaturated";
 
   beforeAll(async () => {
@@ -218,7 +218,7 @@ describe("GET /errors occurrence count vs. ingest throttling", () => {
   });
 
   it("marks a saturated fingerprint's count as a floor on the list page", async () => {
-    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
     // The saturated row's count must be visually distinguishable from an
     // exact count -- rendered as "at least" rather than a bare number.
     const rowStart = html.indexOf("StormError");
@@ -228,10 +228,10 @@ describe("GET /errors occurrence count vs. ingest throttling", () => {
   });
 
   it("does not mark an unsaturated fingerprint's count as a floor", async () => {
-    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
     // FP1's own row (found via its detail link), bounded to just that <tr>
     // so a neighbouring saturated row's markup can't leak into the slice.
-    const linkIndex = html.indexOf(`href="/errors/${FP1}"`);
+    const linkIndex = html.indexOf(`href="/admin/errors/${FP1}"`);
     expect(linkIndex).toBeGreaterThan(-1);
     const rowEnd = html.indexOf("</tr>", linkIndex);
     const rowSlice = html.slice(linkIndex, rowEnd);
@@ -240,7 +240,7 @@ describe("GET /errors occurrence count vs. ingest throttling", () => {
 
   it("marks the floor on the single error group's detail page too", async () => {
     const html = await (
-      await SELF.fetch(`https://relay.mydia.dev/errors/${SATURATED_FP}`)
+      await SELF.fetch(`https://relay.mydia.dev/admin/errors/${SATURATED_FP}`)
     ).text();
     expect(html).toMatch(/&ge;|≥|throttled|at least/i);
   });
@@ -317,7 +317,7 @@ describe("the floor marker survives an hour rollover", () => {
     expect(afterRollover!.count_is_floor).toBe(1);
     expect(afterRollover!.occurrence_count).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET + 1);
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
     const rowStart = html.indexOf(kind);
     expect(rowStart).toBeGreaterThan(-1);
     const rowEnd = html.indexOf("</tr>", rowStart);
@@ -343,7 +343,7 @@ describe("the floor marker survives an hour rollover", () => {
     expect(row!.count_is_floor).toBe(0);
     expect(row!.occurrence_count).toBe(5);
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/errors")).text();
     const rowStart = html.indexOf(kind);
     expect(rowStart).toBeGreaterThan(-1);
     const rowEnd = html.indexOf("</tr>", rowStart);
@@ -368,7 +368,7 @@ describe("the floor marker survives an hour rollover", () => {
 
     const hasFloorMarker = async (): Promise<boolean> => {
       const html = await (
-        await SELF.fetch(`https://relay.mydia.dev/errors/${fingerprint}`)
+        await SELF.fetch(`https://relay.mydia.dev/admin/errors/${fingerprint}`)
       ).text();
       return /&ge;|≥|throttled|at least/i.test(html);
     };
@@ -376,14 +376,14 @@ describe("the floor marker survives an hour rollover", () => {
     expect(await hasFloorMarker()).toBe(true);
 
     const resolveRes = await SELF.fetch(
-      `https://relay.mydia.dev/errors/${fingerprint}/resolve`,
+      `https://relay.mydia.dev/admin/errors/${fingerprint}/resolve`,
       { method: "POST", redirect: "manual" },
     );
     expect(resolveRes.status).toBe(303);
     expect(await hasFloorMarker()).toBe(true);
 
     const unresolveRes = await SELF.fetch(
-      `https://relay.mydia.dev/errors/${fingerprint}/unresolve`,
+      `https://relay.mydia.dev/admin/errors/${fingerprint}/unresolve`,
       { method: "POST", redirect: "manual" },
     );
     expect(unresolveRes.status).toBe(303);

--- a/relay-worker/test/dashboards/errors.test.ts
+++ b/relay-worker/test/dashboards/errors.test.ts
@@ -1,0 +1,165 @@
+import { env, SELF, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { escapeHtml } from "../../src/dashboards/layout";
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
+                         status, first_seen_at, last_seen_at, occurrence_count)
+     VALUES ('fp1', 'RuntimeError', 'boom', 'm.ex', 3, 'unresolved', ?, ?, 7)`,
+  )
+    .bind(now, now)
+    .run();
+});
+
+describe("escapeHtml", () => {
+  it("escapes the characters that would let a crash message inject markup", () => {
+    expect(escapeHtml('<img src=x onerror="alert(1)">')).not.toContain("<img");
+    expect(escapeHtml("a & b")).toContain("&amp;");
+    expect(escapeHtml('"quoted"')).toContain("&quot;");
+  });
+});
+
+describe("GET /errors", () => {
+  it("lists error groups with their occurrence counts", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/errors");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+
+    const html = await res.text();
+    expect(html).toContain("RuntimeError");
+    expect(html).toContain("boom");
+    expect(html).toContain("7");
+  });
+
+  it("shows a single error group with its occurrences", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/errors/fp1");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("RuntimeError");
+  });
+
+  it("returns 404 for an unknown fingerprint", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/errors/nosuchfp");
+    expect(res.status).toBe(404);
+  });
+
+  it("resolves a group and reflects the new status", async () => {
+    // fetch()'s default `redirect: "follow"` would otherwise chase the 303
+    // and hand back the followed page's 200, hiding the redirect status this
+    // assertion cares about.
+    const res = await SELF.fetch("https://relay.mydia.dev/errors/fp1/resolve", {
+      method: "POST",
+      redirect: "manual",
+    });
+    expect(res.status).toBe(303);
+
+    const row = await env.DB.prepare(
+      "SELECT status FROM errors WHERE fingerprint = 'fp1'",
+    ).first<{ status: string }>();
+    expect(row!.status).toBe("resolved");
+  });
+
+  it("never renders a crash message as raw HTML", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, status,
+                           first_seen_at, last_seen_at, occurrence_count)
+       VALUES ('fpxss', 'RuntimeError', '<script>alert(1)</script>', 'unresolved', ?, ?, 1)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  // Every value that ends up inside an HTML attribute (not just a tag body)
+  // must also be escaped -- a message containing a quote could otherwise
+  // break out of a title="" or similar attribute. Also covers the fingerprint
+  // itself, which is attacker-influenced (derived from attacker-controlled
+  // kind/stacktrace text) and lands inside an href.
+  it("escapes an attribute-breaking payload in a crash message", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, status,
+                           first_seen_at, last_seen_at, occurrence_count)
+       VALUES ('fpattr', 'RuntimeError', '"><svg onload=alert(1)>', 'unresolved', ?, ?, 1)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    expect(html).not.toContain('"><svg onload=alert(1)>');
+    expect(html).not.toContain("<svg onload=alert(1)>");
+  });
+
+  // A fingerprint is hex-derived (fingerprintOf hashes with SHA-256 and never
+  // emits HTML-meta characters), but the link href built from it must still
+  // be escaped defensively rather than trusted because "the input happens to
+  // be safe today".
+  it("escapes the fingerprint used to build occurrence links", async () => {
+    const found = await env.DB.prepare(
+      "SELECT fingerprint FROM errors WHERE kind = 'RuntimeError' AND message = 'boom'",
+    ).first<{ fingerprint: string }>();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    expect(html).toContain(`href="/errors/${found!.fingerprint}"`);
+  });
+});
+
+// Task 11's ingest throttle stops counting (and stops writing new rows) once
+// a fingerprint/instance/hour bucket saturates: ingest_buckets.saturated
+// records that occurrence_count is a FLOOR, not an exact total, for the rest
+// of that hour. A dashboard that prints occurrence_count as a plain number
+// presents a throttled undercount as if it were precise -- worst exactly
+// when an operator most needs the real number, during a crash storm.
+describe("GET /errors occurrence count vs. ingest throttling", () => {
+  const SATURATED_FP = "fpsaturated";
+
+  beforeAll(async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, status,
+                           first_seen_at, last_seen_at, occurrence_count)
+       VALUES (?, 'StormError', 'storm', 'unresolved', ?, ?, 3)`,
+    )
+      .bind(SATURATED_FP, now, now)
+      .run();
+    await env.DB.prepare(
+      `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, written, saturated)
+       VALUES (?, 'some-instance', ?, 3, 1)`,
+    )
+      .bind(SATURATED_FP, Math.floor(now / 3600))
+      .run();
+  });
+
+  it("marks a saturated fingerprint's count as a floor on the list page", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    // The saturated row's count must be visually distinguishable from an
+    // exact count -- rendered as "at least" rather than a bare number.
+    const rowStart = html.indexOf("StormError");
+    expect(rowStart).toBeGreaterThan(-1);
+    const rowSlice = html.slice(rowStart, rowStart + 600);
+    expect(rowSlice).toMatch(/&ge;|≥|throttled|at least/i);
+  });
+
+  it("does not mark an unsaturated fingerprint's count as a floor", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/errors")).text();
+    // fp1's own row (found via its detail link), bounded to just that <tr>
+    // so a neighbouring saturated row's markup can't leak into the slice.
+    const linkIndex = html.indexOf('href="/errors/fp1"');
+    expect(linkIndex).toBeGreaterThan(-1);
+    const rowEnd = html.indexOf("</tr>", linkIndex);
+    const rowSlice = html.slice(linkIndex, rowEnd);
+    expect(rowSlice).not.toMatch(/throttled/i);
+  });
+
+  it("marks the floor on the single error group's detail page too", async () => {
+    const html = await (
+      await SELF.fetch(`https://relay.mydia.dev/errors/${SATURATED_FP}`)
+    ).text();
+    expect(html).toMatch(/&ge;|≥|throttled|at least/i);
+  });
+});

--- a/relay-worker/test/dashboards/feedback.test.ts
+++ b/relay-worker/test/dashboards/feedback.test.ts
@@ -16,9 +16,9 @@ beforeAll(async () => {
   const now = Math.floor(Date.now() / 1000);
   await env.DB.prepare(
     `INSERT INTO feedback_submissions
-       (id, type, message, contact, mydia_version, state, inserted_at, updated_at)
+       (id, type, message, contact, mydia_version, source_ip, state, inserted_at, updated_at)
      VALUES (?, 'bug', 'Scanner missed a file', 'someone@example.com',
-             '1.2.3', 'unread', ?, ?)`,
+             '1.2.3', '203.0.113.42', 'unread', ?, ?)`,
   )
     .bind(FB1, now, now)
     .run();
@@ -33,6 +33,35 @@ describe("GET /feedback dashboard", () => {
     const html = await res.text();
     expect(html).toContain("Scanner missed a file");
     expect(html).toContain("1.2.3");
+  });
+
+  // Fix-round-1 finding: index.html.heex surfaces submission.source_ip per
+  // row (a triage/anti-abuse signal -- deciding whether a run of
+  // submissions is one person), and the dashboard dropped it without
+  // disclosing the omission.
+  it("shows the source IP column, an anti-abuse signal the Elixir dashboard also surfaces", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback")).text();
+    expect(html).toContain("Source IP");
+    expect(html).toContain("203.0.113.42");
+  });
+
+  // The Elixir template applies whitespace-pre-wrap to the message; without
+  // it a multi-line submission renders as one run-on line even though the
+  // text is intact in the markup. Assert the CSS hook is actually wired to
+  // the message cell, not just present somewhere in the stylesheet.
+  it("preserves multi-line messages visually via the wrap class", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO feedback_submissions (id, type, message, state, inserted_at, updated_at)
+       VALUES ('fbmultiline', 'bug', 'Line one\nLine two', 'unread', ?, ?)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback")).text();
+    expect(html).toContain("Line one\nLine two");
+    const cellStart = html.indexOf('<td class="wrap">Line one');
+    expect(cellStart).toBeGreaterThan(-1);
   });
 
   it("does not shadow the public POST ingest route", async () => {
@@ -93,11 +122,15 @@ describe("GET /feedback dashboard", () => {
   });
 
   // Submission.github_ref_changeset/2 (metadata-relay) has no
-  // validate_required -- a blank value is accepted and stored as-is
-  // (clearing a previously attached ref), not rejected with a 422. Mirror
-  // that rather than inventing a "github_ref is required" rule the Elixir
-  // dashboard never enforced.
-  it("accepts a blank github ref, clearing any previous one", async () => {
+  // validate_required, so a blank value is accepted rather than rejected
+  // with a 422 the Elixir dashboard never enforced. But Ecto.Changeset.cast/4's
+  // default `empty_values` (which includes "") normalizes that blank change
+  // away entirely, so the Elixir side never persists an empty string -- it
+  // leaves the struct's `nil` default in place. Fix-round-1 finding: this
+  // test originally asserted `.toBe("")`, locking in a persisted-data
+  // mismatch (NULL vs. "") that was invisible in the UI because both
+  // templates render null and "" identically.
+  it("accepts a blank github ref, clearing any previous one to NULL (not empty string)", async () => {
     const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/github`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -110,8 +143,25 @@ describe("GET /feedback dashboard", () => {
       "SELECT github_ref FROM feedback_submissions WHERE id = ?",
     )
       .bind(FB1)
-      .first<{ github_ref: string }>();
-    expect(row!.github_ref).toBe("");
+      .first<{ github_ref: string | null }>();
+    expect(row!.github_ref).toBeNull();
+  });
+
+  it("treats a whitespace-only github ref the same as blank", async () => {
+    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/github`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: `github_ref=${encodeURIComponent("   ")}`,
+      redirect: "manual",
+    });
+    expect(res.status).toBe(303);
+
+    const row = await env.DB.prepare(
+      "SELECT github_ref FROM feedback_submissions WHERE id = ?",
+    )
+      .bind(FB1)
+      .first<{ github_ref: string | null }>();
+    expect(row!.github_ref).toBeNull();
   });
 
   it("escapes submission text, which is user supplied", async () => {

--- a/relay-worker/test/dashboards/feedback.test.ts
+++ b/relay-worker/test/dashboards/feedback.test.ts
@@ -236,7 +236,7 @@ describe("GET /admin/feedback dashboard", () => {
     expect(html).not.toContain("<script>alert(4)</script>");
   });
 
-  // The other non-obvious sink the brief calls out: the row id is
+  // The other non-obvious injection sink: the row id is
   // interpolated into every mutation form's `action="..."` attribute. Real
   // ids are always crypto.randomUUID() output, but this is defense in
   // depth -- same reasoning as dashboards/errors.ts escaping a fingerprint
@@ -281,7 +281,7 @@ describe("GET /admin/feedback?page= guards against hostile input", () => {
 });
 
 // Mirrors Feedback.list_submissions/1's maybe_filter/3: nil and the literal
-// "all" both mean "no filter". Task 12 already fixed listFeedback for this;
+// "all" both mean "no filter". listFeedback already handles this;
 // this confirms the dashboard's own filter links actually produce values
 // that exercise it, including "all".
 describe("GET /admin/feedback?state= filtering", () => {

--- a/relay-worker/test/dashboards/feedback.test.ts
+++ b/relay-worker/test/dashboards/feedback.test.ts
@@ -1,0 +1,316 @@
+import { env, SELF, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+
+// Mutation routes (state, github) now validate the :id path segment against
+// crypto.randomUUID()'s real shape before touching D1 or building a
+// redirect (see dashboards/feedback.ts's isValidIdShape and
+// dashboards/errors.ts's identical fingerprint-shape lesson), so every
+// fixture exercised through those two routes needs a realistic-looking id
+// rather than a short mnemonic string like "fb1". GET-only fixtures (the
+// escaping tests below) never go through shape validation, so they keep
+// short names.
+const FB1 = "0f1e2d3c-4b5a-4c1d-8e2f-1a2b3c4d5e6f";
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO feedback_submissions
+       (id, type, message, contact, mydia_version, state, inserted_at, updated_at)
+     VALUES (?, 'bug', 'Scanner missed a file', 'someone@example.com',
+             '1.2.3', 'unread', ?, ?)`,
+  )
+    .bind(FB1, now, now)
+    .run();
+});
+
+describe("GET /feedback dashboard", () => {
+  it("lists submissions", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/feedback");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+
+    const html = await res.text();
+    expect(html).toContain("Scanner missed a file");
+    expect(html).toContain("1.2.3");
+  });
+
+  it("does not shadow the public POST ingest route", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/feedback", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "idea", message: "still works" }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("marks a submission read", async () => {
+    // fetch()'s default `redirect: "follow"` would otherwise chase the 303
+    // and hand back the followed page's 200, hiding the redirect status this
+    // assertion actually cares about (the same gap the dashboards/errors.ts
+    // tests were fixed for).
+    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/state`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "state=read",
+      redirect: "manual",
+    });
+    expect(res.status).toBe(303);
+
+    const row = await env.DB.prepare(
+      "SELECT state FROM feedback_submissions WHERE id = ?",
+    )
+      .bind(FB1)
+      .first<{ state: string }>();
+    expect(row!.state).toBe("read");
+  });
+
+  it("rejects a state outside the allowed set", async () => {
+    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/state`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "state=deleted",
+      redirect: "manual",
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it("attaches a github ref", async () => {
+    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/github`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "github_ref=getmydia/mydia%23123",
+      redirect: "manual",
+    });
+    expect(res.status).toBe(303);
+
+    const row = await env.DB.prepare(
+      "SELECT github_ref FROM feedback_submissions WHERE id = ?",
+    )
+      .bind(FB1)
+      .first<{ github_ref: string }>();
+    expect(row!.github_ref).toBe("getmydia/mydia#123");
+  });
+
+  // Submission.github_ref_changeset/2 (metadata-relay) has no
+  // validate_required -- a blank value is accepted and stored as-is
+  // (clearing a previously attached ref), not rejected with a 422. Mirror
+  // that rather than inventing a "github_ref is required" rule the Elixir
+  // dashboard never enforced.
+  it("accepts a blank github ref, clearing any previous one", async () => {
+    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/github`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "github_ref=",
+      redirect: "manual",
+    });
+    expect(res.status).toBe(303);
+
+    const row = await env.DB.prepare(
+      "SELECT github_ref FROM feedback_submissions WHERE id = ?",
+    )
+      .bind(FB1)
+      .first<{ github_ref: string }>();
+    expect(row!.github_ref).toBe("");
+  });
+
+  it("escapes submission text, which is user supplied", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO feedback_submissions (id, type, message, state, inserted_at, updated_at)
+       VALUES ('fbxss', 'bug', '<script>alert(1)</script>', 'unread', ?, ?)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  // contact, mydia_version and instance_id are all attacker-controlled
+  // optional fields on the same unauthenticated POST /feedback endpoint as
+  // message -- escaping only the message field and assuming the others are
+  // "just strings" is exactly the kind of gap fix-round reviews keep
+  // finding elsewhere in this codebase.
+  it("escapes contact, mydia_version and instance_id, not just message", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO feedback_submissions
+         (id, type, message, contact, instance_id, mydia_version, state, inserted_at, updated_at)
+       VALUES ('fbfields', 'bug', 'benign message',
+               '"><svg onload=alert(1)>', '"><svg onload=alert(2)>',
+               '"><svg onload=alert(3)>', 'unread', ?, ?)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    expect(html).not.toContain("<svg onload=alert(1)>");
+    expect(html).not.toContain("<svg onload=alert(2)>");
+    expect(html).not.toContain("<svg onload=alert(3)>");
+  });
+
+  // The non-obvious sink: an existing github_ref is pre-filled into the
+  // input's `value="..."` attribute so a maintainer can edit it in place.
+  // An unescaped ref could break out of that attribute.
+  it("escapes a github_ref value rendered inside the input's value attribute", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO feedback_submissions
+         (id, type, message, state, github_ref, inserted_at, updated_at)
+       VALUES ('fbref', 'bug', 'benign message', 'unread',
+               '"><script>alert(4)</script>', ?, ?)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    expect(html).not.toContain('"><script>alert(4)</script>');
+    expect(html).not.toContain("<script>alert(4)</script>");
+  });
+
+  // The other non-obvious sink the brief calls out: the row id is
+  // interpolated into every mutation form's `action="..."` attribute. Real
+  // ids are always crypto.randomUUID() output, but this is defense in
+  // depth -- same reasoning as dashboards/errors.ts escaping a fingerprint
+  // it also trusts structurally.
+  it("escapes a row id used in a form action attribute", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO feedback_submissions (id, type, message, state, inserted_at, updated_at)
+       VALUES ('"><script>alert(5)</script>', 'bug', 'benign message', 'unread', ?, ?)`,
+    )
+      .bind(now, now)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    expect(html).not.toContain('"><script>alert(5)</script>');
+    expect(html).not.toContain("<script>alert(5)</script>");
+  });
+});
+
+// IMPORTANT fix-round finding, mirrored from dashboards/errors.ts: `Number(...)`
+// fed straight into a D1 OFFSET with no guard throws `D1_ERROR: datatype
+// mismatch`, surfaced as an unhandled Hono 500, for each of these inputs.
+describe("GET /feedback?page= guards against hostile input", () => {
+  const hostileValues = ["abc", "NaN", "Infinity", "1e300", "99999999999999999999"];
+
+  it.each(hostileValues)("does not 500 for page=%s", async (value) => {
+    const res = await SELF.fetch(
+      `https://relay.mydia.dev/feedback?page=${encodeURIComponent(value)}`,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("still paginates normally for an ordinary page number", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/feedback?page=1");
+    expect(res.status).toBe(200);
+  });
+
+  it("clamps a negative page to the first page instead of erroring", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/feedback?page=-5");
+    expect(res.status).toBe(200);
+  });
+});
+
+// Mirrors Feedback.list_submissions/1's maybe_filter/3: nil and the literal
+// "all" both mean "no filter". Task 12 already fixed listFeedback for this;
+// this confirms the dashboard's own filter links actually produce values
+// that exercise it, including "all".
+describe("GET /feedback?state= filtering", () => {
+  it("defaults to the unread queue when no state is given, matching mount/3", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback")).text();
+    // fbxss/fbfields/fbref/the escaped-id row were all inserted as 'unread'
+    // in the tests above, so the default (unread) view still contains them,
+    // while FB1 (moved to 'read' earlier in this file) is state-dependent --
+    // check the state-only filters directly instead of relying on FB1 here.
+    expect(html).toContain("Scanner missed a file"); // FB1's message, state notwithstanding
+  });
+
+  it("state=all returns every state, not zero rows", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    expect(html).toContain("Scanner missed a file");
+  });
+
+  it("state=read returns only read rows", async () => {
+    // vitest-pool-workers' isolated storage rolls each test back to the
+    // state right after beforeAll, so FB1's "read" transition from an
+    // earlier test in this file does not carry over here -- do the
+    // transition again within this test rather than relying on it.
+    await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/state`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: "state=read",
+      redirect: "manual",
+    });
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=read")).text();
+    expect(html).toContain("Scanner missed a file");
+
+    const unreadOnly = await (
+      await SELF.fetch("https://relay.mydia.dev/feedback")
+    ).text();
+    expect(unreadOnly).not.toContain("Scanner missed a file");
+  });
+});
+
+// Lesson from dashboards/errors.ts's :fingerprint validation, applied to
+// feedback's :id. A malformed segment here isn't hypothetical: Hono's
+// redirect() builds the Location header directly from the decoded param,
+// and a CRLF sequence (delivered URL-encoded, e.g. %0D%0A) makes the
+// underlying Headers implementation throw -- fails safe, but as an
+// unhandled 500 rather than a clean 404, on an endpoint unauthenticated
+// until Task 15.
+describe("POST /feedback/:id/state and /github validate the id shape first", () => {
+  it("returns 404, not a 500, for a CRLF-injected id segment on /state", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/feedback/abc%0D%0AInjected/state",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "state=read",
+        redirect: "manual",
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404, not a 500, for a CRLF-injected id segment on /github", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/feedback/abc%0D%0AInjected/github",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "github_ref=x",
+        redirect: "manual",
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a non-UUID id on /state", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/feedback/not-a-real-id/state",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "state=read",
+        redirect: "manual",
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a non-UUID id on /github", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/feedback/not-a-real-id/github",
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: "github_ref=x",
+        redirect: "manual",
+      },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/relay-worker/test/dashboards/feedback.test.ts
+++ b/relay-worker/test/dashboards/feedback.test.ts
@@ -24,9 +24,9 @@ beforeAll(async () => {
     .run();
 });
 
-describe("GET /feedback dashboard", () => {
+describe("GET /admin/feedback dashboard", () => {
   it("lists submissions", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/feedback");
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/feedback");
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
 
@@ -40,7 +40,7 @@ describe("GET /feedback dashboard", () => {
   // submissions is one person), and the dashboard dropped it without
   // disclosing the omission.
   it("shows the source IP column, an anti-abuse signal the Elixir dashboard also surfaces", async () => {
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback")).text();
     expect(html).toContain("Source IP");
     expect(html).toContain("203.0.113.42");
   });
@@ -58,13 +58,17 @@ describe("GET /feedback dashboard", () => {
       .bind(now, now)
       .run();
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback")).text();
     expect(html).toContain("Line one\nLine two");
     const cellStart = html.indexOf('<td class="wrap">Line one');
     expect(cellStart).toBeGreaterThan(-1);
   });
 
-  it("does not shadow the public POST ingest route", async () => {
+  it("does not share a path with the public POST ingest route", async () => {
+    // The whole point of moving this dashboard to /admin/feedback: the
+    // public ingest endpoint stays at bare /feedback, completely unaffected
+    // by anything (including a future Cloudflare Access application) scoped
+    // to /admin/*.
     const res = await SELF.fetch("https://relay.mydia.dev/feedback", {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -73,12 +77,25 @@ describe("GET /feedback dashboard", () => {
     expect(res.status).toBe(201);
   });
 
+  it("no longer serves the dashboard at the old /feedback path", async () => {
+    // GET /feedback must not be a second, unauthenticated way to reach
+    // maintainer data now that the real dashboard lives at
+    // /admin/feedback -- whatever this returns, it must not be the
+    // dashboard. registerFeedbackRoutes only registers POST /feedback, so
+    // this falls through to the app-wide 404 catch-all in src/index.ts.
+    const res = await SELF.fetch("https://relay.mydia.dev/feedback");
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    expect(body).not.toContain("Scanner missed a file");
+    expect(body).not.toContain("<table");
+  });
+
   it("marks a submission read", async () => {
     // fetch()'s default `redirect: "follow"` would otherwise chase the 303
     // and hand back the followed page's 200, hiding the redirect status this
     // assertion actually cares about (the same gap the dashboards/errors.ts
     // tests were fixed for).
-    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/state`, {
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/feedback/${FB1}/state`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: "state=read",
@@ -95,7 +112,7 @@ describe("GET /feedback dashboard", () => {
   });
 
   it("rejects a state outside the allowed set", async () => {
-    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/state`, {
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/feedback/${FB1}/state`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: "state=deleted",
@@ -105,7 +122,7 @@ describe("GET /feedback dashboard", () => {
   });
 
   it("attaches a github ref", async () => {
-    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/github`, {
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/feedback/${FB1}/github`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: "github_ref=getmydia/mydia%23123",
@@ -131,7 +148,7 @@ describe("GET /feedback dashboard", () => {
   // mismatch (NULL vs. "") that was invisible in the UI because both
   // templates render null and "" identically.
   it("accepts a blank github ref, clearing any previous one to NULL (not empty string)", async () => {
-    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/github`, {
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/feedback/${FB1}/github`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: "github_ref=",
@@ -148,7 +165,7 @@ describe("GET /feedback dashboard", () => {
   });
 
   it("treats a whitespace-only github ref the same as blank", async () => {
-    const res = await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/github`, {
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/feedback/${FB1}/github`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: `github_ref=${encodeURIComponent("   ")}`,
@@ -173,7 +190,7 @@ describe("GET /feedback dashboard", () => {
       .bind(now, now)
       .run();
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback?state=all")).text();
     expect(html).not.toContain("<script>alert(1)</script>");
   });
 
@@ -194,7 +211,7 @@ describe("GET /feedback dashboard", () => {
       .bind(now, now)
       .run();
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback?state=all")).text();
     expect(html).not.toContain("<svg onload=alert(1)>");
     expect(html).not.toContain("<svg onload=alert(2)>");
     expect(html).not.toContain("<svg onload=alert(3)>");
@@ -214,7 +231,7 @@ describe("GET /feedback dashboard", () => {
       .bind(now, now)
       .run();
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback?state=all")).text();
     expect(html).not.toContain('"><script>alert(4)</script>');
     expect(html).not.toContain("<script>alert(4)</script>");
   });
@@ -233,7 +250,7 @@ describe("GET /feedback dashboard", () => {
       .bind(now, now)
       .run();
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback?state=all")).text();
     expect(html).not.toContain('"><script>alert(5)</script>');
     expect(html).not.toContain("<script>alert(5)</script>");
   });
@@ -242,23 +259,23 @@ describe("GET /feedback dashboard", () => {
 // IMPORTANT fix-round finding, mirrored from dashboards/errors.ts: `Number(...)`
 // fed straight into a D1 OFFSET with no guard throws `D1_ERROR: datatype
 // mismatch`, surfaced as an unhandled Hono 500, for each of these inputs.
-describe("GET /feedback?page= guards against hostile input", () => {
+describe("GET /admin/feedback?page= guards against hostile input", () => {
   const hostileValues = ["abc", "NaN", "Infinity", "1e300", "99999999999999999999"];
 
   it.each(hostileValues)("does not 500 for page=%s", async (value) => {
     const res = await SELF.fetch(
-      `https://relay.mydia.dev/feedback?page=${encodeURIComponent(value)}`,
+      `https://relay.mydia.dev/admin/feedback?page=${encodeURIComponent(value)}`,
     );
     expect(res.status).toBe(200);
   });
 
   it("still paginates normally for an ordinary page number", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/feedback?page=1");
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/feedback?page=1");
     expect(res.status).toBe(200);
   });
 
   it("clamps a negative page to the first page instead of erroring", async () => {
-    const res = await SELF.fetch("https://relay.mydia.dev/feedback?page=-5");
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/feedback?page=-5");
     expect(res.status).toBe(200);
   });
 });
@@ -267,9 +284,9 @@ describe("GET /feedback?page= guards against hostile input", () => {
 // "all" both mean "no filter". Task 12 already fixed listFeedback for this;
 // this confirms the dashboard's own filter links actually produce values
 // that exercise it, including "all".
-describe("GET /feedback?state= filtering", () => {
+describe("GET /admin/feedback?state= filtering", () => {
   it("defaults to the unread queue when no state is given, matching mount/3", async () => {
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback")).text();
     // fbxss/fbfields/fbref/the escaped-id row were all inserted as 'unread'
     // in the tests above, so the default (unread) view still contains them,
     // while FB1 (moved to 'read' earlier in this file) is state-dependent --
@@ -278,7 +295,7 @@ describe("GET /feedback?state= filtering", () => {
   });
 
   it("state=all returns every state, not zero rows", async () => {
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=all")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback?state=all")).text();
     expect(html).toContain("Scanner missed a file");
   });
 
@@ -287,18 +304,18 @@ describe("GET /feedback?state= filtering", () => {
     // state right after beforeAll, so FB1's "read" transition from an
     // earlier test in this file does not carry over here -- do the
     // transition again within this test rather than relying on it.
-    await SELF.fetch(`https://relay.mydia.dev/feedback/${FB1}/state`, {
+    await SELF.fetch(`https://relay.mydia.dev/admin/feedback/${FB1}/state`, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: "state=read",
       redirect: "manual",
     });
 
-    const html = await (await SELF.fetch("https://relay.mydia.dev/feedback?state=read")).text();
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin/feedback?state=read")).text();
     expect(html).toContain("Scanner missed a file");
 
     const unreadOnly = await (
-      await SELF.fetch("https://relay.mydia.dev/feedback")
+      await SELF.fetch("https://relay.mydia.dev/admin/feedback")
     ).text();
     expect(unreadOnly).not.toContain("Scanner missed a file");
   });
@@ -309,12 +326,12 @@ describe("GET /feedback?state= filtering", () => {
 // redirect() builds the Location header directly from the decoded param,
 // and a CRLF sequence (delivered URL-encoded, e.g. %0D%0A) makes the
 // underlying Headers implementation throw -- fails safe, but as an
-// unhandled 500 rather than a clean 404, on an endpoint unauthenticated
-// until Task 15.
-describe("POST /feedback/:id/state and /github validate the id shape first", () => {
+// unhandled 500 rather than a clean 404, on a route with no in-code auth
+// (Cloudflare Access guards /admin/* at the edge; see the README runbook).
+describe("POST /admin/feedback/:id/state and /github validate the id shape first", () => {
   it("returns 404, not a 500, for a CRLF-injected id segment on /state", async () => {
     const res = await SELF.fetch(
-      "https://relay.mydia.dev/feedback/abc%0D%0AInjected/state",
+      "https://relay.mydia.dev/admin/feedback/abc%0D%0AInjected/state",
       {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -327,7 +344,7 @@ describe("POST /feedback/:id/state and /github validate the id shape first", () 
 
   it("returns 404, not a 500, for a CRLF-injected id segment on /github", async () => {
     const res = await SELF.fetch(
-      "https://relay.mydia.dev/feedback/abc%0D%0AInjected/github",
+      "https://relay.mydia.dev/admin/feedback/abc%0D%0AInjected/github",
       {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -340,7 +357,7 @@ describe("POST /feedback/:id/state and /github validate the id shape first", () 
 
   it("returns 404 for a non-UUID id on /state", async () => {
     const res = await SELF.fetch(
-      "https://relay.mydia.dev/feedback/not-a-real-id/state",
+      "https://relay.mydia.dev/admin/feedback/not-a-real-id/state",
       {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },
@@ -353,7 +370,7 @@ describe("POST /feedback/:id/state and /github validate the id shape first", () 
 
   it("returns 404 for a non-UUID id on /github", async () => {
     const res = await SELF.fetch(
-      "https://relay.mydia.dev/feedback/not-a-real-id/github",
+      "https://relay.mydia.dev/admin/feedback/not-a-real-id/github",
       {
         method: "POST",
         headers: { "content-type": "application/x-www-form-urlencoded" },

--- a/relay-worker/test/env.d.ts
+++ b/relay-worker/test/env.d.ts
@@ -1,0 +1,10 @@
+import type { Env } from "../src/env";
+
+// `cloudflare:test`'s `env` export is typed as an empty `ProvidedEnv` until a
+// test augments it via declaration merging (see the comment in
+// @cloudflare/vitest-pool-workers/types/cloudflare-test.d.ts). Without this,
+// `import { env } from "cloudflare:test"` types as `{}` and every binding
+// access fails to typecheck.
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}

--- a/relay-worker/test/env.d.ts
+++ b/relay-worker/test/env.d.ts
@@ -1,10 +1,19 @@
 import type { Env } from "../src/env";
+import type { D1Migration } from "@cloudflare/vitest-pool-workers/config";
 
 // `cloudflare:test`'s `env` export is typed as an empty `ProvidedEnv` until a
 // test augments it via declaration merging (see the comment in
 // @cloudflare/vitest-pool-workers/types/cloudflare-test.d.ts). Without this,
 // `import { env } from "cloudflare:test"` types as `{}` and every binding
 // access fails to typecheck.
+//
+// TEST_MIGRATIONS is injected only by vitest.config.ts's miniflare bindings
+// (see readD1Migrations there) and applied in test setup via
+// applyD1Migrations -- it has no production equivalent, so it lives on this
+// test-only interface rather than on Env, where production code could reach
+// for it.
 declare module "cloudflare:test" {
-  interface ProvidedEnv extends Env {}
+  interface ProvidedEnv extends Env {
+    TEST_MIGRATIONS: D1Migration[];
+  }
 }

--- a/relay-worker/test/feedback/ingest.test.ts
+++ b/relay-worker/test/feedback/ingest.test.ts
@@ -1,0 +1,277 @@
+import { env, SELF, fetchMock, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { validateSubmission, sanitizeHeaderValue } from "../../src/feedback/ingest";
+
+const json = { "content-type": "application/json" };
+const FEEDBACK_URL = "https://relay.mydia.dev/feedback";
+
+interface CreatedResponse {
+  status: string;
+  id: string;
+}
+
+interface ValidationErrorResponse {
+  error: string;
+  errors: string[];
+}
+
+interface FeedbackRowShape {
+  id: string;
+  type: string;
+  message: string;
+  contact: string | null;
+  instance_id: string | null;
+  mydia_version: string | null;
+  state: string;
+}
+
+async function getRowByVersion(version: string): Promise<FeedbackRowShape | null> {
+  return env.DB.prepare(
+    "SELECT id, type, message, contact, instance_id, mydia_version, state FROM feedback_submissions WHERE mydia_version = ?",
+  )
+    .bind(version)
+    .first<FeedbackRowShape>();
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+
+// RESEND_API_KEY is set for every test (vitest.config.ts), so every POST
+// /feedback attempts a real notification call and each test must account for
+// (mock) exactly one -- an unconsumed interceptor is a real bug here, not
+// noise, since it means the code silently stopped calling out to Resend.
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+function mockResendSuccess(): void {
+  fetchMock
+    .get("https://api.resend.com")
+    .intercept({ method: "POST", path: "/emails" })
+    .reply(200, { id: "email-1" });
+}
+
+describe("validateSubmission", () => {
+  it("accepts the three allowed types", () => {
+    for (const type of ["bug", "idea", "question"]) {
+      expect(validateSubmission({ type, message: "hi" }).ok).toBe(true);
+    }
+  });
+
+  it("rejects a type outside the allowed set with router.ex's exact message", () => {
+    const result = validateSubmission({ type: "rant", message: "hi" });
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.errors).toEqual(["Invalid type: rant"]);
+  });
+
+  it("requires both type and message, matching router.ex's exact messages", () => {
+    const missingMessage = validateSubmission({ type: "bug" });
+    expect(!missingMessage.ok && missingMessage.errors).toEqual([
+      "Missing required field: message",
+    ]);
+
+    const missingType = validateSubmission({ message: "hi" });
+    expect(!missingType.ok && missingType.errors).toEqual(["Missing required field: type"]);
+  });
+
+  // router.ex's require_feedback_field/3 treats a whitespace-only value as
+  // absent (String.trim(value) != ""), same as a missing field entirely.
+  it("treats a whitespace-only message as missing", () => {
+    const result = validateSubmission({ type: "bug", message: "   " });
+    expect(!result.ok && result.errors).toContain("Missing required field: message");
+  });
+
+  // The relay never reads a client-supplied `state` at all (router.ex's
+  // get_feedback_param only reads type/message/contact/instance_id/
+  // mydia_version) -- state is always server-assigned. A client sending
+  // state: "archived" must not be able to bypass triage.
+  it("defaults state to unread and ignores a client-supplied state", () => {
+    const result = validateSubmission({ type: "bug", message: "hi", state: "archived" });
+    expect(result.ok && result.value.state).toBe("unread");
+  });
+
+  // router.ex's validate_optional_feedback_field/3: nil is fine, any string
+  // is fine, anything else (a map, here) is rejected outright rather than
+  // silently coerced to null.
+  it("rejects a non-string optional field instead of silently dropping it", () => {
+    const result = validateSubmission({ type: "bug", message: "hi", contact: { x: 1 } });
+    expect(!result.ok && result.errors).toEqual(["Invalid field: contact"]);
+  });
+
+  it("trims contact/instance_id/mydia_version and nulls out whitespace-only values", () => {
+    const result = validateSubmission({
+      type: "bug",
+      message: "hi",
+      contact: "  a@b.com  ",
+      instance_id: "   ",
+    });
+    expect(result.ok && result.value.contact).toBe("a@b.com");
+    expect(result.ok && result.value.instance_id).toBeNull();
+  });
+
+  it("stores type and message untrimmed, as router.ex does", () => {
+    const result = validateSubmission({ type: "bug", message: "  hi  " });
+    expect(result.ok && result.value.message).toBe("  hi  ");
+  });
+});
+
+describe("sanitizeHeaderValue", () => {
+  it("strips CR and LF so a crafted contact cannot inject mail headers", () => {
+    expect(sanitizeHeaderValue("a@b.com\r\nBcc: victim@example.com")).not.toContain("\r");
+    expect(sanitizeHeaderValue("a@b.com\r\nBcc: victim@example.com")).not.toContain("\n");
+  });
+});
+
+describe("POST /feedback", () => {
+  it("stores a submission and returns 201 with the {status, id} shape router.ex sends", async () => {
+    mockResendSuccess();
+
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({
+        type: "bug",
+        message: "Scanner missed a file",
+        mydia_version: "1.2.3",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json<CreatedResponse>();
+    expect(body.status).toBe("created");
+    expect(typeof body.id).toBe("string");
+
+    const row = await getRowByVersion("1.2.3");
+    expect(row).toMatchObject({ type: "bug", message: "Scanner missed a file", state: "unread" });
+  });
+
+  // Mydia.Feedback.Sender.post/1 pattern-matches on exactly {status: 400,
+  // body: response} to extract {:validation_error, errors}. A 422 here (the
+  // brief's original status) falls through Sender's case statement into the
+  // generic {:http_error, status, body} branch instead, silently discarding
+  // the structured validation errors for every caller that checks for
+  // {:validation_error, _}.
+  it("returns 400 (not 422) with router.ex's exact error shape for an invalid submission", async () => {
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ type: "rant", message: "" }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<ValidationErrorResponse>();
+    expect(body.error).toBe("Validation failed");
+    expect(body.errors).toContain("Missing required field: message");
+    expect(body.errors).toContain("Invalid type: rant");
+  });
+
+  it("returns 400 with a distinct body when the message exceeds router.ex's 4096-byte limit", async () => {
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ type: "bug", message: "a".repeat(4097) }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string; limit_bytes: number }>();
+    expect(body).toEqual({ error: "Message too long", limit_bytes: 4096 });
+  });
+
+  it("accepts a message at exactly the 4096-byte limit", async () => {
+    mockResendSuccess();
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ type: "bug", message: "a".repeat(4096) }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it("still stores the submission when the notification email fails", async () => {
+    // Losing the row because a mail provider is down would be a worse
+    // failure than a missed notification.
+    fetchMock
+      .get("https://api.resend.com")
+      .intercept({ method: "POST", path: "/emails" })
+      .reply(500, "provider down");
+
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ type: "idea", message: "Keep the row", mydia_version: "9.9.9" }),
+    });
+
+    expect(res.status).toBe(201);
+    const row = await getRowByVersion("9.9.9");
+    expect(row).not.toBeNull();
+  });
+
+  it("sets reply-to only when contact looks like an email address, matching notifier.ex", async () => {
+    let capturedBody = "";
+    fetchMock
+      .get("https://api.resend.com")
+      .intercept({
+        method: "POST",
+        path: "/emails",
+        body: (b) => {
+          capturedBody = b;
+          return true;
+        },
+      })
+      .reply(200, { id: "email-2" });
+
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({
+        type: "bug",
+        message: "Subtitles are offset",
+        contact: "  Reporter@Example.COM  ",
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    const sent = JSON.parse(capturedBody) as { reply_to?: string; subject: string };
+    expect(sent.reply_to).toBe("Reporter@Example.COM");
+    expect(sent.subject).toContain("bug");
+  });
+
+  it("omits reply-to when contact is not an email address", async () => {
+    let capturedBody = "";
+    fetchMock
+      .get("https://api.resend.com")
+      .intercept({
+        method: "POST",
+        path: "/emails",
+        body: (b) => {
+          capturedBody = b;
+          return true;
+        },
+      })
+      .reply(200, { id: "email-3" });
+
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({
+        type: "idea",
+        message: "Add a dark theme",
+        contact: "@some-github-handle",
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    const sent = JSON.parse(capturedBody) as { reply_to?: string };
+    expect(sent.reply_to).toBeUndefined();
+  });
+
+  it("returns 400 for a body that is not a JSON object", async () => {
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: json,
+      body: "not json",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("Invalid JSON");
+  });
+});

--- a/relay-worker/test/feedback/ingest.test.ts
+++ b/relay-worker/test/feedback/ingest.test.ts
@@ -156,20 +156,48 @@ describe("sanitizeHeaderValue", () => {
 // router.ex's feedback_rate_limit_instance_id/2, including its T-236
 // anti-collision namespacing.
 describe("feedbackInstanceRateLimitKey", () => {
-  it("namespaces a supplied instance_id separately from the IP fallback", () => {
-    expect(feedbackInstanceRateLimitKey("abc", "1.2.3.4")).toBe("instance:supplied:abc");
-    expect(feedbackInstanceRateLimitKey(undefined, "1.2.3.4")).toBe("instance:fallback:1.2.3.4");
-    expect(feedbackInstanceRateLimitKey(null, "1.2.3.4")).toBe("instance:fallback:1.2.3.4");
-    expect(feedbackInstanceRateLimitKey("", "1.2.3.4")).toBe("instance:fallback:1.2.3.4");
+  it("namespaces a supplied instance_id separately from the IP fallback", async () => {
+    expect(await feedbackInstanceRateLimitKey("abc", "1.2.3.4")).toMatch(
+      /^instance:supplied:[0-9a-f]{64}$/,
+    );
+    expect(await feedbackInstanceRateLimitKey(undefined, "1.2.3.4")).toMatch(
+      /^instance:fallback:[0-9a-f]{64}$/,
+    );
+    expect(await feedbackInstanceRateLimitKey(null, "1.2.3.4")).toMatch(
+      /^instance:fallback:[0-9a-f]{64}$/,
+    );
+    expect(await feedbackInstanceRateLimitKey("", "1.2.3.4")).toMatch(
+      /^instance:fallback:[0-9a-f]{64}$/,
+    );
+  });
+
+  // instance_id is an arbitrary client-supplied string with no length cap
+  // anywhere (validateSubmission only bounds `message`), and this check
+  // runs BEFORE validation -- so an unhashed key would let a row's size in
+  // feedback_rate_limits be attacker-chosen. Hashing bounds it to a fixed
+  // size regardless of input length.
+  it("produces a fixed-length key regardless of instance_id length", async () => {
+    const short = await feedbackInstanceRateLimitKey("a", "1.2.3.4");
+    const long = await feedbackInstanceRateLimitKey("x".repeat(50_000), "1.2.3.4");
+    expect(short.length).toBe(long.length);
+  });
+
+  it("still lands two different (long) instance ids in different buckets", async () => {
+    const a = await feedbackInstanceRateLimitKey("x".repeat(50_000), "1.2.3.4");
+    const b = await feedbackInstanceRateLimitKey("y".repeat(50_000), "1.2.3.4");
+    expect(a).not.toBe(b);
   });
 
   // Regression guard for the exact T-236 attack router.ex's own test suite
   // covers: a caller-supplied instance_id crafted to look like the fallback
-  // key format must not land in the same bucket as the real fallback.
-  it("cannot be made to collide with another IP's fallback bucket by crafting instance_id", () => {
+  // key format must not land in the same bucket as the real fallback. Must
+  // still hold after hashing -- the "supplied:"/"fallback:" prefix, not the
+  // hash, is what prevents the collision, so hashing the suffix must not
+  // have disturbed it.
+  it("cannot be made to collide with another IP's fallback bucket by crafting instance_id", async () => {
     const victimIp = "203.0.113.99";
-    const attackerKey = feedbackInstanceRateLimitKey(`fallback:${victimIp}`, "203.0.113.1");
-    const victimKey = feedbackInstanceRateLimitKey(undefined, victimIp);
+    const attackerKey = await feedbackInstanceRateLimitKey(`fallback:${victimIp}`, "203.0.113.1");
+    const victimKey = await feedbackInstanceRateLimitKey(undefined, victimIp);
     expect(attackerKey).not.toBe(victimKey);
   });
 });

--- a/relay-worker/test/feedback/ingest.test.ts
+++ b/relay-worker/test/feedback/ingest.test.ts
@@ -1,6 +1,12 @@
 import { env, SELF, fetchMock, applyD1Migrations } from "cloudflare:test";
 import { describe, it, expect, beforeAll, afterEach } from "vitest";
-import { validateSubmission, sanitizeHeaderValue } from "../../src/feedback/ingest";
+import {
+  validateSubmission,
+  sanitizeHeaderValue,
+  feedbackInstanceRateLimitKey,
+  checkFeedbackRateLimit,
+  FEEDBACK_RATE_LIMIT,
+} from "../../src/feedback/ingest";
 
 const json = { "content-type": "application/json" };
 const FEEDBACK_URL = "https://relay.mydia.dev/feedback";
@@ -15,6 +21,11 @@ interface ValidationErrorResponse {
   errors: string[];
 }
 
+interface RateLimitedResponse {
+  error: string;
+  message: string;
+}
+
 interface FeedbackRowShape {
   id: string;
   type: string;
@@ -25,12 +36,30 @@ interface FeedbackRowShape {
   state: string;
 }
 
+// Every request now spends a rate-limit slot (including rejected ones -- see
+// the "rate limiting" describe block below), so tests that aren't
+// deliberately exercising the limiter must not share an IP: otherwise they'd
+// all pile into the "unknown" bucket and start tripping 429s on each other.
+// Mirrors test/pairing/routes.test.ts's freshIp() for the same reason.
+let nextTestIp = 10;
+function freshIp(): string {
+  return `198.51.100.${nextTestIp++}`;
+}
+
 async function getRowByVersion(version: string): Promise<FeedbackRowShape | null> {
   return env.DB.prepare(
     "SELECT id, type, message, contact, instance_id, mydia_version, state FROM feedback_submissions WHERE mydia_version = ?",
   )
     .bind(version)
     .first<FeedbackRowShape>();
+}
+
+async function tableCounts(): Promise<{ submissions: number; rateLimits: number }> {
+  const [submissions, rateLimits] = await Promise.all([
+    env.DB.prepare("SELECT COUNT(*) AS n FROM feedback_submissions").first<{ n: number }>(),
+    env.DB.prepare("SELECT COUNT(*) AS n FROM feedback_rate_limits").first<{ n: number }>(),
+  ]);
+  return { submissions: submissions!.n, rateLimits: rateLimits!.n };
 }
 
 beforeAll(async () => {
@@ -40,9 +69,10 @@ beforeAll(async () => {
 });
 
 // RESEND_API_KEY is set for every test (vitest.config.ts), so every POST
-// /feedback attempts a real notification call and each test must account for
-// (mock) exactly one -- an unconsumed interceptor is a real bug here, not
-// noise, since it means the code silently stopped calling out to Resend.
+// /feedback that gets past validation attempts a real notification call and
+// each such test must account for (mock) exactly one -- an unconsumed
+// interceptor is a real bug here, not noise, since it means the code
+// silently stopped calling out to Resend.
 afterEach(() => fetchMock.assertNoPendingInterceptors());
 
 function mockResendSuccess(): void {
@@ -123,13 +153,59 @@ describe("sanitizeHeaderValue", () => {
   });
 });
 
+// router.ex's feedback_rate_limit_instance_id/2, including its T-236
+// anti-collision namespacing.
+describe("feedbackInstanceRateLimitKey", () => {
+  it("namespaces a supplied instance_id separately from the IP fallback", () => {
+    expect(feedbackInstanceRateLimitKey("abc", "1.2.3.4")).toBe("instance:supplied:abc");
+    expect(feedbackInstanceRateLimitKey(undefined, "1.2.3.4")).toBe("instance:fallback:1.2.3.4");
+    expect(feedbackInstanceRateLimitKey(null, "1.2.3.4")).toBe("instance:fallback:1.2.3.4");
+    expect(feedbackInstanceRateLimitKey("", "1.2.3.4")).toBe("instance:fallback:1.2.3.4");
+  });
+
+  // Regression guard for the exact T-236 attack router.ex's own test suite
+  // covers: a caller-supplied instance_id crafted to look like the fallback
+  // key format must not land in the same bucket as the real fallback.
+  it("cannot be made to collide with another IP's fallback bucket by crafting instance_id", () => {
+    const victimIp = "203.0.113.99";
+    const attackerKey = feedbackInstanceRateLimitKey(`fallback:${victimIp}`, "203.0.113.1");
+    const victimKey = feedbackInstanceRateLimitKey(undefined, victimIp);
+    expect(attackerKey).not.toBe(victimKey);
+  });
+});
+
+describe("checkFeedbackRateLimit", () => {
+  // Feedback submissions carry no client-supplied timestamp (unlike crash
+  // reports' occurred_at), so hour rollover is tested by calling the
+  // exported function directly with explicit hour_bucket values rather than
+  // faking the Workers runtime clock, which vi.useFakeTimers() cannot reach
+  // inside workerd's own isolate.
+  it("resets the count once the hour bucket advances", async () => {
+    const ip = freshIp();
+    const hourA = 500_000;
+    const hourB = 500_001;
+
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT; i++) {
+      const result = await checkFeedbackRateLimit(env.DB, ip, undefined, hourA);
+      expect(result.allowed).toBe(true);
+    }
+
+    const saturated = await checkFeedbackRateLimit(env.DB, ip, undefined, hourA);
+    expect(saturated.allowed).toBe(false);
+    expect(saturated.writes).toBe(0);
+
+    const nextHour = await checkFeedbackRateLimit(env.DB, ip, undefined, hourB);
+    expect(nextHour.allowed).toBe(true);
+  });
+});
+
 describe("POST /feedback", () => {
   it("stores a submission and returns 201 with the {status, id} shape router.ex sends", async () => {
     mockResendSuccess();
 
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: JSON.stringify({
         type: "bug",
         message: "Scanner missed a file",
@@ -155,7 +231,7 @@ describe("POST /feedback", () => {
   it("returns 400 (not 422) with router.ex's exact error shape for an invalid submission", async () => {
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: JSON.stringify({ type: "rant", message: "" }),
     });
     expect(res.status).toBe(400);
@@ -168,7 +244,7 @@ describe("POST /feedback", () => {
   it("returns 400 with a distinct body when the message exceeds router.ex's 4096-byte limit", async () => {
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: JSON.stringify({ type: "bug", message: "a".repeat(4097) }),
     });
     expect(res.status).toBe(400);
@@ -180,7 +256,7 @@ describe("POST /feedback", () => {
     mockResendSuccess();
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: JSON.stringify({ type: "bug", message: "a".repeat(4096) }),
     });
     expect(res.status).toBe(201);
@@ -196,7 +272,7 @@ describe("POST /feedback", () => {
 
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: JSON.stringify({ type: "idea", message: "Keep the row", mydia_version: "9.9.9" }),
     });
 
@@ -221,7 +297,7 @@ describe("POST /feedback", () => {
 
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: JSON.stringify({
         type: "bug",
         message: "Subtitles are offset",
@@ -251,7 +327,7 @@ describe("POST /feedback", () => {
 
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: JSON.stringify({
         type: "idea",
         message: "Add a dark theme",
@@ -264,14 +340,139 @@ describe("POST /feedback", () => {
     expect(sent.reply_to).toBeUndefined();
   });
 
-  it("returns 400 for a body that is not a JSON object", async () => {
+  it("returns 400 for a body that is not valid JSON at all, without touching the rate limiter", async () => {
     const res = await SELF.fetch(FEEDBACK_URL, {
       method: "POST",
-      headers: json,
+      headers: { ...json, "cf-connecting-ip": freshIp() },
       body: "not json",
     });
     expect(res.status).toBe(400);
     const body = await res.json<{ error: string }>();
     expect(body.error).toBe("Invalid JSON");
+    // No rate-limit check ran at all for genuinely malformed syntax
+    // (mirrors Plug.Parsers rejecting it before routing in the Elixir), so
+    // no x-relay-d1-writes header is present.
+    expect(res.headers.get("x-relay-d1-writes")).toBeNull();
+  });
+
+  it("still consumes a rate-limit slot for parseable-but-non-object JSON, matching router.ex's ordering", async () => {
+    // router.ex checks rate limits inside handle_feedback/1, BEFORE
+    // process_feedback/2 (where the is-this-a-map check actually lives) is
+    // ever called -- so a syntactically valid but non-object body still
+    // spends a slot, unlike genuinely malformed syntax above.
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify([1, 2, 3]),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("Invalid JSON");
+    expect(res.headers.get("x-relay-d1-writes")).not.toBe("0");
+  });
+});
+
+describe("POST /feedback rate limiting", () => {
+  it("rejects the 6th submission from one IP within the hour with router.ex's exact 429 shape", async () => {
+    const ip = freshIp();
+
+    // Distinct instance_id per request so it's the IP bucket, not the
+    // instance bucket, that saturates.
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT; i++) {
+      mockResendSuccess();
+      const res = await SELF.fetch(FEEDBACK_URL, {
+        method: "POST",
+        headers: { ...json, "cf-connecting-ip": ip },
+        body: JSON.stringify({ type: "bug", message: `Message ${i}`, instance_id: `inst-${i}` }),
+      });
+      expect(res.status).toBe(201);
+    }
+
+    const before = await tableCounts();
+
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": ip },
+      body: JSON.stringify({ type: "bug", message: "Message 6", instance_id: "inst-6" }),
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("3600");
+    // The IP bucket is already saturated: the check costs a read, and the
+    // `with`-style short-circuit means the instance check (and the D1
+    // insert) is never even reached -- zero writes total, asserted both via
+    // the write-count header (Task 11's instrument, since a table's row
+    // COUNT(*) can't distinguish a skipped write from an unconditional
+    // UPDATE that happens not to change a row) and via the row-count delta
+    // across both tables below.
+    expect(res.headers.get("x-relay-d1-writes")).toBe("0");
+    const body = await res.json<RateLimitedResponse>();
+    expect(body).toEqual({
+      error: "Too many requests",
+      message: "Rate limit exceeded. Please try again later.",
+    });
+
+    const after = await tableCounts();
+    expect(after).toEqual(before);
+  });
+
+  it("rejects the 6th submission from one instance id even when the IP differs each time", async () => {
+    const instanceId = `shared-${freshIp()}`;
+
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT; i++) {
+      mockResendSuccess();
+      const res = await SELF.fetch(FEEDBACK_URL, {
+        method: "POST",
+        headers: { ...json, "cf-connecting-ip": freshIp() },
+        body: JSON.stringify({ type: "bug", message: `Message ${i}`, instance_id: instanceId }),
+      });
+      expect(res.status).toBe(201);
+    }
+
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ type: "bug", message: "Message 6", instance_id: instanceId }),
+    });
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("retry-after")).toBe("3600");
+    const body = await res.json<RateLimitedResponse>();
+    expect(body).toEqual({
+      error: "Too many requests",
+      message: "Rate limit exceeded. Please try again later.",
+    });
+  });
+
+  // Integration-level version of the T-236 regression above: an attacker
+  // spreading requests across throwaway IPs, all supplying instance_id
+  // crafted to mimic the victim's fallback-key format, must not exhaust the
+  // victim's real (no-instance_id) fallback bucket.
+  it("does not let a crafted instance_id collide with another caller's IP-fallback bucket", async () => {
+    const victimIp = freshIp();
+
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT; i++) {
+      mockResendSuccess();
+      const res = await SELF.fetch(FEEDBACK_URL, {
+        method: "POST",
+        headers: { ...json, "cf-connecting-ip": freshIp() },
+        body: JSON.stringify({
+          type: "bug",
+          message: `Attacker ${i}`,
+          instance_id: `fallback:${victimIp}`,
+        }),
+      });
+      expect(res.status).toBe(201);
+    }
+
+    // The victim, sending from their own IP with no instance_id at all,
+    // must still get through.
+    mockResendSuccess();
+    const res = await SELF.fetch(FEEDBACK_URL, {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": victimIp },
+      body: JSON.stringify({ type: "bug", message: "Victim" }),
+    });
+    expect(res.status).toBe(201);
   });
 });

--- a/relay-worker/test/feedback/ingest.test.ts
+++ b/relay-worker/test/feedback/ingest.test.ts
@@ -503,4 +503,59 @@ describe("POST /feedback rate limiting", () => {
     });
     expect(res.status).toBe(201);
   });
+
+  // Final-review CRITICAL: every test above drives requests sequentially,
+  // which is structurally blind to a defect that only appears under
+  // concurrency. The original checkAndIncrementBucket read the bucket,
+  // decided in JS, then issued a SEPARATE INSERT ... ON CONFLICT DO UPDATE --
+  // not a transaction, so D1 only guaranteed ordering within one statement,
+  // not across those two independent calls. Measured against the pre-fix
+  // code: 20 concurrent identical-IP submissions were ALL 20 admitted
+  // against the 5/hour cap -- a complete bypass, each firing a real outbound
+  // Resend call. Promise.all (not a for loop) is what actually exercises the
+  // race; a for loop with awaited iterations is sequential in disguise.
+  it("bounds admissions under REAL concurrency (Promise.all) to FEEDBACK_RATE_LIMIT, not all of them", async () => {
+    const ip = freshIp();
+
+    // Distinct instance_id per request, same as the sequential IP-cap test
+    // above, so it's the IP bucket alone that's under test here -- exactly
+    // the identity the demonstrated race exploited. Up to FEEDBACK_RATE_LIMIT
+    // requests can legitimately be admitted; register exactly that many
+    // notify() mocks so afterEach's assertNoPendingInterceptors both proves
+    // no MORE than that were admitted (an unconsumed interceptor would be
+    // silent) and, combined with the assertion below, that no FEWER were
+    // either.
+    for (let i = 0; i < FEEDBACK_RATE_LIMIT; i++) {
+      mockResendSuccess();
+    }
+
+    const responses = await Promise.all(
+      Array.from({ length: 20 }, (_, i) =>
+        SELF.fetch(FEEDBACK_URL, {
+          method: "POST",
+          headers: { ...json, "cf-connecting-ip": ip },
+          body: JSON.stringify({
+            type: "bug",
+            message: `Concurrent ${i}`,
+            instance_id: `concurrent-inst-${i}`,
+          }),
+        }),
+      ),
+    );
+
+    const created = responses.filter((r) => r.status === 201).length;
+    const throttled = responses.filter((r) => r.status === 429).length;
+
+    // The atomic admission decision (a single INSERT ... ON CONFLICT DO
+    // UPDATE ... RETURNING per request) guarantees the SAME exact cap holds
+    // under concurrency as under the sequential test above -- not merely "a
+    // smaller number than before".
+    expect(created).toBe(FEEDBACK_RATE_LIMIT);
+    expect(throttled).toBe(20 - FEEDBACK_RATE_LIMIT);
+
+    const row = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM feedback_submissions WHERE message LIKE 'Concurrent %'",
+    ).first<{ n: number }>();
+    expect(row!.n).toBe(FEEDBACK_RATE_LIMIT);
+  });
 });

--- a/relay-worker/test/feedback/ingest.test.ts
+++ b/relay-worker/test/feedback/ingest.test.ts
@@ -252,7 +252,7 @@ describe("POST /feedback", () => {
 
   // Mydia.Feedback.Sender.post/1 pattern-matches on exactly {status: 400,
   // body: response} to extract {:validation_error, errors}. A 422 here (the
-  // brief's original status) falls through Sender's case statement into the
+  // obvious choice for a validation failure) falls through Sender's case into the
   // generic {:http_error, status, body} branch instead, silently discarding
   // the structured validation errors for every caller that checks for
   // {:validation_error, _}.
@@ -429,7 +429,7 @@ describe("POST /feedback rate limiting", () => {
     // The IP bucket is already saturated: the check costs a read, and the
     // `with`-style short-circuit means the instance check (and the D1
     // insert) is never even reached -- zero writes total, asserted both via
-    // the write-count header (Task 11's instrument, since a table's row
+    // the write-count header (added for crash ingest, since a table's row
     // COUNT(*) can't distinguish a skipped write from an unconditional
     // UPDATE that happens not to change a row) and via the row-count delta
     // across both tables below.

--- a/relay-worker/test/health.test.ts
+++ b/relay-worker/test/health.test.ts
@@ -21,7 +21,17 @@ describe("GET /health", () => {
     expect(typeof body.subtitles_configured).toBe("boolean");
   });
 
-  it("reports subtitles_configured false when no SubDL key is set", async () => {
+  it("reports subtitles_configured true when a SubDL key is set", async () => {
+    // Task 6 added a global SUBDL_API_KEY test binding (vitest.config.ts) so
+    // the search/download routes can be exercised without 503ing first, which
+    // means every SELF.fetch dispatch in this pool now sees a configured key.
+    // SELF.fetch has no per-call env override (bindings are fixed for the
+    // whole pool at startup; verified empirically that mutating the imported
+    // `env` object does not propagate to the dispatched worker), so the
+    // "absent key" branch can no longer be reached through this route test.
+    // It is covered directly instead, by src/proxy/subdl.ts's exported
+    // subdlApiKey helper -- see test/proxy/subdl.test.ts's "subdlApiKey"
+    // block for the absent/blank cases this test used to assert.
     const res = await SELF.fetch("https://relay.mydia.dev/health");
     const body = await res.json<{
       status: string;
@@ -29,6 +39,6 @@ describe("GET /health", () => {
       version: string;
       subtitles_configured: boolean;
     }>();
-    expect(body.subtitles_configured).toBe(false);
+    expect(body.subtitles_configured).toBe(true);
   });
 });

--- a/relay-worker/test/health.test.ts
+++ b/relay-worker/test/health.test.ts
@@ -1,0 +1,34 @@
+import { env, SELF } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("GET /health", () => {
+  it("returns the shape deployed monitoring reads", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/health");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+
+    const body = await res.json<{
+      status: string;
+      service: string;
+      version: string;
+      subtitles_configured: boolean;
+    }>();
+    expect(body).toMatchObject({
+      status: "ok",
+      service: "metadata-relay",
+    });
+    expect(typeof body.version).toBe("string");
+    expect(typeof body.subtitles_configured).toBe("boolean");
+  });
+
+  it("reports subtitles_configured false when no SubDL key is set", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/health");
+    const body = await res.json<{
+      status: string;
+      service: string;
+      version: string;
+      subtitles_configured: boolean;
+    }>();
+    expect(body.subtitles_configured).toBe(false);
+  });
+});

--- a/relay-worker/test/health.test.ts
+++ b/relay-worker/test/health.test.ts
@@ -22,7 +22,7 @@ describe("GET /health", () => {
   });
 
   it("reports subtitles_configured true when a SubDL key is set", async () => {
-    // Task 6 added a global SUBDL_API_KEY test binding (vitest.config.ts) so
+    // There is a global SUBDL_API_KEY test binding (vitest.config.ts) so
     // the search/download routes can be exercised without 503ing first, which
     // means every SELF.fetch dispatch in this pool now sees a configured key.
     // SELF.fetch has no per-call env override (bindings are fixed for the

--- a/relay-worker/test/obs/ratelimit.test.ts
+++ b/relay-worker/test/obs/ratelimit.test.ts
@@ -1,0 +1,73 @@
+import { SELF, fetchMock } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { serviceFromPath } from "../../src/obs/log";
+
+describe("serviceFromPath", () => {
+  it("labels each proxied upstream", () => {
+    expect(serviceFromPath("/tmdb/movies/550")).toBe("tmdb");
+    expect(serviceFromPath("/tvdb/series/1")).toBe("tvdb");
+    expect(serviceFromPath("/music/artist/x")).toBe("music");
+    expect(serviceFromPath("/openlibrary/search")).toBe("openlibrary");
+    expect(serviceFromPath("/api/v1/subtitles/search")).toBe("subdl");
+  });
+
+  it("returns null for routes that are not a proxied upstream", () => {
+    expect(serviceFromPath("/health")).toBeNull();
+    expect(serviceFromPath("/pairing/claim")).toBeNull();
+    expect(serviceFromPath("/crashes/report")).toBeNull();
+  });
+});
+
+describe("rate limiting", () => {
+  beforeAll(() => {
+    fetchMock.activate();
+    fetchMock.disableNetConnect();
+  });
+
+  it("returns 429 with a Retry-After header once the budget is spent", async () => {
+    let last: Response | undefined;
+    for (let i = 0; i < 305; i++) {
+      last = await SELF.fetch("https://relay.mydia.dev/tmdb/genre/movie", {
+        headers: { "cf-connecting-ip": "203.0.113.9" },
+      });
+      if (last.status === 429) break;
+    }
+
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("retry-after")).toBe("60");
+    // Exact parity with metadata-relay/lib/metadata_relay/plug/proxy_rate_limit.ex's
+    // send_resp(429, Jason.encode!(%{error: "Too many requests", message: "..."})) --
+    // NOT router.ex's separate send_rate_limited/2 helper, which uses a
+    // differently-cased "rate_limited" error string for pairing/feedback/crash
+    // routes. This is the one the proxy limiter itself uses.
+    const body = await last!.json<{ error: string; message: string }>();
+    expect(body).toMatchObject({
+      error: "Too many requests",
+      message: "Rate limit exceeded. Please try again later.",
+    });
+  });
+
+  it("does not throttle /health, which monitoring polls", async () => {
+    for (let i = 0; i < 50; i++) {
+      const res = await SELF.fetch("https://relay.mydia.dev/health", {
+        headers: { "cf-connecting-ip": "203.0.113.10" },
+      });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it("does not charge pairing against the proxy budget", async () => {
+    // Pairing has its own 10/min and 30/min limiters. Charging both would let
+    // an ordinary pairing flow exhaust the metadata budget for the same IP.
+    for (let i = 0; i < 40; i++) {
+      await SELF.fetch("https://relay.mydia.dev/pairing/claim/NOPE", {
+        headers: { "cf-connecting-ip": "203.0.113.11" },
+      });
+    }
+
+    const res = await SELF.fetch("https://relay.mydia.dev/tmdb/genre/tv", {
+      headers: { "cf-connecting-ip": "203.0.113.11" },
+    });
+    expect(res.status).not.toBe(429);
+  });
+});

--- a/relay-worker/test/obs/ratelimit.test.ts
+++ b/relay-worker/test/obs/ratelimit.test.ts
@@ -18,6 +18,32 @@ describe("serviceFromPath", () => {
   });
 });
 
+// PROXY_LIMITER is limit: 300, period: 60 (wrangler.jsonc). Miniflare's own
+// rate-limit simulator resets its whole counter on wall-clock time, not on
+// consumption -- node_modules/miniflare/dist/src/workers/ratelimit/ratelimit.worker.js:
+//   let epoch = Math.floor(Date.now() / (period * 1e3));
+//   epoch != this.epoch && (this.epoch = epoch, this.buckets.clear());
+// If a real 60s boundary falls in the middle of one of the loops below, the
+// in-flight count is wiped to zero and up to another full `limit` requests
+// are needed to trip the 429 again -- observed as "expected 500 to be 429"
+// (the loop exhausts with the route's own, unthrottled response) at roughly
+// once in four to six full-suite runs, in two independent review sessions.
+// It's a property of the local simulator, not the Worker: production rate
+// limiting is Cloudflare's real service, not this fixed-window-per-process
+// approximation.
+//
+// The cap below (2 * limit + margin) survives exactly one such reset,
+// wherever in the loop it lands: up to `limit - 1` requests before the
+// reset, then a full `limit + 1` after it. `if (last.status === 429) break`
+// means an ordinary run (no reset) still exits after ~301 iterations, same
+// as before -- only a run that hits the reset pays the extra iterations.
+// This does not eliminate the flake (two resets in one loop would still
+// lose), it makes the common single-reset case survivable by construction.
+// Do not shrink this back toward `limit` because "305 was fine before" --
+// that reasoning is exactly what shipped the flake.
+const PROXY_LIMIT = 300;
+const PROXY_LIMIT_ITERATION_CAP = 2 * PROXY_LIMIT + 10;
+
 describe("rate limiting", () => {
   beforeAll(async () => {
     fetchMock.activate();
@@ -32,31 +58,39 @@ describe("rate limiting", () => {
     await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
   });
 
-  it("returns 429 with a Retry-After header once the budget is spent", async () => {
-    let last: Response | undefined;
-    for (let i = 0; i < 305; i++) {
-      last = await SELF.fetch("https://relay.mydia.dev/tmdb/genre/movie", {
-        headers: { "cf-connecting-ip": "203.0.113.9" },
-      });
-      if (last.status === 429) break;
-    }
+  it(
+    "returns 429 with a Retry-After header once the budget is spent",
+    async () => {
+      // Explicit timeout below (not Vitest's 5000ms default): the rare
+      // mid-loop reset case runs up to PROXY_LIMIT_ITERATION_CAP iterations
+      // rather than the usual ~301, and needs the room.
+      let last: Response | undefined;
+      for (let i = 0; i < PROXY_LIMIT_ITERATION_CAP; i++) {
+        last = await SELF.fetch("https://relay.mydia.dev/tmdb/genre/movie", {
+          headers: { "cf-connecting-ip": "203.0.113.9" },
+        });
+        if (last.status === 429) break;
+      }
 
-    expect(last!.status).toBe(429);
-    expect(last!.headers.get("retry-after")).toBe("60");
-    // Exact parity with metadata-relay/lib/metadata_relay/plug/proxy_rate_limit.ex's
-    // send_resp(429, Jason.encode!(%{error: "Too many requests", message: "..."})) --
-    // NOT router.ex's separate send_rate_limited/2 helper, which uses a
-    // differently-cased "rate_limited" error string for pairing/feedback/crash
-    // routes. This is the one the proxy limiter itself uses.
-    const body = await last!.json<{ error: string; message: string }>();
-    expect(body).toMatchObject({
-      error: "Too many requests",
-      message: "Rate limit exceeded. Please try again later.",
-    });
-  });
+      expect(last!.status).toBe(429);
+      expect(last!.headers.get("retry-after")).toBe("60");
+      // Exact parity with metadata-relay/lib/metadata_relay/plug/proxy_rate_limit.ex's
+      // send_resp(429, Jason.encode!(%{error: "Too many requests", message: "..."})) --
+      // NOT router.ex's separate send_rate_limited/2 helper, which uses a
+      // differently-cased "rate_limited" error string for pairing/feedback/crash
+      // routes. This is the one the proxy limiter itself uses.
+      const body = await last!.json<{ error: string; message: string }>();
+      expect(body).toMatchObject({
+        error: "Too many requests",
+        message: "Rate limit exceeded. Please try again later.",
+      });
+    },
+    30000,
+  );
 
   it("logs the final 429 status, not whatever status the route produced before the throttle overwrote it", async () => {
-    // 305 iterations against a real fetchMock and a spied console.log run
+    // Up to PROXY_LIMIT_ITERATION_CAP iterations (see that constant's
+    // comment above) against a real fetchMock and a spied console.log run
     // noticeably slower once other heavy loops in this same file have
     // already run in the same worker instance -- comfortably under a second
     // alone, but into double digits back-to-back with its siblings. Not a
@@ -75,7 +109,7 @@ describe("rate limiting", () => {
     const logSpy = vi.spyOn(console, "log");
 
     let last: Response | undefined;
-    for (let i = 0; i < 305; i++) {
+    for (let i = 0; i < PROXY_LIMIT_ITERATION_CAP; i++) {
       last = await SELF.fetch("https://relay.mydia.dev/tmdb/genre/movie", {
         headers: { "cf-connecting-ip": "203.0.113.20" },
       });

--- a/relay-worker/test/obs/ratelimit.test.ts
+++ b/relay-worker/test/obs/ratelimit.test.ts
@@ -154,6 +154,61 @@ describe("rate limiting", () => {
     });
     expect(res.status).not.toBe(429);
   });
+
+  // Final-review CRITICAL: the middleware used to call `await next()` --
+  // running the real handler and its real upstream fetch() -- BEFORE
+  // checking the limiter, only swapping in a 429 afterward. That shape
+  // cannot prevent the thing this limiter exists to prevent: probed at 320
+  // cache-busted requests from one IP, all 320 (including the 20 that got a
+  // 429 back) still produced a real upstream call. Worst for
+  // /api/v1/subtitles/search, whose SubDL key carries a shared 2000/day
+  // allowance a sustained flood could exhaust in minutes.
+  //
+  // Registers exactly one interceptor for a path this specific throttled
+  // request would hit if (and only if) the handler ran, with a path matcher
+  // that flags whether it was ever even evaluated -- a real outbound fetch
+  // attempt is the only thing that causes undici's MockAgent to consult a
+  // registered interceptor for that origin at all. Deliberately does NOT use
+  // fetchMock.assertNoPendingInterceptors() here: that assertion is designed
+  // to catch an interceptor nobody used (useful in afterEach elsewhere in
+  // this codebase), which is exactly what a CORRECT fix produces in this
+  // specific test -- calling it here would assert the wrong direction.
+  //
+  // Exhausts the budget by calling env.PROXY_LIMITER directly, with the same
+  // key the middleware itself derives, rather than looping real HTTP
+  // requests through the Worker -- the latter would need up to
+  // PROXY_LIMIT_ITERATION_CAP real, unmocked upstream fetch attempts (each
+  // one hitting the exact "check runs after next()" hole this test exists to
+  // close, pre-fix) just to reach the interesting part of this test, which
+  // both defeats the point and reintroduces this file's own documented
+  // wall-clock flake risk for no reason -- this test only needs the budget
+  // to already read as spent, not to reach that state through the route.
+  it("performs NO upstream fetch for a request the limiter throttles, because the check now runs before next()", async () => {
+    const ip = "203.0.113.30";
+
+    for (let i = 0; i < PROXY_LIMIT; i++) {
+      await env.PROXY_LIMITER.limit({ key: `proxy:${ip}` });
+    }
+
+    let upstreamFetchAttempted = false;
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          upstreamFetchAttempted = true;
+          return p.startsWith("/3/genre/tv");
+        },
+      })
+      .reply(200, { genres: [] });
+
+    const throttled = await SELF.fetch("https://relay.mydia.dev/tmdb/genre/tv", {
+      headers: { "cf-connecting-ip": ip },
+    });
+
+    expect(throttled.status).toBe(429);
+    expect(upstreamFetchAttempted).toBe(false);
+  });
 });
 
 // Regression coverage for the maintainer dashboards' move from bare /errors

--- a/relay-worker/test/obs/ratelimit.test.ts
+++ b/relay-worker/test/obs/ratelimit.test.ts
@@ -1,6 +1,7 @@
 import { env, SELF, fetchMock, applyD1Migrations } from "cloudflare:test";
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { serviceFromPath } from "../../src/obs/log";
+import { isExemptFromProxyLimit } from "../../src/obs/ratelimit";
 
 describe("serviceFromPath", () => {
   it("labels each proxied upstream", () => {
@@ -152,5 +153,65 @@ describe("rate limiting", () => {
       headers: { "cf-connecting-ip": "203.0.113.11" },
     });
     expect(res.status).not.toBe(429);
+  });
+});
+
+// Regression coverage for the maintainer dashboards' move from bare /errors
+// and /feedback to /admin/errors and /admin/feedback: isExemptFromProxyLimit
+// has to be updated in lockstep with any dashboard path change, or dashboard
+// reads silently start counting against the shared 300/min proxy budget
+// meant to protect upstream provider quota. Deliberately a direct unit test
+// of the pure predicate, not an integration test driving ~300+ real
+// SELF.fetch() calls to approach PROXY_LIMITER's actual threshold: an
+// earlier version of this test did exactly that (320 iterations against
+// /admin/errors), and empirically made the wall-clock-dependent flake this
+// file's other tests already document (see PROXY_LIMIT_ITERATION_CAP's
+// comment above) measurably worse -- 2 of 2 runs with that loop present
+// failed on an unrelated heavy-loop test in this same file, versus 0 of 3
+// immediately before/after with it removed. Testing the decision function
+// directly gets equivalent coverage of the actual regression (a path falling
+// out of the exempt list) in microseconds, with no shared mutable rate-limit
+// state and no wall-clock dependency at all.
+describe("isExemptFromProxyLimit", () => {
+  it("exempts both maintainer dashboards under /admin/*", () => {
+    expect(isExemptFromProxyLimit("/admin/errors")).toBe(true);
+    expect(isExemptFromProxyLimit("/admin/errors/somefingerprint")).toBe(true);
+    expect(isExemptFromProxyLimit("/admin/feedback")).toBe(true);
+    expect(isExemptFromProxyLimit("/admin/feedback/some-id/state")).toBe(true);
+  });
+
+  it("exempts the public feedback ingest path, but not by prefix collision with /admin/feedback", () => {
+    expect(isExemptFromProxyLimit("/feedback")).toBe(true);
+    // A prefix check on "/feedback" must never accidentally match
+    // "/admin/feedback" -- confirmed here by the fact that /admin/feedback
+    // is exempt via the SEPARATE "/admin/" prefix in the test above, not
+    // this one; this test only asserts the bare ingest path itself.
+  });
+
+  it("exempts pairing and crash ingest", () => {
+    expect(isExemptFromProxyLimit("/pairing/claim")).toBe(true);
+    expect(isExemptFromProxyLimit("/crashes/report")).toBe(true);
+  });
+
+  it("exempts /health and /stats exactly, not by prefix", () => {
+    expect(isExemptFromProxyLimit("/health")).toBe(true);
+    expect(isExemptFromProxyLimit("/stats")).toBe(true);
+    // /health and /stats are EXACT matches (a Set), not prefixes -- a path
+    // that merely starts with one must still be charged against the budget.
+    expect(isExemptFromProxyLimit("/healthcheck")).toBe(false);
+  });
+
+  it("does not exempt real proxy/metadata routes", () => {
+    expect(isExemptFromProxyLimit("/tmdb/genre/movie")).toBe(false);
+    expect(isExemptFromProxyLimit("/tvdb/search")).toBe(false);
+    expect(isExemptFromProxyLimit("/music/search")).toBe(false);
+    expect(isExemptFromProxyLimit("/api/v1/subtitles/search")).toBe(false);
+  });
+
+  // The literal regression this whole test exists to catch: before the
+  // dashboards moved, this list read "/errors" (bare), which is what a
+  // revert -- accidental or otherwise -- would reintroduce.
+  it("does not exempt the old, pre-move dashboard paths", () => {
+    expect(isExemptFromProxyLimit("/errors")).toBe(false);
   });
 });

--- a/relay-worker/test/obs/ratelimit.test.ts
+++ b/relay-worker/test/obs/ratelimit.test.ts
@@ -1,4 +1,4 @@
-import { SELF, fetchMock } from "cloudflare:test";
+import { env, SELF, fetchMock, applyD1Migrations } from "cloudflare:test";
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { serviceFromPath } from "../../src/obs/log";
 
@@ -19,9 +19,17 @@ describe("serviceFromPath", () => {
 });
 
 describe("rate limiting", () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     fetchMock.activate();
     fetchMock.disableNetConnect();
+
+    // "does not charge pairing against the proxy budget" below drives real
+    // requests through /pairing/claim/:code, which is now D1-backed (Task
+    // 10). Without migrating this file's own isolated storage first, every
+    // one of those requests throws "SQLITE_ERROR: no such table:
+    // pairing_claims" to stderr -- the assertion still passes (it only
+    // checks the sibling /tmdb call), but the noise drowns out real errors.
+    await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
   });
 
   it("returns 429 with a Retry-After header once the budget is spent", async () => {

--- a/relay-worker/test/obs/ratelimit.test.ts
+++ b/relay-worker/test/obs/ratelimit.test.ts
@@ -1,5 +1,5 @@
 import { SELF, fetchMock } from "cloudflare:test";
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { serviceFromPath } from "../../src/obs/log";
 
 describe("serviceFromPath", () => {
@@ -46,6 +46,47 @@ describe("rate limiting", () => {
       message: "Rate limit exceeded. Please try again later.",
     });
   });
+
+  it("logs the final 429 status, not whatever status the route produced before the throttle overwrote it", async () => {
+    // 305 iterations against a real fetchMock and a spied console.log run
+    // noticeably slower once other heavy loops in this same file have
+    // already run in the same worker instance -- comfortably under a second
+    // alone, but into double digits back-to-back with its siblings. Not a
+    // hang: bumping the timeout is enough (see the isolated per-test timing
+    // versus the full-file timing checked while writing this test).
+    //
+    // Hono composes middleware as an onion: whichever of rateLimitMiddleware
+    // and the logging middleware is registered SECOND runs as the INNER
+    // layer, closer to the route. If the logging middleware is inner, its
+    // `await next()` returns -- and it reads c.res.status -- before control
+    // unwinds back out to rateLimitMiddleware, which only then overwrites
+    // c.res with the 429. That logs the route's pre-throttle status instead
+    // of what the client actually received. Spying on console.log (rather
+    // than matching a substring) and parsing the JSON line guards against a
+    // regression that happens to still contain "429" somewhere.
+    const logSpy = vi.spyOn(console, "log");
+
+    let last: Response | undefined;
+    for (let i = 0; i < 305; i++) {
+      last = await SELF.fetch("https://relay.mydia.dev/tmdb/genre/movie", {
+        headers: { "cf-connecting-ip": "203.0.113.20" },
+      });
+      if (last.status === 429) break;
+    }
+    expect(last!.status).toBe(429);
+
+    const lastCall = logSpy.mock.calls.at(-1);
+    expect(lastCall).toBeDefined();
+    const logged = JSON.parse(lastCall![0] as string) as {
+      service: string;
+      path: string;
+      status: number;
+      cache: string;
+    };
+    expect(logged.status).toBe(429);
+
+    logSpy.mockRestore();
+  }, 30000);
 
   it("does not throttle /health, which monitoring polls", async () => {
     for (let i = 0; i < 50; i++) {

--- a/relay-worker/test/obs/sweep.test.ts
+++ b/relay-worker/test/obs/sweep.test.ts
@@ -1,0 +1,102 @@
+import {
+  env,
+  applyD1Migrations,
+  createScheduledController,
+  createExecutionContext,
+  waitOnExecutionContext,
+} from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import worker from "../../src/index";
+import { sweepStaleFeedbackRateLimits } from "../../src/obs/sweep";
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+async function insertRateLimitBucket(
+  bucketKey: string,
+  hourBucket: number,
+  count: number,
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO feedback_rate_limits (bucket_key, hour_bucket, count) VALUES (?, ?, ?)
+     ON CONFLICT(bucket_key) DO UPDATE SET hour_bucket = excluded.hour_bucket, count = excluded.count`,
+  )
+    .bind(bucketKey, hourBucket, count)
+    .run();
+}
+
+async function insertPairingClaim(key: string, expiresAt: number): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO pairing_claims (key, value, expires_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, expires_at = excluded.expires_at`,
+  )
+    .bind(key, "test-value", expiresAt)
+    .run();
+}
+
+async function rateLimitBucketExists(bucketKey: string): Promise<boolean> {
+  const row = await env.DB.prepare("SELECT 1 FROM feedback_rate_limits WHERE bucket_key = ?")
+    .bind(bucketKey)
+    .first();
+  return row !== null;
+}
+
+async function pairingClaimExists(key: string): Promise<boolean> {
+  const row = await env.DB.prepare("SELECT 1 FROM pairing_claims WHERE key = ?").bind(key).first();
+  return row !== null;
+}
+
+describe("sweepStaleFeedbackRateLimits", () => {
+  it("deletes rows from a stale hour bucket and leaves the current hour's rows alone", async () => {
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    await insertRateLimitBucket("sweep-unit:stale", currentHour - 5, 5);
+    await insertRateLimitBucket("sweep-unit:current", currentHour, 3);
+
+    const deleted = await sweepStaleFeedbackRateLimits(env);
+
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    expect(await rateLimitBucketExists("sweep-unit:stale")).toBe(false);
+    expect(await rateLimitBucketExists("sweep-unit:current")).toBe(true);
+  });
+
+  // hour_bucket < currentHour - 1, not <= currentHour: the previous hour's
+  // rows are kept for one extra sweep cycle rather than cut exactly at the
+  // current hour, since checkAndIncrementBucket already treats any
+  // non-current hour_bucket as fully stale regardless.
+  it("leaves the previous hour's rows alone for one extra cycle", async () => {
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    await insertRateLimitBucket("sweep-unit:previous", currentHour - 1, 2);
+
+    await sweepStaleFeedbackRateLimits(env);
+
+    expect(await rateLimitBucketExists("sweep-unit:previous")).toBe(true);
+  });
+});
+
+describe("scheduled() handler", () => {
+  it("sweeps stale feedback_rate_limits rows and expired pairing_claims rows, leaving live ones alone", async () => {
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    const now = Math.floor(Date.now() / 1000);
+
+    await insertRateLimitBucket("sweep-scheduled:stale", currentHour - 10, 5);
+    await insertRateLimitBucket("sweep-scheduled:current", currentHour, 1);
+    await insertPairingClaim("sweep-scheduled:expired", now - 3600);
+    await insertPairingClaim("sweep-scheduled:live", now + 3600);
+
+    if (!worker.scheduled) throw new Error("scheduled handler is not wired");
+
+    const controller = createScheduledController();
+    const ctx = createExecutionContext();
+    await worker.scheduled(controller, env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(await rateLimitBucketExists("sweep-scheduled:stale")).toBe(false);
+    expect(await rateLimitBucketExists("sweep-scheduled:current")).toBe(true);
+    // pairing/store.ts's purgeExpiredClaims, written in Task 10 and never
+    // wired to anything until this handler -- the identical "table with no
+    // eviction path" defect in a different table.
+    expect(await pairingClaimExists("sweep-scheduled:expired")).toBe(false);
+    expect(await pairingClaimExists("sweep-scheduled:live")).toBe(true);
+  });
+});

--- a/relay-worker/test/obs/sweep.test.ts
+++ b/relay-worker/test/obs/sweep.test.ts
@@ -93,8 +93,8 @@ describe("scheduled() handler", () => {
 
     expect(await rateLimitBucketExists("sweep-scheduled:stale")).toBe(false);
     expect(await rateLimitBucketExists("sweep-scheduled:current")).toBe(true);
-    // pairing/store.ts's purgeExpiredClaims, written in Task 10 and never
-    // wired to anything until this handler -- the identical "table with no
+    // pairing/store.ts's purgeExpiredClaims, written when pairing landed and
+    // never wired to anything until this handler -- the identical "table with no
     // eviction path" defect in a different table.
     expect(await pairingClaimExists("sweep-scheduled:expired")).toBe(false);
     expect(await pairingClaimExists("sweep-scheduled:live")).toBe(true);

--- a/relay-worker/test/pairing/routes.test.ts
+++ b/relay-worker/test/pairing/routes.test.ts
@@ -304,6 +304,34 @@ describe("pairing v2 sealed claims", () => {
     });
   });
 
+  // Regression guard: every case above is ASCII, where UTF-8 byte length and
+  // JS UTF-16 string length are numerically identical, so none of them can
+  // tell a correct byte-length check apart from an accidental `.length`
+  // check (a reviewer previously had to hand-probe this distinction). "é" is
+  // 1 UTF-16 code unit but 2 UTF-8 bytes: 4200 repeats is a JS string of
+  // length 4200 -- comfortably under 8192 -- but 8400 UTF-8 bytes, over the
+  // cap. A `.length`-based implementation would wrongly ACCEPT this payload
+  // (letting a caller store roughly double the intended byte budget per
+  // key); validateSealed's real `new TextEncoder().encode(sealed).length`
+  // check must reject it.
+  it("rejects an oversized sealed blob using multi-byte UTF-8 characters, where byte length and string length diverge", async () => {
+    const MAX_SEALED_BYTES = 8192; // mirrors the unexported cap in src/pairing/routes.ts
+    const nonAsciiSealed = "é".repeat(4200);
+    expect(nonAsciiSealed.length).toBeLessThan(MAX_SEALED_BYTES);
+    expect(new TextEncoder().encode(nonAsciiSealed).length).toBeGreaterThan(MAX_SEALED_BYTES);
+
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ lookup_key: "e".repeat(64), sealed: nonAsciiSealed }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json<{ error: string; message: string }>()).toMatchObject({
+      error: "Validation error",
+      message: "sealed exceeds 8192 bytes",
+    });
+  });
+
   it("returns 404 for an unknown lookup key", async () => {
     const res = await SELF.fetch(
       `https://relay.mydia.dev/pairing/v2/claim/${"c".repeat(64)}`,

--- a/relay-worker/test/pairing/routes.test.ts
+++ b/relay-worker/test/pairing/routes.test.ts
@@ -1,0 +1,321 @@
+import { env, SELF, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+
+const json = { "content-type": "application/json" };
+
+// PAIRING_CREATE_LIMITER is a shared 10/min budget per IP (wrangler.jsonc),
+// and every POST call below defaults to the same "unknown" bucket without an
+// explicit cf-connecting-ip header. With a dozen create calls in this file
+// that aren't themselves testing the limiter, sharing one bucket would trip
+// it partway through the suite for reasons that have nothing to do with the
+// test being run. Giving each its own IP keeps that budget irrelevant except
+// in the two tests that deliberately exhaust it.
+let nextTestIp = 10;
+function freshIp(): string {
+  return `203.0.113.${nextTestIp++}`;
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+describe("pairing v1", () => {
+  it("stores a claim and reads it back by claim_code", async () => {
+    // Handler.create_claim/1 responds {"claim_code": "..."} -- not {"code",
+    // "expires_in"}; confirmed against metadata_relay/pairing/handler.ex and
+    // its handler_test.exs, which asserts the same key.
+    const created = await SELF.fetch("https://relay.mydia.dev/pairing/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ node_addr: '{"id":"09ecb63dd2"}' }),
+    });
+
+    expect(created.status).toBe(200);
+    const { claim_code } = await created.json<{ claim_code: string }>();
+    expect(typeof claim_code).toBe("string");
+    expect(claim_code).toHaveLength(6);
+
+    const fetched = await SELF.fetch(`https://relay.mydia.dev/pairing/claim/${claim_code}`);
+    expect(fetched.status).toBe(200);
+    expect(await fetched.json<{ node_addr: string }>()).toMatchObject({
+      node_addr: '{"id":"09ecb63dd2"}',
+    });
+  });
+
+  it("returns 404 for an unknown code", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim/NOSUCHCODE");
+    expect(res.status).toBe(404);
+  });
+
+  it("normalizes a hand-typed code (case, dashes, spaces), like Pairing.normalize_code/1", async () => {
+    const created = await SELF.fetch("https://relay.mydia.dev/pairing/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ node_addr: '{"id":"norm-test"}' }),
+    });
+    const { claim_code } = await created.json<{ claim_code: string }>();
+
+    const typedByHand = claim_code.toLowerCase().split("").join("-");
+    const fetched = await SELF.fetch(`https://relay.mydia.dev/pairing/claim/${typedByHand}`);
+    expect(fetched.status).toBe(200);
+  });
+
+  it("returns the Elixir validation error shape when node_addr is missing", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json<{ error: string; message: string }>()).toMatchObject({
+      error: "Validation error",
+      message: "node_addr is required",
+    });
+  });
+
+  it("returns the Elixir validation error shape when node_addr is not valid JSON", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      // Deliberately a JSON body whose node_addr *value* is not itself valid
+      // JSON text -- Handler.validate_node_addr/1 Jason.decodes the string
+      // and rejects "addr" (no surrounding quotes) as malformed.
+      body: JSON.stringify({ node_addr: "addr" }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json<{ error: string; message: string }>()).toMatchObject({
+      error: "Validation error",
+      message: "node_addr must be valid JSON",
+    });
+  });
+
+  it("deletes a claim and then returns 404", async () => {
+    const created = await SELF.fetch("https://relay.mydia.dev/pairing/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ node_addr: '{"id":"delete-test"}' }),
+    });
+    const { claim_code } = await created.json<{ claim_code: string }>();
+
+    const deleted = await SELF.fetch(`https://relay.mydia.dev/pairing/claim/${claim_code}`, {
+      method: "DELETE",
+    });
+    expect(deleted.status).toBe(204);
+
+    const after = await SELF.fetch(`https://relay.mydia.dev/pairing/claim/${claim_code}`);
+    expect(after.status).toBe(404);
+  });
+
+  it("deletes an unknown code with 204 anyway, matching Pairing.delete_claim/1's idempotence", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim/NOSUCHCODE", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("treats an expired claim as absent", async () => {
+    await env.DB.prepare(
+      "INSERT INTO pairing_claims (key, value, expires_at) VALUES (?, ?, ?)",
+    )
+      .bind("pairing:EXPIRED1", "stale", Math.floor(Date.now() / 1000) - 10)
+      .run();
+
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim/EXPIRED1");
+    expect(res.status).toBe(404);
+  });
+
+  it("answers the CORS preflight with 204, the allowed methods, and no allow-headers", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim/ABC", {
+      method: "OPTIONS",
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-methods")).toBe("GET, DELETE");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    // router.ex's allow_web_player/1 never sets this header, even on the
+    // preflight -- a real (if pre-existing) gap in the Elixir, not something
+    // to silently "fix" while porting.
+    expect(res.headers.get("access-control-allow-headers")).toBeNull();
+  });
+
+  it("carries the CORS origin header on a 404, not just a 200", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim/NOSUCHCODE");
+    expect(res.status).toBe(404);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("does not send a CORS header on the create route, matching router.ex", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ node_addr: '{"id":"no-cors-on-create"}' }),
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("uses send_rate_limited/2's body shape, not the proxy plug's, once the create limiter trips", async () => {
+    // PAIRING_CREATE_LIMITER is 10/min (wrangler.jsonc); an 11th request from
+    // the same IP inside the window must trip it. Distinct IP from every
+    // other test in this file/suite to avoid cross-test contamination of the
+    // shared limiter state.
+    let last: Response | undefined;
+    for (let i = 0; i < 11; i++) {
+      last = await SELF.fetch("https://relay.mydia.dev/pairing/claim", {
+        method: "POST",
+        headers: { ...json, "cf-connecting-ip": "203.0.113.77" },
+        body: JSON.stringify({ node_addr: '{"id":"rl-create"}' }),
+      });
+      if (last.status === 429) break;
+    }
+
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("retry-after")).toBe("60");
+    // No CORS header either: the create route never calls allow_web_player.
+    expect(last!.headers.get("access-control-allow-origin")).toBeNull();
+
+    const body = await last!.json<{ error: string; message: string; retry_after: number }>();
+    expect(body).toMatchObject({
+      error: "rate_limited",
+      message: "Too many requests. Please try again later.",
+      retry_after: 60,
+    });
+  });
+
+  it("uses send_rate_limited/2's body shape once the read limiter trips, with CORS present", async () => {
+    // PAIRING_READ_LIMITER is 30/min.
+    let last: Response | undefined;
+    for (let i = 0; i < 31; i++) {
+      last = await SELF.fetch("https://relay.mydia.dev/pairing/claim/NOSUCHCODE", {
+        headers: { "cf-connecting-ip": "203.0.113.78" },
+      });
+      if (last.status === 429) break;
+    }
+
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("retry-after")).toBe("60");
+    expect(last!.headers.get("access-control-allow-origin")).toBe("*");
+
+    const body = await last!.json<{ error: string; message: string; retry_after: number }>();
+    expect(body).toMatchObject({
+      error: "rate_limited",
+      message: "Too many requests. Please try again later.",
+      retry_after: 60,
+    });
+  });
+});
+
+describe("pairing v2 sealed claims", () => {
+  it("stores a sealed blob against a lookup key and returns 204 with no CORS header", async () => {
+    const lookupKey = "a".repeat(64);
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ lookup_key: lookupKey, sealed: "c2VhbGVk" }),
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+
+    const fetched = await SELF.fetch(
+      `https://relay.mydia.dev/pairing/v2/claim/${lookupKey}`,
+    );
+    expect(fetched.status).toBe(200);
+    expect(await fetched.json<{ sealed: string }>()).toMatchObject({ sealed: "c2VhbGVk" });
+    expect(fetched.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("keeps v1 and v2 keyspaces separate", async () => {
+    // The key prefixes "pairing:" and "pairing:v2:" are what stop the same
+    // string colliding across versions, exactly as the Redis keys did.
+    const shared = "b".repeat(64);
+    await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ lookup_key: shared, sealed: "v2value" }),
+    });
+
+    const v1 = await SELF.fetch(`https://relay.mydia.dev/pairing/claim/${shared}`);
+    expect(v1.status).toBe(404);
+  });
+
+  it("rejects a lookup key that is not 64 lowercase hex characters, with the Elixir's exact message", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ lookup_key: "tooshort", sealed: "x" }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json<{ error: string; message: string }>()).toMatchObject({
+      error: "Validation error",
+      message: "lookup_key must be 64 lowercase hex characters",
+    });
+  });
+
+  it("rejects a missing sealed blob, with the Elixir's exact message", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ lookup_key: "d".repeat(64) }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json<{ error: string; message: string }>()).toMatchObject({
+      error: "Validation error",
+      message: "sealed is required",
+    });
+  });
+
+  it("rejects an oversized sealed blob", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ lookup_key: "f".repeat(64), sealed: "x".repeat(8193) }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json<{ error: string; message: string }>()).toMatchObject({
+      error: "Validation error",
+      message: "sealed exceeds 8192 bytes",
+    });
+  });
+
+  it("returns 404 for an unknown lookup key", async () => {
+    const res = await SELF.fetch(
+      `https://relay.mydia.dev/pairing/v2/claim/${"c".repeat(64)}`,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("validates the lookup_key format on GET too, before doing a lookup", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim/tooshort");
+    expect(res.status).toBe(400);
+    expect(await res.json<{ error: string; message: string }>()).toMatchObject({
+      error: "Validation error",
+      message: "lookup_key must be 64 lowercase hex characters",
+    });
+  });
+
+  it("deletes a sealed claim and then returns 404", async () => {
+    const lookupKey = "e".repeat(64);
+    await SELF.fetch("https://relay.mydia.dev/pairing/v2/claim", {
+      method: "POST",
+      headers: { ...json, "cf-connecting-ip": freshIp() },
+      body: JSON.stringify({ lookup_key: lookupKey, sealed: "c2VhbGVk" }),
+    });
+
+    const deleted = await SELF.fetch(`https://relay.mydia.dev/pairing/v2/claim/${lookupKey}`, {
+      method: "DELETE",
+    });
+    expect(deleted.status).toBe(204);
+    expect(deleted.headers.get("access-control-allow-origin")).toBe("*");
+
+    const after = await SELF.fetch(`https://relay.mydia.dev/pairing/v2/claim/${lookupKey}`);
+    expect(after.status).toBe(404);
+  });
+
+  it("answers the v2 CORS preflight with 204 and the allowed methods", async () => {
+    const res = await SELF.fetch(
+      `https://relay.mydia.dev/pairing/v2/claim/${"1".repeat(64)}`,
+      { method: "OPTIONS" },
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-methods")).toBe("GET, DELETE");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+});

--- a/relay-worker/test/pairing/routes.test.ts
+++ b/relay-worker/test/pairing/routes.test.ts
@@ -124,17 +124,46 @@ describe("pairing v1", () => {
     expect(res.status).toBe(404);
   });
 
-  it("answers the CORS preflight with 204, the allowed methods, and no allow-headers", async () => {
+  it("answers a bare OPTIONS (no Origin, no Access-Control-Request-Method) with router.ex's own 204", async () => {
+    // Missing both headers means Corsica's preflight_req?/1 doesn't consider
+    // this a CORS request at all, so it falls through to router.ex's own
+    // `options "/pairing/claim/:code"` handler untouched.
     const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim/ABC", {
       method: "OPTIONS",
     });
     expect(res.status).toBe(204);
     expect(res.headers.get("access-control-allow-methods")).toBe("GET, DELETE");
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
-    // router.ex's allow_web_player/1 never sets this header, even on the
-    // preflight -- a real (if pre-existing) gap in the Elixir, not something
-    // to silently "fix" while porting.
+    // router.ex's allow_web_player/1 never sets this header itself. It
+    // doesn't need to for a real browser preflight, though -- see the
+    // genuine-preflight test below for why.
     expect(res.headers.get("access-control-allow-headers")).toBeNull();
+  });
+
+  it("answers a genuine preflight (Origin + Access-Control-Request-Method) the way Corsica does, not router.ex", async () => {
+    // endpoint.ex plugs Corsica globally, in front of the router. A request
+    // carrying both headers is a real CORS preflight to Corsica, which
+    // halts the pipeline and answers directly -- router.ex's own 204 handler
+    // (exercised by the bare-OPTIONS test above) is never reached in
+    // production for this shape of request.
+    const res = await SELF.fetch("https://relay.mydia.dev/pairing/claim/ABC", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://player.example.com",
+        "access-control-request-method": "GET",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    // Corsica's Enum.join(list, ",") -- a bare comma, not ", " -- over the
+    // endpoint's FULL configured lists, not the two methods this specific
+    // route supports.
+    expect(res.headers.get("access-control-allow-methods")).toBe(
+      "GET,POST,PUT,DELETE,OPTIONS",
+    );
+    expect(res.headers.get("access-control-allow-headers")).toBe(
+      "content-type,authorization,x-request-id",
+    );
   });
 
   it("carries the CORS origin header on a 404, not just a 200", async () => {
@@ -309,7 +338,7 @@ describe("pairing v2 sealed claims", () => {
     expect(after.status).toBe(404);
   });
 
-  it("answers the v2 CORS preflight with 204 and the allowed methods", async () => {
+  it("answers a bare v2 OPTIONS with router.ex's own 204", async () => {
     const res = await SELF.fetch(
       `https://relay.mydia.dev/pairing/v2/claim/${"1".repeat(64)}`,
       { method: "OPTIONS" },
@@ -317,5 +346,26 @@ describe("pairing v2 sealed claims", () => {
     expect(res.status).toBe(204);
     expect(res.headers.get("access-control-allow-methods")).toBe("GET, DELETE");
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  it("answers a genuine v2 preflight the way Corsica does, not router.ex", async () => {
+    const res = await SELF.fetch(
+      `https://relay.mydia.dev/pairing/v2/claim/${"2".repeat(64)}`,
+      {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://player.example.com",
+          "access-control-request-method": "DELETE",
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-methods")).toBe(
+      "GET,POST,PUT,DELETE,OPTIONS",
+    );
+    expect(res.headers.get("access-control-allow-headers")).toBe(
+      "content-type,authorization,x-request-id",
+    );
   });
 });

--- a/relay-worker/test/proxy/forward.test.ts
+++ b/relay-worker/test/proxy/forward.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { forwardParams } from "../../src/proxy/forward";
+
+describe("forwardParams", () => {
+  it("forwards arbitrary params verbatim, with no allowlist", () => {
+    const incoming = new URLSearchParams({
+      language: "en-US",
+      append_to_response: "credits,keywords,images,videos,recommendations",
+      some_future_param: "value",
+    });
+
+    const out = forwardParams(incoming, { api_key: "SECRET" });
+
+    expect(out.get("language")).toBe("en-US");
+    expect(out.get("append_to_response")).toBe(
+      "credits,keywords,images,videos,recommendations",
+    );
+    expect(out.get("some_future_param")).toBe("value");
+  });
+
+  it("injects the credential", () => {
+    const out = forwardParams(new URLSearchParams(), { api_key: "SECRET" });
+    expect(out.get("api_key")).toBe("SECRET");
+  });
+
+  it("drops a caller-supplied api_key so it cannot be sent twice", () => {
+    // TMDB resolves a duplicated api_key unpredictably; the relay has always
+    // stripped the caller's copy rather than forwarding it.
+    const incoming = new URLSearchParams({ api_key: "ATTACKER", language: "fr" });
+
+    const out = forwardParams(incoming, { api_key: "SECRET" });
+
+    expect(out.getAll("api_key")).toEqual(["SECRET"]);
+    expect(out.get("language")).toBe("fr");
+  });
+
+  it("preserves repeated params", () => {
+    const incoming = new URLSearchParams();
+    incoming.append("with_genres", "28");
+    incoming.append("with_genres", "12");
+
+    const out = forwardParams(incoming, {});
+
+    expect(out.getAll("with_genres")).toEqual(["28", "12"]);
+  });
+});

--- a/relay-worker/test/proxy/forward.test.ts
+++ b/relay-worker/test/proxy/forward.test.ts
@@ -43,4 +43,22 @@ describe("forwardParams", () => {
 
     expect(out.getAll("with_genres")).toEqual(["28", "12"]);
   });
+
+  it("forwards params named after Object.prototype members", () => {
+    // A naive `key in inject` check walks the prototype chain, so params
+    // named toString/constructor/etc are silently dropped even though
+    // `inject` never owns those keys. This is the exact allowlist-by-accident
+    // this task's central rule forbids.
+    const incoming = new URLSearchParams({
+      toString: "1",
+      constructor: "2",
+      api_key: "ATTACKER",
+    });
+
+    const out = forwardParams(incoming, { api_key: "SECRET" });
+
+    expect(out.get("toString")).toBe("1");
+    expect(out.get("constructor")).toBe("2");
+    expect(out.getAll("api_key")).toEqual(["SECRET"]);
+  });
 });

--- a/relay-worker/test/proxy/passthrough.test.ts
+++ b/relay-worker/test/proxy/passthrough.test.ts
@@ -1,0 +1,365 @@
+import { SELF, fetchMock } from "cloudflare:test";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+describe("pass-through routes", () => {
+  // -- OpenLibrary ---------------------------------------------------------
+
+  it("proxies an openlibrary isbn lookup", async () => {
+    fetchMock
+      .get("https://openlibrary.org")
+      .intercept({ method: "GET", path: (p) => p.includes("9780000000001") })
+      .reply(200, { title: "Invented Book" });
+
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/openlibrary/isbn/9780000000001",
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ title: "Invented Book" });
+  });
+
+  // open_library/handler.ex's get_by_isbn/2 does not hit
+  // /isbn/:isbn.json (that endpoint does not exist on Open Library) -- it
+  // calls the Books API at /api/books with bibkeys=ISBN:<isbn>, jscmd=data
+  // and format=json (open_library/handler.ex:8-12).
+  it("hits the Open Library Books API, not an /isbn/*.json path", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://openlibrary.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/api/books");
+        },
+      })
+      .reply(200, { "ISBN:9780000000002": { title: "Another Book" } });
+
+    await SELF.fetch("https://relay.mydia.dev/openlibrary/isbn/9780000000002");
+
+    expect(seenPath).toContain("bibkeys=ISBN%3A9780000000002");
+    expect(seenPath).toContain("jscmd=data");
+    expect(seenPath).toContain("format=json");
+  });
+
+  it("forwards the caller's query params on openlibrary search", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://openlibrary.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/search.json");
+        },
+      })
+      .reply(200, { docs: [] });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/openlibrary/search?q=invented+title&author=nobody",
+    );
+
+    expect(seenPath).toContain("q=invented");
+    expect(seenPath).toContain("author=nobody");
+  });
+
+  // open_library/handler.ex's get_work/2 and get_author/2 declare `_params`
+  // and call Client.get/1 with no :params option, so a caller-supplied query
+  // string must not leak upstream.
+  it("does not forward query params on the works route", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://openlibrary.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/works/OL1234W");
+        },
+      })
+      .reply(200, { title: "A Work" });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/openlibrary/works/OL1234W?foo=bar",
+    );
+
+    expect(seenPath).toBe("/works/OL1234W.json");
+  });
+
+  it("does not forward query params on the authors route", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://openlibrary.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/authors/OL5678A");
+        },
+      })
+      .reply(200, { name: "An Author" });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/openlibrary/authors/OL5678A?foo=bar",
+    );
+
+    expect(seenPath).toBe("/authors/OL5678A.json");
+  });
+
+  // -- MusicBrainz -----------------------------------------------------
+
+  it("sends a User-Agent to MusicBrainz, which rejects requests without one", async () => {
+    let sawUserAgent = false;
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => p.startsWith("/ws/2/artist"),
+        headers: (h) => {
+          sawUserAgent = Boolean(h["user-agent"]);
+          return true;
+        },
+      })
+      .reply(200, { id: "abc" });
+
+    await SELF.fetch("https://relay.mydia.dev/music/artist/abc");
+    expect(sawUserAgent).toBe(true);
+  });
+
+  // The exact string matters: it is what MusicBrainz's rate limiting keys
+  // on. Copied verbatim from music/client.ex:9.
+  it("sends the exact MusicBrainz User-Agent string", async () => {
+    let seenUserAgent: string | undefined;
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => p.startsWith("/ws/2/artist/def"),
+        headers: (h) => {
+          seenUserAgent = h["user-agent"] as string | undefined;
+          return true;
+        },
+      })
+      .reply(200, { id: "def" });
+
+    await SELF.fetch("https://relay.mydia.dev/music/artist/def");
+
+    expect(seenUserAgent).toBe(
+      "MetadataRelay/1.0 ( https://github.com/mydia-org/mydia )",
+    );
+  });
+
+  // music/client.ex's get_mb/2 always prepends fmt: "json" -- without it
+  // MusicBrainz answers with XML, which nothing downstream can parse.
+  it("always asks MusicBrainz for JSON via fmt=json", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/ws/2/artist/ghi");
+        },
+      })
+      .reply(200, { id: "ghi" });
+
+    await SELF.fetch("https://relay.mydia.dev/music/artist/ghi");
+
+    expect(seenPath).toContain("fmt=json");
+  });
+
+  // music/handler.ex's get_artist/2, get_release/2, get_release_group/2 and
+  // get_recording/2 all declare `_params` and inject their own `inc=` value
+  // -- the caller's query string is never forwarded, and dropping the
+  // server-chosen inc= would silently thin out every music detail response.
+  it("injects the artist inc= value and ignores caller query params", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/ws/2/artist/jkl");
+        },
+      })
+      .reply(200, { id: "jkl" });
+
+    await SELF.fetch("https://relay.mydia.dev/music/artist/jkl?inc=nothing");
+
+    expect(seenPath).toContain("inc=url-rels%2Bgenres%2Brelease-groups");
+    expect(seenPath).not.toContain("inc=nothing");
+  });
+
+  it("injects the release inc= value", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/ws/2/release/mno");
+        },
+      })
+      .reply(200, { id: "mno" });
+
+    await SELF.fetch("https://relay.mydia.dev/music/release/mno");
+
+    expect(seenPath).toContain(
+      "inc=recordings%2Bartist-credits%2Blabels%2Brelease-groups%2Bgenres",
+    );
+  });
+
+  it("injects the release-group inc= value", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/ws/2/release-group/pqr");
+        },
+      })
+      .reply(200, { id: "pqr" });
+
+    await SELF.fetch("https://relay.mydia.dev/music/release-group/pqr");
+
+    expect(seenPath).toContain("inc=releases%2Bartist-credits%2Bgenres");
+  });
+
+  it("injects the recording inc= value", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/ws/2/recording/stu");
+        },
+      })
+      .reply(200, { id: "stu" });
+
+    await SELF.fetch("https://relay.mydia.dev/music/recording/stu");
+
+    expect(seenPath).toContain("inc=releases%2Bartist-credits%2Bgenres");
+  });
+
+  // music/handler.ex's search/1 picks the upstream resource straight from
+  // the caller's `type` param (Client.get_mb("/#{type}", ...)) -- it is not
+  // a fixed /release-group endpoint.
+  it("routes music search to the resource named by the type param", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://musicbrainz.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/ws/2/recording");
+        },
+      })
+      .reply(200, { recordings: [] });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/music/search?query=Invented+Song&type=recording",
+    );
+
+    expect(seenPath.startsWith("/ws/2/recording")).toBe(true);
+    expect(seenPath).toContain("query=Invented");
+    expect(seenPath).toContain("fmt=json");
+  });
+
+  it("rejects a music search missing query or type", async () => {
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/music/search?query=only",
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: "Missing required parameters: query, type",
+    });
+  });
+
+  // -- Cover Art Archive -----------------------------------------------
+
+  it("gives music cover art the 90 day images TTL", async () => {
+    fetchMock
+      .get("https://coverartarchive.org")
+      .intercept({ method: "GET", path: (p) => p.includes("abc") })
+      .reply(200, { images: [] });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/music/cover/abc");
+    expect(res.headers.get("cache-control")).toContain("s-maxage=7776000");
+  });
+
+  // music/client.ex's get_caa/1 sends only a User-Agent header, no
+  // accept -- distinct from the MusicBrainz JSON client.
+  it("requests the 500px cover first", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://coverartarchive.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.includes("vwx");
+        },
+      })
+      .reply(200, "binary-image-bytes");
+
+    await SELF.fetch("https://relay.mydia.dev/music/cover/vwx");
+
+    expect(seenPath).toBe("/release/vwx/front-500");
+  });
+
+  // music/handler.ex's get_cover_art/1 falls back to the full-size /front
+  // only when the 500px variant is missing (404), and the router serves the
+  // successful body back with content-type image/jpeg regardless of upstream
+  // content-type (router.ex's handle_image_request/2).
+  it("falls back to the full-size cover when the 500px variant is missing", async () => {
+    fetchMock
+      .get("https://coverartarchive.org")
+      .intercept({ method: "GET", path: "/release/yz1/front-500" })
+      .reply(404, "not found");
+
+    fetchMock
+      .get("https://coverartarchive.org")
+      .intercept({ method: "GET", path: "/release/yz1/front" })
+      .reply(200, "full-size-bytes");
+
+    const res = await SELF.fetch("https://relay.mydia.dev/music/cover/yz1");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/jpeg");
+    expect(await res.text()).toBe("full-size-bytes");
+  });
+
+  it("answers 404 when both cover sizes are missing", async () => {
+    fetchMock
+      .get("https://coverartarchive.org")
+      .intercept({ method: "GET", path: "/release/missing/front-500" })
+      .reply(404, "not found");
+
+    fetchMock
+      .get("https://coverartarchive.org")
+      .intercept({ method: "GET", path: "/release/missing/front" })
+      .reply(404, "not found");
+
+    const res = await SELF.fetch(
+      "https://relay.mydia.dev/music/cover/missing",
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/relay-worker/test/proxy/subdl.test.ts
+++ b/relay-worker/test/proxy/subdl.test.ts
@@ -341,4 +341,24 @@ describe("GET /api/v1/subtitles/download/:id", () => {
 
     expect(res.status).toBe(502);
   });
+
+  it("rejects a response whose declared Content-Length is at the archive cap, before buffering it", async () => {
+    // Defence in depth ahead of extractSubtitle's own cap: the compressed
+    // body is unbounded before any ZIP parsing happens, so this is rejected
+    // on the header alone. The body here is tiny -- if the route buffered it
+    // first and only rejected afterward, this would still incidentally pass,
+    // so the point is that a real 20MB body is never required to prove it.
+    fetchMock
+      .get("https://dl.subdl.com")
+      .intercept({ method: "GET", path: "/subtitle/huge.zip" })
+      .reply(200, Buffer.from("short body"), {
+        headers: { "content-length": "20000000" },
+      });
+
+    const id = btoa("/subtitle/huge.zip").replace(/=+$/, "");
+    const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+    expect(res.status).toBe(502);
+    expect(await res.text()).not.toContain("short body");
+  });
 });

--- a/relay-worker/test/proxy/subdl.test.ts
+++ b/relay-worker/test/proxy/subdl.test.ts
@@ -1,0 +1,344 @@
+import { env, SELF, fetchMock } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { zipSync, strToU8 } from "fflate";
+import { subdlApiKey } from "../../src/proxy/subdl";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+
+interface SearchResponseBody {
+  subtitles: Array<Record<string, unknown>>;
+}
+
+interface ErrorBody {
+  error: string;
+  message?: string;
+}
+
+interface DownloadUrlBody {
+  download_url: string;
+  file_name: string;
+  requests_used: unknown;
+  requests_remaining: unknown;
+}
+
+describe("POST /api/v1/subtitles/search", () => {
+  // The route itself can't be driven through this 503 branch via SELF.fetch:
+  // vitest.config.ts carries a global SUBDL_API_KEY test binding fixed for the
+  // whole pool, and mutating the imported `env` object does not propagate to
+  // the bindings the dispatched worker actually reads (verified empirically --
+  // the request still carried the real test key). subdlApiKey is exported
+  // standalone for exactly this reason, matching tvdb-auth.ts's getTvdbToken.
+  describe("subdlApiKey", () => {
+    it("is null when the key is absent", () => {
+      expect(subdlApiKey({ ...env, SUBDL_API_KEY: undefined })).toBeNull();
+    });
+
+    it("is null when the key is blank", () => {
+      expect(subdlApiKey({ ...env, SUBDL_API_KEY: "   " })).toBeNull();
+    });
+
+    it("returns the key when present", () => {
+      expect(subdlApiKey({ ...env, SUBDL_API_KEY: "a-real-key" })).toBe("a-real-key");
+    });
+  });
+
+  it("returns the transformed wire shape", async () => {
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, {
+        status: true,
+        subtitles: [
+          {
+            url: "/subtitle/abc.zip",
+            language: "EN",
+            release_name: "Fictional.Film.2020",
+            author: "some-uploader",
+            hi: true,
+            season: 2,
+            episode: 5,
+          },
+        ],
+        results: [
+          {
+            type: "movie",
+            name: "Fictional Film",
+            year: 2020,
+            imdb_id: "tt9999999",
+            tmdb_id: 12345,
+          },
+        ],
+      });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "Fictional Film", languages: "en" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json<SearchResponseBody>();
+    expect(body.subtitles).toHaveLength(1);
+    expect(body.subtitles[0]).toMatchObject({
+      source: "SubDL",
+      format: "srt",
+      rating: null,
+      download_count: null,
+      release: "Fictional.Film.2020",
+      language: "en",
+      uploader: "some-uploader",
+      hearing_impaired: true,
+      foreign_parts_only: false,
+      moviehash_match: false,
+      season: 2,
+      episode: 5,
+      feature_type: "movie",
+      title: "Fictional Film",
+      year: 2020,
+      imdb_id: "tt9999999",
+      tmdb_id: 12345,
+    });
+    expect(typeof body.subtitles[0].id).toBe("string");
+  });
+
+  it("defaults feature fields to null when the upstream sends no results", async () => {
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, {
+        status: true,
+        subtitles: [{ url: "/subtitle/no-feature.zip", language: "fr", release_name: "Some.Release" }],
+      });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "No Feature Title" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json<SearchResponseBody>();
+    expect(body.subtitles[0]).toMatchObject({
+      feature_type: null,
+      title: null,
+      year: null,
+      imdb_id: null,
+      tmdb_id: null,
+      uploader: "",
+      hearing_impaired: false,
+      season: null,
+      episode: null,
+    });
+  });
+
+  it("maps a status:false miss to an empty list, not an error", async () => {
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, { status: false, error: "No subtitles" });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "Unfindable Title" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json<SearchResponseBody>()).toEqual({ subtitles: [] });
+  });
+
+  it("returns 502 for an unexpected upstream shape rather than an empty list", async () => {
+    // An anomaly cached as "no subtitles exist" would pin that claim on every
+    // install for the full search TTL, with nothing to invalidate it.
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, "<html>blocked</html>", {
+        headers: { "content-type": "text/html" },
+      });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "Anything" }),
+    });
+
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 for a map response that is neither a hit nor a status:false miss", async () => {
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, { unexpected: "shape" });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "Anything Else" }),
+    });
+
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 400 when no search identity is present", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ languages: "en" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json<ErrorBody>();
+    expect(body.error).toBe("Insufficient search criteria");
+  });
+
+  it("never caches a 502 anomaly: an identical retry hits SubDL again", async () => {
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, "not json at all", { headers: { "content-type": "text/plain" } });
+
+    const first = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "Retry Title" }),
+    });
+    expect(first.status).toBe(502);
+
+    // A second interceptor is required: if the anomaly had been cached, this
+    // request would never reach the mock and fetchMock would throw instead.
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, { status: true, subtitles: [] });
+
+    const second = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "Retry Title" }),
+    });
+    expect(second.status).toBe(200);
+  });
+
+  it("serves an identical search from cache regardless of JSON key order", async () => {
+    fetchMock
+      .get("https://api.subdl.com")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/api/v1/subtitles") })
+      .reply(200, { status: true, subtitles: [] });
+
+    const first = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "Cached Title", year: 2020 }),
+    });
+    expect(first.status).toBe(200);
+
+    // Only one interceptor, so a second upstream call would throw.
+    const second = await SELF.fetch("https://relay.mydia.dev/api/v1/subtitles/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ year: 2020, query: "Cached Title" }),
+    });
+    expect(second.status).toBe(200);
+  });
+});
+
+describe("GET /api/v1/subtitles/download-url/:id", () => {
+  it("returns a relay-hosted download url plus the file name, never SubDL's", async () => {
+    const id = btoa("/subtitle/abc-123.zip").replace(/=+$/, "");
+    const res = await SELF.fetch(
+      `https://relay.mydia.dev/api/v1/subtitles/download-url/${id}`,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json<DownloadUrlBody>();
+    expect(body.download_url).toBe(
+      `https://relay.mydia.dev/api/v1/subtitles/download/${id}`,
+    );
+    expect(body.file_name).toBe("abc-123.srt");
+    // SubDL publishes no quota headers; reporting a number would be invention.
+    expect(body.requests_used).toBeNull();
+    expect(body.requests_remaining).toBeNull();
+  });
+
+  it("rejects a file id whose decoded path is not a subtitle zip", async () => {
+    const hostile = btoa("/etc/passwd").replace(/=+$/, "");
+    const res = await SELF.fetch(
+      `https://relay.mydia.dev/api/v1/subtitles/download-url/${hostile}`,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/v1/subtitles/download/:id", () => {
+  it("unwraps the archive and returns plain subtitle bytes", async () => {
+    const zip = zipSync({ "sub.srt": strToU8("1\n00:00:01,000 --> 00:00:02,000\nline\n") });
+    fetchMock
+      .get("https://dl.subdl.com")
+      .intercept({ method: "GET", path: "/subtitle/abc.zip" })
+      // undici's mock reply serializes a bare Uint8Array as JSON (its numeric
+      // indices become object keys); wrapping in Buffer is what sends it as
+      // the raw bytes a real upstream would.
+      .reply(200, Buffer.from(zip));
+
+    const id = btoa("/subtitle/abc.zip").replace(/=+$/, "");
+    const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/octet-stream");
+    expect(await res.text()).toContain("00:00:01,000");
+  });
+
+  it("rejects a file id whose decoded path is not a subtitle zip", async () => {
+    const hostile = btoa("/etc/passwd").replace(/=+$/, "");
+    const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${hostile}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("never echoes an upstream body on an upstream error", async () => {
+    // api.subdl.com is the one host that could echo the key back, so no
+    // upstream body is forwarded on this route, ever.
+    fetchMock
+      .get("https://dl.subdl.com")
+      .intercept({ method: "GET", path: "/subtitle/leak.zip" })
+      .reply(403, "api_key=SUPERSECRET rejected");
+
+    const id = btoa("/subtitle/leak.zip").replace(/=+$/, "");
+    const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    expect(text).not.toContain("SUPERSECRET");
+    expect(text).not.toContain("api_key");
+  });
+
+  it("maps a 404 archive to a distinct 404, still without echoing the body", async () => {
+    fetchMock
+      .get("https://dl.subdl.com")
+      .intercept({ method: "GET", path: "/subtitle/gone.zip" })
+      .reply(404, "gone");
+
+    const id = btoa("/subtitle/gone.zip").replace(/=+$/, "");
+    const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+    expect(res.status).toBe(404);
+    expect(await res.text()).not.toContain("gone");
+  });
+
+  it("returns 502 rather than the archive's bytes when the zip holds no subtitle", async () => {
+    const zip = zipSync({ "cover.jpg": strToU8("binary") });
+    fetchMock
+      .get("https://dl.subdl.com")
+      .intercept({ method: "GET", path: "/subtitle/no-sub.zip" })
+      .reply(200, Buffer.from(zip));
+
+    const id = btoa("/subtitle/no-sub.zip").replace(/=+$/, "");
+    const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/relay-worker/test/proxy/subdl.test.ts
+++ b/relay-worker/test/proxy/subdl.test.ts
@@ -8,6 +8,21 @@ beforeAll(() => {
   fetchMock.disableNetConnect();
 });
 
+// Genuinely incompressible filler: deflate cannot shrink random bytes, so a
+// zip built from this stays close to `size` on the wire. Needed so the
+// "oversized body" tests below prove the streaming cap specifically --
+// a same-byte-repeated buffer would compress to near nothing and, wrapped in
+// a real .srt entry, get rejected by extractSubtitle's own unrelated checks
+// either way, masking whether the download route's byte cap ever ran.
+function randomBytes(size: number): Uint8Array {
+  const out = new Uint8Array(size);
+  const chunk = 65536;
+  for (let offset = 0; offset < size; offset += chunk) {
+    crypto.getRandomValues(out.subarray(offset, Math.min(offset + chunk, size)));
+  }
+  return out;
+}
+
 interface SearchResponseBody {
   subtitles: Array<Record<string, unknown>>;
 }
@@ -342,17 +357,16 @@ describe("GET /api/v1/subtitles/download/:id", () => {
     expect(res.status).toBe(502);
   });
 
-  it("rejects a response whose declared Content-Length is at the archive cap, before buffering it", async () => {
-    // Defence in depth ahead of extractSubtitle's own cap: the compressed
-    // body is unbounded before any ZIP parsing happens, so this is rejected
-    // on the header alone. The body here is tiny -- if the route buffered it
-    // first and only rejected afterward, this would still incidentally pass,
-    // so the point is that a real 20MB body is never required to prove it.
+  it("rejects a response whose declared Content-Length is at the download cap, before buffering it", async () => {
+    // Cheap early-out ahead of the real streaming cap: the body here is tiny
+    // -- if the route buffered it first and only rejected afterward, this
+    // would still incidentally pass, so the point is that a real oversized
+    // body is never required to prove the header check alone fires.
     fetchMock
       .get("https://dl.subdl.com")
       .intercept({ method: "GET", path: "/subtitle/huge.zip" })
       .reply(200, Buffer.from("short body"), {
-        headers: { "content-length": "20000000" },
+        headers: { "content-length": "2000000" },
       });
 
     const id = btoa("/subtitle/huge.zip").replace(/=+$/, "");
@@ -360,5 +374,60 @@ describe("GET /api/v1/subtitles/download/:id", () => {
 
     expect(res.status).toBe(502);
     expect(await res.text()).not.toContain("short body");
+  });
+
+  // The Content-Length check above is only a cheap early-out for an honest
+  // server. These three prove the real bound: a streaming read that counts
+  // actual bytes and does not trust the header at all, since it can be
+  // absent, non-numeric, or simply a lie -- and dl.subdl.com serves content
+  // uploaded by arbitrary third parties, not a cooperating host.
+  describe("streaming byte cap (Content-Length is not trusted)", () => {
+    it("rejects an oversized body with no Content-Length header at all", async () => {
+      // A real (if pointless) zip around 3MB of incompressible content --
+      // under the old 20MB expansion cap, so the ONLY thing that can reject
+      // this is the download route's own byte cap on the transfer itself.
+      const big = Buffer.from(zipSync({ "big.srt": randomBytes(3_000_000) }));
+      // undici's mock does not auto-set content-length unless told to
+      // (verified: a bare .reply(200, buffer) yields no headers at all), so
+      // this reproduces a real "absent header" upstream with no extra work.
+      fetchMock
+        .get("https://dl.subdl.com")
+        .intercept({ method: "GET", path: "/subtitle/nolen.zip" })
+        .reply(200, big);
+
+      const id = btoa("/subtitle/nolen.zip").replace(/=+$/, "");
+      const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+      expect(res.status).toBe(502);
+    });
+
+    it("rejects an oversized body behind a lying, small Content-Length", async () => {
+      const big = Buffer.from(zipSync({ "big.srt": randomBytes(3_000_000) }));
+      fetchMock
+        .get("https://dl.subdl.com")
+        .intercept({ method: "GET", path: "/subtitle/lying.zip" })
+        .reply(200, big, { headers: { "content-length": "10" } });
+
+      const id = btoa("/subtitle/lying.zip").replace(/=+$/, "");
+      const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+      expect(res.status).toBe(502);
+    });
+
+    it("still succeeds for a normal small archive with no Content-Length header", async () => {
+      const zip = zipSync({
+        "sub.srt": strToU8("1\n00:00:01,000 --> 00:00:02,000\nno header\n"),
+      });
+      fetchMock
+        .get("https://dl.subdl.com")
+        .intercept({ method: "GET", path: "/subtitle/plain.zip" })
+        .reply(200, Buffer.from(zip));
+
+      const id = btoa("/subtitle/plain.zip").replace(/=+$/, "");
+      const res = await SELF.fetch(`https://relay.mydia.dev/api/v1/subtitles/download/${id}`);
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain("00:00:01,000");
+    });
   });
 });

--- a/relay-worker/test/proxy/tmdb.test.ts
+++ b/relay-worker/test/proxy/tmdb.test.ts
@@ -1,0 +1,77 @@
+import { SELF, fetchMock } from "cloudflare:test";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+describe("TMDB routes", () => {
+  it("proxies movie details and injects the key", async () => {
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({
+        method: "GET",
+        path: (p) => p.startsWith("/3/movie/550") && p.includes("api_key="),
+      })
+      .reply(200, { id: 550, title: "Fictional Film" });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/tmdb/movies/550");
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: 550 });
+  });
+
+  it("passes append_to_response through untouched", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/3/movie/551");
+        },
+      })
+      .reply(200, { id: 551 });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/tmdb/movies/551?append_to_response=credits,release_dates",
+    );
+
+    expect(seenPath).toContain("append_to_response=credits%2Crelease_dates");
+  });
+
+  it("emits an edge-cacheable cache-control header, not private no-store", async () => {
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/3/configuration") })
+      .reply(200, { images: {} });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/configuration");
+    const cc = res.headers.get("cache-control") ?? "";
+
+    expect(cc).toContain("public");
+    expect(cc).toContain("s-maxage=");
+    expect(cc).toContain("stale-if-error=");
+    expect(cc).not.toContain("private");
+  });
+
+  it("serves the second identical request from cache without a second upstream call", async () => {
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/3/movie/552") })
+      .reply(200, { id: 552 });
+
+    const first = await SELF.fetch("https://relay.mydia.dev/tmdb/movies/552");
+    expect(first.headers.get("x-relay-cache")).toBe("MISS");
+
+    // Only one interceptor was registered, so a second upstream call would
+    // throw rather than silently succeeding.
+    const second = await SELF.fetch("https://relay.mydia.dev/tmdb/movies/552");
+    expect(second.headers.get("x-relay-cache")).toBe("HIT");
+    expect(await second.json()).toMatchObject({ id: 552 });
+  });
+});

--- a/relay-worker/test/proxy/tvdb-auth.test.ts
+++ b/relay-worker/test/proxy/tvdb-auth.test.ts
@@ -1,0 +1,92 @@
+import { env, fetchMock } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { parseJwtExpiry, getTvdbToken } from "../../src/proxy/tvdb-auth";
+
+beforeAll(() => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+});
+
+function makeJwt(expUnixSeconds: number): string {
+  const payload = btoa(JSON.stringify({ exp: expUnixSeconds }))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `header.${payload}.signature`;
+}
+
+describe("parseJwtExpiry", () => {
+  it("reads exp from the payload", () => {
+    const exp = Math.floor(Date.now() / 1000) + 12345;
+    expect(parseJwtExpiry(makeJwt(exp))).toBe(exp);
+  });
+
+  it("falls back to 30 days when the token is not a JWT", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const got = parseJwtExpiry("not-a-jwt");
+    expect(got).toBeGreaterThan(now + 29 * 86400);
+    expect(got).toBeLessThanOrEqual(now + 30 * 86400 + 5);
+  });
+
+  it("falls back to 30 days when the payload has no exp", () => {
+    const now = Math.floor(Date.now() / 1000);
+    const noExp = `header.${btoa(JSON.stringify({ sub: "x" })).replace(/=+$/, "")}.sig`;
+    expect(parseJwtExpiry(noExp)).toBeGreaterThan(now + 29 * 86400);
+  });
+});
+
+describe("getTvdbToken", () => {
+  it("logs in when KV holds no token, and stores what it got", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 30 * 86400;
+    const token = makeJwt(exp);
+
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({ method: "POST", path: "/v4/login" })
+      .reply(200, { data: { token } });
+
+    const got = await getTvdbToken({ ...env, TVDB_API_KEY: "key" } as never);
+
+    expect(got).toBe(token);
+    const stored = await env.CACHE_KV.get("tvdb:jwt", "json");
+    expect(stored).toMatchObject({ token });
+  });
+
+  it("reuses a stored token that is not near expiry, with no login call", async () => {
+    const exp = Math.floor(Date.now() / 1000) + 20 * 86400;
+    await env.CACHE_KV.put(
+      "tvdb:jwt",
+      JSON.stringify({ token: "stored-token", exp }),
+    );
+
+    // No interceptor registered: a login attempt would throw.
+    const got = await getTvdbToken({ ...env, TVDB_API_KEY: "key" } as never);
+    expect(got).toBe("stored-token");
+  });
+
+  it("refreshes a token inside the one hour window before expiry", async () => {
+    const nearlyExpired = Math.floor(Date.now() / 1000) + 600;
+    await env.CACHE_KV.put(
+      "tvdb:jwt",
+      JSON.stringify({ token: "old-token", exp: nearlyExpired }),
+    );
+
+    const fresh = makeJwt(Math.floor(Date.now() / 1000) + 30 * 86400);
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({ method: "POST", path: "/v4/login" })
+      .reply(200, { data: { token: fresh } });
+
+    const got = await getTvdbToken({ ...env, TVDB_API_KEY: "key" } as never);
+    expect(got).toBe(fresh);
+  });
+
+  it("throws when TVDB_API_KEY is absent rather than sending an empty key", async () => {
+    // vitest.config.ts binds a test-wide TVDB_API_KEY so route tests reach
+    // upstream instead of 503ing, so this must clear it explicitly rather
+    // than relying on the ambient env lacking the key.
+    await expect(
+      getTvdbToken({ ...env, TVDB_API_KEY: undefined } as never),
+    ).rejects.toThrow(/TVDB_API_KEY/);
+  });
+});

--- a/relay-worker/test/proxy/tvdb.test.ts
+++ b/relay-worker/test/proxy/tvdb.test.ts
@@ -60,8 +60,8 @@ describe("TVDB routes", () => {
   // metadata_relay/tvdb/handler.ex's get_series_episodes/2 reads `page`
   // (default 0) out of the params map and bakes it into the path as
   // .../episodes/default/page/N — it is not simply /series/{id}/episodes,
-  // and the brief's naive `/series/{id}/episodes/default` mapping still
-  // silently drops the page segment TVDB requires.
+  // and the naive `/series/{id}/episodes/default` mapping this route is easy
+  // to write silently drops the page segment TVDB requires.
   it("maps the episodes route to the paginated default-season upstream path", async () => {
     let seenPath = "";
     fetchMock

--- a/relay-worker/test/proxy/tvdb.test.ts
+++ b/relay-worker/test/proxy/tvdb.test.ts
@@ -1,0 +1,160 @@
+import { env, SELF, fetchMock } from "cloudflare:test";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+
+beforeAll(async () => {
+  fetchMock.activate();
+  fetchMock.disableNetConnect();
+  // Pre-seed a valid token so route tests do not each need a login interceptor.
+  await env.CACHE_KV.put(
+    "tvdb:jwt",
+    JSON.stringify({
+      token: "test-token",
+      exp: Math.floor(Date.now() / 1000) + 20 * 86400,
+    }),
+  );
+});
+
+afterEach(() => fetchMock.assertNoPendingInterceptors());
+
+describe("TVDB routes", () => {
+  it("sends the stored JWT as a bearer token", async () => {
+    let sawAuth: string | undefined;
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => p.startsWith("/v4/series/331753"),
+        headers: (h) => {
+          sawAuth = h["authorization"];
+          return true;
+        },
+      })
+      .reply(200, { data: { id: 331753 } });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/tvdb/series/331753");
+
+    expect(res.status).toBe(200);
+    expect(await res.json<{ data: { id: number } }>()).toMatchObject({
+      data: { id: 331753 },
+    });
+    expect(sawAuth).toBe("Bearer test-token");
+  });
+
+  it("routes the extended variant to the extended upstream path", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.includes("/v4/series/1/extended");
+        },
+      })
+      .reply(200, { data: {} });
+
+    await SELF.fetch("https://relay.mydia.dev/tvdb/series/1/extended");
+    expect(seenPath).toContain("/v4/series/1/extended");
+  });
+
+  // metadata_relay/tvdb/handler.ex's get_series_episodes/2 reads `page`
+  // (default 0) out of the params map and bakes it into the path as
+  // .../episodes/default/page/N — it is not simply /series/{id}/episodes,
+  // and the brief's naive `/series/{id}/episodes/default` mapping still
+  // silently drops the page segment TVDB requires.
+  it("maps the episodes route to the paginated default-season upstream path", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/v4/series/81189/episodes/default/page/");
+        },
+      })
+      .reply(200, { data: { episodes: [] } });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/tvdb/series/81189/episodes?page=2",
+    );
+
+    expect(seenPath).toBe("/v4/series/81189/episodes/default/page/2");
+  });
+
+  it("defaults the episodes page to 0 when the caller sends none", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/v4/series/81189/episodes/default/page/");
+        },
+      })
+      .reply(200, { data: { episodes: [] } });
+
+    await SELF.fetch("https://relay.mydia.dev/tvdb/series/81189/episodes");
+
+    expect(seenPath).toBe("/v4/series/81189/episodes/default/page/0");
+  });
+
+  // handler.ex's plain lookups (get_series/2, get_season/2, get_episode/2,
+  // get_artwork/2) declare `_params \\ []` and call Client.get(path) with no
+  // :params option at all, so nothing forwards upstream. Only the *_extended
+  // handlers and search pass `params: params` through. A caller-supplied
+  // query string on a plain route must not leak into the upstream request.
+  it("does not forward query params on the plain series route", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/v4/series/2");
+        },
+      })
+      .reply(200, { data: {} });
+
+    await SELF.fetch("https://relay.mydia.dev/tvdb/series/2?foo=bar");
+
+    expect(seenPath).toBe("/v4/series/2");
+  });
+
+  it("forwards query params on the extended route", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return p.startsWith("/v4/series/3/extended");
+        },
+      })
+      .reply(200, { data: {} });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/tvdb/series/3/extended?meta=translations",
+    );
+
+    expect(seenPath).toContain("meta=translations");
+  });
+
+  it("maps a login failure to 502 rather than passing it off as a metadata error", async () => {
+    await env.CACHE_KV.delete("tvdb:jwt");
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({ method: "POST", path: "/v4/login" })
+      .reply(401, { message: "unauthorized" });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/tvdb/series/999");
+
+    expect(res.status).toBe(502);
+    expect(await res.json<{ error: string }>()).toMatchObject({
+      error: "TVDB authentication failed",
+    });
+  });
+});

--- a/relay-worker/tsconfig.json
+++ b/relay-worker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/relay-worker/tsconfig.json
+++ b/relay-worker/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/relay-worker/tsconfig.json
+++ b/relay-worker/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["es2022"],
     "module": "es2022",
     "moduleResolution": "bundler",
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers", "node"],
     "strict": true,
     "noEmit": true,
     "skipLibCheck": true,

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: {
+        wrangler: { configPath: "./wrangler.jsonc" },
+      },
+    },
+  },
+});

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineWorkersConfig({
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.jsonc" },
+        // Test-only secret so upstream-proxying tests (fetchMock-intercepted)
+        // exercise the real forwarding path instead of the "not configured"
+        // 503. Production keys are set with `wrangler secret put` and never
+        // live in source.
+        miniflare: {
+          bindings: { TMDB_API_KEY: "test-tmdb-key" },
+        },
       },
     },
   },

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -1,4 +1,10 @@
-import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+import { defineWorkersConfig, readD1Migrations } from "@cloudflare/vitest-pool-workers/config";
+import path from "node:path";
+
+// Read once at config load so every test file's beforeAll can apply the same
+// migration set via applyD1Migrations(env.DB, env.TEST_MIGRATIONS) rather
+// than each reading migrations/ off disk itself.
+const migrations = await readD1Migrations(path.join(__dirname, "migrations"));
 
 export default defineWorkersConfig({
   test: {
@@ -9,15 +15,16 @@ export default defineWorkersConfig({
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.jsonc" },
-        // Test-only secret so upstream-proxying tests (fetchMock-intercepted)
-        // exercise the real forwarding path instead of the "not configured"
-        // 503. Production keys are set with `wrangler secret put` and never
-        // live in source.
         miniflare: {
+          // Test-only secret so upstream-proxying tests (fetchMock-intercepted)
+          // exercise the real forwarding path instead of the "not configured"
+          // 503. Production keys are set with `wrangler secret put` and never
+          // live in source.
           bindings: {
             TMDB_API_KEY: "test-tmdb-key",
             TVDB_API_KEY: "test-tvdb-key",
             SUBDL_API_KEY: "test-subdl-key",
+            TEST_MIGRATIONS: migrations,
           },
         },
       },

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -10,7 +10,10 @@ export default defineWorkersConfig({
         // 503. Production keys are set with `wrangler secret put` and never
         // live in source.
         miniflare: {
-          bindings: { TMDB_API_KEY: "test-tmdb-key" },
+          bindings: {
+            TMDB_API_KEY: "test-tmdb-key",
+            TVDB_API_KEY: "test-tvdb-key",
+          },
         },
       },
     },

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
 
 export default defineWorkersConfig({
   test: {
+    // test/contract is a separate Vitest project (vitest.workspace.ts): a
+    // plain-Node HTTP diff against two external services, not a workerd test.
+    // Excluded here so this project's workerd pool never tries to load it.
+    exclude: ["test/contract/**", "**/node_modules/**"],
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.jsonc" },

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineWorkersConfig({
           bindings: {
             TMDB_API_KEY: "test-tmdb-key",
             TVDB_API_KEY: "test-tvdb-key",
+            SUBDL_API_KEY: "test-subdl-key",
           },
         },
       },

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineWorkersConfig({
             TMDB_API_KEY: "test-tmdb-key",
             TVDB_API_KEY: "test-tvdb-key",
             SUBDL_API_KEY: "test-subdl-key",
+            RESEND_API_KEY: "test-resend-key",
             TEST_MIGRATIONS: migrations,
           },
         },

--- a/relay-worker/vitest.workspace.ts
+++ b/relay-worker/vitest.workspace.ts
@@ -1,0 +1,33 @@
+import { defineWorkspace } from "vitest/config";
+
+// Two projects, because they need genuinely different runtimes:
+//
+// - Everything under src/ is exercised inside workerd itself (vitest.config.ts,
+//   @cloudflare/vitest-pool-workers) so tests see the real Cache API, KV, and
+//   rate-limit bindings the Worker will run against in production.
+//
+// - test/contract treats both the Worker and the live Elixir relay as opaque
+//   HTTP services reached over the real network by URL. It needs none of the
+//   above -- no bindings, no SELF.fetch, no Cache API -- and workerd's
+//   self-contained root CA store does not trust every TLS-intercepting proxy
+//   a given network puts in front of outbound HTTPS (observed directly in
+//   this sandbox: plain Node/curl reach https://relay.mydia.dev fine, but the
+//   same fetch() from inside a workerd test fails with "TLS peer's
+//   certificate is not trusted"). Running this project under plain Node
+//   sidesteps that risk entirely and is also just the more honest runtime for
+//   a black-box HTTP diff that has nothing to do with the Worker's own code.
+export default defineWorkspace([
+  "vitest.config.ts",
+  {
+    test: {
+      name: "contract",
+      include: ["test/contract/**/*.test.ts"],
+      environment: "node",
+      // Real network round trips to a live service (two in parallel per
+      // route, one of which -- OpenLibrary search -- routinely takes longer
+      // than Vitest's 5s default) rather than the sub-millisecond in-process
+      // calls the rest of the suite makes.
+      testTimeout: 20_000,
+    },
+  },
+]);

--- a/relay-worker/vitest.workspace.ts
+++ b/relay-worker/vitest.workspace.ts
@@ -31,9 +31,9 @@ export default defineWorkspace([
       // 500ms-20s+ across otherwise-identical runs, most likely MusicBrainz's
       // documented ~1req/s courtesy rate limit applied per source IP, shared
       // across every mydia install this relay serves in production plus this
-      // test's own doubled (Worker+relay) concurrent calls. Not a body
-      // mismatch -- see task-9-report.md's diagnosis of the two timeouts this
-      // was raised to fix.
+      // test's own doubled (Worker+relay) concurrent calls. The two timeouts
+      // this was raised to fix were both slow responses, not body mismatches:
+      // the same routes passed on a rerun with no code change.
       testTimeout: 60_000,
     },
   },

--- a/relay-worker/vitest.workspace.ts
+++ b/relay-worker/vitest.workspace.ts
@@ -24,10 +24,17 @@ export default defineWorkspace([
       include: ["test/contract/**/*.test.ts"],
       environment: "node",
       // Real network round trips to a live service (two in parallel per
-      // route, one of which -- OpenLibrary search -- routinely takes longer
-      // than Vitest's 5s default) rather than the sub-millisecond in-process
-      // calls the rest of the suite makes.
-      testTimeout: 20_000,
+      // route) rather than the sub-millisecond in-process calls the rest of
+      // the suite makes. OpenLibrary search alone can take several seconds.
+      // MusicBrainz-backed routes (search, artist, release, release-group,
+      // recording) are the slowest and least predictable of all: observed
+      // 500ms-20s+ across otherwise-identical runs, most likely MusicBrainz's
+      // documented ~1req/s courtesy rate limit applied per source IP, shared
+      // across every mydia install this relay serves in production plus this
+      // test's own doubled (Worker+relay) concurrent calls. Not a body
+      // mismatch -- see task-9-report.md's diagnosis of the two timeouts this
+      // was raised to fix.
+      testTimeout: 60_000,
     },
   },
 ]);

--- a/relay-worker/wrangler.jsonc
+++ b/relay-worker/wrangler.jsonc
@@ -16,5 +16,12 @@
   // local namespace regardless of the id below.
   "kv_namespaces": [
     { "binding": "CACHE_KV", "id": "placeholder_local_dev_only" }
+  ],
+  // namespace_id values are arbitrary identifiers for this binding, not
+  // provisioned cloud resources -- nothing to create in the dashboard.
+  "ratelimits": [
+    { "name": "PROXY_LIMITER", "namespace_id": "1001", "simple": { "limit": 300, "period": 60 } },
+    { "name": "PAIRING_CREATE_LIMITER", "namespace_id": "1002", "simple": { "limit": 10, "period": 60 } },
+    { "name": "PAIRING_READ_LIMITER", "namespace_id": "1003", "simple": { "limit": 30, "period": 60 } }
   ]
 }

--- a/relay-worker/wrangler.jsonc
+++ b/relay-worker/wrangler.jsonc
@@ -36,5 +36,16 @@
     { "name": "PROXY_LIMITER", "namespace_id": "1001", "simple": { "limit": 300, "period": 60 } },
     { "name": "PAIRING_CREATE_LIMITER", "namespace_id": "1002", "simple": { "limit": 10, "period": 60 } },
     { "name": "PAIRING_READ_LIMITER", "namespace_id": "1003", "simple": { "limit": 30, "period": 60 } }
-  ]
+  ],
+  // Drives src/index.ts's scheduled() handler (src/obs/sweep.ts), which
+  // deletes stale feedback_rate_limits rows and expired pairing_claims
+  // rows. Hourly matches the rate-limit bucket's own granularity: at most
+  // two hours of feedback_rate_limits rows (current + previous) are ever
+  // resident between sweeps, and pairing claims are short-lived (minutes),
+  // so hourly is frequent enough that its own table growth stays bounded
+  // between runs without needing sub-hourly scheduling. Cron Triggers cost
+  // nothing on Workers.
+  "triggers": {
+    "crons": ["0 * * * *"]
+  }
 }

--- a/relay-worker/wrangler.jsonc
+++ b/relay-worker/wrangler.jsonc
@@ -17,6 +17,19 @@
   "kv_namespaces": [
     { "binding": "CACHE_KV", "id": "placeholder_local_dev_only" }
   ],
+  // Same placeholder pattern as CACHE_KV above: the real database is
+  // provisioned at deploy time with `npx wrangler d1 create mydia-relay`,
+  // which needs Cloudflare credentials this environment does not have.
+  // Miniflare/vitest-pool-workers back DB with a working local D1 regardless
+  // of the id below, and apply migrations/ automatically for tests.
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "mydia-relay",
+      "database_id": "placeholder_local_dev_only",
+      "migrations_dir": "migrations"
+    }
+  ],
   // namespace_id values are arbitrary identifiers for this binding, not
   // provisioned cloud resources -- nothing to create in the dashboard.
   "ratelimits": [

--- a/relay-worker/wrangler.jsonc
+++ b/relay-worker/wrangler.jsonc
@@ -32,10 +32,38 @@
   ],
   // namespace_id values are arbitrary identifiers for this binding, not
   // provisioned cloud resources -- nothing to create in the dashboard.
+  //
+  // CRASH_INGEST_LIMITER / FEEDBACK_INGEST_LIMITER (final review fix round):
+  // burst guards in front of the two D1-backed hourly budgets in
+  // src/crashes/ingest.ts and src/feedback/ingest.ts. Those budgets are read
+  // a bucket row, decide in JS, then issue separate D1 writes -- D1 only
+  // guarantees ordering within one statement or a .batch(), not across two
+  // independent .prepare()/.run() calls, so concurrent requests can all read
+  // the same pre-increment state and all decide to admit, defeating the cap
+  // (measured: 20 concurrent identical crash reports produced 142 writes
+  // against a cap the sequential test suite asserted was always 23; 20
+  // concurrent identical-IP feedback submissions were all 20 admitted
+  // against a 5/hour cap). `period` here only supports 10 or 60 seconds, so
+  // this can't replace either hourly budget -- it only bounds how many
+  // requests per window can even reach the D1 read-then-write path at all.
+  // 10/10s (=60/min) for crash ingest is well above the client-side
+  // throttle's 10/min per-instance cap ACROSS ALL fingerprints combined
+  // (Mydia.CrashReporter.Throttle), so a single exact (fingerprint,
+  // instance) pair -- this binding's key granularity -- sees far less than
+  // that legitimately, while still bounding a concurrent flood down from
+  // "unlimited" to a small, fixed number reaching the D1 path per window.
+  // 10/10s for feedback (user-initiated, not automated) gives comparable
+  // headroom above any plausible shared-IP burst. The D1-side accounting
+  // itself was also made atomic (a single
+  // INSERT ... ON CONFLICT DO UPDATE ... RETURNING per request, not a
+  // separate SELECT-then-write) -- see the ingest files' comments for what
+  // that closes outright versus what these bindings merely bound.
   "ratelimits": [
     { "name": "PROXY_LIMITER", "namespace_id": "1001", "simple": { "limit": 300, "period": 60 } },
     { "name": "PAIRING_CREATE_LIMITER", "namespace_id": "1002", "simple": { "limit": 10, "period": 60 } },
-    { "name": "PAIRING_READ_LIMITER", "namespace_id": "1003", "simple": { "limit": 30, "period": 60 } }
+    { "name": "PAIRING_READ_LIMITER", "namespace_id": "1003", "simple": { "limit": 30, "period": 60 } },
+    { "name": "CRASH_INGEST_LIMITER", "namespace_id": "1004", "simple": { "limit": 10, "period": 10 } },
+    { "name": "FEEDBACK_INGEST_LIMITER", "namespace_id": "1005", "simple": { "limit": 10, "period": 10 } }
   ],
   // Drives src/index.ts's scheduled() handler (src/obs/sweep.ts), which
   // deletes stale feedback_rate_limits rows and expired pairing_claims

--- a/relay-worker/wrangler.jsonc
+++ b/relay-worker/wrangler.jsonc
@@ -9,5 +9,12 @@
     "RELAY_VERSION": "1.0.0",
     "FEEDBACK_FROM": "metadata-relay@mydia.dev",
     "FEEDBACK_TO": "arsfeld@gmail.com"
-  }
+  },
+  // The real namespace is provisioned at deploy time with
+  // `npx wrangler kv namespace create CACHE_KV`; this id is a placeholder for
+  // local dev only. Miniflare/vitest-pool-workers back CACHE_KV with a working
+  // local namespace regardless of the id below.
+  "kv_namespaces": [
+    { "binding": "CACHE_KV", "id": "placeholder_local_dev_only" }
+  ]
 }

--- a/relay-worker/wrangler.jsonc
+++ b/relay-worker/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "mydia-relay",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-09-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "observability": { "enabled": true },
+  "vars": {
+    "RELAY_VERSION": "1.0.0",
+    "FEEDBACK_FROM": "metadata-relay@mydia.dev",
+    "FEEDBACK_TO": "arsfeld@gmail.com"
+  }
+}


### PR DESCRIPTION
Rebuilds `metadata-relay/` (the Elixir/Bandit service) as a Cloudflare Worker under `relay-worker/`: TypeScript, Hono for routing, D1 + KV + Cache API + Rate Limiting bindings, no server and no tunnel.

**Nothing cuts over in this PR.** `relay.mydia.dev` stays on the Elixir relay. The Worker deploys continuously from `master` but owns no production traffic until the cutover, which is a manual runbook at the bottom of `relay-worker/README.md`, not a merge.

## What's in it

- **Proxy parity**: TMDB, TVDB (including JWT acquisition and refresh cached in KV), SubDL search / download-url / ZIP extraction, and passthrough for MusicBrainz and OpenLibrary.
- **Caching**: cache key derivation and TTL policy ported from the Elixir side, served through the Cache API with a KV read-through for the two things that outlive an edge cache (the TVDB JWT, the SubDL search response).
- **Pairing, crashes, feedback**: pairing claims, crash reports and feedback submissions all move to D1. Feedback notification email goes out through Resend.
- **Maintainer dashboards**: `/admin/errors` and `/admin/feedback`, replacing ErrorTracker and `FeedbackLive.Index`.
- **Edge rate limiting and structured request logging**, plus an hourly cron sweep that evicts stale rate-limit rows and expired pairing claims.
- **CI**: a `deploy-worker` job in `.github/workflows/deploy-relay.yml` that tests, typechecks, applies D1 migrations `--remote`, then `wrangler deploy`.

## Things an operator who knew the Elixir relay would not expect

- **Responses are actually cached at the edge now.** The Elixir relay sent `cache-control: max-age=0, private, must-revalidate` on every response, so `cf-cache-status` was `DYNAMIC` on every single hit. Nothing was ever cached at Cloudflare despite the in-process cache. The Worker emits real `s-maxage` / `stale-while-revalidate` / `stale-if-error` and gets genuine `HIT`s. That is a latency and a TMDB/TVDB quota improvement, and it is why the cutover verification checks `cf-cache-status` rather than just a 200.
- **The dashboards moved to `/admin/*`.** The obvious paths were `/errors` and `/feedback`, but `/feedback` already serves the public ingest POST, and Cloudflare Access matches by path with no method dimension. One Access application scoped to `/admin*` now covers every maintainer route by construction. The public ingest paths did not move, so no mydia install has to change.
- **The deploy ritual is a `git push`, not a tag.** The Elixir relay ships on a `metadata-relay-v*` tag through GHCR and Keel's five minute poll. The Worker ships on every push to `master` touching `relay-worker/**`. `git log` on that directory is effectively the release history now.
- **The proxy rate limiter charges cache hits.** It used to check the budget after running the request so it could read `x-relay-cache` and skip charging a hit, which meant a throttled request still made its real upstream call every time. That defeats the point of the limiter, worst for SubDL's shared 2000/day key. The check now runs first, fail closed, at the cost of a bulk metadata refresh spending budget on hits it previously got for free.
- **A crash occurrence count can be a floor.** D1 writes are bounded per install per hour; once a bucket saturates the dashboard marks the group's count sticky-floored so `/admin/errors` renders "500+" instead of a wrong exact number.

## Verification

`npm test` in `relay-worker/`: 245 passed, 42 skipped (the contract-diff suite, which needs both a deployed Worker and the live Elixir relay). `npm run typecheck`: clean.

## What is still manual, and not done here

Everything in `relay-worker/README.md` below the "Runbook" heading needs Cloudflare dashboard access that CI does not have, and none of it has been executed:

- Step 0: create the D1 database and KV namespace, replace the placeholder ids in `wrangler.jsonc`, add `CLOUDFLARE_API_TOKEN` (Workers/D1/KV scope, not the existing Pages-scoped one) and `CLOUDFLARE_ACCOUNT_ID`, put the four provider secrets.
- Step 1: the Cloudflare Access application over `/admin*`. Hard ordering constraint, documented in place.
- Steps 2 and 3: the contract diff against the live relay, and the CPU measurement on the subtitle download path, both of which need a deployed Worker.
- Steps 4 and 5: the production cutover and the decommission of the Elixir relay on can-1.

## Known gap

There is no PR-time CI for `relay-worker/**`. `ci-relay.yml` covers the Elixir service on every push and PR; this branch has no equivalent, so the first automated signal is the deploy job after merge. That job is safe (a failing test stops it before `wrangler deploy`), but it means a broken PR gets no feedback until it lands. Worth a small follow-up.

One more, for whoever touches the schema next: `migrations/` has been amended in place so far, which was safe only because nothing had ever deployed. Wrangler tracks applied migrations by filename, so after the first remote apply an edit to an existing file silently does nothing to production while every local run keeps passing. From that point on, schema changes are new numbered files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cloudflare-based metadata relay supporting TMDB, TVDB, SubDL, MusicBrainz, OpenLibrary, and Cover Art Archive requests.
  * Added subtitle search and secure archive downloads.
  * Added device pairing, crash reporting, and feedback submission endpoints.
  * Added admin dashboards for crash reports and feedback.
  * Added response caching, request rate limits, health checks, and scheduled cleanup.

* **Documentation**
  * Added setup, testing, deployment, and production migration guidance.

* **Tests**
  * Added extensive integration, contract, security, caching, and rate-limit coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->