### PR TITLE
feat(p2p): resolve the iroh relay list from the metadata relay

### DIFF
--- a/lib/mydia/p2p.ex
+++ b/lib/mydia/p2p.ex
@@ -12,7 +12,8 @@ defmodule Mydia.P2p do
   Start the p2p host with configuration.
 
   ## Options
-    * `:relay_url` - Custom relay URL for NAT traversal (uses iroh default relays if nil).
+    * `:relay_urls` - Custom relay URLs for NAT traversal, in preference order.
+      An empty list uses iroh's default relays.
     * `:bind_port` - UDP port for direct connections (enables hole punching in Docker).
       If nil or 0, a random port is used.
     * `:keypair_path` - Path to store/load the node's keypair for persistent identity.
@@ -20,7 +21,7 @@ defmodule Mydia.P2p do
 
   Returns `{:ok, {resource, node_id}}` on success.
   """
-  def start_host(_relay_url \\ nil, _bind_port \\ nil, _keypair_path \\ nil),
+  def start_host(_relay_urls \\ [], _bind_port \\ nil, _keypair_path \\ nil),
     do: :erlang.nif_error(:nif_not_loaded)
 
   @doc """

--- a/lib/mydia/p2p/relay_list.ex
+++ b/lib/mydia/p2p/relay_list.ex
@@ -1,0 +1,181 @@
+defmodule Mydia.P2p.RelayList do
+  @moduledoc """
+  Resolves which iroh relays this install should use.
+
+  The relay hostname used to be compiled in, so moving it meant shipping a new
+  server image and waiting for every install to upgrade. This reads the list
+  from the metadata relay's `/client-config` at boot instead, so a relay move
+  is a relay deploy.
+
+  Precedence, highest first:
+
+    1. An explicit `IROH_RELAY_URL`. Used alone, and the fetch is skipped
+       entirely. Someone who set it did so to pin their install to one relay,
+       so merging mydia's list into theirs would defeat the setting.
+    2. `p2p.relays` from a successful fetch.
+    3. The last successful fetch, read from disk.
+    4. The compiled-in default.
+
+  iroh's own public relays are appended underneath whatever this returns, by
+  `build_relay_mode` in `native/mydia_p2p_core/src/lib.rs`. That is why losing
+  a mydia relay degrades rather than breaks, and why this module never needs to
+  carry them.
+
+  The fetch goes to the *configured* metadata relay, not a hardcoded
+  `relay.mydia.dev`, so a self-hoster running their own relay serves their own
+  list and no install gains a network dependency it did not already have.
+
+  `player/lib/core/p2p/relay_list.dart` is the Dart twin of this module and
+  implements the same four levels and the same validation.
+  """
+
+  require Logger
+
+  alias Mydia.Metadata
+
+  @default_relay_url "https://cae1-1.relay.mydia.dev"
+  @timeout_ms 3_000
+  @path "/client-config"
+
+  @type source :: :override | :fetched | :cached | :default
+
+  @doc """
+  The relay compiled into this build, used when nothing else is available.
+  """
+  @spec default_relay_url() :: String.t()
+  def default_relay_url, do: @default_relay_url
+
+  @doc """
+  Resolves the relay list.
+
+  Returns the URLs and which precedence level produced them, so the caller can
+  log something honest at boot.
+
+  Options exist for tests: `:cache_path`, `:base_url`, `:req_options` and
+  `:override`. In production all four come from the environment.
+  """
+  @spec resolve(keyword()) :: {[String.t()], source()}
+  def resolve(opts \\ []) do
+    case override(opts) do
+      [_ | _] = urls -> {urls, :override}
+      [] -> resolve_from_relay(opts)
+    end
+  end
+
+  defp resolve_from_relay(opts) do
+    cache_path = Keyword.get(opts, :cache_path) || default_cache_path()
+
+    case fetch(opts) do
+      [_ | _] = urls ->
+        write_cache(cache_path, urls)
+        {urls, :fetched}
+
+      [] ->
+        case read_cache(cache_path) do
+          [_ | _] = urls -> {urls, :cached}
+          [] -> {[@default_relay_url], :default}
+        end
+    end
+  end
+
+  defp override(opts) do
+    raw =
+      case Keyword.fetch(opts, :override) do
+        {:ok, value} -> value
+        :error -> System.get_env("IROH_RELAY_URL")
+      end
+
+    # System.get_env/1 returns "" for a variable explicitly set empty, and ""
+    # is truthy in Elixir, so trimming is what actually treats blank as unset.
+    case raw do
+      nil -> []
+      value -> value |> String.trim() |> List.wrap() |> valid_urls()
+    end
+  end
+
+  defp fetch(opts) do
+    base_url = Keyword.get(opts, :base_url) || Metadata.default_relay_config().base_url
+    req_options = Keyword.get(opts, :req_options, [])
+
+    req =
+      Req.new(
+        base_url: base_url,
+        receive_timeout: @timeout_ms,
+        connect_options: [timeout: @timeout_ms],
+        retry: false,
+        headers: [accept: "application/json"]
+      )
+      |> Req.merge(req_options)
+
+    case Req.get(req, url: @path) do
+      {:ok, %Req.Response{status: 200, body: body}} ->
+        relays_from(body)
+
+      {:ok, %Req.Response{status: status}} ->
+        Logger.warning("Relay list fetch returned HTTP #{status}, falling back")
+        []
+
+      {:error, reason} ->
+        Logger.warning("Relay list fetch failed: #{inspect(reason)}, falling back")
+        []
+    end
+  rescue
+    e ->
+      Logger.warning("Relay list fetch raised: #{inspect(e)}, falling back")
+      []
+  end
+
+  # Unknown keys are ignored on purpose: the document is meant to grow without
+  # a client change.
+  defp relays_from(%{"p2p" => %{"relays" => relays}}) when is_list(relays),
+    do: valid_urls(relays)
+
+  defp relays_from(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> relays_from(decoded)
+      {:error, _} -> []
+    end
+  end
+
+  defp relays_from(_), do: []
+
+  defp valid_urls(urls) do
+    Enum.filter(urls, fn
+      url when is_binary(url) ->
+        case URI.parse(url) do
+          %URI{scheme: "https", host: host} when is_binary(host) and host != "" -> true
+          _ -> false
+        end
+
+      _ ->
+        false
+    end)
+  end
+
+  defp read_cache(path) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, urls} when is_list(urls) <- Jason.decode(contents) do
+      valid_urls(urls)
+    else
+      _ -> []
+    end
+  end
+
+  defp write_cache(path, urls) do
+    path |> Path.dirname() |> File.mkdir_p!()
+    File.write!(path, Jason.encode!(urls))
+  rescue
+    e ->
+      # A cache we cannot write costs us the next offline boot, nothing more.
+      Logger.warning("Could not cache the relay list at #{path}: #{inspect(e)}")
+      :ok
+  end
+
+  defp default_cache_path do
+    keypair_path =
+      Application.get_env(:mydia, :p2p_keypair_path) ||
+        raise "p2p_keypair_path is not configured"
+
+    Path.join(Path.dirname(keypair_path), "relays.json")
+  end
+end

--- a/lib/mydia/p2p/relay_list.ex
+++ b/lib/mydia/p2p/relay_list.ex
@@ -100,7 +100,15 @@ defmodule Mydia.P2p.RelayList do
     req =
       Req.new(
         base_url: base_url,
+        # receive_timeout only bounds the gap between chunks (Finch default
+        # 15s), not the whole response. A relay that trickles bytes with
+        # gaps under that limit would otherwise hang Req.get/1 forever,
+        # because Finch's request_timeout defaults to :infinity. This runs
+        # from Mydia.P2p.Server's handle_continue, which OTP runs before any
+        # other message, so an unbounded fetch here means the GenServer
+        # never finishes starting and never answers any call.
         receive_timeout: @timeout_ms,
+        request_timeout: @timeout_ms,
         connect_options: [timeout: @timeout_ms],
         retry: false,
         headers: [accept: "application/json"]

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -66,9 +66,6 @@ defmodule Mydia.P2p.Server do
 
   @impl true
   def init(_) do
-    # Default to our own relay; override via IROH_RELAY_URL env var
-    relay_url = System.get_env("IROH_RELAY_URL", "https://cae1-1.relay.mydia.dev")
-
     # Get bind_port from config (required for hole punching in Docker)
     bind_port = Application.get_env(:mydia, :p2p_bind_port)
 
@@ -93,15 +90,42 @@ defmodule Mydia.P2p.Server do
     # install does not exist yet. The NIF cannot create it.
     keypair_path |> Path.dirname() |> File.mkdir_p!()
 
+    state = %{
+      resource: nil,
+      node_id: nil,
+      node_addr: nil,
+      relay_connected: false,
+      bind_port: bind_port,
+      keypair_path: keypair_path,
+      # Track connected peers (Map of peer_id => connection_type)
+      connected_peers: %{}
+    }
+
+    # Resolving the relay list means an HTTP call with a 3s timeout, and
+    # starting the host opens an iroh endpoint. Neither belongs in init/1,
+    # which runs inside the supervisor's start_link and would block the whole
+    # application boot behind an unreachable network.
+    #
+    # A {:continue, _} is processed before any other message in the mailbox, so
+    # every handle_call clause below still sees a started host. A caller that
+    # arrives during startup blocks until this finishes, which is correct.
+    {:ok, state, {:continue, :start_host}}
+  end
+
+  @impl true
+  def handle_continue(:start_host, state) do
+    {relay_urls, source} = Mydia.P2p.RelayList.resolve()
+
+    Logger.info("P2P relay list (#{source}): #{Enum.join(relay_urls, ", ")}")
+
     # Start the host - NIF returns {resource, node_id} directly (raises on error)
-    {resource, node_id} = P2p.start_host([relay_url], bind_port, keypair_path)
+    {resource, node_id} = P2p.start_host(relay_urls, state.bind_port, state.keypair_path)
 
-    Logger.info("P2P Host started with NodeID: #{node_id}, relay: #{relay_url}")
+    Logger.info("P2P Host started with NodeID: #{node_id}")
+    Logger.info("P2P Host using persistent keypair at #{state.keypair_path}")
 
-    Logger.info("P2P Host using persistent keypair at #{keypair_path}")
-
-    if bind_port do
-      Logger.info("P2P Host using UDP port #{bind_port}")
+    if state.bind_port do
+      Logger.info("P2P Host using UDP port #{state.bind_port}")
     else
       Logger.info("P2P Host using random port")
     end
@@ -110,16 +134,7 @@ defmodule Mydia.P2p.Server do
     # NIF returns "ok" directly (raises on error)
     "ok" = P2p.start_listening(resource, self())
 
-    state = %{
-      resource: resource,
-      node_id: node_id,
-      node_addr: nil,
-      relay_connected: false,
-      # Track connected peers (Map of peer_id => connection_type)
-      connected_peers: %{}
-    }
-
-    {:ok, state}
+    {:noreply, %{state | resource: resource, node_id: node_id}}
   end
 
   @doc """

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -94,7 +94,7 @@ defmodule Mydia.P2p.Server do
     keypair_path |> Path.dirname() |> File.mkdir_p!()
 
     # Start the host - NIF returns {resource, node_id} directly (raises on error)
-    {resource, node_id} = P2p.start_host(relay_url, bind_port, keypair_path)
+    {resource, node_id} = P2p.start_host([relay_url], bind_port, keypair_path)
 
     Logger.info("P2P Host started with NodeID: #{node_id}, relay: #{relay_url}")
 

--- a/metadata-relay/Dockerfile
+++ b/metadata-relay/Dockerfile
@@ -17,11 +17,21 @@ ENV HEX_HTTP_TIMEOUT=300000
 
 WORKDIR /app
 
-# Install hex and rebar with cache
-# Use id=relay-* to avoid cache contamination with mydia builds (different OTP version)
-RUN --mount=type=cache,id=relay-hex,target=/root/.hex \
-    --mount=type=cache,id=relay-mix,target=/root/.mix \
-    mix local.hex --force && \
+# Install hex and rebar into the image layer, NOT into a cache mount.
+#
+# These used to be written to --mount=type=cache at /root/.hex and /root/.mix.
+# A cache mount is not part of the layer, so on a cold or evicted BuildKit
+# cache the archives installed here were simply absent by the time a later
+# step ran, and `mix compile` died with "Shall I install Hex?" followed by
+# "Could not find an SCM for dependency :bandit". That is a build that
+# succeeds or fails on cache state rather than on the tree, and it only
+# surfaces on the path that builds the relay image from source, which CI takes
+# only when metadata-relay/** changes.
+#
+# The archives are a few hundred KB and this is the builder stage of a
+# multi-stage build, so nothing here reaches the final image. Caching them
+# saved nothing and cost determinism.
+RUN mix local.hex --force && \
     mix local.rebar --force
 
 # Copy mix files (building from repo root)
@@ -29,9 +39,7 @@ COPY metadata-relay/mix.exs metadata-relay/mix.lock ./
 COPY metadata-relay/assets/package.json metadata-relay/assets/package-lock.json ./assets/
 
 # Install dependencies with cache (with retry for transient network failures)
-RUN --mount=type=cache,id=relay-hex,target=/root/.hex \
-    --mount=type=cache,id=relay-mix,target=/root/.mix \
-    --mount=type=cache,id=relay-deps,target=/app/deps \
+RUN --mount=type=cache,id=relay-deps,target=/app/deps \
     for i in 1 2 3; do \
       mix deps.get --only prod && break || \
       (echo "Attempt $i failed, retrying in 10s..." && sleep 10); \
@@ -45,9 +53,7 @@ RUN rm -rf deps && mv deps_copy deps
 RUN cd assets && npm ci
 
 # Compile dependencies with cache
-RUN --mount=type=cache,id=relay-hex,target=/root/.hex \
-    --mount=type=cache,id=relay-mix,target=/root/.mix \
-    --mount=type=cache,id=relay-build,target=/app/_build,sharing=locked \
+RUN --mount=type=cache,id=relay-build,target=/app/_build,sharing=locked \
     mix deps.compile && \
     cp -r _build _build_copy
 
@@ -61,19 +67,13 @@ COPY metadata-relay/lib ./lib
 COPY metadata-relay/priv ./priv
 
 # Compile the application
-RUN --mount=type=cache,id=relay-hex,target=/root/.hex \
-    --mount=type=cache,id=relay-mix,target=/root/.mix \
-    mix compile
+RUN mix compile
 
 # Build frontend assets
-RUN --mount=type=cache,id=relay-hex,target=/root/.hex \
-    --mount=type=cache,id=relay-mix,target=/root/.mix \
-    mix assets.deploy
+RUN mix assets.deploy
 
 # Build release
-RUN --mount=type=cache,id=relay-hex,target=/root/.hex \
-    --mount=type=cache,id=relay-mix,target=/root/.mix \
-    mix release
+RUN mix release
 
 # Start a new stage for the final image
 # Alpine 3.23, not 3.24, on purpose. musl 1.2.6 (Alpine 3.24) tightened

--- a/metadata-relay/lib/metadata_relay/client_config.ex
+++ b/metadata-relay/lib/metadata_relay/client_config.ex
@@ -1,0 +1,39 @@
+defmodule MetadataRelay.ClientConfig do
+  @moduledoc """
+  The client configuration document served at `GET /client-config`.
+
+  Installs read this at boot to learn which iroh relays mydia operates, so a
+  relay can be moved or replaced by deploying this service instead of shipping
+  a new server image and player build and waiting for every install to upgrade.
+
+  The list below is the source of truth. Changing it is a `metadata-relay-v*`
+  tag plus Keel's five minute poll, which is minutes rather than the weeks a
+  client release takes.
+
+  `relay-worker/src/config/client_config.ts` carries the same list and must be
+  changed in the same commit. `relay-worker/test/contract/routes.json` includes
+  this route so the cutover gate diffs the two.
+
+  Clients ignore keys they do not know, so a new key can be added here without
+  a client change. There is deliberately no version field: an incompatible
+  change adds a new key and leaves the old one in place for a release, which is
+  the same shape as the `pairing/v2` fallback in the player's relay client.
+  """
+
+  @relay_urls ["https://cae1-1.relay.mydia.dev"]
+
+  @doc """
+  The iroh relays mydia operates, in preference order.
+
+  Clients append iroh's own public relays underneath these as a fallback, so
+  this list carries only mydia's own.
+  """
+  @spec relay_urls() :: [String.t()]
+  def relay_urls, do: @relay_urls
+
+  @doc """
+  The full client configuration document.
+  """
+  @spec document() :: %{p2p: %{relays: [String.t()]}}
+  def document, do: %{p2p: %{relays: relay_urls()}}
+end

--- a/metadata-relay/lib/metadata_relay/plug/cache.ex
+++ b/metadata-relay/lib/metadata_relay/plug/cache.ex
@@ -58,8 +58,10 @@ defmodule MetadataRelay.Plug.Cache do
 
   @impl true
   def call(%Plug.Conn{method: "GET", request_path: path} = conn, _opts)
-      when path in ["/health", "/stats", "/metrics"] do
-    # Skip caching for health/stats/metrics endpoints
+      when path in ["/health", "/stats", "/metrics", "/client-config"] do
+    # Skip caching for health/stats/metrics/client-config endpoints. These are
+    # answered from local constants or process state, so the ETS cache would
+    # only add a copy of data that is already free to produce.
     conn
   end
 

--- a/metadata-relay/lib/metadata_relay/router.ex
+++ b/metadata-relay/lib/metadata_relay/router.ex
@@ -64,6 +64,14 @@ defmodule MetadataRelay.Router do
     |> send_resp(200, metrics)
   end
 
+  # Client configuration. Read by mydia servers and players at boot to learn
+  # which iroh relays to use. See MetadataRelay.ClientConfig.
+  get "/client-config" do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, Jason.encode!(MetadataRelay.ClientConfig.document()))
+  end
+
   # TMDB Configuration
   get "/configuration" do
     handle_tmdb_request(conn, fn -> Handler.configuration() end)

--- a/metadata-relay/test/metadata_relay/client_config_test.exs
+++ b/metadata-relay/test/metadata_relay/client_config_test.exs
@@ -13,7 +13,6 @@ defmodule MetadataRelay.ClientConfigTest do
       urls = ClientConfig.relay_urls()
 
       assert is_list(urls)
-      assert urls != []
       assert "https://cae1-1.relay.mydia.dev" in urls
     end
 

--- a/metadata-relay/test/metadata_relay/client_config_test.exs
+++ b/metadata-relay/test/metadata_relay/client_config_test.exs
@@ -1,0 +1,43 @@
+defmodule MetadataRelay.ClientConfigTest do
+  use ExUnit.Case, async: true
+
+  # Plug 1.18 deprecates `use Plug.Test`, and this suite is on 1.20.3, so
+  # follow the rest of it: call Plug.Test.conn/2 fully qualified and import
+  # only what is needed from Plug.Conn.
+  import Plug.Conn, only: [get_resp_header: 2]
+
+  alias MetadataRelay.ClientConfig
+
+  describe "relay_urls/0" do
+    test "lists the mydia-operated iroh relays" do
+      urls = ClientConfig.relay_urls()
+
+      assert is_list(urls)
+      assert urls != []
+      assert "https://cae1-1.relay.mydia.dev" in urls
+    end
+
+    test "every entry is an https URL with a host" do
+      for url <- ClientConfig.relay_urls() do
+        uri = URI.parse(url)
+        assert uri.scheme == "https", "#{url} is not https"
+        assert is_binary(uri.host) and uri.host != "", "#{url} has no host"
+      end
+    end
+  end
+
+  describe "GET /client-config" do
+    test "returns the p2p relay list as JSON" do
+      conn = MetadataRelay.Router.call(Plug.Test.conn(:get, "/client-config"), [])
+
+      assert conn.status == 200
+      assert conn.state == :sent
+
+      assert ["application/json" <> _] = get_resp_header(conn, "content-type")
+
+      body = Jason.decode!(conn.resp_body)
+      assert %{"p2p" => %{"relays" => relays}} = body
+      assert relays == MetadataRelay.ClientConfig.relay_urls()
+    end
+  end
+end

--- a/native/README.md
+++ b/native/README.md
@@ -137,3 +137,23 @@ format. The one real change inside the generator is rejection sampling replacing
 When relay registration fails, `relay_registered: false` makes the UI hide the
 code entirely and show a `#pairing-relay-warning` box reading "Typed code
 unavailable", so a server on master against a pre-0.13.0 relay offers QR only.
+
+## The relay list is resolved outside the core
+
+`HostConfig.relay_urls` is a plain `Vec<String>` and the core does no I/O to
+fill it. `build_relay_mode` parses the entries, drops anything unparseable, and
+appends n0's three production relays underneath as fallbacks. An empty vec, or
+one where nothing parsed, leaves iroh's preset alone: an empty
+`RelayMode::Custom` map is invalid, because `Endpoint` requires at least one
+relay.
+
+Deciding what goes in that vec belongs to the callers, and there are two of
+them with the same four precedence levels:
+
+- `lib/mydia/p2p/relay_list.ex` for the server
+- `player/lib/core/p2p/relay_list.dart` for the player
+
+Both read `GET /client-config` from the metadata relay at boot, so a relay can
+be moved by deploying the metadata relay rather than shipping a new server
+image and player build. Change one of those two files and you almost certainly
+need to change the other.

--- a/native/mydia_p2p/src/lib.rs
+++ b/native/mydia_p2p/src/lib.rs
@@ -27,19 +27,20 @@ struct HostResource {
 impl rustler::Resource for HostResource {}
 
 /// Start the p2p host with configuration.
-/// relay_url: Custom relay URL for NAT traversal (uses default relays if None).
+/// relay_urls: Custom relay URLs for NAT traversal, in preference order.
+/// An empty list uses iroh's default relays.
 /// bind_port: UDP port for direct connections (0 or None for random port).
 /// keypair_path: Path to store/load the node's keypair for persistent identity.
 /// Returns (resource, node_id_string).
 #[rustler::nif]
 fn start_host<'a>(
     env: Env<'a>,
-    relay_url: Option<String>,
+    relay_urls: Vec<String>,
     bind_port: Option<u16>,
     keypair_path: Option<String>,
 ) -> Term<'a> {
     let config = HostConfig {
-        relay_url,
+        relay_urls,
         bind_port,
         keypair_path,
         // The server reads its identity off disk; only a browser hands raw

--- a/native/mydia_p2p_core/examples/dial_by_node_id.rs
+++ b/native/mydia_p2p_core/examples/dial_by_node_id.rs
@@ -34,7 +34,7 @@ use std::env;
 
 fn host_config() -> HostConfig {
     HostConfig {
-        relay_url: None,
+        relay_urls: Vec::new(),
         bind_port: Some(0),
         keypair_path: None,
         keypair_bytes: None,

--- a/native/mydia_p2p_core/src/lib.rs
+++ b/native/mydia_p2p_core/src/lib.rs
@@ -799,9 +799,16 @@ fn create_dns_resolver() -> DnsResolver {
 
 /// Build the relay mode for a config, or None to leave iroh's preset alone.
 ///
-/// mydia's own relays come first and n0's three production relays follow as
+/// mydia's own relays come first and n0's four production relays follow as
 /// fallbacks, so losing a mydia relay degrades to a slower path rather than
 /// taking remote access down.
+///
+/// The fallback set must stay in step with `iroh::defaults::prod::default_relay_map`,
+/// which is what a node gets when no custom relay is configured at all. Listing
+/// them individually rather than calling that function is deliberate: the
+/// configured relays have to come first. An earlier revision omitted
+/// `default_na_west_relay`, which silently cost NA-west nodes their nearest
+/// fallback and made the custom-relay path strictly worse than the preset.
 fn build_relay_mode(config: &HostConfig) -> Option<RelayMode> {
     let configured: Vec<RelayConfig> = config
         .relay_urls
@@ -821,6 +828,7 @@ fn build_relay_mode(config: &HostConfig) -> Option<RelayMode> {
 
     let relay_map = RelayMap::from_iter(configured.into_iter().chain([
         default_relays::default_na_east_relay(),
+        default_relays::default_na_west_relay(),
         default_relays::default_eu_relay(),
         default_relays::default_ap_relay(),
     ]));
@@ -2718,8 +2726,8 @@ mod relay_map_tests {
             panic!("expected a custom relay mode");
         };
 
-        // Two configured plus n0's na-east, eu and ap.
-        assert_eq!(map.len(), 5);
+        // Two configured plus n0's four production relays.
+        assert_eq!(map.len(), 6);
         assert!(map.contains(&"https://relay-one.example.test".parse().unwrap()));
         assert!(map.contains(&"https://relay-two.example.test".parse().unwrap()));
     }
@@ -2738,8 +2746,41 @@ mod relay_map_tests {
             panic!("expected a custom relay mode");
         };
 
-        assert_eq!(map.len(), 4);
+        // One surviving configured relay plus n0's four production relays.
+        assert_eq!(map.len(), 5);
         assert!(map.contains(&"https://relay-one.example.test".parse().unwrap()));
+    }
+
+    /// The fallbacks must stay in step with what a node gets when no custom
+    /// relay is configured. Asserting the count alone would not catch a swap,
+    /// and hardcoding hostnames would break on an n0 rollout, so compare
+    /// against iroh's own preset: every relay it would have used must still be
+    /// reachable through ours.
+    #[test]
+    fn the_fallbacks_are_every_relay_in_iroh_s_own_preset() {
+        let config = HostConfig {
+            relay_urls: vec!["https://relay-one.example.test".to_string()],
+            ..Default::default()
+        };
+
+        let RelayMode::Custom(map) = build_relay_mode(&config).expect("custom mode") else {
+            panic!("expected a custom relay mode");
+        };
+
+        let preset = default_relays::default_relay_map();
+        let preset_urls: Vec<RelayUrl> = preset.urls();
+
+        assert!(
+            !preset_urls.is_empty(),
+            "iroh's preset should not be empty; the rest of this test proves nothing if it is"
+        );
+
+        for url in preset_urls {
+            assert!(
+                map.contains(&url),
+                "custom relay map is missing {url}, which iroh's own preset includes"
+            );
+        }
     }
 
     #[test]

--- a/native/mydia_p2p_core/src/lib.rs
+++ b/native/mydia_p2p_core/src/lib.rs
@@ -409,8 +409,11 @@ impl Default for PeerConnectionType {
 /// Configuration for the Host
 #[derive(Clone, Default)]
 pub struct HostConfig {
-    /// Custom relay URL for NAT traversal. If None, uses iroh's default relays.
-    pub relay_url: Option<String>,
+    /// Custom relay URLs for NAT traversal, in preference order. Empty means
+    /// use iroh's default relays. Entries that do not parse as a RelayUrl are
+    /// dropped; if that leaves nothing, the defaults are used rather than an
+    /// empty custom map, which Endpoint rejects.
+    pub relay_urls: Vec<String>,
     /// UDP port for direct connections. If None or 0, uses a random port.
     pub bind_port: Option<u16>,
     /// Path to store/load keypair (optional). If not set, a new random keypair is generated.
@@ -794,6 +797,37 @@ fn create_dns_resolver() -> DnsResolver {
     DnsResolver::default()
 }
 
+/// Build the relay mode for a config, or None to leave iroh's preset alone.
+///
+/// mydia's own relays come first and n0's three production relays follow as
+/// fallbacks, so losing a mydia relay degrades to a slower path rather than
+/// taking remote access down.
+fn build_relay_mode(config: &HostConfig) -> Option<RelayMode> {
+    let configured: Vec<RelayConfig> = config
+        .relay_urls
+        .iter()
+        .filter_map(|raw| match raw.parse::<RelayUrl>() {
+            Ok(url) => Some(RelayConfig::new(url, Some(RelayQuicConfig::default()))),
+            Err(e) => {
+                tracing::warn!("Ignoring unparseable relay URL {raw:?}: {e}");
+                None
+            }
+        })
+        .collect();
+
+    if configured.is_empty() {
+        return None;
+    }
+
+    let relay_map = RelayMap::from_iter(configured.into_iter().chain([
+        default_relays::default_na_east_relay(),
+        default_relays::default_eu_relay(),
+        default_relays::default_ap_relay(),
+    ]));
+
+    Some(RelayMode::Custom(relay_map))
+}
+
 /// Main event loop that runs in a background thread
 async fn run_event_loop(
     secret_key: SecretKey,
@@ -816,19 +850,8 @@ async fn run_event_loop(
     }
 
     // Configure relay
-    if let Some(relay_url) = &config.relay_url {
-        if let Ok(url) = relay_url.parse::<RelayUrl>() {
-            // Custom relay with QUIC enabled
-            let custom = RelayConfig::new(url, Some(RelayQuicConfig::default()));
-            // Combine with iroh's default production relays for fallback
-            let relay_map = RelayMap::from_iter([
-                custom,
-                default_relays::default_na_east_relay(),
-                default_relays::default_eu_relay(),
-                default_relays::default_ap_relay(),
-            ]);
-            builder = builder.relay_mode(RelayMode::Custom(relay_map));
-        }
+    if let Some(mode) = build_relay_mode(&config) {
+        builder = builder.relay_mode(mode);
     }
 
     // Configure bind port. A browser owns no UDP socket, so iroh compiles the
@@ -2263,7 +2286,7 @@ mod tests {
 
     fn test_config() -> HostConfig {
         HostConfig {
-            relay_url: None,
+            relay_urls: Vec::new(),
             bind_port: Some(0),
             keypair_path: None,
             keypair_bytes: None,
@@ -2667,5 +2690,67 @@ mod tests {
             );
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         }
+    }
+}
+
+#[cfg(test)]
+mod relay_map_tests {
+    use super::*;
+
+    #[test]
+    fn empty_relay_urls_leaves_the_default_mode() {
+        let config = HostConfig::default();
+        assert!(config.relay_urls.is_empty());
+        assert!(build_relay_mode(&config).is_none());
+    }
+
+    #[test]
+    fn configured_relays_come_first_then_n0_defaults() {
+        let config = HostConfig {
+            relay_urls: vec![
+                "https://relay-one.example.test".to_string(),
+                "https://relay-two.example.test".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        let RelayMode::Custom(map) = build_relay_mode(&config).expect("custom mode") else {
+            panic!("expected a custom relay mode");
+        };
+
+        // Two configured plus n0's na-east, eu and ap.
+        assert_eq!(map.len(), 5);
+        assert!(map.contains(&"https://relay-one.example.test".parse().unwrap()));
+        assert!(map.contains(&"https://relay-two.example.test".parse().unwrap()));
+    }
+
+    #[test]
+    fn unparseable_entries_are_dropped_without_losing_the_rest() {
+        let config = HostConfig {
+            relay_urls: vec![
+                "not a url at all".to_string(),
+                "https://relay-one.example.test".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        let RelayMode::Custom(map) = build_relay_mode(&config).expect("custom mode") else {
+            panic!("expected a custom relay mode");
+        };
+
+        assert_eq!(map.len(), 4);
+        assert!(map.contains(&"https://relay-one.example.test".parse().unwrap()));
+    }
+
+    #[test]
+    fn all_entries_unparseable_falls_back_to_the_default_mode() {
+        let config = HostConfig {
+            relay_urls: vec!["not a url at all".to_string()],
+            ..Default::default()
+        };
+
+        // An empty custom map is invalid: Endpoint requires at least one relay.
+        // Falling back to the preset is the only safe answer.
+        assert!(build_relay_mode(&config).is_none());
     }
 }

--- a/native/mydia_p2p_core/tests/two_node_control.rs
+++ b/native/mydia_p2p_core/tests/two_node_control.rs
@@ -15,7 +15,7 @@ const TEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 fn test_config() -> HostConfig {
     HostConfig {
-        relay_url: None,
+        relay_urls: Vec::new(),
         bind_port: Some(0),
         keypair_path: None,
         keypair_bytes: None,

--- a/player/lib/core/p2p/p2p_service.dart
+++ b/player/lib/core/p2p/p2p_service.dart
@@ -230,6 +230,18 @@ class P2pService {
   /// otherwise finish building a host for a service that is already gone.
   bool _disposed = false;
 
+  /// Bumped by [reset] and [dispose]. An in-flight [_initialize] captures this
+  /// on entry and abandons its work the moment it changes.
+  ///
+  /// Resolving the relay list is a network call, so an attempt can sit in that
+  /// await for seconds. `reinitializeWithRelayUrl` calls `reset()` and then
+  /// `initialize()` inside that window whenever the user saves a relay while
+  /// the app is still starting, which is exactly when they would. Without this,
+  /// the stale attempt walks on to build a second iroh host, overwrite `_host`
+  /// and `_configuredRelayUrls` with the relay the user just replaced, and
+  /// install a second event subscription, leaving the abandoned host running.
+  int _initGeneration = 0;
+
   final _statusController = StreamController<P2pStatus>.broadcast();
   Stream<P2pStatus> get onStatusChanged => _statusController.stream;
 
@@ -407,15 +419,21 @@ class P2pService {
   }
 
   Future<void> _initialize({List<String>? relayUrls}) async {
-    // Resolving the relay list is a network call, so this await can be seconds
-    // long. `dispose()` can land inside it, and it cannot defend itself here:
-    // it closes the controllers after cancelling `_eventSubscription`, but that
-    // subscription does not exist yet, so there is nothing for it to cancel.
-    // Without the checks below, initialization would carry on after dispose,
-    // build a host, subscribe, and fire into closed controllers with
-    // "Bad state: Cannot add new events after calling close".
+    // Every await below can be raced by dispose() or reset(). Resolving the
+    // relay list is a network call, so this first one can be seconds long.
+    //
+    // dispose() cannot defend itself here: it cancels `_eventSubscription`
+    // before closing the controllers, but during this window that subscription
+    // does not exist yet, so there is nothing to cancel. Without these checks
+    // initialization carried on, built a host, subscribed, and fired into
+    // closed controllers with "Bad state: Cannot add new events after calling
+    // close". reset() is the same shape with a different ending: the stale
+    // attempt would install its host over the replacement's.
+    final generation = _initGeneration;
+    bool stale() => _disposed || generation != _initGeneration;
+
     final resolved = relayUrls ?? (await resolveRelayList()).urls;
-    if (_disposed) return;
+    if (stale()) return;
 
     _configuredRelayUrls = List.unmodifiable(resolved);
 
@@ -424,13 +442,20 @@ class P2pService {
           '[P2P] Initializing iroh-based P2P Host with relays: $resolved');
 
       final keypairBytes = await _loadOrCreateKeypairBytes();
-      if (_disposed) return;
+      if (stale()) return;
 
       // Initialize Host via FRB - returns (P2PHost, String)
       final (host, nodeId) = P2PHost.init(
         relayUrls: resolved,
         keypairBytes: keypairBytes,
       );
+
+      // P2PHost.init is synchronous, but the two awaits above mean this
+      // attempt may already have been superseded. Drop the host on the floor
+      // rather than publishing it: the Rust side is released when the Dart
+      // object is garbage collected, the same way dispose() releases it.
+      if (stale()) return;
+
       _host = host;
       _nodeId = nodeId;
 
@@ -499,8 +524,14 @@ class P2pService {
       _isInitialized = true;
       _emitStatus();
 
-      // Get initial node address (async FFI call, runs on worker thread)
-      _nodeAddr = await _host!.getNodeAddr();
+      // Get initial node address (async FFI call, runs on worker thread).
+      // Read through the local `host`, not `_host!`: a reset() during this
+      // await nulls the field, and the bang would then throw rather than
+      // letting the stale check below do its job.
+      final nodeAddr = await host.getNodeAddr();
+      if (stale()) return;
+
+      _nodeAddr = nodeAddr;
       debugPrint('[P2P] Initial node addr: $_nodeAddr');
     } catch (e) {
       debugPrint('[P2P] Failed to initialize: $e');
@@ -823,6 +854,9 @@ class P2pService {
   /// and attach an error handler to the cancellation itself so a rejected
   /// Future cannot surface as an unhandled async error.
   void reset() {
+    // Abandon any in-flight _initialize before tearing state down, so it
+    // cannot publish its host over the one the next initialize() builds.
+    _initGeneration++;
     _autoReconnectTimer?.cancel();
     _autoReconnectAttempts = 0;
     _lastDialedEndpointAddr = null;
@@ -887,6 +921,7 @@ class P2pService {
 
   Future<void> dispose() async {
     _disposed = true;
+    _initGeneration++;
     _autoReconnectTimer?.cancel();
     // Cancel before closing the controllers below: the Rust host is only
     // dropped when it is garbage collected, not synchronously here, so a

--- a/player/lib/core/p2p/p2p_service.dart
+++ b/player/lib/core/p2p/p2p_service.dart
@@ -7,13 +7,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:player/core/p2p/p2p_keystore.dart';
 import 'package:player/native/lib.dart';
 
-/// Default iroh relay URL (our own relay).
-/// Can be overridden at build time via dart-define IROH_RELAY_URL.
-const _defaultRelayUrl = 'https://cae1-1.relay.mydia.dev';
-const _customIrohRelayUrl = String.fromEnvironment('IROH_RELAY_URL');
+import 'relay_list.dart';
 
-/// Display placeholder for when using the default relay
-const defaultRelayUrl = _defaultRelayUrl;
+/// The iroh relay compiled into this build.
+///
+/// Re-exported from `relay_list.dart`, which owns the constant now, so callers
+/// that already import it from here keep working.
+const defaultRelayUrl = defaultIrohRelayUrl;
 
 /// Provider for the P2pService
 final p2pServiceProvider = Provider<P2pService>((ref) {
@@ -64,8 +64,11 @@ class P2pStatusNotifier extends Notifier<P2pStatus> {
       // Reset old host (allows re-initialization)
       p2pService.reset();
 
-      // Reinitialize with new relay URL
-      await p2pService.initialize(relayUrl: relayUrl);
+      // Reinitialize with new relay URL. A null relayUrl means "go back to
+      // resolving the list normally" rather than "use this one relay".
+      await p2pService.initialize(
+        relayUrls: relayUrl == null ? null : [relayUrl],
+      );
 
       if (!ref.mounted) return;
 
@@ -303,15 +306,26 @@ class P2pService {
     };
   }
 
-  /// The custom relay URL passed during initialization (null if using iroh defaults)
-  String? _customRelayUrl;
+  /// The relay URLs this host was configured with, in preference order. Empty
+  /// before initialization.
+  List<String> _configuredRelayUrls = const [];
+
+  /// Set the configured relays without initializing a host. Tests only.
+  @visibleForTesting
+  void debugSetConfiguredRelays(List<String> urls) {
+    _configuredRelayUrls = List.unmodifiable(urls);
+  }
 
   /// Get the active relay URL (null before initialization)
   String? get activeRelayUrl => _getEffectiveRelayUrl();
 
-  /// Get the effective relay URL from cached event data (no FFI call)
+  /// Get the effective relay URL from cached event data (no FFI call).
+  ///
+  /// The relay the node actually landed on, which only the `ready:` event
+  /// knows, falling back to the first relay it was configured with.
   String? _getEffectiveRelayUrl() {
-    return _cachedRelayUrl ?? _customRelayUrl;
+    if (_cachedRelayUrl != null) return _cachedRelayUrl;
+    return _configuredRelayUrls.isEmpty ? null : _configuredRelayUrls.first;
   }
 
   /// Extract the relay URL from a nodeAddr JSON string.
@@ -338,14 +352,16 @@ class P2pService {
 
   /// Initialize the P2P host.
   ///
-  /// [relayUrl] - Optional custom iroh relay URL. If not provided, uses
-  /// the build-time IROH_RELAY_URL or falls back to [_defaultRelayUrl].
+  /// [relayUrls] - Optional explicit relay list, which skips resolution
+  /// entirely. When omitted the list comes from [resolveRelayList]: a build
+  /// time or user override, else the metadata relay's `/client-config`, else
+  /// the last cached fetch, else the compiled-in default.
   ///
   /// Concurrent callers join the attempt already in flight instead of each
   /// building a host of their own. That guard is needed because reading the
   /// keypair is asynchronous, so the `_isInitialized` check and the assignment
   /// that satisfies it no longer happen in one synchronous run.
-  Future<void> initialize({String? relayUrl}) async {
+  Future<void> initialize({List<String>? relayUrls}) async {
     if (_isInitialized) return;
 
     final inFlight = _initializeFuture;
@@ -354,7 +370,7 @@ class P2pService {
       return;
     }
 
-    final attempt = _initialize(relayUrl: relayUrl);
+    final attempt = _initialize(relayUrls: relayUrls);
     _initializeFuture = attempt;
     try {
       await attempt;
@@ -386,23 +402,19 @@ class P2pService {
     return secret;
   }
 
-  Future<void> _initialize({String? relayUrl}) async {
-    // Use provided URL, or custom from env, or our default relay
-    final effectiveRelayUrl = relayUrl ??
-        (_customIrohRelayUrl.isNotEmpty
-            ? _customIrohRelayUrl
-            : _defaultRelayUrl);
-    _customRelayUrl = effectiveRelayUrl;
+  Future<void> _initialize({List<String>? relayUrls}) async {
+    final resolved = relayUrls ?? (await resolveRelayList()).urls;
+    _configuredRelayUrls = List.unmodifiable(resolved);
 
     try {
       debugPrint(
-          '[P2P] Initializing iroh-based P2P Host with relay: $effectiveRelayUrl');
+          '[P2P] Initializing iroh-based P2P Host with relays: $resolved');
 
       final keypairBytes = await _loadOrCreateKeypairBytes();
 
       // Initialize Host via FRB - returns (P2PHost, String)
       final (host, nodeId) = P2PHost.init(
-        relayUrls: [effectiveRelayUrl],
+        relayUrls: resolved,
         keypairBytes: keypairBytes,
       );
       _host = host;
@@ -809,7 +821,7 @@ class P2pService {
     _isRelayConnected = false;
     _nodeAddr = null;
     _nodeId = null;
-    _customRelayUrl = null;
+    _configuredRelayUrls = const [];
     _currentConnectionType = P2pConnectionType.none;
     _cachedRelayUrl = null;
     _connectedPeers.clear();

--- a/player/lib/core/p2p/p2p_service.dart
+++ b/player/lib/core/p2p/p2p_service.dart
@@ -226,6 +226,10 @@ class P2pService {
   StreamSubscription<FlutterInboundControlRequest>? _controlSubscription;
 
   // Stream of P2P status updates
+  /// Set by [dispose]. Checked after every await in [_initialize], which can
+  /// otherwise finish building a host for a service that is already gone.
+  bool _disposed = false;
+
   final _statusController = StreamController<P2pStatus>.broadcast();
   Stream<P2pStatus> get onStatusChanged => _statusController.stream;
 
@@ -403,7 +407,16 @@ class P2pService {
   }
 
   Future<void> _initialize({List<String>? relayUrls}) async {
+    // Resolving the relay list is a network call, so this await can be seconds
+    // long. `dispose()` can land inside it, and it cannot defend itself here:
+    // it closes the controllers after cancelling `_eventSubscription`, but that
+    // subscription does not exist yet, so there is nothing for it to cancel.
+    // Without the checks below, initialization would carry on after dispose,
+    // build a host, subscribe, and fire into closed controllers with
+    // "Bad state: Cannot add new events after calling close".
     final resolved = relayUrls ?? (await resolveRelayList()).urls;
+    if (_disposed) return;
+
     _configuredRelayUrls = List.unmodifiable(resolved);
 
     try {
@@ -411,6 +424,7 @@ class P2pService {
           '[P2P] Initializing iroh-based P2P Host with relays: $resolved');
 
       final keypairBytes = await _loadOrCreateKeypairBytes();
+      if (_disposed) return;
 
       // Initialize Host via FRB - returns (P2PHost, String)
       final (host, nodeId) = P2PHost.init(
@@ -436,7 +450,9 @@ class P2pService {
           _currentConnectionType = _parseConnectionType(connectionType);
           _autoReconnectAttempts = 0;
           _autoReconnectTimer?.cancel();
-          _peerConnectedController.add(peerId);
+          if (!_peerConnectedController.isClosed) {
+            _peerConnectedController.add(peerId);
+          }
           _emitStatus();
         } else if (event.startsWith('connection_type_changed:')) {
           final parts =
@@ -476,6 +492,7 @@ class P2pService {
       _controlSubscription = _host!.remoteControlStream().listen((request) {
         debugPrint(
             '[P2P] Control request: ${request.requestId} from ${request.peer}');
+        if (_controlRequestController.isClosed) return;
         _controlRequestController.add(request);
       });
 
@@ -492,6 +509,10 @@ class P2pService {
   }
 
   void _emitStatus() {
+    // Defence in depth alongside the `_disposed` checks in `_initialize`. The
+    // Rust host is dropped on garbage collection rather than synchronously, so
+    // an event can still arrive from a host whose service is already gone.
+    if (_statusController.isClosed) return;
     _statusController.add(status);
   }
 
@@ -865,6 +886,7 @@ class P2pService {
   }
 
   Future<void> dispose() async {
+    _disposed = true;
     _autoReconnectTimer?.cancel();
     // Cancel before closing the controllers below: the Rust host is only
     // dropped when it is garbage collected, not synchronously here, so a

--- a/player/lib/core/p2p/p2p_service.dart
+++ b/player/lib/core/p2p/p2p_service.dart
@@ -402,7 +402,7 @@ class P2pService {
 
       // Initialize Host via FRB - returns (P2PHost, String)
       final (host, nodeId) = P2PHost.init(
-        relayUrl: effectiveRelayUrl,
+        relayUrls: [effectiveRelayUrl],
         keypairBytes: keypairBytes,
       );
       _host = host;

--- a/player/lib/core/p2p/relay_list.dart
+++ b/player/lib/core/p2p/relay_list.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:http/http.dart' as http;
+
+import '../auth/auth_storage.dart';
+import '../relay/relay_api_client.dart' show metadataRelayBaseUrl;
+
+/// The iroh relay compiled into this build, used when nothing else is
+/// available. Overridable at build time with `--dart-define IROH_RELAY_URL`.
+const String defaultIrohRelayUrl = 'https://cae1-1.relay.mydia.dev';
+
+/// The build-time iroh relay override. Empty when not supplied.
+const String buildTimeIrohRelayUrl = String.fromEnvironment('IROH_RELAY_URL');
+
+/// Where the last successful fetch is cached.
+///
+/// AuthStorage rather than a file so the web build works unchanged: a browser
+/// has no filesystem, and AuthStorage already abstracts that split.
+///
+/// Not to be confused with `_ConnectionStorageKeys.relayUrl` in
+/// `core/connection/connection_provider.dart`, which records the relay a
+/// paired server was reachable through. That key is a different thing and is
+/// left alone.
+const String relayListStorageKey = 'p2p_relays';
+
+const Duration _timeout = Duration(seconds: 3);
+const String _path = '/client-config';
+
+/// Which precedence level produced a relay list.
+enum RelayListSource { override, fetched, cached, defaultBuiltIn }
+
+/// A resolved relay list and where it came from.
+class RelayListResult {
+  const RelayListResult(this.urls, this.source);
+
+  final List<String> urls;
+  final RelayListSource source;
+}
+
+/// Resolves which iroh relays this player should use.
+///
+/// Precedence, highest first: an explicit override (used alone, no request is
+/// made), a successful fetch of the metadata relay's `/client-config`, the last
+/// successful fetch from storage, then the compiled-in default.
+///
+/// iroh's own public relays are appended underneath whatever this returns, by
+/// `build_relay_mode` in `native/mydia_p2p_core/src/lib.rs`.
+///
+/// `lib/mydia/p2p/relay_list.ex` is the Elixir twin of this function and
+/// implements the same four levels and the same validation.
+Future<RelayListResult> resolveRelayList({
+  String? override,
+  String baseUrl = metadataRelayBaseUrl,
+  http.Client? client,
+  AuthStorage? storage,
+}) async {
+  final effectiveOverride = _validUrls([
+    if (override != null)
+      override
+    else if (buildTimeIrohRelayUrl.isNotEmpty)
+      buildTimeIrohRelayUrl,
+  ]);
+
+  if (effectiveOverride.isNotEmpty) {
+    return RelayListResult(effectiveOverride, RelayListSource.override);
+  }
+
+  final store = storage ?? getAuthStorage();
+  final fetched = await _fetch(baseUrl, client);
+
+  if (fetched.isNotEmpty) {
+    await _writeCache(store, fetched);
+    return RelayListResult(fetched, RelayListSource.fetched);
+  }
+
+  final cached = await _readCache(store);
+  if (cached.isNotEmpty) {
+    return RelayListResult(cached, RelayListSource.cached);
+  }
+
+  return const RelayListResult(
+    [defaultIrohRelayUrl],
+    RelayListSource.defaultBuiltIn,
+  );
+}
+
+Future<List<String>> _fetch(String baseUrl, http.Client? client) async {
+  final own = client == null;
+  final httpClient = client ?? http.Client();
+
+  try {
+    final response = await httpClient.get(Uri.parse('$baseUrl$_path'),
+        headers: {'accept': 'application/json'}).timeout(_timeout);
+
+    if (response.statusCode != 200) {
+      debugPrint(
+          '[P2P] Relay list fetch returned ${response.statusCode}, falling back');
+      return const [];
+    }
+
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map<String, dynamic>) return const [];
+
+    // Unknown keys are ignored on purpose: the document is meant to grow
+    // without a client change.
+    final p2p = decoded['p2p'];
+    if (p2p is! Map<String, dynamic>) return const [];
+
+    final relays = p2p['relays'];
+    if (relays is! List) return const [];
+
+    return _validUrls(relays);
+  } catch (e) {
+    debugPrint('[P2P] Relay list fetch failed: $e, falling back');
+    return const [];
+  } finally {
+    if (own) httpClient.close();
+  }
+}
+
+List<String> _validUrls(List<dynamic> urls) {
+  return urls
+      .whereType<String>()
+      .where((url) {
+        final parsed = Uri.tryParse(url.trim());
+        return parsed != null &&
+            parsed.scheme == 'https' &&
+            parsed.host.isNotEmpty;
+      })
+      .map((url) => url.trim())
+      .toList();
+}
+
+Future<List<String>> _readCache(AuthStorage storage) async {
+  try {
+    final raw = await storage.read(relayListStorageKey);
+    if (raw == null) return const [];
+
+    final decoded = jsonDecode(raw);
+    if (decoded is! List) return const [];
+
+    return _validUrls(decoded);
+  } catch (e) {
+    debugPrint('[P2P] Could not read the cached relay list: $e');
+    return const [];
+  }
+}
+
+Future<void> _writeCache(AuthStorage storage, List<String> urls) async {
+  try {
+    await storage.write(relayListStorageKey, jsonEncode(urls));
+  } catch (e) {
+    // A cache we cannot write costs us the next offline start, nothing more.
+    debugPrint('[P2P] Could not cache the relay list: $e');
+  }
+}

--- a/player/lib/core/relay/relay_api_client.dart
+++ b/player/lib/core/relay/relay_api_client.dart
@@ -8,7 +8,11 @@ import 'pairing_key_handle.dart';
 export 'claim_resolve_result.dart'
     show ServerNotOnlineException, TamperedClaimException;
 
-const _defaultRelayUrl = String.fromEnvironment(
+/// The metadata relay this build talks to for pairing and client config.
+///
+/// Distinct from the *iroh* relay in `core/p2p/relay_list.dart`: this one is
+/// mydia's HTTP service, that one is the QUIC relay for NAT traversal.
+const String metadataRelayBaseUrl = String.fromEnvironment(
   'RELAY_URL',
   defaultValue: 'https://relay.mydia.dev',
 );
@@ -19,7 +23,7 @@ class RelayApiClient {
   final PairingKeyFactory _pairingKeys;
 
   RelayApiClient({
-    this.baseUrl = _defaultRelayUrl,
+    this.baseUrl = metadataRelayBaseUrl,
     http.Client? client,
     PairingKeyFactory? pairingKeys,
   })  : _client = client ?? http.Client(),

--- a/player/lib/native/frb_generated.dart
+++ b/player/lib/native/frb_generated.dart
@@ -93,7 +93,7 @@ abstract class RustLibApi extends BaseApi {
   Future<String> crateP2PHostGetNodeAddr({required P2PHost that});
 
   (P2PHost, String) crateP2PHostInit(
-      {String? relayUrl, Uint8List? keypairBytes});
+      {required List<String> relayUrls, Uint8List? keypairBytes});
 
   Stream<FlutterInboundControlRequest> crateP2PHostRemoteControlStream(
       {required P2PHost that});
@@ -261,11 +261,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @override
   (P2PHost, String) crateP2PHostInit(
-      {String? relayUrl, Uint8List? keypairBytes}) {
+      {required List<String> relayUrls, Uint8List? keypairBytes}) {
     return handler.executeSync(SyncTask(
       callFfi: () {
         final serializer = SseSerializer(generalizedFrbRustBinding);
-        sse_encode_opt_String(relayUrl, serializer);
+        sse_encode_list_String(relayUrls, serializer);
         sse_encode_opt_list_prim_u_8_strict(keypairBytes, serializer);
         return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 5)!;
       },
@@ -275,14 +275,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         decodeErrorData: null,
       ),
       constMeta: kCrateP2PHostInitConstMeta,
-      argValues: [relayUrl, keypairBytes],
+      argValues: [relayUrls, keypairBytes],
       apiImpl: this,
     ));
   }
 
   TaskConstMeta get kCrateP2PHostInitConstMeta => const TaskConstMeta(
         debugName: "P2PHost_init",
-        argNames: ["relayUrl", "keypairBytes"],
+        argNames: ["relayUrls", "keypairBytes"],
       );
 
   @override

--- a/player/lib/native/lib.dart
+++ b/player/lib/native/lib.dart
@@ -31,7 +31,8 @@ abstract class P2PHost implements RustOpaqueInterface {
   /// Get this node's EndpointAddr as JSON for sharing.
   Future<String> getNodeAddr();
 
-  /// Initialize a new P2P host with optional custom relay URL.
+  /// Initialize a new P2P host with custom relay URLs, in preference
+  /// order. An empty list uses iroh's default relays.
   ///
   /// `keypair_bytes` is the node's raw 32-byte Ed25519 secret. A browser has
   /// no filesystem, so it reads the secret out of IndexedDB and hands it in
@@ -39,9 +40,10 @@ abstract class P2PHost implements RustOpaqueInterface {
   /// where it was already decided. A slice of the wrong length is dropped
   /// rather than trusted, which costs a fresh identity but never a
   /// malformed one.
-  static (P2PHost, String) init({String? relayUrl, Uint8List? keypairBytes}) =>
+  static (P2PHost, String) init(
+          {required List<String> relayUrls, Uint8List? keypairBytes}) =>
       RustLib.instance.api
-          .crateP2PHostInit(relayUrl: relayUrl, keypairBytes: keypairBytes);
+          .crateP2PHostInit(relayUrls: relayUrls, keypairBytes: keypairBytes);
 
   /// Stream inbound control requests to Flutter.
   ///

--- a/player/rust/mydia_player_p2p/src/frb_generated.rs
+++ b/player/rust/mydia_player_p2p/src/frb_generated.rs
@@ -293,12 +293,12 @@ fn wire__crate__P2PHost_init_impl(
             };
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_relay_url = <Option<String>>::sse_decode(&mut deserializer);
+            let api_relay_urls = <Vec<String>>::sse_decode(&mut deserializer);
             let api_keypair_bytes = <Option<Vec<u8>>>::sse_decode(&mut deserializer);
             deserializer.end();
             transform_result_sse::<_, ()>((move || {
                 let output_ok =
-                    Ok::<_, ()>(crate::P2pHost::init(api_relay_url, api_keypair_bytes))?;
+                    Ok::<_, ()>(crate::P2pHost::init(api_relay_urls, api_keypair_bytes))?;
                 std::result::Result::Ok(output_ok)
             })())
         },

--- a/player/rust/mydia_player_p2p/src/lib.rs
+++ b/player/rust/mydia_player_p2p/src/lib.rs
@@ -631,7 +631,8 @@ async fn run_event_dispatcher(
 }
 
 impl P2pHost {
-    /// Initialize a new P2P host with optional custom relay URL.
+    /// Initialize a new P2P host with custom relay URLs, in preference
+    /// order. An empty list uses iroh's default relays.
     ///
     /// `keypair_bytes` is the node's raw 32-byte Ed25519 secret. A browser has
     /// no filesystem, so it reads the secret out of IndexedDB and hands it in
@@ -640,10 +641,10 @@ impl P2pHost {
     /// rather than trusted, which costs a fresh identity but never a
     /// malformed one.
     #[frb(sync)]
-    pub fn init(relay_url: Option<String>, keypair_bytes: Option<Vec<u8>>) -> (Self, String) {
+    pub fn init(relay_urls: Vec<String>, keypair_bytes: Option<Vec<u8>>) -> (Self, String) {
         let keypair_supplied = keypair_bytes.is_some();
         log::info!(
-            "P2pHost::init() called with relay_url: {relay_url:?}, keypair_supplied: {keypair_supplied}"
+            "P2pHost::init() called with relay_urls: {relay_urls:?}, keypair_supplied: {keypair_supplied}"
         );
         let keypair_bytes = keypair_bytes.and_then(|bytes| {
             let len = bytes.len();
@@ -656,7 +657,7 @@ impl P2pHost {
                 .ok()
         });
         let config = HostConfig {
-            relay_url,
+            relay_urls,
             bind_port: None,
             keypair_path: None,
             keypair_bytes,

--- a/player/test/core/p2p/p2p_service_relay_test.dart
+++ b/player/test/core/p2p/p2p_service_relay_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/p2p/p2p_service.dart';
+import 'package:player/core/p2p/relay_list.dart';
+
+void main() {
+  test('the compiled-in default is the relay this build ships with', () {
+    // p2p_service.dart used to own this constant. relay_list.dart owns it now,
+    // and p2p_service re-exports it so existing importers keep working.
+    expect(defaultRelayUrl, defaultIrohRelayUrl);
+    expect(defaultRelayUrl, 'https://cae1-1.relay.mydia.dev');
+  });
+
+  test('an uninitialized service reports no active relay', () {
+    final service = P2pService();
+    expect(service.activeRelayUrl, isNull);
+    expect(service.status.relayUrl, isNull);
+  });
+
+  test('the configured list is reported before the ready event arrives', () {
+    final service = P2pService();
+    service.debugSetConfiguredRelays(const [
+      'https://relay-one.example.test',
+      'https://relay-two.example.test',
+    ]);
+
+    // activeRelayUrl prefers the relay the node actually landed on, which only
+    // the ready: event knows. Until then, the first configured relay is the
+    // honest answer.
+    expect(service.activeRelayUrl, 'https://relay-one.example.test');
+  });
+}

--- a/player/test/core/p2p/p2p_service_relay_test.dart
+++ b/player/test/core/p2p/p2p_service_relay_test.dart
@@ -28,4 +28,24 @@ void main() {
     // honest answer.
     expect(service.activeRelayUrl, 'https://relay-one.example.test');
   });
+
+  test('reset clears the configured relays so a stale list cannot linger', () {
+    final service = P2pService();
+    service.debugSetConfiguredRelays(const ['https://relay-one.example.test']);
+    expect(service.activeRelayUrl, 'https://relay-one.example.test');
+
+    service.reset();
+
+    // reinitializeWithRelayUrl is reset() followed by initialize(). If reset
+    // left the old list in place, the window between the two would report the
+    // relay the user just replaced.
+    //
+    // This covers reset's own teardown only. The related race, where an
+    // initialize() still awaiting resolveRelayList() publishes its host over
+    // the replacement's, is guarded by _initGeneration but is not reachable
+    // from here: driving _initialize past that await needs P2PHost.init and so
+    // the native bridge, which the unit suite does not load. The Player E2E
+    // suite is what exercises it.
+    expect(service.activeRelayUrl, isNull);
+  });
 }

--- a/player/test/core/p2p/relay_list_test.dart
+++ b/player/test/core/p2p/relay_list_test.dart
@@ -1,0 +1,213 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:player/core/auth/auth_storage.dart';
+import 'package:player/core/p2p/relay_list.dart';
+
+/// An in-memory AuthStorage so the resolver's cache can be asserted without a
+/// platform channel.
+class _MemoryStorage implements AuthStorage {
+  final Map<String, String> values = {};
+
+  @override
+  bool get degraded => false;
+
+  @override
+  Future<String?> read(String key) async => values[key];
+
+  @override
+  Future<void> write(String key, String value) async => values[key] = value;
+
+  @override
+  Future<void> delete(String key) async => values.remove(key);
+
+  @override
+  Future<void> deleteAll() async => values.clear();
+}
+
+const _fetched = 'https://relay-one.example.test';
+const _other = 'https://relay-two.example.test';
+
+http.Client _responds(int status, String body) =>
+    MockClient((_) async => http.Response(body, status));
+
+http.Client _fails() =>
+    MockClient((_) async => throw http.ClientException('refused'));
+
+http.Client _neverCalled() =>
+    MockClient((_) async => fail('no request should have been made'));
+
+void main() {
+  group('override', () {
+    test('wins outright and makes no request', () async {
+      final result = await resolveRelayList(
+        override: _other,
+        client: _neverCalled(),
+        storage: _MemoryStorage(),
+      );
+
+      expect(result.urls, [_other]);
+      expect(result.source, RelayListSource.override);
+    });
+
+    test('a blank override is treated as unset', () async {
+      final result = await resolveRelayList(
+        override: '   ',
+        client: _responds(
+            200,
+            jsonEncode({
+              'p2p': {
+                'relays': [_fetched]
+              }
+            })),
+        storage: _MemoryStorage(),
+      );
+
+      expect(result.urls, [_fetched]);
+      expect(result.source, RelayListSource.fetched);
+    });
+
+    test('a non-https override falls through', () async {
+      final result = await resolveRelayList(
+        override: 'ftp://nope.example.test',
+        client: _responds(
+            200,
+            jsonEncode({
+              'p2p': {
+                'relays': [_fetched]
+              }
+            })),
+        storage: _MemoryStorage(),
+      );
+
+      expect(result.source, RelayListSource.fetched);
+    });
+  });
+
+  group('fetch', () {
+    test('uses the fetched list and caches it', () async {
+      final storage = _MemoryStorage();
+
+      final result = await resolveRelayList(
+        client: _responds(
+            200,
+            jsonEncode({
+              'p2p': {
+                'relays': [_fetched, _other]
+              }
+            })),
+        storage: storage,
+      );
+
+      expect(result.urls, [_fetched, _other]);
+      expect(result.source, RelayListSource.fetched);
+      expect(
+          jsonDecode(storage.values[relayListStorageKey]!), [_fetched, _other]);
+    });
+
+    test('drops entries that are not https URLs', () async {
+      final result = await resolveRelayList(
+        client: _responds(
+            200,
+            jsonEncode({
+              'p2p': {
+                'relays': ['http://insecure.test', 'not a url', _fetched]
+              }
+            })),
+        storage: _MemoryStorage(),
+      );
+
+      expect(result.urls, [_fetched]);
+    });
+
+    test('ignores unknown keys', () async {
+      final result = await resolveRelayList(
+        client: _responds(
+            200,
+            jsonEncode({
+              'future': {'thing': 1},
+              'p2p': {
+                'relays': [_fetched],
+                'extra': 2
+              }
+            })),
+        storage: _MemoryStorage(),
+      );
+
+      expect(result.urls, [_fetched]);
+      expect(result.source, RelayListSource.fetched);
+    });
+  });
+
+  group('fallback', () {
+    Future<RelayListResult> withCache(http.Client client) {
+      final storage = _MemoryStorage();
+      storage.values[relayListStorageKey] = jsonEncode([_other]);
+      return resolveRelayList(client: client, storage: storage);
+    }
+
+    test('a 500 falls back to the cache', () async {
+      final result = await withCache(_responds(500, 'nope'));
+      expect(result.urls, [_other]);
+      expect(result.source, RelayListSource.cached);
+    });
+
+    test('a transport failure falls back to the cache', () async {
+      final result = await withCache(_fails());
+      expect(result.urls, [_other]);
+      expect(result.source, RelayListSource.cached);
+    });
+
+    test('malformed JSON falls back to the cache', () async {
+      final result = await withCache(_responds(200, '{{{'));
+      expect(result.urls, [_other]);
+      expect(result.source, RelayListSource.cached);
+    });
+
+    test('an empty list after filtering falls back to the cache', () async {
+      final result = await withCache(_responds(
+          200,
+          jsonEncode({
+            'p2p': {
+              'relays': ['http://insecure.test']
+            }
+          })));
+      expect(result.urls, [_other]);
+      expect(result.source, RelayListSource.cached);
+    });
+
+    test('no cache falls back to the compiled-in default', () async {
+      final result = await resolveRelayList(
+        client: _responds(500, 'nope'),
+        storage: _MemoryStorage(),
+      );
+
+      expect(result.urls, [defaultIrohRelayUrl]);
+      expect(result.source, RelayListSource.defaultBuiltIn);
+    });
+
+    test('an unreadable cache falls back to the compiled-in default', () async {
+      final storage = _MemoryStorage();
+      storage.values[relayListStorageKey] = '{{{ not json';
+
+      final result = await resolveRelayList(
+        client: _responds(500, 'nope'),
+        storage: storage,
+      );
+
+      expect(result.urls, [defaultIrohRelayUrl]);
+      expect(result.source, RelayListSource.defaultBuiltIn);
+    });
+
+    test('a failed fetch does not overwrite a good cache', () async {
+      final storage = _MemoryStorage();
+      storage.values[relayListStorageKey] = jsonEncode([_other]);
+
+      await resolveRelayList(client: _responds(500, 'nope'), storage: storage);
+
+      expect(jsonDecode(storage.values[relayListStorageKey]!), [_other]);
+    });
+  });
+}

--- a/relay-worker/src/config/client_config.ts
+++ b/relay-worker/src/config/client_config.ts
@@ -1,0 +1,30 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+
+// The iroh relays mydia operates, in preference order. Source of truth,
+// alongside metadata-relay/lib/metadata_relay/client_config.ex, which carries
+// the same list and must change in the same commit. test/contract/routes.json
+// includes /client-config so the cutover gate diffs the two live services.
+//
+// Installs read this at boot to learn which relays to use, which is what lets
+// a relay be moved by deploying this Worker rather than shipping a new server
+// image and player build. Changing it is a relay-worker-v* tag.
+//
+// Clients append iroh's own public relays underneath these, so this list
+// carries only mydia's own.
+export const RELAY_URLS = ["https://cae1-1.relay.mydia.dev"] as const;
+
+// One hour at the edge, a day of serving stale while revalidating, a week of
+// serving stale if the origin is failing. A relay move is a planned change, so
+// an hour of staleness costs nothing, and every install calls this on every
+// boot, so the cache is worth having.
+const CACHE_CONTROL =
+  "public, s-maxage=3600, stale-while-revalidate=86400, stale-if-error=604800";
+
+export function registerClientConfigRoutes(app: Hono<{ Bindings: Env }>): void {
+  app.get("/client-config", (c) =>
+    c.json({ p2p: { relays: RELAY_URLS } }, 200, {
+      "cache-control": CACHE_CONTROL,
+    }),
+  );
+}

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -9,6 +9,7 @@ import { registerCrashRoutes } from "./crashes/ingest";
 import { registerErrorDashboard } from "./dashboards/errors";
 import { registerFeedbackRoutes } from "./feedback/ingest";
 import { registerFeedbackDashboard } from "./dashboards/feedback";
+import { registerClientConfigRoutes } from "./config/client_config";
 import { rateLimitMiddleware } from "./obs/ratelimit";
 import { logRequest } from "./obs/log";
 import { runScheduledSweep } from "./obs/sweep";
@@ -103,6 +104,7 @@ registerSubdlRoutes(app);
 registerPassthroughRoutes(app);
 registerPairingRoutes(app);
 registerCrashRoutes(app);
+registerClientConfigRoutes(app);
 // GET/POST /admin/errors and /admin/errors/:fingerprint -- the maintainer
 // dashboard replacing error_tracker's LiveView UI. Deliberately under
 // /admin/* (not the bare /errors a naive port would use) so one Cloudflare

--- a/relay-worker/src/obs/ratelimit.ts
+++ b/relay-worker/src/obs/ratelimit.ts
@@ -3,8 +3,11 @@ import type { Env } from "../env";
 
 // Paths that are never throttled here. /health and /stats are polled by
 // deployed monitoring, and throttling those would turn a busy relay into an
-// apparently dead one.
-const EXEMPT = new Set(["/health", "/stats"]);
+// apparently dead one. /client-config is called once per install per boot,
+// costs no upstream quota, and throttling it would silently push installs
+// onto their cached or compiled-in relay list, which is the exact failure
+// this endpoint exists to avoid.
+const EXEMPT = new Set(["/health", "/stats", "/client-config"]);
 
 // Prefixes that carry their own, tighter limiter and must not also be charged
 // against the 300/min proxy budget. Pairing uses 10/min create and 30/min

--- a/relay-worker/test/config/client_config.test.ts
+++ b/relay-worker/test/config/client_config.test.ts
@@ -1,0 +1,37 @@
+import { SELF } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+import { RELAY_URLS } from "../../src/config/client_config";
+
+describe("GET /client-config", () => {
+  it("returns the p2p relay list", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/client-config");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+
+    const body = await res.json<{ p2p: { relays: string[] } }>();
+    expect(body.p2p.relays).toEqual([...RELAY_URLS]);
+  });
+
+  it("is edge cacheable, unlike the Elixir relay it replaces", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/client-config");
+    const cc = res.headers.get("cache-control") ?? "";
+    expect(cc).toContain("public");
+    expect(cc).toContain("s-maxage=3600");
+    expect(cc).toContain("stale-while-revalidate=86400");
+    expect(cc).toContain("stale-if-error=604800");
+  });
+
+  it("ships the same list the Elixir relay does", () => {
+    // Kept in step by hand with metadata-relay/lib/metadata_relay/client_config.ex.
+    // test/contract/routes.json diffs the two live services as well.
+    expect(RELAY_URLS).toContain("https://cae1-1.relay.mydia.dev");
+  });
+
+  it("only lists https URLs with a host", () => {
+    for (const url of RELAY_URLS) {
+      const parsed = new URL(url);
+      expect(parsed.protocol).toBe("https:");
+      expect(parsed.hostname).not.toBe("");
+    }
+  });
+});

--- a/relay-worker/test/contract/routes.json
+++ b/relay-worker/test/contract/routes.json
@@ -1,5 +1,6 @@
 [
   { "method": "GET", "path": "/health" },
+  { "method": "GET", "path": "/client-config" },
   { "method": "GET", "path": "/configuration" },
   { "method": "GET", "path": "/tmdb/genre/movie" },
   { "method": "GET", "path": "/tmdb/genre/tv" },

--- a/test/mydia/p2p/relay_list_test.exs
+++ b/test/mydia/p2p/relay_list_test.exs
@@ -1,0 +1,138 @@
+defmodule Mydia.P2p.RelayListTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.P2p.RelayList
+
+  @default "https://cae1-1.relay.mydia.dev"
+  @fetched "https://relay-one.example.test"
+  @other "https://relay-two.example.test"
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "relay_list_test_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+    {:ok, cache_path: Path.join(dir, "relays.json")}
+  end
+
+  # Req accepts a plug as a 1-arity function, which is the cheapest way to
+  # stand in for the relay without a socket.
+  defp responds(status, body) do
+    fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(status, body)
+    end
+  end
+
+  defp raises do
+    fn _conn -> raise "connection refused" end
+  end
+
+  defp opts(cache_path, plug, extra \\ []) do
+    Keyword.merge(
+      [
+        cache_path: cache_path,
+        base_url: "https://relay.example.test",
+        req_options: [plug: plug, retry: false],
+        override: nil
+      ],
+      extra
+    )
+  end
+
+  describe "override" do
+    test "wins outright and makes no request", %{cache_path: cache_path} do
+      plug = fn _conn -> raise "the override must not fetch" end
+
+      assert {[@other], :override} =
+               RelayList.resolve(opts(cache_path, plug, override: @other))
+    end
+
+    test "a blank override is treated as unset", %{cache_path: cache_path} do
+      plug = responds(200, ~s({"p2p":{"relays":["#{@fetched}"]}}))
+
+      assert {[@fetched], :fetched} =
+               RelayList.resolve(opts(cache_path, plug, override: "   "))
+    end
+
+    test "a non-https override is rejected and falls through", %{cache_path: cache_path} do
+      plug = responds(200, ~s({"p2p":{"relays":["#{@fetched}"]}}))
+
+      assert {[@fetched], :fetched} =
+               RelayList.resolve(opts(cache_path, plug, override: "ftp://nope.example.test"))
+    end
+  end
+
+  describe "fetch" do
+    test "uses the fetched list and writes the cache", %{cache_path: cache_path} do
+      plug = responds(200, ~s({"p2p":{"relays":["#{@fetched}","#{@other}"]}}))
+
+      assert {[@fetched, @other], :fetched} = RelayList.resolve(opts(cache_path, plug))
+      assert Jason.decode!(File.read!(cache_path)) == [@fetched, @other]
+    end
+
+    test "drops entries that are not https URLs", %{cache_path: cache_path} do
+      plug =
+        responds(200, ~s({"p2p":{"relays":["http://insecure.test","not a url","#{@fetched}"]}}))
+
+      assert {[@fetched], :fetched} = RelayList.resolve(opts(cache_path, plug))
+    end
+
+    test "ignores unknown keys in the document", %{cache_path: cache_path} do
+      plug = responds(200, ~s({"future":{"thing":1},"p2p":{"relays":["#{@fetched}"],"extra":2}}))
+
+      assert {[@fetched], :fetched} = RelayList.resolve(opts(cache_path, plug))
+    end
+  end
+
+  describe "fallback" do
+    test "a 500 falls back to the cache", %{cache_path: cache_path} do
+      File.write!(cache_path, Jason.encode!([@other]))
+
+      assert {[@other], :cached} = RelayList.resolve(opts(cache_path, responds(500, "nope")))
+    end
+
+    test "a transport failure falls back to the cache", %{cache_path: cache_path} do
+      File.write!(cache_path, Jason.encode!([@other]))
+
+      assert {[@other], :cached} = RelayList.resolve(opts(cache_path, raises()))
+    end
+
+    test "malformed JSON falls back to the cache", %{cache_path: cache_path} do
+      File.write!(cache_path, Jason.encode!([@other]))
+
+      assert {[@other], :cached} = RelayList.resolve(opts(cache_path, responds(200, "{{{")))
+    end
+
+    test "an empty list after filtering falls back to the cache", %{cache_path: cache_path} do
+      File.write!(cache_path, Jason.encode!([@other]))
+      plug = responds(200, ~s({"p2p":{"relays":["http://insecure.test"]}}))
+
+      assert {[@other], :cached} = RelayList.resolve(opts(cache_path, plug))
+    end
+
+    test "no cache falls back to the compiled-in default", %{cache_path: cache_path} do
+      assert {[@default], :default} = RelayList.resolve(opts(cache_path, responds(500, "nope")))
+    end
+
+    test "an unreadable cache falls back to the compiled-in default", %{cache_path: cache_path} do
+      File.write!(cache_path, "{{{ not json")
+
+      assert {[@default], :default} = RelayList.resolve(opts(cache_path, responds(500, "nope")))
+    end
+
+    test "a failed fetch does not overwrite a good cache", %{cache_path: cache_path} do
+      File.write!(cache_path, Jason.encode!([@other]))
+
+      RelayList.resolve(opts(cache_path, responds(500, "nope")))
+
+      assert Jason.decode!(File.read!(cache_path)) == [@other]
+    end
+  end
+
+  describe "default_relay_url/0" do
+    test "is the relay compiled into this build" do
+      assert RelayList.default_relay_url() == @default
+    end
+  end
+end

--- a/test/mydia/p2p/server_boot_test.exs
+++ b/test/mydia/p2p/server_boot_test.exs
@@ -1,0 +1,32 @@
+defmodule Mydia.P2p.ServerBootTest do
+  @moduledoc """
+  Covers the relay-list wiring and the non-blocking boot shape without
+  starting a real iroh endpoint. The NIF is exercised by the integration
+  suites; what matters here is that the GenServer no longer blocks its
+  supervisor on a network call.
+  """
+  # async: false because the second test mutates application env, which is
+  # global and would race any other async test reading it. The on_exit restore
+  # is what keeps this file from leaving the env changed behind it.
+  use ExUnit.Case, async: false
+
+  alias Mydia.P2p.Server
+
+  test "init returns a continue instead of starting the host inline" do
+    # If init/1 still started the host, this call would load the NIF and dial a
+    # relay. The continue tuple is the proof that it does not.
+    assert {:ok, state, {:continue, :start_host}} = Server.init([])
+    assert state.resource == nil
+    assert state.node_id == nil
+  end
+
+  test "init still fails loudly when the keypair path is unconfigured" do
+    original = Application.get_env(:mydia, :p2p_keypair_path)
+    Application.delete_env(:mydia, :p2p_keypair_path)
+    on_exit(fn -> Application.put_env(:mydia, :p2p_keypair_path, original) end)
+
+    assert_raise RuntimeError, ~r/keypair path not configured/i, fn ->
+      Server.init([])
+    end
+  end
+end


### PR DESCRIPTION
## Why

The iroh relay hostname is compiled into every server image and player build (`lib/mydia/p2p/server.ex`, `player/lib/core/p2p/p2p_service.dart`). Moving or replacing the relay therefore means shipping new clients and waiting for every install to upgrade, which is weeks at best and never for installs that do not update.

This makes both sides read the relay list from the metadata relay at boot, so a relay move becomes a relay deploy.

Relevant context: the iroh relay is being moved from `can-1` to `basestar`, and that host is an Oracle free-tier instance that Oracle can reclaim. Until now, losing it meant every install fell back to n0's public relays with no way to point them anywhere else without a release.

## What

A `GET /client-config` document on the metadata relay:

```json
{ "p2p": { "relays": ["https://cae1-1.relay.mydia.dev"] } }
```

Both the server and the player resolve their relay list through four precedence levels:

1. An explicit override (`IROH_RELAY_URL`, the dart-define, or the player's user-set relay). Used alone, and the fetch is skipped entirely.
2. `p2p.relays` from a successful fetch.
3. The last successful fetch, from local storage.
4. The compiled-in `https://cae1-1.relay.mydia.dev`.

n0's three public relays are still appended underneath by the Rust core, so losing a mydia relay stays a degradation rather than an outage.

The fetch goes to the *configured* metadata relay, not a hardcoded `relay.mydia.dev`, so a self-hoster running their own relay serves their own list and no install gains a network dependency it did not already have.

## Shape of the change

- `metadata-relay/` and `relay-worker/` both gain the endpoint. The Elixir one serves `relay.mydia.dev` today; the Worker copy is what survives the Cloudflare cutover. `test/contract/routes.json` includes the route so the cutover gate diffs the two.
- `HostConfig.relay_url: Option<String>` becomes `relay_urls: Vec<String>`, rippling through the Rustler NIF, the flutter_rust_bridge crate, and regenerated bridge output. An empty list means what `None` meant: use iroh's preset. An all-unparseable list falls back to the preset rather than building an empty `RelayMode::Custom`, which `Endpoint` rejects.
- `Mydia.P2p.RelayList` and `player/lib/core/p2p/relay_list.dart` are parallel implementations of the same four levels. Deliberately not shared: different runtimes, and putting an HTTP client in the core would drag it into the wasm build too.
- `Mydia.P2p.Server` starts its host in `handle_continue/2` instead of `init/1`, so a 3 second fetch cannot block the supervision tree during application boot. A `{:continue, _}` runs before any other mailbox message, so no `state.resource` call site needs a nil guard.

## Notes for review

Two things worth a closer look:

- **The two resolvers can drift.** Nothing enforces that the Elixir and Dart implementations agree; it holds by inspection. The final review caught exactly this class of bug: `receive_timeout` bounds only the gap between chunks (Finch's `request_timeout` defaults to `:infinity`), so a relay trickling bytes could have hung `handle_continue` forever and left p2p silently dead. The Dart side was already correct. Fixed in 95bb9da05.
- **`relay-worker`'s `/client-config` sets no CORS headers**, unlike the Elixir relay's global Corsica plug. This only bites a browser-based player after the Cloudflare cutover, and mirrors an existing gap on the Worker's other routes, so it is left as a follow-up rather than fixed here.

## Compatibility

No deploy ordering required. An install running old code ignores the endpoint; an install running new code against a relay that does not serve it yet gets a 404 and falls through to its compiled-in default. Self-hosters need do nothing.

## Testing

- Root Elixir: 13 doctests + 10,868 tests, 0 failures, credo strict and format clean (run at 8e66d10c; the one later commit adds a Req option and deletes a test assertion). `test/mydia/p2p/` re-run green at HEAD.
- metadata-relay: 312 tests, 0 failures.
- relay-worker: 303 passed, contract project skipped by design (needs `CONTRACT_WORKER_URL`).
- Rust: `cargo test` green in `mydia_p2p_core`, including four new tests covering relay-map construction, dropped unparseable entries, and the empty-map fallback.
- Player: 3,273 passed / 7 skipped; `flutter analyze` 0 errors, 0 warnings.
- Generated-code freshness gate passing.

Both resolvers are covered by parallel suites exercising every precedence level: override skips the fetch (proved with a client that fails the test if called), non-200, transport failure, malformed JSON, empty-after-filtering, cache preserved on failure, and blank env var read as unset.

## Not in scope

Region-aware relay selection, reconfiguring a running host, dropping n0's relays, and any kill switch. A relay change reaches an install on its next restart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added centralized client configuration for discovering multiple secure P2P relay servers.
  - P2P connections now support ordered relay lists, with cached and built-in fallback settings.
  - Added cache-friendly relay configuration endpoints for clients and relay workers.

- **Bug Fixes**
  - Invalid, unavailable, or malformed relay configuration now falls back to usable settings.
  - Improved P2P service startup and shutdown handling.

- **Tests**
  - Added coverage for relay discovery, caching, validation, fallback behavior, and server startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->