### PR TITLE
test(relay-worker): give PROXY_LIMITER a small test-only budget

### DIFF
--- a/relay-worker/test/obs/ratelimit.test.ts
+++ b/relay-worker/test/obs/ratelimit.test.ts
@@ -19,9 +19,24 @@ describe("serviceFromPath", () => {
   });
 });
 
-// PROXY_LIMITER is limit: 300, period: 60 (wrangler.jsonc). Miniflare's own
-// rate-limit simulator resets its whole counter on wall-clock time, not on
-// consumption -- node_modules/miniflare/dist/src/workers/ratelimit/ratelimit.worker.js:
+// PROXY_LIMITER is limit: 25, period: 60 UNDER TEST, set by
+// vitest.config.ts's miniflare.ratelimits override. Production is 300/60s
+// (wrangler.jsonc) and is untouched by that override -- this constant must
+// track the TEST value, since it is what the loops below actually spend.
+//
+// Why the test value is not the production one: nothing in Miniflare can
+// spend a rate-limit budget except real requests, so proving a 429 costs
+// `limit + 1` round trips through the whole Hono stack, and this file needs
+// that four times over. At 300 the file took ~17s locally and blew the 30s
+// per-test timeout on CI hardware, failing the deploy job on master
+// (2026-09-06). None of these tests assert anything about the SIZE of the
+// budget -- they assert that exceeding it produces a 429, with the right
+// header, logged in the right order, and not charged to exempt paths. All of
+// that holds at 25 exactly as it did at 300, in a fortieth of the requests.
+//
+// Miniflare's own rate-limit simulator resets its whole counter on wall-clock
+// time, not on consumption --
+// node_modules/miniflare/dist/src/workers/ratelimit/ratelimit.worker.js:
 //   let epoch = Math.floor(Date.now() / (period * 1e3));
 //   epoch != this.epoch && (this.epoch = epoch, this.buckets.clear());
 // If a real 60s boundary falls in the middle of one of the loops below, the
@@ -33,16 +48,19 @@ describe("serviceFromPath", () => {
 // limiting is Cloudflare's real service, not this fixed-window-per-process
 // approximation.
 //
-// The cap below (2 * limit + margin) survives exactly one such reset,
-// wherever in the loop it lands: up to `limit - 1` requests before the
-// reset, then a full `limit + 1` after it. `if (last.status === 429) break`
-// means an ordinary run (no reset) still exits after ~301 iterations, same
-// as before -- only a run that hits the reset pays the extra iterations.
-// This does not eliminate the flake (two resets in one loop would still
-// lose), it makes the common single-reset case survivable by construction.
-// Do not shrink this back toward `limit` because "305 was fine before" --
-// that reasoning is exactly what shipped the flake.
-const PROXY_LIMIT = 300;
+// The smaller budget shrinks that flake too, without being a fix for it: a
+// loop that spans ~26 requests occupies a few tens of milliseconds instead of
+// seconds, so the odds of a 60s boundary landing inside one drop by roughly
+// the same factor the runtime does. The window is narrower, not closed.
+//
+// So the cap below stays. It survives exactly one reset wherever in the loop
+// it lands: up to `limit - 1` requests before the reset, then a full
+// `limit + 1` after it. `if (last.status === 429) break` means an ordinary
+// run (no reset) still exits after ~26 iterations -- only a run that hits the
+// reset pays the extra ones. Do not shrink this toward `limit` because "26
+// was fine before"; that reasoning is exactly what shipped the flake, and it
+// is no more true at 25 than it was at 300.
+const PROXY_LIMIT = 25;
 const PROXY_LIMIT_ITERATION_CAP = 2 * PROXY_LIMIT + 10;
 
 describe("rate limiting", () => {

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -27,6 +27,48 @@ export default defineWorkersConfig({
             RESEND_API_KEY: "test-resend-key",
             TEST_MIGRATIONS: migrations,
           },
+          // Overrides wrangler.jsonc's PROXY_LIMITER (300/60s) for tests only.
+          // These entries take precedence over the ones the `wrangler` block
+          // above loads, so production is untouched -- the deployed Worker
+          // still gets 300/60s from wrangler.jsonc.
+          //
+          // The production number is unreachable in a test. Nothing in
+          // Miniflare can spend the budget except real requests, so proving a
+          // 429 costs `limit + 1` round trips through the whole Hono stack,
+          // and test/obs/ratelimit.test.ts needs that four times over. At 300
+          // that was ~17s locally and over the 30s per-test timeout on CI
+          // hardware, which is how the suite came to fail the deploy job on
+          // master (2026-09-06). Raising the timeout would only have moved the
+          // threshold; the loops are the cost.
+          //
+          // It also shrinks the OTHER flake that file documents at length.
+          // Miniflare's simulator clears its buckets on a wall-clock epoch
+          // boundary rather than on consumption, so a 60s boundary landing
+          // mid-loop wipes the in-flight count and the loop has to start over.
+          // A loop that takes ~50ms instead of several seconds is far less
+          // likely to span one at all.
+          //
+          // ONLY PROXY_LIMITER's limit differs from wrangler.jsonc. The other
+          // four are repeated here at their exact production values, not
+          // because they need overriding, but because this key may replace the
+          // wrangler-derived set rather than merge into it -- listing all five
+          // is correct either way, and omitting four of them would silently
+          // delete those bindings if it replaces.
+          //
+          // Do not "tidy" the other four to round numbers. Tests depend on
+          // their exact values: the crash and feedback suites assert D1 write
+          // counts that follow directly from the 10/10s burst guards, and the
+          // pairing suite deliberately exhausts the 10/min create budget.
+          // Changing one of those is a test-expectation change, not a config
+          // tweak. PROXY_LIMITER is the only one no test asserts a count
+          // against -- every loop that spends it stops at the first 429.
+          ratelimits: {
+            PROXY_LIMITER: { simple: { limit: 25, period: 60 } },
+            PAIRING_CREATE_LIMITER: { simple: { limit: 10, period: 60 } },
+            PAIRING_READ_LIMITER: { simple: { limit: 30, period: 60 } },
+            CRASH_INGEST_LIMITER: { simple: { limit: 10, period: 10 } },
+            FEEDBACK_INGEST_LIMITER: { simple: { limit: 10, period: 10 } },
+          },
         },
       },
     },


### PR DESCRIPTION
Fixes the `relay-worker` test flake that failed the `deploy-worker` job on `master` after #727 merged.

## What broke

The `Deploy relay Worker` run for the #727 merge commit failed at the **Test** step, not at the D1 migration step you would expect from the placeholder binding ids:

```
FAIL test/obs/ratelimit.test.ts > rate limiting > logs the final 429 status, ...
Error: Test timed out in 30000ms.
Tests  1 failed | 235 passed | 42 skipped (287)
```

Plus the isolated-storage teardown errors that follow any timed-out workerd test.

## Why

Nothing in Miniflare can spend a rate-limit budget except real requests. Proving a 429 therefore costs `limit + 1` round trips through the whole Hono stack, and `ratelimit.test.ts` needs that four separate times. Against the production `PROXY_LIMITER` of 300/60s that is roughly 1,200 requests:

| | before | after |
| --- | --- | --- |
| `ratelimit.test.ts` | 17.45s | 1.25s |
| `logs the final 429 status` (the test that timed out) | 9.73s | well under 1s |
| whole suite | ~30s | 5.4s |

CI hardware runs this materially slower than my local machine, which is how 9.73s locally becomes >30s there. The per-test timeout had already been raised once for exactly this test; raising it again only moves the threshold, because the loops are the cost, not the clock.

## The fix

Lower the budget rather than stretch the timeout. `vitest.config.ts`'s `miniflare.ratelimits` sets `PROXY_LIMITER` to 25/60s **for tests only** — `wrangler.jsonc` still deploys 300/60s, unchanged.

**No coverage is lost.** None of these tests assert anything about the *size* of the budget. They assert that exceeding it produces a 429, with the right `Retry-After` header, logged in the right order (the middleware-composition regression the slow test exists to catch), and not charged to exempt paths. All of that holds at 25 exactly as it did at 300, in a fortieth of the requests. Every loop stops at the first 429, so the count was never the assertion.

The other four limiters are repeated at their **exact** production values, because this key may replace the wrangler-derived set rather than merge into it — listing all five is correct either way, and omitting four would silently delete those bindings if it replaces. Those four must not be "tidied": the crash and feedback suites assert D1 write counts that follow directly from the 10/10s burst guards, and the pairing suite deliberately exhausts the 10/min create budget.

## The other flake in that file

`ratelimit.test.ts` documents a second, separate flake at length: Miniflare's simulator clears its buckets on a wall-clock 60s epoch boundary rather than on consumption, so a boundary landing mid-loop wipes the in-flight count and the loop has to start over — surfacing as `expected 500 to be 429` roughly once in four to six full-suite runs.

This change narrows that window without closing it. A loop occupying tens of milliseconds instead of several seconds is far less likely to span a 60s boundary at all, by roughly the factor the runtime drops. It is not a fix, so the `2 * limit + 10` iteration cap and its "do not shrink this" comment both stay — that reasoning is no more true at 25 than it was at 300.

## Verification

- `ratelimit.test.ts` alone: **10 consecutive runs, 10 green**.
- Full suite: **5 consecutive runs, 5 green** — 282 passed / 42 skipped.
- `npm run typecheck` clean.
- `wrangler.jsonc` confirmed still at `"limit": 300` for `PROXY_LIMITER`.

Note that the relay-worker suite runs in CI only on push to `master` (via `deploy-relay.yml`), never on pull requests, so this PR's own checks do not exercise it. The verification above is local and deliberately repeated, since a single green run proves nothing about a flake.

The deploy job will still fail at **Apply D1 migrations** until runbook Step 0 provisions the real D1 and KV resources — that failure is documented and expected. This PR removes the *other* reason it was failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated rate-limit test scenarios to use a smaller request allowance, reducing test duration and the likelihood of timing-related flakiness.
  - Added test-specific configuration to ensure rate-limiter behavior remains accurately validated while keeping production limits unchanged.
  - Preserved coverage for limiter resets and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->