### PR TITLE
fix(relay-worker): close the #727 review round's input-bounding and hostname gaps

### DIFF
--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -58,8 +58,19 @@ Things an operator who knew the Elixir relay would not expect:
 ## Bindings
 
 Declared in `wrangler.jsonc` (KV, D1, rate limiters, vars) and `src/env.ts`
-(the full `Env` interface, including secrets). Nothing below is optional in
-production; a missing secret degrades a route to a 503/502, not a crash.
+(the full `Env` interface, including secrets).
+
+`RESEND_API_KEY` is the one genuinely optional entry below, and it is optional
+by design rather than by oversight: without it `POST /feedback` still accepts
+and stores every submission, and only the maintainer's notification email is
+skipped. A relay running without it is a supported configuration, not a broken
+one, so do not go looking for a fault when `/health` is green and no mail
+arrives.
+
+Everything else is required in production. A missing value there degrades its
+route to a 503/502 rather than crashing the Worker, which means the symptom is
+a dead route, not a dead deployment — check the secret before assuming the
+route itself regressed.
 
 | Binding | Kind | Set via | Used for |
 | --- | --- | --- | --- |
@@ -74,7 +85,7 @@ production; a missing secret degrades a route to a 503/502, not a crash.
 | `PROXY_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Shared per-edge-IP budget across the metadata/music/openlibrary/subtitle proxy routes |
 | `PAIRING_CREATE_LIMITER` / `PAIRING_READ_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Remote-access pairing claim creation/lookup |
 | `CRASH_INGEST_LIMITER` / `FEEDBACK_INGEST_LIMITER` | Rate Limiting binding | `wrangler.jsonc` (`ratelimits`) | Atomic, D1-free burst guards in front of crash ingest's and feedback ingest's D1-backed hourly budgets — see those files' comments for why the D1 accounting alone isn't safe under concurrency |
-| Cron Trigger `0 * * * *` | scheduled | `wrangler.jsonc` (`triggers.crons`) | Hourly sweep (`src/obs/sweep.ts`): evicts stale `feedback_rate_limits` rows and expired `pairing_claims` |
+| Cron Trigger `0 * * * *` | scheduled | `wrangler.jsonc` (`triggers.crons`) | Hourly sweep (`src/obs/sweep.ts`): evicts stale `feedback_rate_limits` and `ingest_buckets` rows and expired `pairing_claims` |
 
 `ratelimits[].namespace_id` values (`1001`-`1005`) are arbitrary identifiers
 for the binding, not provisioned cloud resources — there is nothing to create
@@ -180,6 +191,21 @@ equivalent exists in `Env`, and none should ever be added; that pattern is
 exactly what Access retires (see the runbook below for the operational trap
 it closes). Setting up the Access application is a manual, one-time step —
 see the runbook.
+
+**Access is configured per hostname, and the Worker answers on more than
+one.** The Step 1 Access application covers `relay.mydia.dev/admin*`. From the
+first successful CI deploy the Worker is *also* live on its `*.workers.dev`
+subdomain, plus the versioned preview URLs alongside it, and Access never sees
+those requests. `src/index.ts` therefore answers `/admin/*` with a 404 on any
+`.workers.dev` hostname, so the dashboards are unreachable there for the whole
+window between the first deploy and the Step 4 cutover. `workers_dev: false`
+would have been the blunter fix, but Step 3's CPU measurement and Step 4a's
+staging contract diff both need that hostname serving the public routes.
+
+That deny is not authentication and must not be mistaken for it — it removes
+an unprotected hostname from reach, it does not decide who may look. Access
+still decides that, and skipping Step 1 still leaves the dashboards open on
+the production hostname the moment Step 4b adds the route.
 
 ## Project structure
 

--- a/relay-worker/migrations/0002_crash_reports.sql
+++ b/relay-worker/migrations/0002_crash_reports.sql
@@ -108,3 +108,20 @@ CREATE TABLE ingest_buckets (
   saturated INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (fingerprint, instance_key)
 );
+
+-- Exists for sweepStaleIngestBuckets (src/obs/sweep.ts), not for the request
+-- path, which always addresses a row by the full (fingerprint, instance_key)
+-- primary key.
+--
+-- This table needs a sweep for a reason feedback_rate_limits does not: the
+-- primary key is (fingerprint, instance_key), so rolling into a new hour
+-- RESETS an existing row rather than creating a second one. A row is therefore
+-- only ever abandoned, never superseded -- and `instance_key` is per install,
+-- so every install that ever reports a given crash leaves one row behind
+-- permanently once it stops reporting. Nothing in the request path can
+-- reclaim those, because the request path only ever touches the exact key it
+-- was handed. Growth is bounded by (distinct fingerprints x distinct installs
+-- that ever hit them), which is unbounded in the only direction that matters:
+-- it never goes down on its own.
+CREATE INDEX ingest_buckets_hour_bucket_idx
+  ON ingest_buckets (hour_bucket);

--- a/relay-worker/migrations/0003_feedback.sql
+++ b/relay-worker/migrations/0003_feedback.sql
@@ -59,3 +59,14 @@ CREATE TABLE feedback_rate_limits (
   hour_bucket INTEGER NOT NULL,
   count INTEGER NOT NULL
 );
+
+-- The only index this table needs beyond its primary key, and it exists for
+-- the sweep rather than for any request: sweepStaleFeedbackRateLimits
+-- (src/obs/sweep.ts) deletes by `hour_bucket < ?`, a column the bucket_key
+-- primary key cannot serve. Without it the hourly Cron Trigger full-scans
+-- feedback_rate_limits every run, and this table's live cardinality is one row
+-- per distinct submitter IP per hour, which nothing in the code bounds.
+-- Request-path access is always by bucket_key, so the primary key still covers
+-- every read and write ingest performs.
+CREATE INDEX feedback_rate_limits_hour_bucket_idx
+  ON feedback_rate_limits (hour_bucket);

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -51,6 +51,45 @@ export interface OccurrenceRow {
 // the crash is still counted, but no new row is written.
 export const MAX_OCCURRENCE_ROWS_PER_BUCKET = 3;
 
+// Size caps on what one report can persist. POST /crashes/report is
+// unauthenticated, and none of `error_message`, `stacktrace` or `metadata`
+// was bounded before: a single request could bind a multi-megabyte string
+// into the INSERT. D1 rejects an oversized bound value, so `.batch()` throws
+// and the route answers an unhandled 500 -- and
+// Mydia.CrashReporter.Sender.send_http_request/2 retries every non-201
+// status, so the producer would keep re-sending a request that can never
+// succeed until it exhausts its 10 attempts / 24 hours. The per-bucket cap
+// (MAX_OCCURRENCE_ROWS_PER_BUCKET) bounds how MANY rows a fingerprint can
+// write, never how big any one of them is.
+//
+// The numbers are chosen to be far above any real report from
+// Mydia.CrashReporter and far below anything D1 objects to. An Elixir
+// exception message runs to a few hundred characters even when it inlines a
+// struct; BEAM stacktraces are tens of frames, not hundreds; and the
+// `metadata` map is Logger metadata, which is small by construction.
+// Truncation is deliberately silent and non-fatal rather than a 400 -- a
+// report that is too big is still worth keeping the head of, and rejecting it
+// would just feed the producer's retry loop.
+const MAX_MESSAGE_CHARS = 4_096;
+const MAX_FRAME_STRING_CHARS = 1_024;
+const MAX_STACK_FRAMES = 64;
+const MAX_CONTEXT_BYTES = 16_384;
+
+// The marker is appended after the cut, so the result is bounded by
+// max + marker length rather than exactly max. Being able to see that a value
+// was cut is worth more than the handful of characters.
+const TRUNCATION_MARKER = "...[truncated]";
+
+function truncate(value: string, max: number): string {
+  return value.length <= max
+    ? value
+    : `${value.slice(0, max)}${TRUNCATION_MARKER}`;
+}
+
+function truncateOrNull(value: unknown, max: number): string | null {
+  return typeof value === "string" ? truncate(value, max) : null;
+}
+
 function frame(
   module: unknown,
   fn: unknown,
@@ -58,10 +97,26 @@ function frame(
   line: unknown,
 ): CrashFrame {
   return {
-    module: typeof module === "string" ? module : null,
-    function: typeof fn === "string" ? fn : null,
-    file: typeof file === "string" ? file : null,
+    module: truncateOrNull(module, MAX_FRAME_STRING_CHARS),
+    function: truncateOrNull(fn, MAX_FRAME_STRING_CHARS),
+    file: truncateOrNull(file, MAX_FRAME_STRING_CHARS),
     line: typeof line === "number" ? line : null,
+  };
+}
+
+// `context` is persisted as one JSON string, so its cost is the cost of the
+// whole serialized object, not of any single key -- there is no useful
+// per-field cap here the way there is for a frame. Rather than cut the JSON
+// text (which would store something that no longer parses, breaking the
+// dashboard on read), an over-budget map is replaced wholesale by a marker
+// object that is itself valid JSON and says what happened.
+function boundContext(context: Record<string, unknown>): Record<string, unknown> {
+  const encoded = new TextEncoder().encode(JSON.stringify(context));
+  if (encoded.byteLength <= MAX_CONTEXT_BYTES) return context;
+  return {
+    _truncated: true,
+    _reason: `metadata exceeded ${MAX_CONTEXT_BYTES} bytes and was dropped`,
+    _original_bytes: encoded.byteLength,
   };
 }
 
@@ -113,12 +168,40 @@ function metadataStackFrame(metadata: unknown): CrashFrame | null {
 // discard this field on every real report and substitute ingestion time
 // instead. A Unix-seconds number is still accepted for callers other than
 // the Elixir producer (e.g. direct API use, tests).
+//
+// Number.isFinite is not a tight enough gate on the numeric branch. This
+// endpoint is unauthenticated, and `occurred_at: 1e300` is finite, so it used
+// to be stored verbatim; the dashboard then renders that row through
+// `when()` (src/dashboards/layout.ts), whose `new Date(unix * 1000)` is
+// outside the +/-8.64e15ms range Date represents, and `toISOString()` throws
+// `RangeError: Invalid time value`. One such row does not corrupt a cell, it
+// throws while building the page, so /admin/errors returns 500 and stays
+// broken until someone deletes the row by hand -- a stored, unauthenticated
+// denial of service against the maintainer's own view of crashes.
+//
+// MAX_OCCURRED_AT is Date's own limit expressed in the seconds this column
+// stores. Out-of-range values fall through to ingestion time rather than
+// being rejected, matching what this function already does for an
+// unparseable string: `occurred_at` is a report ATTRIBUTE, not something the
+// producer must get right for the report to be worth keeping, and the Elixir
+// producer's own retry loop (Mydia.CrashReporter.Sender) would hammer a 400
+// forever. Negative values are legal and kept -- a clock skewed before the
+// epoch is odd but representable, and `when()` renders it fine.
+const MAX_OCCURRED_AT = 8_640_000_000_000; // 8.64e15 ms / 1000
+
+function inDateRange(seconds: number): boolean {
+  return Math.abs(seconds) <= MAX_OCCURRED_AT;
+}
+
 function parseOccurredAt(value: unknown): number {
   if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.floor(value);
+    const seconds = Math.floor(value);
+    if (inDateRange(seconds)) return seconds;
   }
   if (typeof value === "string") {
     const parsed = Date.parse(value);
+    // Date.parse already rejects out-of-range input with NaN, so a successful
+    // parse is in range by construction; inDateRange is not repeated here.
     if (!Number.isNaN(parsed)) return Math.floor(parsed / 1000);
   }
   return Math.floor(Date.now() / 1000);
@@ -127,15 +210,31 @@ function parseOccurredAt(value: unknown): number {
 export function normalizeCrashReport(
   body: Record<string, unknown>,
 ): NormalizedCrash {
+  // Capped like every other caller-supplied string here. `kind` is also one
+  // of the two fingerprint inputs, so an uncapped value would additionally
+  // let one request write an arbitrarily long primary-key-adjacent grouping
+  // label; the SHA-256 in fingerprintOf hides that from the errors table's
+  // key, but `kind` itself is stored and rendered.
   const kind =
-    typeof body.error_type === "string" ? body.error_type : "RuntimeError";
+    typeof body.error_type === "string"
+      ? truncate(body.error_type, MAX_FRAME_STRING_CHARS)
+      : "RuntimeError";
   const message =
-    typeof body.error_message === "string" ? body.error_message : "Unknown error";
+    typeof body.error_message === "string"
+      ? truncate(body.error_message, MAX_MESSAGE_CHARS)
+      : "Unknown error";
 
+  // Sliced AFTER parsing rather than before, so MAX_STACK_FRAMES counts
+  // frames that survived parseStacktraceEntry's drop rule, not raw array
+  // entries -- a caller padding the array with junk entries can't push real
+  // frames out of the window that way. The top frame is what the fingerprint
+  // is derived from, and this keeps the top of the trace, so the grouping a
+  // truncated report lands in is the same one it would have had.
   const rawStack = Array.isArray(body.stacktrace) ? body.stacktrace : [];
   let stacktrace = rawStack
     .map(parseStacktraceEntry)
-    .filter((f): f is CrashFrame => f !== null);
+    .filter((f): f is CrashFrame => f !== null)
+    .slice(0, MAX_STACK_FRAMES);
 
   // Without any source info every report derives the same fingerprint and
   // collapses into one useless group, so metadata stands in for a frame.
@@ -152,10 +251,10 @@ export function normalizeCrashReport(
     stacktrace,
     sourceFile: top?.file ?? null,
     sourceLine: top?.line ?? null,
-    version: typeof body.version === "string" ? body.version : null,
-    environment: typeof body.environment === "string" ? body.environment : null,
+    version: truncateOrNull(body.version, MAX_FRAME_STRING_CHARS),
+    environment: truncateOrNull(body.environment, MAX_FRAME_STRING_CHARS),
     occurredAt: parseOccurredAt(body.occurred_at),
-    context: isPlainObject(body.metadata) ? body.metadata : {},
+    context: boundContext(isPlainObject(body.metadata) ? body.metadata : {}),
   };
 }
 

--- a/relay-worker/src/dashboards/layout.ts
+++ b/relay-worker/src/dashboards/layout.ts
@@ -47,8 +47,23 @@ export function parsePage(raw: string | undefined): number {
 
 // Shared "unix seconds -> readable UTC timestamp" formatter for both
 // dashboards' list tables. Same extraction reasoning as parsePage above.
+//
+// The guard is not defensive padding. `toISOString()` throws
+// `RangeError: Invalid time value` once `unix * 1000` leaves Date's
+// +/-8.64e15ms range, and this runs while BUILDING the page, so one bad row
+// does not render as a bad cell -- it takes the whole dashboard down with a
+// 500 and keeps it down until someone deletes the row by hand.
+//
+// The values reach here from `occurred_at` on the unauthenticated
+// POST /crashes/report, whose parseOccurredAt (src/crashes/ingest.ts) is
+// where this is actually fixed: it now clamps to the same range before
+// anything is stored. This guard stays anyway, because that fix only governs
+// rows written after it ships, and a row stored before it must not be able to
+// break the dashboard the maintainer would use to find it.
 export function when(unix: number): string {
-  return new Date(unix * 1000).toISOString().replace("T", " ").slice(0, 19);
+  const ms = unix * 1000;
+  if (!Number.isFinite(ms) || Math.abs(ms) > 8.64e15) return "invalid date";
+  return new Date(ms).toISOString().replace("T", " ").slice(0, 19);
 }
 
 export function layout(title: string, body: string): string {

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -62,6 +62,41 @@ app.get("/stats", (c) =>
   }),
 );
 
+// Cloudflare Access is the real gate on /admin/*, and it is configured per
+// hostname: the Step 1 Access application in relay-worker/README.md's runbook
+// covers `relay.mydia.dev/admin*` and nothing else. The Worker is ALSO live on
+// its `*.workers.dev` subdomain from the first successful CI deploy onwards
+// (runbook Step 3 and Step 4a both depend on that, which is why
+// `workers_dev: false` is not the fix here), and Access does not see requests
+// to that hostname at all. Without this middleware the maintainer dashboards
+// would be anonymously readable on the workers.dev URL for the whole window
+// between the first deploy and the Step 4 cutover -- the same
+// path-not-method, hostname-by-hostname trap the runbook's cutover
+// preconditions already warn about for the wildcard route, one hostname
+// earlier.
+//
+// So: /admin/* answers 404 on any workers.dev hostname, which covers both the
+// deploy subdomain (`mydia-relay.<subdomain>.workers.dev`) and the versioned
+// preview URLs Cloudflare mints alongside it. Every other hostname -- the
+// production custom domain, local dev, Miniflare in tests -- is unaffected,
+// and none of test/contract/routes.json's routes are under /admin, so the
+// staging contract diff still exercises everything it did before.
+//
+// This is not authentication and must never grow into it: it removes an
+// UNPROTECTED hostname from reach, it does not decide who may look. Access
+// still decides that, and the README's "the Worker holds no dashboard
+// credentials, and none should ever be added" rule stands unchanged.
+//
+// Registered before the dashboards it guards, since app.use() only wraps
+// routes registered after it (same composition rule as the two middlewares
+// above).
+app.use("/admin/*", async (c, next) => {
+  if (new URL(c.req.url).hostname.endsWith(".workers.dev")) {
+    return c.json({ error: "Not found" }, 404);
+  }
+  await next();
+});
+
 registerTmdbRoutes(app);
 registerTvdbRoutes(app);
 registerSubdlRoutes(app);
@@ -77,7 +112,9 @@ registerCrashRoutes(app);
 // Worker route, matches on path only, with no HTTP-method dimension, so a
 // dashboard sharing a path with a public endpoint could never be gated
 // without also gating the public one. Creating that Access application is
-// still a manual step; until it exists, this route has no auth at all.
+// still a manual step; until it exists, this route has no auth at all on any
+// hostname Access does not cover -- which is why the workers.dev deny above
+// exists, and why it is not a substitute for doing Step 1.
 registerErrorDashboard(app);
 // POST /feedback is the public ingest endpoint every mydia install calls --
 // a wire contract that must never move. registerFeedbackDashboard below

--- a/relay-worker/src/obs/sweep.ts
+++ b/relay-worker/src/obs/sweep.ts
@@ -25,7 +25,33 @@ export async function sweepStaleFeedbackRateLimits(env: Env): Promise<number> {
   return result.meta.changes;
 }
 
-// Runs both sweeps under one Cron Trigger. pairing/store.ts's
+// The third table with no eviction path, missed when the other two were
+// wired up. It is the worst of the three, because its primary key is
+// (fingerprint, instance_key) rather than anything time-derived: rolling into
+// a new hour RESETS an existing row (see incrementBucketAtomically's
+// ON CONFLICT in src/crashes/ingest.ts), so a row is only ever abandoned,
+// never superseded by a newer one that a later sweep would catch. Every
+// install that ever reported a given crash and then stopped leaves its row
+// behind forever, and the request path cannot reclaim any of them because it
+// only ever touches the exact key it was handed.
+//
+// Same cutoff and the same reasoning as sweepStaleFeedbackRateLimits above:
+// incrementBucketAtomically resets hits/written/saturated outright the moment
+// hour_bucket doesn't match the current hour, so a row older than that
+// carries no state any live request can read, and the extra hour of margin
+// keeps a sweep landing on an hour boundary from racing a request rolling
+// into it.
+export async function sweepStaleIngestBuckets(env: Env): Promise<number> {
+  const currentHour = Math.floor(Date.now() / 3_600_000);
+  const result = await env.DB.prepare(
+    "DELETE FROM ingest_buckets WHERE hour_bucket < ?",
+  )
+    .bind(currentHour - 1)
+    .run();
+  return result.meta.changes;
+}
+
+// Runs all three sweeps under one Cron Trigger. pairing/store.ts's
 // purgeExpiredClaims was written when pairing landed and then never wired to
 // anything -- the identical defect (a table with no eviction path) in a
 // different table, closed here in the same commit rather than left to be
@@ -34,5 +60,9 @@ export async function sweepStaleFeedbackRateLimits(env: Env): Promise<number> {
 // feedback sweep above, is housekeeping (bounding table growth), not a
 // correctness fix.
 export async function runScheduledSweep(env: Env): Promise<void> {
-  await Promise.all([sweepStaleFeedbackRateLimits(env), purgeExpiredClaims(env)]);
+  await Promise.all([
+    sweepStaleFeedbackRateLimits(env),
+    sweepStaleIngestBuckets(env),
+    purgeExpiredClaims(env),
+  ]);
 }

--- a/relay-worker/src/pairing/routes.ts
+++ b/relay-worker/src/pairing/routes.ts
@@ -15,15 +15,44 @@ const MAX_SEALED_BYTES = 8192;
 // Matches Pairing.generate_code/1's alphabet exactly: excludes 0, O, I, 1 AND
 // L (easy to misread as 1) so a code read aloud or typed by hand is
 // unambiguous. Length 6, also matching the Elixir default.
-const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+export const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
 const CODE_LENGTH = 6;
 
 type PairingContext = Context<{ Bindings: Env }>;
 type ErrorBody = { error: string; message: string };
 
-function generateCode(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(CODE_LENGTH));
-  return [...bytes].map((b) => CODE_ALPHABET[b % CODE_ALPHABET.length]).join("");
+// Rejection sampling, not `byte % 31`. 256 is not a multiple of the
+// alphabet's 31 characters: taking the modulo of a uniform byte maps nine
+// byte values onto each of the first eight characters and eight onto each of
+// the remaining twenty-three, so those eight are 12.5% likelier per position
+// than the rest. Over a 6-character code that is a measurable skew in the
+// search space an attacker guessing a live claim has to cover, which is the
+// only property this code has -- it is the whole secret protecting a pairing
+// claim for its 300-second TTL. CodeQL flags the modulo form directly (alert
+// 249, "Creating biased random numbers from a cryptographically secure
+// source").
+//
+// 248 is the largest multiple of 31 that fits in a byte, so discarding
+// 248-255 leaves exactly 8 uniform values per character. Rejection is drawn
+// from a fresh block rather than a single fixed-size draw: ~3.1% of bytes are
+// rejected, so a 6-character code almost always completes on the first block,
+// and the loop is what makes "almost always" irrelevant to correctness.
+// Exported so test/pairing/routes.test.ts can sample it directly. Going
+// through POST /pairing/claim instead would mean paying PAIRING_CREATE_LIMITER
+// and a D1 write per sample, and a uniformity check needs thousands.
+export const REJECTION_THRESHOLD = 248; // floor(256 / 31) * 31
+
+export function generateCode(): string {
+  const chars: string[] = [];
+  while (chars.length < CODE_LENGTH) {
+    const bytes = crypto.getRandomValues(new Uint8Array(CODE_LENGTH));
+    for (const b of bytes) {
+      if (b >= REJECTION_THRESHOLD) continue;
+      chars.push(CODE_ALPHABET[b % CODE_ALPHABET.length]);
+      if (chars.length === CODE_LENGTH) break;
+    }
+  }
+  return chars.join("");
 }
 
 // Mirrors Pairing.normalize_code/1, applied by the Elixir context to every

--- a/relay-worker/src/proxy/forward.ts
+++ b/relay-worker/src/proxy/forward.ts
@@ -21,6 +21,24 @@ export function forwardParams(
   return out;
 }
 
+// Every caller-supplied value interpolated into an upstream PATH goes through
+// this. Hono hands `c.req.param()` values back already percent-decoded, so a
+// request for `/tmdb/movies/%2e%2e%2f%2e%2e%2fauthentication` arrives as the
+// literal `../../authentication` in `p.id`; interpolated raw into
+// `${TMDB_BASE}/movie/${p.id}`, the URL parser then resolves those segments
+// and the relay issues an authenticated request to a path the caller chose,
+// with the relay's own API key attached. The host is fixed, so this is not
+// SSRF -- it is a confused deputy: the caller cannot reach a new server, but
+// it can reach a different endpoint on the one the relay holds credentials
+// for. `?`, `#` and `;` in a segment are the same class of problem, splicing
+// query or parameters into a path the caller was not supposed to control.
+//
+// encodeURIComponent, not encodeURI: encodeURI deliberately leaves `/`, `?`
+// and `#` intact, which is exactly the set that has to be escaped here.
+export function pathSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
 export async function proxyJson(
   env: Env,
   upstreamUrl: string,
@@ -40,6 +58,7 @@ export async function proxyJson(
 
   const upstream = await fetch(upstreamUrl, init);
   const body = await upstream.text();
+  const ok = upstream.status >= 200 && upstream.status < 300;
 
   const res = new Response(body, {
     status: upstream.status,
@@ -50,12 +69,12 @@ export async function proxyJson(
       // "max-age=0, private, must-revalidate", which is why Cloudflare
       // reported cf-cache-status: DYNAMIC on every route and nothing was
       // ever cached at the edge.
-      "cache-control": cacheableHeader(cacheKey),
+      "cache-control": cacheableHeader(cacheKey, ok),
     },
   });
 
   // Only successful responses are cached, matching plug/cache.ex.
-  if (upstream.status >= 200 && upstream.status < 300) {
+  if (ok) {
     await cachePut(env, cacheKey, res.clone());
   }
 
@@ -63,7 +82,21 @@ export async function proxyJson(
   return res;
 }
 
-function cacheableHeader(cacheKey: string): string {
+// The `ok` split is what stops this header from outliving the relay's own
+// caching decision. cachePut above is already limited to 2xx, but the header
+// went out on every response regardless -- including an upstream 404, 429,
+// 500 or 502 -- and the header is what Cloudflare's edge cache and every
+// downstream client obey. Giving an explicit freshness lifetime to a status
+// that is otherwise uncacheable is what makes it cacheable: one transient
+// TMDB or TVDB failure would then be replayed for the whole TTL, and
+// `stale-if-error=604800` would license reusing it for a further week, from a
+// cache the relay does not own and cannot purge.
+//
+// `no-store` rather than `no-cache`: `no-cache` still permits storing the
+// response and revalidating, which is a distinction no client here needs and
+// leaves the error body sitting in intermediary caches.
+function cacheableHeader(cacheKey: string, ok: boolean): string {
+  if (!ok) return "no-store";
   const ttl = ttlSecondsFor(cacheKey);
   return `public, s-maxage=${ttl}, stale-while-revalidate=86400, stale-if-error=604800`;
 }

--- a/relay-worker/src/proxy/passthrough.ts
+++ b/relay-worker/src/proxy/passthrough.ts
@@ -169,10 +169,23 @@ function registerCoverArt(app: Hono<{ Bindings: Env }>): void {
     try {
       upstream = await fetchCoverArt(id);
     } catch (err) {
-      // Mirrors router.ex's `{:error, reason} -> send_resp(conn, 500, inspect(reason))`.
-      return new Response(err instanceof Error ? err.message : String(err), {
-        status: 500,
-      });
+      // router.ex answered this with `send_resp(conn, 500, inspect(reason))`,
+      // and this deliberately does NOT port that verbatim. `reason` here is a
+      // workerd fetch failure against coverartarchive.org, and its text
+      // describes the relay's own outbound network state -- resolved
+      // addresses, connection and TLS failures, internal subrequest limits --
+      // to an anonymous caller who supplied only a release id. CodeQL flags
+      // the same line (alert 250, "Information exposure through a stack
+      // trace"). Nothing on the client side reads this body: mydia's music
+      // client checks the status, and the contract suite compares bodies
+      // between the two relays only for JSON routes, so a fixed string is
+      // both safer and contract-neutral.
+      //
+      // The detail is not discarded, it moves to where it is useful: the
+      // Worker's own logs (Workers Logs / `wrangler tail`), which every
+      // uncaught throw already reaches and which the maintainer can read.
+      console.error("cover art upstream fetch failed", err);
+      return new Response("Upstream error", { status: 500 });
     }
 
     if (upstream.status === 404) {

--- a/relay-worker/src/proxy/tmdb.ts
+++ b/relay-worker/src/proxy/tmdb.ts
@@ -1,7 +1,7 @@
 import type { Hono } from "hono";
 import type { Env } from "../env";
 import { buildKey } from "../cache/key";
-import { forwardParams, proxyJson } from "./forward";
+import { forwardParams, pathSegment, proxyJson } from "./forward";
 
 const TMDB_BASE = "https://api.themoviedb.org/3";
 
@@ -23,13 +23,20 @@ const ROUTES: Array<[string, (p: Record<string, string>) => string]> = [
   ["/tmdb/tv/discover", () => "/discover/tv"],
   ["/tmdb/genre/movie", () => "/genre/movie/list"],
   ["/tmdb/genre/tv", () => "/genre/tv/list"],
-  ["/tmdb/list/:id", (p) => `/list/${p.id}`],
-  ["/tmdb/collections/:id", (p) => `/collection/${p.id}`],
-  ["/tmdb/movies/:id", (p) => `/movie/${p.id}`],
-  ["/tmdb/tv/shows/:id", (p) => `/tv/${p.id}`],
-  ["/tmdb/movies/:id/images", (p) => `/movie/${p.id}/images`],
-  ["/tmdb/tv/shows/:id/images", (p) => `/tv/${p.id}/images`],
-  ["/tmdb/tv/shows/:id/:season", (p) => `/tv/${p.id}/season/${p.season}`],
+  // Every `:id`/`:season` below goes through pathSegment (see forward.ts for
+  // why): these values are caller-controlled and Hono percent-decodes them,
+  // so interpolating one raw lets the caller pick which TMDB endpoint the
+  // relay's own API key gets spent on.
+  ["/tmdb/list/:id", (p) => `/list/${pathSegment(p.id)}`],
+  ["/tmdb/collections/:id", (p) => `/collection/${pathSegment(p.id)}`],
+  ["/tmdb/movies/:id", (p) => `/movie/${pathSegment(p.id)}`],
+  ["/tmdb/tv/shows/:id", (p) => `/tv/${pathSegment(p.id)}`],
+  ["/tmdb/movies/:id/images", (p) => `/movie/${pathSegment(p.id)}/images`],
+  ["/tmdb/tv/shows/:id/images", (p) => `/tv/${pathSegment(p.id)}/images`],
+  [
+    "/tmdb/tv/shows/:id/:season",
+    (p) => `/tv/${pathSegment(p.id)}/season/${pathSegment(p.season)}`,
+  ],
 ];
 
 export function registerTmdbRoutes(app: Hono<{ Bindings: Env }>): void {

--- a/relay-worker/src/proxy/tvdb.ts
+++ b/relay-worker/src/proxy/tvdb.ts
@@ -1,7 +1,7 @@
 import type { Hono } from "hono";
 import type { Env } from "../env";
 import { buildKey } from "../cache/key";
-import { forwardParams, proxyJson } from "./forward";
+import { forwardParams, pathSegment, proxyJson } from "./forward";
 import { getTvdbToken } from "./tvdb-auth";
 
 const TVDB_BASE = "https://api4.thetvdb.com/v4";
@@ -23,16 +23,35 @@ interface TvdbRoute {
 }
 
 // Source of truth: metadata-relay/lib/metadata_relay/tvdb/handler.ex.
+// `page` is the one caller-controlled value here that is NOT a Hono path
+// param, and it is spliced into the upstream path rather than sent as a query
+// parameter (see the get_series_episodes note below). pathSegment would make
+// it safe, but a percent-encoded non-number is still a nonsense TVDB path, so
+// this rejects outright instead: anything that is not a run of digits becomes
+// the same "0" an absent `page` already produces. That keeps this route
+// bug-compatible with handler.ex for every input either side would treat as
+// real -- both still answer 400, for the reason recorded in
+// test/contract/routes.json -- while removing the traversal.
+const PAGE_PATTERN = /^\d+$/;
+
+function pagePathValue(query: URLSearchParams): string {
+  const raw = query.get("page");
+  return raw !== null && PAGE_PATTERN.test(raw) ? raw : "0";
+}
+
+// Every `:id` below goes through pathSegment (see forward.ts for why): Hono
+// percent-decodes path params, so interpolating one raw lets the caller
+// choose which TVDB endpoint the relay's own bearer token is spent on.
 const ROUTES: TvdbRoute[] = [
   { path: "/tvdb/search", toUpstream: () => "/search", forwardQuery: true },
   {
     path: "/tvdb/series/:id",
-    toUpstream: (p) => `/series/${p.id}`,
+    toUpstream: (p) => `/series/${pathSegment(p.id)}`,
     forwardQuery: false,
   },
   {
     path: "/tvdb/series/:id/extended",
-    toUpstream: (p) => `/series/${p.id}/extended`,
+    toUpstream: (p) => `/series/${pathSegment(p.id)}/extended`,
     forwardQuery: true,
   },
   // get_series_episodes/2 reads `page` (default 0) out of the params map and
@@ -42,32 +61,32 @@ const ROUTES: TvdbRoute[] = [
   {
     path: "/tvdb/series/:id/episodes",
     toUpstream: (p, query) =>
-      `/series/${p.id}/episodes/default/page/${query.get("page") ?? "0"}`,
+      `/series/${pathSegment(p.id)}/episodes/default/page/${pagePathValue(query)}`,
     forwardQuery: false,
   },
   {
     path: "/tvdb/seasons/:id",
-    toUpstream: (p) => `/seasons/${p.id}`,
+    toUpstream: (p) => `/seasons/${pathSegment(p.id)}`,
     forwardQuery: false,
   },
   {
     path: "/tvdb/seasons/:id/extended",
-    toUpstream: (p) => `/seasons/${p.id}/extended`,
+    toUpstream: (p) => `/seasons/${pathSegment(p.id)}/extended`,
     forwardQuery: true,
   },
   {
     path: "/tvdb/episodes/:id",
-    toUpstream: (p) => `/episodes/${p.id}`,
+    toUpstream: (p) => `/episodes/${pathSegment(p.id)}`,
     forwardQuery: false,
   },
   {
     path: "/tvdb/episodes/:id/extended",
-    toUpstream: (p) => `/episodes/${p.id}/extended`,
+    toUpstream: (p) => `/episodes/${pathSegment(p.id)}/extended`,
     forwardQuery: true,
   },
   {
     path: "/tvdb/artwork/:id",
-    toUpstream: (p) => `/artwork/${p.id}`,
+    toUpstream: (p) => `/artwork/${pathSegment(p.id)}`,
     forwardQuery: false,
   },
 ];

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -111,6 +111,112 @@ describe("normalizeCrashReport", () => {
 
     expect(out.occurredAt).toBe(Math.floor(Date.parse("2026-01-15T10:30:00.000000Z") / 1000));
   });
+
+  // Number.isFinite alone let `occurred_at: 1e300` through: finite, so stored
+  // verbatim, and then `when()` (src/dashboards/layout.ts) throws
+  // `RangeError: Invalid time value` while BUILDING /admin/errors -- one
+  // unauthenticated POST leaving the maintainer's dashboard at a 500 until
+  // someone deletes the row by hand.
+  it("substitutes ingestion time for a finite but out-of-Date-range occurred_at", () => {
+    const before = Math.floor(Date.now() / 1000);
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      occurred_at: 1e300,
+    });
+
+    expect(out.occurredAt).toBeGreaterThanOrEqual(before);
+    expect(new Date(out.occurredAt * 1000).toISOString()).toBeTypeOf("string");
+  });
+
+  it("keeps an in-range negative occurred_at rather than clamping it", () => {
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      occurred_at: -86_400,
+    });
+
+    expect(out.occurredAt).toBe(-86_400);
+  });
+
+  // D1 rejects an oversized bound value, so an unbounded message made
+  // `.batch()` throw and the route answer 500 -- which
+  // Mydia.CrashReporter.Sender then retries, because it retries every non-201
+  // status, on a request that can never succeed.
+  it("truncates an oversized error_message instead of binding it whole", () => {
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "x".repeat(5_000_000),
+      stacktrace: [],
+    });
+
+    expect(out.message.length).toBeLessThan(5_000);
+    expect(out.message.endsWith("...[truncated]")).toBe(true);
+  });
+
+  it("caps the number of stacktrace frames it keeps", () => {
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace: Array.from({ length: 5_000 }, (_, i) => ({
+        module: "Elixir.Fake",
+        function: "run/0",
+        file: `lib/fake_${i}.ex`,
+        line: i,
+      })),
+    });
+
+    expect(out.stacktrace.length).toBe(64);
+    // The top frame decides the fingerprint, so truncation must keep the head
+    // of the trace or a truncated report would group somewhere else entirely.
+    expect(out.stacktrace[0]?.file).toBe("lib/fake_0.ex");
+  });
+
+  it("truncates oversized strings inside a frame", () => {
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace: [
+        {
+          module: "m".repeat(100_000),
+          function: "run/0",
+          file: "f".repeat(100_000),
+          line: 1,
+        },
+      ],
+    });
+
+    expect(out.stacktrace[0]?.module?.length).toBeLessThan(2_000);
+    expect(out.stacktrace[0]?.file?.length).toBeLessThan(2_000);
+  });
+
+  // `context` persists as one JSON string, so cutting the text would store
+  // something that no longer parses and break the dashboard on read. The
+  // over-budget map is replaced wholesale by a marker that is valid JSON.
+  it("replaces an oversized metadata map with a marker that still parses", () => {
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace: [],
+      metadata: { blob: "y".repeat(2_000_000) },
+    });
+
+    expect(out.context.blob).toBeUndefined();
+    expect(out.context._truncated).toBe(true);
+    expect(() => JSON.parse(JSON.stringify(out.context))).not.toThrow();
+  });
+
+  it("leaves a normal-sized metadata map exactly as it was", () => {
+    const metadata = { file: "lib/fake.ex", line: 12, request_id: "abc123" };
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace: [],
+      metadata,
+    });
+
+    expect(out.context).toEqual(metadata);
+  });
 });
 
 describe("POST /crashes/report", () => {

--- a/relay-worker/test/dashboards/hostname.test.ts
+++ b/relay-worker/test/dashboards/hostname.test.ts
@@ -1,0 +1,65 @@
+import { env, SELF, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+// Cloudflare Access is configured per hostname: the runbook's Step 1
+// application covers `relay.mydia.dev/admin*` and nothing else. The Worker is
+// ALSO live on its `*.workers.dev` subdomain from the first successful CI
+// deploy, plus the versioned preview URLs alongside it, and Access never sees
+// those requests -- so without this deny the maintainer dashboards would be
+// anonymously readable there for the whole window between the first deploy
+// and the Step 4 cutover.
+//
+// This is not authentication and these tests do not claim it is. It removes an
+// unprotected hostname from reach; Access still decides who may look.
+describe("/admin/* on a workers.dev hostname", () => {
+  const ADMIN_PATHS = ["/admin/errors", "/admin/feedback"];
+
+  for (const path of ADMIN_PATHS) {
+    it(`answers 404 for ${path} on the deploy subdomain`, async () => {
+      const res = await SELF.fetch(`https://mydia-relay.someacct.workers.dev${path}`);
+
+      expect(res.status).toBe(404);
+      const body = await res.text();
+      expect(body).not.toContain("<table");
+    });
+
+    it(`answers 404 for ${path} on a versioned preview URL`, async () => {
+      const res = await SELF.fetch(
+        `https://a1b2c3-mydia-relay.someacct.workers.dev${path}`,
+      );
+
+      expect(res.status).toBe(404);
+    });
+
+    it(`still serves ${path} on the production hostname, where Access is the gate`, async () => {
+      const res = await SELF.fetch(`https://relay.mydia.dev${path}`);
+
+      expect(res.status).toBe(200);
+    });
+  }
+
+  // The mutation routes live under /admin/* too, and a deny that only covered
+  // the two GET dashboards would leave them reachable.
+  it("covers the dashboard mutation routes, not just the list pages", async () => {
+    const res = await SELF.fetch(
+      "https://mydia-relay.someacct.workers.dev/admin/errors/a1b2c3d4e5f60718293a4b5c6d7e8f90/resolve",
+      { method: "POST" },
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  // The public ingest routes every mydia install already calls must keep
+  // working on every hostname -- they are not under /admin and must never be
+  // caught by this.
+  it("leaves the public ingest routes reachable on workers.dev", async () => {
+    const res = await SELF.fetch("https://mydia-relay.someacct.workers.dev/health");
+
+    expect(res.status).toBe(200);
+    expect(await res.json<{ status: string }>()).toMatchObject({ status: "ok" });
+  });
+});

--- a/relay-worker/test/dashboards/layout.test.ts
+++ b/relay-worker/test/dashboards/layout.test.ts
@@ -1,0 +1,60 @@
+import { env, SELF, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+import { when, parsePage, MAX_PAGE } from "../../src/dashboards/layout";
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+describe("when", () => {
+  it("formats a normal unix timestamp as a readable UTC string", () => {
+    expect(when(Date.parse("2026-01-15T10:30:00Z") / 1000)).toBe("2026-01-15 10:30:00");
+  });
+
+  // `toISOString()` throws RangeError past Date's +/-8.64e15ms range, and this
+  // runs while BUILDING the page -- so without the guard one row does not
+  // render as a bad cell, it takes /admin/errors down with a 500.
+  it("returns a placeholder instead of throwing on an out-of-range timestamp", () => {
+    expect(() => when(1e300)).not.toThrow();
+    expect(when(1e300)).toBe("invalid date");
+    expect(when(-1e300)).toBe("invalid date");
+  });
+
+  it("still renders a timestamp at the very edge of the representable range", () => {
+    expect(() => when(8_640_000_000_000)).not.toThrow();
+    expect(when(8_640_000_000_000)).not.toBe("invalid date");
+  });
+});
+
+describe("parsePage", () => {
+  it("clamps to the documented maximum and floors anything nonsensical at 0", () => {
+    expect(parsePage(undefined)).toBe(0);
+    expect(parsePage("not-a-number")).toBe(0);
+    expect(parsePage("-5")).toBe(0);
+    expect(parsePage("3")).toBe(3);
+    expect(parsePage(String(MAX_PAGE + 1_000))).toBe(MAX_PAGE);
+  });
+});
+
+// The end-to-end version of the `when` guard: a row whose occurred_at is
+// already stored out of range (written before parseOccurredAt started
+// clamping) must not be able to break the dashboard the maintainer would use
+// to find it.
+describe("/admin/errors with an out-of-range stored timestamp", () => {
+  it("renders the page instead of returning a 500", async () => {
+    const fingerprint = "ffffffffffffffffffffffffffffffff";
+    await env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
+                           status, first_seen_at, last_seen_at, occurrence_count)
+       VALUES (?, 'RuntimeError', 'stored before the clamp', 'm.ex', 1, 'unresolved', ?, ?, 1)
+       ON CONFLICT(fingerprint) DO UPDATE SET last_seen_at = excluded.last_seen_at`,
+    )
+      .bind(fingerprint, 1e300, 1e300)
+      .run();
+
+    const res = await SELF.fetch("https://relay.mydia.dev/admin/errors");
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("invalid date");
+  });
+});

--- a/relay-worker/test/obs/sweep.test.ts
+++ b/relay-worker/test/obs/sweep.test.ts
@@ -7,7 +7,10 @@ import {
 } from "cloudflare:test";
 import { describe, it, expect, beforeAll } from "vitest";
 import worker from "../../src/index";
-import { sweepStaleFeedbackRateLimits } from "../../src/obs/sweep";
+import {
+  sweepStaleFeedbackRateLimits,
+  sweepStaleIngestBuckets,
+} from "../../src/obs/sweep";
 
 beforeAll(async () => {
   await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
@@ -47,6 +50,32 @@ async function pairingClaimExists(key: string): Promise<boolean> {
   return row !== null;
 }
 
+async function insertIngestBucket(
+  fingerprint: string,
+  instanceKey: string,
+  hourBucket: number,
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO ingest_buckets (fingerprint, instance_key, hour_bucket, hits, written, saturated)
+     VALUES (?, ?, ?, 1, 1, 0)
+     ON CONFLICT(fingerprint, instance_key) DO UPDATE SET hour_bucket = excluded.hour_bucket`,
+  )
+    .bind(fingerprint, instanceKey, hourBucket)
+    .run();
+}
+
+async function ingestBucketExists(
+  fingerprint: string,
+  instanceKey: string,
+): Promise<boolean> {
+  const row = await env.DB.prepare(
+    "SELECT 1 FROM ingest_buckets WHERE fingerprint = ? AND instance_key = ?",
+  )
+    .bind(fingerprint, instanceKey)
+    .first();
+  return row !== null;
+}
+
 describe("sweepStaleFeedbackRateLimits", () => {
   it("deletes rows from a stale hour bucket and leaves the current hour's rows alone", async () => {
     const currentHour = Math.floor(Date.now() / 3_600_000);
@@ -74,13 +103,61 @@ describe("sweepStaleFeedbackRateLimits", () => {
   });
 });
 
+describe("sweepStaleIngestBuckets", () => {
+  it("deletes rows from a stale hour bucket and leaves the current hour's rows alone", async () => {
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    await insertIngestBucket("sweep-unit-fp", "stale-instance", currentHour - 5);
+    await insertIngestBucket("sweep-unit-fp", "current-instance", currentHour);
+
+    const deleted = await sweepStaleIngestBuckets(env);
+
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    expect(await ingestBucketExists("sweep-unit-fp", "stale-instance")).toBe(false);
+    expect(await ingestBucketExists("sweep-unit-fp", "current-instance")).toBe(true);
+  });
+
+  it("leaves the previous hour's rows alone for one extra cycle", async () => {
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    await insertIngestBucket("sweep-unit-fp", "previous-instance", currentHour - 1);
+
+    await sweepStaleIngestBuckets(env);
+
+    expect(await ingestBucketExists("sweep-unit-fp", "previous-instance")).toBe(true);
+  });
+
+  // The reason this table needs a sweep at all, stated as a test: the primary
+  // key is (fingerprint, instance_key), so a new hour RESETS an existing row
+  // rather than adding a second one. A row belonging to an instance that
+  // stopped reporting is therefore never superseded, only abandoned, and
+  // nothing on the request path can ever reach it again.
+  it("reclaims rows left behind by instances that stopped reporting", async () => {
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    for (let i = 0; i < 5; i++) {
+      await insertIngestBucket("sweep-abandoned-fp", `gone-instance-${i}`, currentHour - 3);
+    }
+    await insertIngestBucket("sweep-abandoned-fp", "still-reporting", currentHour);
+
+    await sweepStaleIngestBuckets(env);
+
+    const remaining = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM ingest_buckets WHERE fingerprint = ?",
+    )
+      .bind("sweep-abandoned-fp")
+      .first<{ n: number }>();
+    expect(remaining?.n).toBe(1);
+    expect(await ingestBucketExists("sweep-abandoned-fp", "still-reporting")).toBe(true);
+  });
+});
+
 describe("scheduled() handler", () => {
-  it("sweeps stale feedback_rate_limits rows and expired pairing_claims rows, leaving live ones alone", async () => {
+  it("sweeps stale feedback_rate_limits, ingest_buckets and expired pairing_claims rows, leaving live ones alone", async () => {
     const currentHour = Math.floor(Date.now() / 3_600_000);
     const now = Math.floor(Date.now() / 1000);
 
     await insertRateLimitBucket("sweep-scheduled:stale", currentHour - 10, 5);
     await insertRateLimitBucket("sweep-scheduled:current", currentHour, 1);
+    await insertIngestBucket("sweep-scheduled-fp", "stale-instance", currentHour - 10);
+    await insertIngestBucket("sweep-scheduled-fp", "current-instance", currentHour);
     await insertPairingClaim("sweep-scheduled:expired", now - 3600);
     await insertPairingClaim("sweep-scheduled:live", now + 3600);
 
@@ -93,6 +170,8 @@ describe("scheduled() handler", () => {
 
     expect(await rateLimitBucketExists("sweep-scheduled:stale")).toBe(false);
     expect(await rateLimitBucketExists("sweep-scheduled:current")).toBe(true);
+    expect(await ingestBucketExists("sweep-scheduled-fp", "stale-instance")).toBe(false);
+    expect(await ingestBucketExists("sweep-scheduled-fp", "current-instance")).toBe(true);
     // pairing/store.ts's purgeExpiredClaims, written when pairing landed and
     // never wired to anything until this handler -- the identical "table with no
     // eviction path" defect in a different table.

--- a/relay-worker/test/pairing/routes.test.ts
+++ b/relay-worker/test/pairing/routes.test.ts
@@ -1,5 +1,10 @@
 import { env, SELF, applyD1Migrations } from "cloudflare:test";
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import {
+  generateCode,
+  CODE_ALPHABET,
+  REJECTION_THRESHOLD,
+} from "../../src/pairing/routes";
 
 const json = { "content-type": "application/json" };
 
@@ -17,6 +22,87 @@ function freshIp(): string {
 
 beforeAll(async () => {
   await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+describe("generateCode", () => {
+  it("only ever emits characters from the alphabet, at the documented length", () => {
+    for (let i = 0; i < 200; i++) {
+      const code = generateCode();
+      expect(code).toHaveLength(6);
+      for (const ch of code) expect(CODE_ALPHABET).toContain(ch);
+    }
+  });
+
+  // The claim code is the entire secret protecting a pairing claim for its
+  // 300-second TTL, so a skewed alphabet directly shrinks the space an
+  // attacker has to cover. `byte % 31` gave the first eight characters nine
+  // byte values each and the remaining twenty-three only eight -- 12.5%
+  // likelier per position. Rejecting bytes >= 248 leaves exactly eight values
+  // per character.
+  //
+  // Asserted by feeding generateCode a known byte stream rather than by
+  // sampling its output distribution. A statistical check is the obvious
+  // instrument and the wrong one here: telling a 12.5% bias apart from
+  // sampling noise needs a sample large enough that the noise band sits well
+  // under 12.5%, and any bound tight enough to be meaningful is close enough
+  // to the noise to flake. Driving the rejection directly tests the actual
+  // mechanism, deterministically, in microseconds.
+  it("rejects bytes at or above the threshold instead of folding them in with modulo", () => {
+    // Every byte in the first block is rejected; the second block supplies the
+    // whole code. Under `byte % 31` the first block would have produced a code
+    // outright (248 % 31 = 1 -> "B", 249 -> "C", ...), which is precisely the
+    // path that made those characters over-represented.
+    const blocks = [
+      new Uint8Array([248, 249, 250, 251, 252, 255]),
+      new Uint8Array([0, 1, 2, 3, 4, 5]),
+    ];
+    let call = 0;
+    const spy = vi
+      .spyOn(crypto, "getRandomValues")
+      .mockImplementation(((target: Uint8Array) => {
+        target.set(blocks[Math.min(call++, blocks.length - 1)]!);
+        return target;
+      }) as typeof crypto.getRandomValues);
+
+    try {
+      expect(generateCode()).toBe("ABCDEF");
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("keeps drawing until it has a full-length code, however many blocks that takes", () => {
+    // Three consecutive fully-rejected blocks: the loop has to survive all of
+    // them rather than returning a short code.
+    const rejected = new Uint8Array([248, 249, 250, 251, 252, 253]);
+    const accepted = new Uint8Array([30, 29, 28, 27, 26, 25]);
+    let call = 0;
+    const spy = vi
+      .spyOn(crypto, "getRandomValues")
+      .mockImplementation(((target: Uint8Array) => {
+        target.set(call++ < 3 ? rejected : accepted);
+        return target;
+      }) as typeof crypto.getRandomValues);
+
+    try {
+      const code = generateCode();
+      expect(code).toHaveLength(6);
+      for (const ch of code) expect(CODE_ALPHABET).toContain(ch);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  // 248 is the largest multiple of 31 that fits in a byte. If that constant
+  // ever drifts, every uniformity claim above it silently becomes false, so
+  // pin the arithmetic rather than the number alone.
+  it("uses the largest multiple of the alphabet size that fits in a byte", () => {
+    expect(REJECTION_THRESHOLD).toBe(
+      Math.floor(256 / CODE_ALPHABET.length) * CODE_ALPHABET.length,
+    );
+    expect(REJECTION_THRESHOLD % CODE_ALPHABET.length).toBe(0);
+  });
 });
 
 describe("pairing v1", () => {

--- a/relay-worker/test/proxy/tmdb.test.ts
+++ b/relay-worker/test/proxy/tmdb.test.ts
@@ -74,4 +74,77 @@ describe("TMDB routes", () => {
     expect(second.headers.get("x-relay-cache")).toBe("HIT");
     expect(await second.json()).toMatchObject({ id: 552 });
   });
+
+  // cachePut was already limited to 2xx, but the cache-control header went out
+  // on every status. An explicit freshness lifetime is what MAKES an otherwise
+  // uncacheable status cacheable, so a transient upstream 500 would be
+  // replayed by Cloudflare's edge and every downstream client for the whole
+  // TTL, and stale-if-error would license reusing it for a further week.
+  it("sends no-store rather than a cacheable header on an upstream error", async () => {
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/3/movie/553") })
+      .reply(500, { status_message: "upstream is having a day" });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/tmdb/movies/553");
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("sends no-store on an upstream 404 too, so a miss is not cached for the TTL", async () => {
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({ method: "GET", path: (p) => p.startsWith("/3/movie/554") })
+      .reply(404, { status_message: "The resource you requested could not be found." });
+
+    const res = await SELF.fetch("https://relay.mydia.dev/tmdb/movies/554");
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  // Hono percent-decodes path params, so `%2e%2e%2f` arrives as `../`. Without
+  // encoding, interpolating that into `${TMDB_BASE}/movie/${p.id}` lets the
+  // caller pick which TMDB endpoint the relay's own API key is spent on --
+  // a confused deputy, not SSRF: the host stays fixed, the path does not.
+  it("encodes a traversal attempt in :id instead of resolving it upstream", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return true;
+        },
+      })
+      .reply(200, {});
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/tmdb/movies/%2e%2e%2f%2e%2e%2fauthentication",
+    );
+
+    expect(seenPath.startsWith("/3/movie/")).toBe(true);
+    expect(seenPath).not.toContain("/3/authentication");
+    expect(seenPath).not.toContain("../");
+  });
+
+  it("encodes a query-splicing attempt in :id", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api.themoviedb.org")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return true;
+        },
+      })
+      .reply(200, {});
+
+    await SELF.fetch("https://relay.mydia.dev/tmdb/movies/550%3Fapi_key%3Dstolen");
+
+    expect(seenPath.startsWith("/3/movie/550%3F")).toBe(true);
+  });
 });

--- a/relay-worker/test/proxy/tvdb.test.ts
+++ b/relay-worker/test/proxy/tvdb.test.ts
@@ -143,6 +143,72 @@ describe("TVDB routes", () => {
     expect(seenPath).toContain("meta=translations");
   });
 
+  // Same confused-deputy class as the TMDB traversal test: the host stays
+  // fixed, but an unencoded path param lets the caller choose the endpoint the
+  // relay's bearer token is spent on.
+  it("encodes a traversal attempt in :id instead of resolving it upstream", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return true;
+        },
+      })
+      .reply(200, { data: {} });
+
+    await SELF.fetch("https://relay.mydia.dev/tvdb/series/%2e%2e%2f%2e%2e%2flogin");
+
+    expect(seenPath.startsWith("/v4/series/")).toBe(true);
+    expect(seenPath).not.toContain("/v4/login");
+    expect(seenPath).not.toContain("../");
+  });
+
+  // `page` is spliced into the upstream PATH rather than sent as a query
+  // parameter (handler.ex bakes it in), so a non-numeric value was a traversal
+  // vector too. Anything that is not a run of digits becomes the same "0" an
+  // absent page already produces, which keeps this route bug-compatible with
+  // handler.ex for every input either side would treat as real.
+  it("falls back to page 0 for a non-numeric page rather than splicing it into the path", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return true;
+        },
+      })
+      .reply(200, { data: { episodes: [] } });
+
+    await SELF.fetch(
+      "https://relay.mydia.dev/tvdb/series/81189/episodes?page=..%2F..%2Flogin",
+    );
+
+    expect(seenPath).toBe("/v4/series/81189/episodes/default/page/0");
+  });
+
+  it("still forwards a legitimate numeric page", async () => {
+    let seenPath = "";
+    fetchMock
+      .get("https://api4.thetvdb.com")
+      .intercept({
+        method: "GET",
+        path: (p) => {
+          seenPath = p;
+          return true;
+        },
+      })
+      .reply(200, { data: { episodes: [] } });
+
+    await SELF.fetch("https://relay.mydia.dev/tvdb/series/81189/episodes?page=4");
+
+    expect(seenPath).toBe("/v4/series/81189/episodes/default/page/4");
+  });
+
   it("maps a login failure to 502 rather than passing it off as a metadata error", async () => {
     await env.CACHE_KV.delete("tvdb:jwt");
     fetchMock


### PR DESCRIPTION
Follow-up to #727. Auto-merge landed that PR at its old head while CodeRabbit's review round was still being worked through, so these nine fixes never made it in. Everything here is a finding from that review, all of it in code that faces an unauthenticated caller or an unprotected hostname.

Nothing has been deployed yet — `database_id` is still `placeholder_local_dev_only` and `deploy-worker` has never had a successful run — so the two migrations are amended in place rather than superseded, which `relay-worker/README.md` permits only until the first remote apply.

## Fixed

**`occurred_at` unbounded** (`crashes/ingest.ts`, `dashboards/layout.ts`)
`Number.isFinite` let `1e300` through to storage. `when()` then threw `RangeError: Invalid time value` *while building* `/admin/errors`, so one anonymous POST left the maintainer dashboard at a 500 until the row was deleted by hand. Clamped at ingest to Date's representable range, and `when()` guards regardless — the ingest fix only governs rows written after it ships, and a row stored before it must not be able to break the dashboard you would use to find it.

**Crash payload size unbounded** (`crashes/ingest.ts`)
`error_message`, `metadata` and `stacktrace` were bound with no length limit at all. D1 rejects an oversized bound value, so `.batch()` threw and the route answered an unhandled 500 — and `Mydia.CrashReporter.Sender` retries every non-201, so the producer would keep re-sending a request that can never succeed. Message, frame strings, frame count and serialized context are all capped now. `context` is replaced wholesale by a marker object rather than having its JSON cut, so what is stored still parses on read. The per-bucket cap only ever bounded row *count*, never row *size*.

**`cache-control` on non-2xx** (`proxy/forward.ts`)
Non-2xx now sends `no-store`. `cachePut` was already 2xx-only, but the header is what Cloudflare's edge and every downstream client obey, and an explicit freshness lifetime is what *makes* an otherwise uncacheable status cacheable — one transient TMDB or TVDB failure would have been replayed for the whole TTL, with `stale-if-error=604800` licensing reuse for a further week, from a cache the relay does not own and cannot purge.

**Unencoded upstream path values** (`proxy/tmdb.ts`, `proxy/tvdb.ts`)
Hono percent-decodes path params, so `/tmdb/movies/%2e%2e%2f%2e%2e%2fauthentication` reached TMDB as `/3/authentication` with the relay's own API key attached. A confused deputy rather than SSRF: the host stays fixed, only the path moves. Every path value goes through a shared `pathSegment`. TVDB's `page` — which handler.ex splices into the path rather than sending as a query parameter — falls back to `0` unless it is a run of digits, keeping the route bug-compatible with the Elixir for every input either side would treat as real.

**Biased claim codes** (`pairing/routes.ts`, CodeQL 249)
`byte % 31` gave the first eight alphabet characters nine byte values each against eight for the rest, 12.5% likelier per position, in the only secret protecting a pairing claim for its 300-second TTL. Rejection sampling above 248 instead.

**Stack-trace exposure** (`proxy/passthrough.ts`, CodeQL 250)
The cover-art 500 echoed the fetch failure's message, describing the relay's own outbound network state to an anonymous caller who supplied only a release id. It logs instead.

**`ingest_buckets` never swept** (`obs/sweep.ts`)
Swept hourly alongside the other two tables. This one is the worst of the three: the primary key is `(fingerprint, instance_key)`, so rolling into a new hour *resets* a row rather than creating a second one. A row is only ever abandoned, never superseded, and every install that ever reported a given crash and then stopped leaves one behind permanently — the request path cannot reclaim any of them, because it only ever touches the exact key it was handed.

**Missing `hour_bucket` indexes** (both migrations)
Both sweep predicates filter on `hour_bucket`, which neither table indexed, so each hourly Cron run full-scanned.

**`RESEND_API_KEY` documented as required** (`README.md`)
It is the one genuinely optional binding, and the prose said the opposite two lines above the table that said so.

## `/admin/*` on `workers.dev`

Called out separately because the fix is not the one CodeRabbit proposed.

Cloudflare Access is configured per hostname. The runbook's Step 1 application covers `relay.mydia.dev/admin*`; the Worker is also live on its `*.workers.dev` subdomain from the first successful CI deploy onwards, plus the versioned preview URLs alongside it, and Access never sees those requests. The maintainer dashboards were therefore anonymously readable there for the whole window between the first deploy and the Step 4 cutover — the same path-not-method, hostname-by-hostname trap the runbook's cutover preconditions already warn about for the wildcard route, one hostname earlier.

`workers_dev: false` would be the blunter fix, but the runbook depends on that hostname: Step 3 measures real platform CPU on the subtitle download path against it, and Step 4a runs the contract diff against a `*.workers.dev` staging URL. So `src/index.ts` denies `/admin/*` on any `.workers.dev` hostname instead, which covers the preview URLs too. No route in `test/contract/routes.json` is under `/admin`, so the staging diff still exercises everything it did before.

That deny is not authentication and must not grow into it — it removes an unprotected hostname from reach, it does not decide who may look. Access still decides that, Step 1 is still required, and the README says so alongside the existing "the Worker holds no dashboard credentials" rule.

## Declined, with reasons in the #727 threads

- **`wrangler.jsonc` placeholder ids** — deliberate and documented (runbook Step 0); the real ids need Cloudflare credentials this repo's CI does not have, and the first `deploy-worker` run is meant to fail loudly at "Apply D1 migrations" with nothing deployed.
- **MusicBrainz contract route nondeterminism** — already documented on the route itself, including the observed instance and how to read a single failure. Dropping it to a non-gating smoke check would mean the cutover diff never compares that path at all.
- **Subtitle-search KV staleness** — real, and the "fresh KV namespace or purge `CACHE_KV`" precondition it asks for is already stated in `contract.test.ts` above `bytesEqual`, and repeated in the route's own note.

## Verification

`npm run typecheck` clean. `npm test` 279 passed / 42 skipped — the skipped set is the contract suite, which needs live `CONTRACT_WORKER_URL`/`CONTRACT_RELAY_URL`. New coverage in `test/dashboards/hostname.test.ts` and `test/dashboards/layout.test.ts`, plus additions to the crash-ingest, sweep, pairing, TMDB and TVDB suites.

One note on the pairing tests: the claim-code fix is asserted by feeding `generateCode` a known byte stream, not by sampling its output distribution. A statistical check is the obvious instrument and the wrong one — telling a 12.5% bias apart from sampling noise needs a sample large enough that the noise band sits well under 12.5%, and any bound tight enough to be meaningful is close enough to the noise to flake. The first draft of that test did exactly that, and failed at 0.103 against a 0.1 bound on its first run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic cleanup of stale ingestion and rate-limit records.
  - Added hostname-specific protection for admin dashboards on preview and workers.dev URLs.
  - Feedback submissions remain available without notification email configuration.

- **Bug Fixes**
  - Improved handling of oversized or malformed crash reports.
  - Prevented invalid timestamps from breaking dashboards.
  - Secured media proxy paths against traversal and query injection.
  - Error responses no longer expose upstream details and are excluded from caching.
  - Improved pairing-code randomness and validation of TVDB pagination inputs.

- **Documentation**
  - Clarified production configuration requirements, route behavior, scheduled cleanup, and dashboard access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->