### PR TITLE
relay-worker: serve /admin on the Access-guarded staging hostname

### DIFF
--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -248,17 +248,26 @@ it closes). Setting up the Access application is a manual, one-time step —
 see the runbook.
 
 **Access is configured per hostname, and the Worker answers on more than
-one.** The Step 1 Access application covers `relay.mydia.dev/admin*`. From the
-first successful CI deploy the Worker is *also* live on its `*.workers.dev`
-subdomain, plus the versioned preview URLs alongside it, and Access never sees
-those requests. `src/index.ts` therefore answers `/admin/*` with a 404 on any
-`.workers.dev` hostname, so the dashboards are unreachable there for the whole
-window between the first deploy and the Step 4 cutover. `workers_dev: false`
-would have been the blunter fix, but Step 3's CPU measurement and Step 4a's
-staging contract diff both need that hostname serving the public routes.
+one.** Access *can* cover a `workers.dev` hostname: Cloudflare documents
+[hostname-based applications](https://developers.cloudflare.com/workers/configuration/cloudflare-access/)
+on `<worker>.<subdomain>.workers.dev` explicitly, and shipped one-click Access
+for workers.dev in October 2025. What no per-hostname application covers is
+the **versioned preview URLs** minted alongside every deploy, each on a
+hostname nobody named in advance.
 
-That deny is not authentication and must not be mistaken for it — it removes
-an unprotected hostname from reach, it does not decide who may look. Access
+`src/index.ts` therefore answers `/admin/*` with a 404 on every `.workers.dev`
+hostname *except* the one named by `ADMIN_ACCESS_HOSTNAME`, a var set on
+`env.staging` only. That makes the dashboards reachable on
+`mydia-relay-staging.<subdomain>.workers.dev`, where the staging Access
+application gates them, and nowhere else under workers.dev. It fails closed:
+the var is optional, and an unset or blank value never matches a hostname, so
+production's workers.dev host and every preview URL keep 404ing.
+`workers_dev: false` would have been the blunter fix, but Step 3's CPU
+measurement and Step 4a's staging contract diff both need that hostname
+serving the public routes.
+
+That deny is not authentication and must not be mistaken for it -- it removes
+unprotected hostnames from reach, it does not decide who may look. Access
 still decides that, and skipping Step 1 still leaves the dashboards open on
 the production hostname the moment Step 4b adds the route.
 
@@ -458,6 +467,19 @@ collision with anything public.
    - Policy: Allow, Include → Emails → the maintainer address
 
 That's it — one application, one path pattern, no exclusion list to maintain.
+
+**Step 1 has already been rehearsed on staging.** A second, identical
+application covers `mydia-relay-staging.arsfeld.workers.dev/admin*` with the
+same `/admin*` path scope and the same maintainer-email policy. It exists so
+the maintainer dashboards are usable on staging, and it doubles as proof that
+the path scoping this runbook depends on behaves as described: it was verified
+to return 302 on both `/admin` routes while leaving `GET /health` at 200 and
+`POST /feedback` at 201. Configure the production application to match it.
+
+If the production application ever behaves differently from the staging one,
+the difference is in the application config, not in the Worker. The Worker
+treats every hostname the same except for the single allowlist entry described
+above.
 
 **Verify both halves after configuring Access:**
 

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -468,18 +468,22 @@ collision with anything public.
 
 That's it — one application, one path pattern, no exclusion list to maintain.
 
-**Step 1 has already been rehearsed on staging.** A second, identical
-application covers `mydia-relay-staging.arsfeld.workers.dev/admin*` with the
-same `/admin*` path scope and the same maintainer-email policy. It exists so
-the maintainer dashboards are usable on staging, and it doubles as proof that
-the path scoping this runbook depends on behaves as described: it was verified
-to return 302 on both `/admin` routes while leaving `GET /health` at 200 and
-`POST /feedback` at 201. Configure the production application to match it.
+**Rehearse this on staging first.** `mydia-relay-staging.arsfeld.workers.dev`
+takes its own self-hosted application, with the same `/admin*` path scope and
+the same maintainer-email policy. Doing staging first exercises the path
+scoping this runbook depends on against a deploy that serves no real traffic,
+and it is the cheapest place to find out if that scoping does not behave as
+described here.
 
-If the production application ever behaves differently from the staging one,
-the difference is in the application config, not in the Worker. The Worker
-treats every hostname the same except for the single allowlist entry described
-above.
+Note that staging's `/admin/*` becomes reachable as soon as
+`ADMIN_ACCESS_HOSTNAME` names its hostname, whether or not the Access
+application exists: the Worker's allowlist controls reachability, Access
+controls who may look. Create the application first, not after.
+
+Configure the production application to match staging's, and still run the
+verification curls below against production. A working staging application is
+encouraging, not evidence about production: Access is configured per hostname,
+and the two are configured independently.
 
 **Verify both halves after configuring Access:**
 

--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -475,6 +475,12 @@ scoping this runbook depends on against a deploy that serves no real traffic,
 and it is the cheapest place to find out if that scoping does not behave as
 described here.
 
+Verify it there too, before touching production: run the same four curls below
+against `mydia-relay-staging.arsfeld.workers.dev` instead of `relay.mydia.dev`.
+The expected answers are identical, and a 404 rather than a 302 on the two
+`/admin` routes is the signal that path-scoped Access is not covering that
+hostname at all, which is worth learning on staging.
+
 Note that staging's `/admin/*` becomes reachable as soon as
 `ADMIN_ACCESS_HOSTNAME` names its hostname, whether or not the Access
 application exists: the Worker's allowlist controls reachability, Access

--- a/relay-worker/src/dashboards/hostname-guard.ts
+++ b/relay-worker/src/dashboards/hostname-guard.ts
@@ -1,0 +1,32 @@
+/**
+ * Whether a request to `/admin/*` on this hostname must be refused.
+ *
+ * Cloudflare Access is the real gate on the maintainer dashboards, and it is
+ * configured per hostname. Access CAN cover a workers.dev hostname:
+ * Cloudflare documents hostname-based applications on
+ * `<worker>.<subdomain>.workers.dev` explicitly, and shipped one-click Access
+ * for workers.dev in October 2025. What no per-hostname application covers is
+ * the versioned PREVIEW URLs Cloudflare mints alongside every deploy, each on
+ * a hostname nobody named in advance.
+ *
+ * So this is an allowlist of exactly one host. `accessGuardedHostname` is the
+ * single workers.dev hostname where an Access application is known to cover
+ * `/admin*`, supplied by the `ADMIN_ACCESS_HOSTNAME` var and set on
+ * `env.staging` only.
+ *
+ * It fails closed by construction rather than by a branch: `undefined` and
+ * `""` never equal a hostname, so an unset or blank value reproduces the
+ * blanket 404 this function replaced. The match is exact and unnormalised, so
+ * any typo in the configured value also fails closed. That is deliberate;
+ * normalising only case would create false confidence in the other typos.
+ *
+ * This is not authentication and must never grow into it. It removes
+ * unprotected hostnames from reach; Access decides who may look.
+ */
+export function adminHostnameBlocked(
+  hostname: string,
+  accessGuardedHostname: string | undefined,
+): boolean {
+  if (!hostname.endsWith(".workers.dev")) return false;
+  return hostname !== accessGuardedHostname;
+}

--- a/relay-worker/src/env.ts
+++ b/relay-worker/src/env.ts
@@ -10,6 +10,14 @@ export interface Env {
   FEEDBACK_FROM: string;
   FEEDBACK_TO: string;
 
+  // The single `*.workers.dev` hostname where a Cloudflare Access application
+  // is known to cover `/admin*`. Set on `env.staging` only (wrangler.jsonc),
+  // so the maintainer dashboards are reachable on the staging deploy
+  // subdomain and nowhere else under workers.dev. Optional on purpose: an
+  // absent value makes src/dashboards/hostname-guard.ts fail closed, which is
+  // exactly the behaviour production and local dev want.
+  ADMIN_ACCESS_HOSTNAME?: string;
+
   // Bindings
   CACHE_KV: KVNamespace;
   DB: D1Database;

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -9,6 +9,7 @@ import { registerCrashRoutes } from "./crashes/ingest";
 import { registerErrorDashboard } from "./dashboards/errors";
 import { registerFeedbackRoutes } from "./feedback/ingest";
 import { registerFeedbackDashboard } from "./dashboards/feedback";
+import { adminHostnameBlocked } from "./dashboards/hostname-guard";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
 import { runScheduledSweep } from "./obs/sweep";
@@ -91,7 +92,8 @@ app.get("/stats", (c) =>
 // routes registered after it (same composition rule as the two middlewares
 // above).
 app.use("/admin/*", async (c, next) => {
-  if (new URL(c.req.url).hostname.endsWith(".workers.dev")) {
+  const hostname = new URL(c.req.url).hostname;
+  if (adminHostnameBlocked(hostname, c.env.ADMIN_ACCESS_HOSTNAME)) {
     return c.json({ error: "Not found" }, 404);
   }
   await next();

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -64,27 +64,32 @@ app.get("/stats", (c) =>
 );
 
 // Cloudflare Access is the real gate on /admin/*, and it is configured per
-// hostname: the Step 1 Access application in relay-worker/README.md's runbook
-// covers `relay.mydia.dev/admin*` and nothing else. The Worker is ALSO live on
-// its `*.workers.dev` subdomain from the first successful CI deploy onwards
-// (runbook Step 3 and Step 4a both depend on that, which is why
-// `workers_dev: false` is not the fix here), and Access does not see requests
-// to that hostname at all. Without this middleware the maintainer dashboards
-// would be anonymously readable on the workers.dev URL for the whole window
-// between the first deploy and the Step 4 cutover -- the same
-// path-not-method, hostname-by-hostname trap the runbook's cutover
-// preconditions already warn about for the wildcard route, one hostname
-// earlier.
+// hostname. Access CAN cover a workers.dev hostname: Cloudflare documents
+// hostname-based applications on `<worker>.<subdomain>.workers.dev`
+// explicitly, and shipped one-click Access for workers.dev in October 2025.
+// An earlier revision of this comment claimed the opposite and used it to
+// justify a blanket deny; that claim was wrong.
 //
-// So: /admin/* answers 404 on any workers.dev hostname, which covers both the
-// deploy subdomain (`mydia-relay.<subdomain>.workers.dev`) and the versioned
-// preview URLs Cloudflare mints alongside it. Every other hostname -- the
-// production custom domain, local dev, Miniflare in tests -- is unaffected,
-// and none of test/contract/routes.json's routes are under /admin, so the
-// staging contract diff still exercises everything it did before.
+// What no per-hostname application covers is the versioned PREVIEW URLs
+// Cloudflare mints alongside every deploy, each on a hostname nobody named in
+// advance. That is this middleware's real and continuing justification.
 //
-// This is not authentication and must never grow into it: it removes an
-// UNPROTECTED hostname from reach, it does not decide who may look. Access
+// So: an allowlist of exactly one hostname, ADMIN_ACCESS_HOSTNAME, set on
+// env.staging only (wrangler.jsonc). The dashboards are reachable on
+// `mydia-relay-staging.<subdomain>.workers.dev`, where a staging Access
+// application gates them, and nowhere else under workers.dev -- not on
+// preview URLs, and not on production's `mydia-relay.<subdomain>.workers.dev`,
+// whose dashboards wait for the relay.mydia.dev Access application at
+// cutover. It fails closed when the var is absent or blank; see
+// src/dashboards/hostname-guard.ts for why that needs no branch.
+//
+// Every other hostname -- the eventual production custom domain, local dev,
+// Miniflare in tests -- is unaffected, and none of test/contract/routes.json's
+// routes are under /admin, so the staging contract diff still exercises
+// everything it did before.
+//
+// This is not authentication and must never grow into it: it removes
+// UNPROTECTED hostnames from reach, it does not decide who may look. Access
 // still decides that, and the README's "the Worker holds no dashboard
 // credentials, and none should ever be added" rule stands unchanged.
 //

--- a/relay-worker/test/dashboards/hostname-guard.test.ts
+++ b/relay-worker/test/dashboards/hostname-guard.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { adminHostnameBlocked } from "../../src/dashboards/hostname-guard";
+
+// The guard's whole job is to answer one question: may a request to /admin/*
+// on this hostname reach the dashboards? These are unit tests rather than
+// SELF.fetch integration tests because the security-relevant case -- the
+// variable being unset entirely -- cannot be expressed through the Miniflare
+// bindings, which always provide it.
+describe("adminHostnameBlocked", () => {
+  const STAGING = "mydia-relay-staging.someacct.workers.dev";
+
+  it("blocks every workers.dev hostname when nothing is configured", () => {
+    expect(adminHostnameBlocked(STAGING, undefined)).toBe(true);
+    expect(adminHostnameBlocked("mydia-relay.someacct.workers.dev", undefined)).toBe(true);
+    expect(adminHostnameBlocked("a1b2c3-mydia-relay.someacct.workers.dev", undefined)).toBe(true);
+  });
+
+  it("blocks every workers.dev hostname when the configured value is blank", () => {
+    expect(adminHostnameBlocked(STAGING, "")).toBe(true);
+    expect(adminHostnameBlocked(STAGING, "   ")).toBe(true);
+  });
+
+  it("allows the exact configured hostname", () => {
+    expect(adminHostnameBlocked(STAGING, STAGING)).toBe(false);
+  });
+
+  it("blocks a versioned preview URL derived from the configured hostname", () => {
+    expect(adminHostnameBlocked(`a1b2c3-${STAGING}`, STAGING)).toBe(true);
+  });
+
+  it("blocks a different Worker on the same account subdomain", () => {
+    expect(adminHostnameBlocked("mydia-relay.someacct.workers.dev", STAGING)).toBe(true);
+  });
+
+  it("matches exactly, so a case mismatch fails closed", () => {
+    expect(adminHostnameBlocked(STAGING, STAGING.toUpperCase())).toBe(true);
+  });
+
+  it("never blocks a non-workers.dev hostname, configured or not", () => {
+    expect(adminHostnameBlocked("relay.mydia.dev", undefined)).toBe(false);
+    expect(adminHostnameBlocked("relay.mydia.dev", STAGING)).toBe(false);
+    expect(adminHostnameBlocked("localhost", undefined)).toBe(false);
+  });
+});

--- a/relay-worker/test/dashboards/hostname.test.ts
+++ b/relay-worker/test/dashboards/hostname.test.ts
@@ -18,6 +18,12 @@ beforeAll(async () => {
 describe("/admin/* on a workers.dev hostname", () => {
   const ADMIN_PATHS = ["/admin/errors", "/admin/feedback"];
 
+  // Mirrors vitest.config.ts's miniflare binding. The deliberately different
+  // worker name (`-staging`) is what keeps every pre-existing case in this
+  // file valid: they all use `mydia-relay.someacct.workers.dev`, which is not
+  // this hostname and must still 404.
+  const ACCESS_HOSTNAME = "mydia-relay-staging.someacct.workers.dev";
+
   for (const path of ADMIN_PATHS) {
     it(`answers 404 for ${path} on the deploy subdomain`, async () => {
       const res = await SELF.fetch(`https://mydia-relay.someacct.workers.dev${path}`);
@@ -39,6 +45,22 @@ describe("/admin/* on a workers.dev hostname", () => {
       const res = await SELF.fetch(`https://relay.mydia.dev${path}`);
 
       expect(res.status).toBe(200);
+    });
+
+    it(`serves ${path} on the Access-guarded staging hostname`, async () => {
+      const res = await SELF.fetch(`https://${ACCESS_HOSTNAME}${path}`);
+
+      expect(res.status).toBe(200);
+    });
+
+    // The case that matters most. A per-hostname Access application does not
+    // cover the versioned preview URLs Cloudflare mints alongside every
+    // deploy, so they must keep 404ing even though their suffix matches the
+    // hostname that is allowed.
+    it(`still answers 404 for ${path} on a preview URL of that hostname`, async () => {
+      const res = await SELF.fetch(`https://a1b2c3-${ACCESS_HOSTNAME}${path}`);
+
+      expect(res.status).toBe(404);
     });
   }
 

--- a/relay-worker/test/dashboards/hostname.test.ts
+++ b/relay-worker/test/dashboards/hostname.test.ts
@@ -5,16 +5,18 @@ beforeAll(async () => {
   await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
 });
 
-// Cloudflare Access is configured per hostname: the runbook's Step 1
-// application covers `relay.mydia.dev/admin*` and nothing else. The Worker is
-// ALSO live on its `*.workers.dev` subdomain from the first successful CI
-// deploy, plus the versioned preview URLs alongside it, and Access never sees
-// those requests -- so without this deny the maintainer dashboards would be
-// anonymously readable there for the whole window between the first deploy
-// and the Step 4 cutover.
+// Cloudflare Access is configured per hostname, and it CAN cover a
+// workers.dev hostname -- the staging deploy subdomain has an application
+// scoped to `/admin*`, which is why ACCESS_HOSTNAME below is served rather
+// than denied.
 //
-// This is not authentication and these tests do not claim it is. It removes an
-// unprotected hostname from reach; Access still decides who may look.
+// What no per-hostname application covers is the versioned preview URLs
+// Cloudflare mints alongside every deploy. Those, production's own workers.dev
+// hostname, and anything else under `.workers.dev` must keep answering 404.
+// That is what these tests pin.
+//
+// This is not authentication and these tests do not claim it is. It removes
+// unprotected hostnames from reach; Access still decides who may look.
 describe("/admin/* on a workers.dev hostname", () => {
   const ADMIN_PATHS = ["/admin/errors", "/admin/feedback"];
 

--- a/relay-worker/vitest.config.ts
+++ b/relay-worker/vitest.config.ts
@@ -25,6 +25,13 @@ export default defineWorkersConfig({
             TVDB_API_KEY: "test-tvdb-key",
             SUBDL_API_KEY: "test-subdl-key",
             RESEND_API_KEY: "test-resend-key",
+            // The one workers.dev hostname /admin/* is served on. Real value
+            // lives in wrangler.jsonc's env.staging; this stand-in follows the
+            // `someacct` convention the hostname tests already use. Note the
+            // `-staging` in the worker name: the pre-existing cases in
+            // test/dashboards/hostname.test.ts use `mydia-relay.someacct...`
+            // and must keep 404ing against this.
+            ADMIN_ACCESS_HOSTNAME: "mydia-relay-staging.someacct.workers.dev",
             TEST_MIGRATIONS: migrations,
           },
           // Overrides wrangler.jsonc's PROXY_LIMITER (300/60s) for tests only.

--- a/relay-worker/wrangler.jsonc
+++ b/relay-worker/wrangler.jsonc
@@ -132,7 +132,14 @@
         // is the only way to tell them apart once both answer on workers.dev.
         "RELAY_VERSION": "1.0.0-staging",
         "FEEDBACK_FROM": "metadata-relay@mydia.dev",
-        "FEEDBACK_TO": "arsfeld@gmail.com"
+        "FEEDBACK_TO": "arsfeld@gmail.com",
+        // The one workers.dev hostname where /admin/* is served, matching the
+        // Cloudflare Access application scoped to
+        // `mydia-relay-staging.arsfeld.workers.dev/admin*`. Absent from
+        // env.production on purpose: production's dashboards wait for the
+        // relay.mydia.dev Access application at cutover, and its workers.dev
+        // host must stay dark until then. See src/dashboards/hostname-guard.ts.
+        "ADMIN_ACCESS_HOSTNAME": "mydia-relay-staging.arsfeld.workers.dev"
       },
       "kv_namespaces": [
         { "binding": "CACHE_KV", "id": "19d00e7cf9524ebe809786d6b96e1951" }


### PR DESCRIPTION
## What this does

Makes `GET /admin/errors` and `GET /admin/feedback` reachable on the deployed staging Worker, gated by Cloudflare Access, without exposing them on any other `workers.dev` hostname.

Before this, they were unreachable anywhere on staging: `src/index.ts` answered `/admin/*` with a 404 on every `*.workers.dev` hostname, and staging has no other hostname.

## The premise that was wrong

Three comment blocks justified that blanket deny by asserting that Cloudflare Access cannot see requests to a `workers.dev` hostname. That is not true:

- [workers.dev routing](https://developers.cloudflare.com/workers/configuration/routing/workers-dev/): "To require visitors to sign in before they can access a `workers.dev` URL, use Cloudflare Access."
- [Access for Workers](https://developers.cloudflare.com/workers/configuration/cloudflare-access/) gives `my-worker.example.workers.dev` as an explicit hostname-based example.
- Cloudflare shipped one-click Access for workers.dev in October 2025.

What no per-hostname Access application covers is the **versioned preview URLs** minted alongside every deploy, on hostnames nobody names in advance. That is the guard's real and continuing justification, and the comments now say so.

## The change

The blanket deny becomes an allowlist of exactly one hostname:

```ts
if (adminHostnameBlocked(hostname, c.env.ADMIN_ACCESS_HOSTNAME)) {
  return c.json({ error: "Not found" }, 404);
}
```

`ADMIN_ACCESS_HOSTNAME` is optional on `Env` and set in `env.staging.vars` only. It **fails closed by construction** rather than by a branch: `undefined` and `""` never equal a hostname, so production and local dev keep exactly today's behaviour with no second code path to keep correct.

The comparison lives in `src/dashboards/hostname-guard.ts` as a pure function, because the security-relevant case — the variable unset entirely — cannot be expressed through Miniflare's bindings, which always supply it. It needs a unit test, not an integration one.

## The Access application already exists and was verified

Created before this branch was opened, deliberately in that order: the old 404 guard is what made it safe to verify Access first, since an intercepted request never reaches the Worker at all.

Application on `mydia-relay-staging.arsfeld.workers.dev/admin*`, one allow policy for the maintainer email, 24h sessions.

```
GET  /admin/errors    -> 302   (redirects to the Access login for this exact hostname)
GET  /admin/feedback  -> 302
GET  /health          -> 200   (anonymous, scope did not leak)
POST /feedback        -> 201   (anonymous, ingest intact)
```

and production's own workers.dev hostname:

```
GET https://mydia-relay.arsfeld.workers.dev/admin/errors -> 404
```

This also settles the open question the runbook flagged as its highest-risk assumption: **path-scoped Access does work on a workers.dev hostname.** Step 1 of the production cutover now has a rehearsal behind it rather than a hope.

## Tests

Full suite: 310 passed, 42 skipped, up from 306/42. Exactly the 11 new cases, no regressions.

The case that matters most is the preview URL: `a1b2c3-mydia-relay-staging.someacct.workers.dev` must still 404 even though its suffix matches the allowed hostname. Also covered: unset variable, blank variable, a sibling Worker on the same account subdomain, and a case-differing value.

The match is exact and unnormalised, so any typo in the configured value fails closed. That is deliberate. Normalising only case would create false confidence about the other typos.

## What this does not do

No production route, no custom domain, no change to production's guard behaviour, no change to public-route behaviour on any hostname, and no credentials in the Worker. The rule that the Worker holds no dashboard credentials is unchanged and unviolated: a hostname is not a credential, and the guard decides reachability, not identity.

## Accepted tradeoff, now documented in the runbook

Staging's `/admin/*` becomes reachable as soon as `ADMIN_ACCESS_HOSTNAME` names its hostname, whether or not the Access application exists. The Worker's allowlist controls reachability; Access controls who may look. Create the application first, not after. Staging's D1 holds only deliberately-sent test data, since every install in the field posts to `relay.mydia.dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staging `/admin/*` routes are reachable on the configured staging hostname while remaining blocked on preview URLs and unapproved Workers hostnames.
  * Access remains blocked when the staging hostname setting is missing or blank.
  * Production behavior remains unchanged unless separately configured.

* **Documentation**
  * Added staging-first setup and verification guidance for protecting administrative routes with Cloudflare Access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->