### PR TITLE
fix(relay-worker): bound the stacktrace scan, not just the frames kept

### DIFF
--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -75,6 +75,39 @@ const MAX_FRAME_STRING_CHARS = 1_024;
 const MAX_STACK_FRAMES = 64;
 const MAX_CONTEXT_BYTES = 16_384;
 
+// How many RAW array entries are even looked at, as distinct from how many
+// parsed frames are kept. Both limits are needed and neither implies the
+// other.
+//
+// A first pass here kept only MAX_STACK_FRAMES but applied it with
+// `.map(...).filter(...).slice(...)`, which allocates a parsed object for
+// every one of an attacker's entries before discarding all but 64.
+// POST /crashes/report is unauthenticated and exempt from the proxy limiter
+// (EXEMPT_PREFIXES in src/obs/ratelimit.ts, because it carries its own
+// per-hour write budget instead), and normalization runs before
+// admittedByBurstGuard, so that work happens on every request that reaches
+// the route -- a million-entry array is a million allocations against the
+// Workers CPU budget, whatever the eventual 64-frame result.
+//
+// 256 is comfortably above any real BEAM stacktrace while keeping the scan
+// bounded, and scanning raw entries in order (rather than truncating the
+// array up front) preserves the property the first version had: entries that
+// parseStacktraceEntry drops do not consume frame slots, so padding the array
+// with junk cannot push real frames out of the kept window. The top frame
+// decides the fingerprint, and this keeps the top of the trace, so a
+// truncated report still groups where an untruncated one would have.
+const MAX_RAW_STACK_ENTRIES = 256;
+
+function parseStackFrames(raw: unknown[]): CrashFrame[] {
+  const frames: CrashFrame[] = [];
+  const scanLimit = Math.min(raw.length, MAX_RAW_STACK_ENTRIES);
+  for (let i = 0; i < scanLimit && frames.length < MAX_STACK_FRAMES; i++) {
+    const parsed = parseStacktraceEntry(raw[i]);
+    if (parsed !== null) frames.push(parsed);
+  }
+  return frames;
+}
+
 // The marker is appended after the cut, so the result is bounded by
 // max + marker length rather than exactly max. Being able to see that a value
 // was cut is worth more than the handful of characters.
@@ -224,17 +257,8 @@ export function normalizeCrashReport(
       ? truncate(body.error_message, MAX_MESSAGE_CHARS)
       : "Unknown error";
 
-  // Sliced AFTER parsing rather than before, so MAX_STACK_FRAMES counts
-  // frames that survived parseStacktraceEntry's drop rule, not raw array
-  // entries -- a caller padding the array with junk entries can't push real
-  // frames out of the window that way. The top frame is what the fingerprint
-  // is derived from, and this keeps the top of the trace, so the grouping a
-  // truncated report lands in is the same one it would have had.
   const rawStack = Array.isArray(body.stacktrace) ? body.stacktrace : [];
-  let stacktrace = rawStack
-    .map(parseStacktraceEntry)
-    .filter((f): f is CrashFrame => f !== null)
-    .slice(0, MAX_STACK_FRAMES);
+  let stacktrace = parseStackFrames(rawStack);
 
   // Without any source info every report derives the same fingerprint and
   // collapses into one useless group, so metadata stands in for a frame.

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -198,18 +198,62 @@ describe("normalizeCrashReport", () => {
   // allocates one parsed object per attacker-supplied entry first. This route
   // is unauthenticated and exempt from the proxy limiter, and normalization
   // runs before the burst guard, so the scan itself has to be bounded too.
+  //
+  // The input shape is the whole point, and getting it wrong makes this test
+  // worthless rather than merely weak. A first version passed a large array of
+  // entries that were ALL unparseable and asserted an empty result -- which the
+  // eager `map().filter().slice()` version produces too, so it held equally
+  // under the implementation it was written to rule out.
+  //
+  // Putting a valid frame at index MAX_RAW_STACK_ENTRIES is what separates
+  // them: the bounded scan never reaches it and returns nothing, while any
+  // implementation that walks the whole array finds it and keeps it. Every
+  // entry before it is unparseable so the 64-frame early exit can never fire,
+  // leaving the raw scan bound as the only thing that can stop the walk.
   it("stops scanning raw entries at the cap rather than parsing the whole array", () => {
-    // Every entry is unparseable, so the 64-frame limit can never trigger the
-    // early exit -- only the raw scan bound can stop this.
-    const unparseable = Array.from({ length: 100_000 }, () => ({ module: "Elixir.Junk" }));
+    const beyondTheBound = {
+      module: "Elixir.Fake",
+      function: "run/0",
+      file: "lib/beyond_raw_limit.ex",
+      line: 1,
+    };
+    const stacktrace = [
+      ...Array.from({ length: 256 }, () => ({ module: "Elixir.Junk" })),
+      beyondTheBound,
+    ];
 
     const out = normalizeCrashReport({
       error_type: "RuntimeError",
       error_message: "boom",
-      stacktrace: unparseable,
+      stacktrace,
     });
 
     expect(out.stacktrace).toEqual([]);
+    expect(out.stacktrace.map((f) => f.file)).not.toContain("lib/beyond_raw_limit.ex");
+  });
+
+  // The complement of the test above: one entry earlier and the same frame IS
+  // kept, which is what shows the bound is at the documented place rather than
+  // the scan simply being broken.
+  it("still reaches a valid frame that sits just inside the raw scan bound", () => {
+    const stacktrace = [
+      ...Array.from({ length: 255 }, () => ({ module: "Elixir.Junk" })),
+      {
+        module: "Elixir.Fake",
+        function: "run/0",
+        file: "lib/last_scanned.ex",
+        line: 1,
+      },
+    ];
+
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace,
+    });
+
+    expect(out.stacktrace.length).toBe(1);
+    expect(out.stacktrace[0]?.file).toBe("lib/last_scanned.ex");
   });
 
   it("truncates oversized strings inside a frame", () => {

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -172,6 +172,46 @@ describe("normalizeCrashReport", () => {
     expect(out.stacktrace[0]?.file).toBe("lib/fake_0.ex");
   });
 
+  // Entries parseStacktraceEntry drops must not consume frame slots, or a
+  // caller could pad the head of the array with junk and push the real frames
+  // -- including the one the fingerprint is derived from -- out of the window.
+  it("does not let unparseable entries push real frames out of the kept window", () => {
+    const junk = Array.from({ length: 40 }, () => ({ module: "Elixir.NoFileNoLine" }));
+    const real = Array.from({ length: 10 }, (_, i) => ({
+      module: "Elixir.Fake",
+      function: "run/0",
+      file: `lib/real_${i}.ex`,
+      line: i,
+    }));
+
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace: [...junk, ...real],
+    });
+
+    expect(out.stacktrace.length).toBe(10);
+    expect(out.stacktrace[0]?.file).toBe("lib/real_0.ex");
+  });
+
+  // The frame cap alone does not bound the WORK: mapping then slicing still
+  // allocates one parsed object per attacker-supplied entry first. This route
+  // is unauthenticated and exempt from the proxy limiter, and normalization
+  // runs before the burst guard, so the scan itself has to be bounded too.
+  it("stops scanning raw entries at the cap rather than parsing the whole array", () => {
+    // Every entry is unparseable, so the 64-frame limit can never trigger the
+    // early exit -- only the raw scan bound can stop this.
+    const unparseable = Array.from({ length: 100_000 }, () => ({ module: "Elixir.Junk" }));
+
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace: unparseable,
+    });
+
+    expect(out.stacktrace).toEqual([]);
+  });
+
   it("truncates oversized strings inside a frame", () => {
     const out = normalizeCrashReport({
       error_type: "RuntimeError",


### PR DESCRIPTION
Follow-up to #729, which CodeRabbit reviewed after auto-merge had already landed it. The finding is valid and this is the fix.

## The problem

#729 added a 64-frame cap on `stacktrace`, applied as `map -> filter -> slice`. That bounds the **result** and does nothing to the **work**: a parsed object is allocated for every entry the caller sends, and only then are all but 64 discarded.

That work is not free on this route:

- `POST /crashes/report` is unauthenticated.
- It is exempt from the proxy limiter (`EXEMPT_PREFIXES` in `obs/ratelimit.ts`), because it carries its own per-hour write budget instead.
- `normalizeCrashReport` runs **before** `admittedByBurstGuard`, so the parsing happens on every request that reaches the route, including ones the burst guard is about to reject.

So a million-entry `stacktrace` array is a million allocations against the Workers CPU budget, whatever the eventual 64-frame result. The frame cap never touched that path.

## The fix

Scan at most `MAX_RAW_STACK_ENTRIES` (256) raw entries, stopping early once `MAX_STACK_FRAMES` (64) valid frames are collected.

Scanning in order rather than truncating the array up front is deliberate — it preserves the property #729 was after. Entries that `parseStacktraceEntry` drops do not consume frame slots, so padding the head of the array with junk cannot push the real frames out of the kept window. That matters specifically because the top frame is what the fingerprint is derived from: losing it would silently regroup the report.

Both limits are needed and neither implies the other, so there is now a test for each:

- **frame cap** — 5,000 valid frames in, 64 kept, `lib/fake_0.ex` still on top.
- **junk padding** — 40 unparseable entries ahead of 10 real ones, all 10 real frames kept, correct top frame.
- **raw scan bound** — 100,000 entries that are *all* unparseable, so the 64-frame early exit can never fire and only the raw scan bound can stop it.

## Verification

`npm run typecheck` clean. `npm test` 281 passed / 42 skipped (the skipped set is the contract suite, which needs live `CONTRACT_WORKER_URL`/`CONTRACT_RELAY_URL`).

Note that the relay-worker suite only runs in CI on push to `master`, via `deploy-relay.yml` — not on pull requests — so these checks do not exercise it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash report processing for very large or malformed stack traces.
  * Preserved relevant parsed frames and fingerprinting behavior while limiting unnecessary processing.

* **Tests**
  * Added coverage confirming processing stops at the raw-entry limit.
  * Added coverage confirming valid frames within the limit are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->