### PR TITLE
relay-worker: add the /admin maintainer overview

### DIFF
--- a/relay-worker/README.md
+++ b/relay-worker/README.md
@@ -230,15 +230,31 @@ fails parsing a semver out of the wrong tag name.
 
 ### Dashboards
 
-`GET /admin/errors` and `GET /admin/feedback` are maintainer dashboards,
-replacing the Elixir's ErrorTracker page and `FeedbackLive.Index`. Both live
-under a shared `/admin/*` prefix **on purpose**: it lets one Cloudflare
-Access application, scoped to `/admin*`, cover every maintainer-only route by
-construction, so adding a third dashboard later inherits the gate instead of
-needing its own conscious Access decision. Neither dashboard shares a path
-with a public endpoint — the public ingest routes (`POST /feedback`,
-`POST /crashes/report`) stay exactly where every mydia install already calls
-them.
+`GET /admin`, `GET /admin/errors` and `GET /admin/feedback` are maintainer
+dashboards, replacing the Elixir's ErrorTracker page and `FeedbackLive.Index`.
+All three live under a shared `/admin/*` prefix **on purpose**: it lets one
+Cloudflare Access application, scoped to `/admin*`, cover every
+maintainer-only route by construction, so adding a fourth dashboard later
+inherits the gate instead of needing its own conscious Access decision.
+Neither `/admin/errors` nor `/admin/feedback` shares a path with a public
+endpoint — the public ingest routes (`POST /feedback`, `POST /crashes/report`)
+stay exactly where every mydia install already calls them.
+
+`GET /admin` is the overview: crash volume and distinct crash sources over a
+selectable window, unresolved and throttled group counts, unread feedback,
+live pairing claims, a version breakdown, the top unresolved errors, D1 table
+row counts, and when the hourly sweep last ran. Every number comes from D1
+tables that already exist, in one `DB.batch()`. Proxy request volume and cache
+hit rate are deliberately absent: nothing counts them anywhere durable, and
+adding them needs an Analytics Engine binding plus an account API token.
+
+Two numbers on it mean something narrower than they look, and the page says so
+on the page rather than in this file. "Crash sources" counts distinct
+`occurrences.instance_key` values, and that column holds `cf-connecting-ip`, so
+it undercounts installs behind one NAT and overcounts one install on a changing
+address. Crash totals carry a `throttled` badge whenever any unresolved group
+has `errors.count_is_floor` set, because ingest stops writing occurrence rows
+once an hour's budget saturates.
 
 **Cloudflare Access guards `/admin/*`, not code.** The Worker holds no
 dashboard credentials at all — no `DASHBOARD_USERNAME`/`DASHBOARD_PASSWORD`
@@ -266,6 +282,13 @@ production's workers.dev host and every preview URL keep 404ing.
 measurement and Step 4a's staging contract diff both need that hostname
 serving the public routes.
 
+The deny covers the bare `/admin` as well as the subpaths. Hono's `/admin/*`
+wildcard matches a path with no trailing segment (measured against 4.13.7, and
+pinned by `test/dashboards/hostname.test.ts`), so the overview needs no
+separate registration. Cloudflare Access's application scope is `/admin*`
+rather than `/admin/*`, so it covers the bare path too, with no configuration
+change at cutover.
+
 That deny is not authentication and must not be mistaken for it -- it removes
 unprotected hostnames from reach, it does not decide who may look. Access
 still decides that, and skipping Step 1 still leaves the dashboards open on
@@ -283,7 +306,8 @@ relay-worker/
 │   ├── pairing/            # remote-access pairing claims
 │   ├── crashes/            # crash report ingest
 │   ├── feedback/           # feedback ingest (public POST) + email notification
-│   ├── dashboards/         # errors + feedback maintainer dashboards, under /admin/*
+│   ├── dashboards/         # overview + errors + feedback maintainer dashboards, under /admin/*
+│   ├── stats/              # the overview's D1 aggregates, one batch per page load
 │   ├── archive/             # SubDL zip extraction with size caps
 │   └── obs/                # rate limiting, request logging, scheduled sweep
 ├── migrations/              # D1 migrations, applied by wrangler + vitest-pool-workers
@@ -421,9 +445,10 @@ having deployed anything broken (the failure is expected and safe).
 
 ### Step 1: Cloudflare Access — hard ordering constraint
 
-**The dashboards are currently unauthenticated.** `GET /admin/errors` and
-`GET /admin/feedback` expose crash reports and user-submitted feedback,
-including instance identifiers. **Nothing may be routed to a public hostname
+**The dashboards are currently unauthenticated.** `GET /admin`,
+`GET /admin/errors` and `GET /admin/feedback` expose crash reports,
+user-submitted feedback, and the aggregate stats built from both, including
+instance identifiers. **Nothing may be routed to a public hostname
 before the Access application below exists.** This is not a recommendation to
 configure Access soon after cutover — it is a precondition of cutover.
 (Today this Worker has no production route, so the constraint is not yet
@@ -451,7 +476,7 @@ the moment Access was configured.
 `/admin/errors` and `/admin/feedback` — entirely separate paths from any
 public endpoint. `POST /feedback` and `POST /crashes/report` did **not**
 move; they are wire contracts every deployed mydia instance already calls.
-One Access application scoped to `/admin*` now cleanly covers both
+One Access application scoped to `/admin*` now cleanly covers all three
 dashboards, present and future, with no per-route decision and no path
 collision with anything public.
 
@@ -459,7 +484,7 @@ collision with anything public.
 
 1. Create one self-hosted Access application:
    - Application domain: `relay.mydia.dev`
-   - Path: `/admin*` (covers `/admin/errors`, `/admin/errors/:fingerprint`,
+   - Path: `/admin*` (covers `/admin`, `/admin/errors`, `/admin/errors/:fingerprint`,
      `/admin/errors/:fingerprint/resolve`, `/admin/errors/:fingerprint/unresolve`,
      `/admin/feedback`, `/admin/feedback/:id/state`, and
      `/admin/feedback/:id/github` — every maintainer-only route in the
@@ -475,11 +500,11 @@ scoping this runbook depends on against a deploy that serves no real traffic,
 and it is the cheapest place to find out if that scoping does not behave as
 described here.
 
-Verify it there too, before touching production: run the same four curls below
+Verify it there too, before touching production: run the same five curls below
 against `mydia-relay-staging.arsfeld.workers.dev` instead of `relay.mydia.dev`.
-The expected answers are identical, and a 404 rather than a 302 on the two
-`/admin` routes is the signal that path-scoped Access is not covering that
-hostname at all, which is worth learning on staging.
+The expected answers are identical, and a 404 rather than a 302 on any of the
+three `/admin` routes is the signal that path-scoped Access is not covering
+that hostname at all, which is worth learning on staging.
 
 Note that staging's `/admin/*` becomes reachable as soon as
 `ADMIN_ACCESS_HOSTNAME` names its hostname, whether or not the Access
@@ -494,6 +519,10 @@ and the two are configured independently.
 **Verify both halves after configuring Access:**
 
 ```bash
+# GET /admin: must require login
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/admin
+# expect: 302 (redirect to the Access login)
+
 # GET /admin/errors: must require login
 curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/admin/errors
 # expect: 302 (redirect to the Access login)
@@ -516,7 +545,7 @@ curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/feedback
 # expect: 404
 ```
 
-If either `/admin/*` curl ever comes back 200 instead of 302, or the `POST
+If any `/admin` curl ever comes back 200 instead of 302, or the `POST
 /feedback` curl comes back anything but 201, stop and re-check the Access
 application's path scope before proceeding with cutover.
 
@@ -604,12 +633,12 @@ today, on purpose. Add it by hand, deliberately, following this sequence.
   `placeholder_local_dev_only`), the four secrets are set, CI has deployed at
   least once to the Worker's `*.workers.dev` subdomain, and the Step 3 CPU
   measurement has a recorded number.
-- **The `/admin*` Access application from Step 1 exists and both its
+- **The `/admin*` Access application from Step 1 exists and all three of its
   verification curls pass.** This is the ordering constraint that matters
   most in this whole runbook: neither a Worker route nor a Cloudflare Access
   application can be scoped by HTTP method, only by path. A bare
   `relay.mydia.dev/*` route (added below in 4b) exposes every path the
-  Worker answers, `/admin/errors` and `/admin/feedback` included, to
+  Worker answers, `/admin`, `/admin/errors` and `/admin/feedback` included, to
   anonymous traffic the instant it deploys — regardless of what Access
   policy exists for any other path. Do not add the wildcard route on the
   assumption Access can follow "right after." If Step 1 isn't done, stop and
@@ -725,6 +754,10 @@ curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://relay.mydia.dev/crashe
   -d '{"error_type":"RuntimeError","error_message":"cutover smoke test","version":"0.0.0"}'
 # expect 201, NOT 202: CrashReporter.Sender matches only 201 as success and
 # retries/logs-failed on anything else.
+
+curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/admin
+# expect 302 (Access login redirect) -- confirms the overview is not
+# reachable without logging in either.
 
 curl -sS -o /dev/null -w '%{http_code}\n' https://relay.mydia.dev/admin/errors
 # expect 302 (Access login redirect) -- confirms the smoke-test crash landed

--- a/relay-worker/migrations/0004_admin_overview.sql
+++ b/relay-worker/migrations/0004_admin_overview.sql
@@ -1,0 +1,43 @@
+-- Backs GET /admin, the maintainer overview. Its windowed aggregates filter
+-- on occurred_at alone, and the only pre-existing index on this table is
+-- (fingerprint, occurred_at DESC), whose leading column those queries never
+-- constrain. Without this index every window query full-scans occurrences and
+-- reads every column of every row, which is the unit D1 actually bills.
+--
+-- instance_key and version trail the sort column so the three heaviest
+-- queries (crash count, distinct sources, version breakdown) are satisfied
+-- from the index alone and never touch the table. test/stats/schema.test.ts
+-- pins that with EXPLAIN QUERY PLAN rather than trusting it: drop either
+-- trailing column and those assertions fail.
+--
+-- The top-errors query joins on fingerprint and is still served by the
+-- existing occurrences_fingerprint_time_idx, so it needs nothing here.
+CREATE INDEX occurrences_occurred_at_idx
+  ON occurrences (occurred_at DESC, instance_key, version);
+
+-- One row per scheduled sweep (src/obs/sweep.ts, wrangler.jsonc's hourly Cron
+-- Trigger). Before this, a sweep left no trace anywhere durable, so "is the
+-- cron actually running" had no answer short of reading Workers Logs.
+--
+-- `id` is a plain rowid alias rather than `ran_at` as the primary key on
+-- purpose: a manually triggered sweep landing in the same second as the cron
+-- would collide on a ran_at key and lose one of the two runs.
+--
+-- THIS TABLE EVICTS ITSELF. Three tables in this Worker shipped with no
+-- eviction path and had to be retrofitted (feedback_rate_limits,
+-- ingest_buckets, pairing_claims); a fourth will not repeat it. The same
+-- sweep that inserts a row deletes rows older than
+-- SWEEP_RUN_RETENTION_SECONDS in the same .batch(), holding this at roughly
+-- 168 rows.
+CREATE TABLE sweep_runs (
+  id INTEGER PRIMARY KEY,
+  ran_at INTEGER NOT NULL,
+  feedback_rate_limits_deleted INTEGER NOT NULL,
+  ingest_buckets_deleted INTEGER NOT NULL,
+  pairing_claims_deleted INTEGER NOT NULL,
+  duration_ms INTEGER NOT NULL
+);
+
+-- Serves both readers: the overview's "latest run" (ORDER BY ran_at DESC
+-- LIMIT 1) and the sweep's own retention delete (WHERE ran_at < ?).
+CREATE INDEX sweep_runs_ran_at_idx ON sweep_runs (ran_at DESC);

--- a/relay-worker/src/dashboards/errors.tsx
+++ b/relay-worker/src/dashboards/errors.tsx
@@ -3,7 +3,7 @@ import type { Env } from "../env";
 import type { ErrorRow, OccurrenceRow } from "../crashes/ingest";
 import { listErrors, getError, setErrorStatus } from "../crashes/queries";
 import { page, when, parsePage } from "./layout";
-import { Tabs, DataTable, Badge, PostButton, Pager } from "./ui";
+import { Tabs, DataTable, Badge, PostButton, Pager, FLOOR_TITLE } from "./ui";
 
 const PAGE_SIZE = 50;
 
@@ -19,11 +19,6 @@ function isValidFingerprintShape(value: string): boolean {
 function formatInteger(n: number): string {
   return Math.trunc(n).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
-
-const FLOOR_TITLE =
-  "The ingest throttle saturated at least one hourly bucket for this error at " +
-  "some point. Crashes beyond the per-hour cap were accepted but not counted, " +
-  "so this total is a permanent floor, not an exact count.";
 
 // The single place a raw occurrence_count is turned into markup. When
 // errors.count_is_floor is set (ingest.ts sets it the moment any of this

--- a/relay-worker/src/dashboards/layout.tsx
+++ b/relay-worker/src/dashboards/layout.tsx
@@ -89,6 +89,7 @@ export function Layout({ title, children }: { title: string; children?: Child })
       </head>
       <body>
         <nav class="chrome-nav">
+          <a href="/admin">Overview</a>
           <a href="/admin/errors">Errors</a>
           <a href="/admin/feedback">Feedback</a>
         </nav>

--- a/relay-worker/src/dashboards/overview.tsx
+++ b/relay-worker/src/dashboards/overview.tsx
@@ -1,0 +1,174 @@
+import type { Hono } from "hono";
+import type { Env } from "../env";
+import {
+  loadOverviewStats,
+  parseWindow,
+  WINDOWS,
+  type OverviewStats,
+  type WindowKey,
+} from "../stats/queries";
+import { page, when } from "./layout";
+import { Tabs, DataTable, Badge, StatGrid, StatCard, FLOOR_TITLE } from "./ui";
+
+// occurrences.instance_key holds cf-connecting-ip, falling back to the crash
+// report's version string and then to the literal "unknown" (see
+// crashes/ingest.ts). It was chosen as a rate-limiting key and carries no
+// identity, so this number is emphatically not an install count. Only the
+// count renders; the addresses themselves stay in D1.
+const SOURCES_HINT =
+  "IP-derived, so this undercounts installs behind one NAT and overcounts " +
+  "one install on a changing address.";
+
+// Every count on this page goes through here. loadOverviewStats already
+// coerces a missing aggregate to 0, so this is the second line of defence:
+// one unreadable value blanks one card instead of rendering NaN across the
+// page.
+function count(value: number | null | undefined): string {
+  return typeof value === "number" && Number.isFinite(value)
+    ? String(value)
+    : "—";
+}
+
+const WINDOW_LABELS: Record<WindowKey, string> = {
+  "24h": "24h",
+  "7d": "7d",
+  "30d": "30d",
+};
+
+const VERSION_HEADERS = ["Version", "Occurrences", "Sources"];
+const TOP_ERROR_HEADERS = ["Error", "In window", "Last seen"];
+const TABLE_HEADERS = ["Table", "Rows"];
+
+function windowTabs(active: WindowKey) {
+  return (
+    <Tabs
+      links={(Object.keys(WINDOWS) as WindowKey[]).map((key) => ({
+        href: `/admin?window=${key}`,
+        label: WINDOW_LABELS[key],
+        active: key === active,
+      }))}
+    />
+  );
+}
+
+function LastSweep({ stats }: { stats: OverviewStats }) {
+  if (!stats.lastSweep) {
+    return (
+      <p class="muted">
+        Last sweep: never. The hourly Cron Trigger has not run since this table
+        was added.
+      </p>
+    );
+  }
+
+  const run = stats.lastSweep;
+  return (
+    <p class="muted">
+      Last sweep: {when(run.ran_at)} UTC, {count(run.duration_ms)}ms, deleting{" "}
+      {count(run.feedback_rate_limits_deleted)} rate-limit,{" "}
+      {count(run.ingest_buckets_deleted)} ingest-bucket and{" "}
+      {count(run.pairing_claims_deleted)} pairing rows.
+    </p>
+  );
+}
+
+function OverviewPage({ stats }: { stats: OverviewStats }) {
+  const unread = stats.feedbackByState.unread ?? 0;
+  const feedbackTypes = Object.entries(stats.feedbackByType)
+    .map(([type, n]) => `${type} ${n}`)
+    .join(", ");
+
+  return (
+    <>
+      {windowTabs(stats.window)}
+
+      <StatGrid>
+        <StatCard
+          label="Crashes"
+          value={count(stats.crashes)}
+          badge={
+            stats.throttledGroups > 0 ? (
+              <Badge label="throttled" title={FLOOR_TITLE} />
+            ) : undefined
+          }
+          hint={
+            stats.throttledGroups > 0
+              ? `${stats.throttledGroups} unresolved group(s) hit the hourly ingest cap, so this is a floor.`
+              : undefined
+          }
+        />
+        <StatCard
+          label="Crash sources"
+          value={count(stats.crashSources)}
+          hint={SOURCES_HINT}
+        />
+        <StatCard label="Unresolved groups" value={count(stats.unresolvedGroups)} />
+        <StatCard
+          label="Unread feedback"
+          value={count(unread)}
+          hint={feedbackTypes === "" ? undefined : `In window: ${feedbackTypes}`}
+        />
+        <StatCard
+          label="Live pairing claims"
+          value={count(stats.livePairingClaims)}
+        />
+      </StatGrid>
+
+      <h2>Top unresolved errors</h2>
+      <DataTable headers={TOP_ERROR_HEADERS}>
+        {stats.topErrors.map((error) => (
+          <tr>
+            <td class="wrap">
+              <a href={`/admin/errors/${error.fingerprint}`}>{error.kind}</a>{" "}
+              {error.message}
+              {error.count_is_floor === 1 && (
+                <Badge label="throttled" title={FLOOR_TITLE} />
+              )}
+            </td>
+            <td class="num">{count(error.recent)}</td>
+            <td class="muted num">{when(error.last_seen_at)}</td>
+          </tr>
+        ))}
+      </DataTable>
+
+      <h2>Versions</h2>
+      <DataTable headers={VERSION_HEADERS}>
+        {stats.versions.map((row) => (
+          <tr>
+            <td>{row.version}</td>
+            <td class="num">{count(row.occurrences)}</td>
+            <td class="num">{count(row.sources)}</td>
+          </tr>
+        ))}
+      </DataTable>
+
+      <h2>Service health</h2>
+      <DataTable headers={TABLE_HEADERS}>
+        {Object.entries(stats.tableCounts).map(([table, n]) => (
+          <tr>
+            <td>{table}</td>
+            <td class="num">{count(n)}</td>
+          </tr>
+        ))}
+      </DataTable>
+      <LastSweep stats={stats} />
+    </>
+  );
+}
+
+// GET /admin, the maintainer overview. It is the landing page for the other
+// two dashboards, which is why it sits at the bare prefix rather than at
+// /admin/stats: typing /admin used to reach the JSON 404 catch-all.
+//
+// The /admin/* hostname guard in src/index.ts covers this path. That was
+// measured against Hono 4.13.7 rather than assumed, and
+// test/dashboards/hostname.test.ts pins it, because a router change that
+// stopped matching the bare path would start serving this page on
+// production's workers.dev host and on every versioned preview URL.
+export function registerOverviewDashboard(app: Hono<{ Bindings: Env }>): void {
+  app.get("/admin", async (c) => {
+    const window = parseWindow(c.req.query("window"));
+    const stats = await loadOverviewStats(c.env, window);
+    return c.html(page("Overview", <OverviewPage stats={stats} />));
+  });
+}

--- a/relay-worker/src/dashboards/styles.ts
+++ b/relay-worker/src/dashboards/styles.ts
@@ -124,4 +124,22 @@ input[type="text"] {
 input[type="text"]:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
 .pager { margin-top: 1.25rem; }
+
+/* The overview's headline row. auto-fit rather than a fixed column count so
+   the same markup works from a phone to a wide desktop with no breakpoints. */
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.75rem;
+}
+.stat-card {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 0.85rem 1rem;
+}
+.stat-label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--muted); }
+.stat-value { font-size: 1.5rem; font-variant-numeric: tabular-nums; margin-top: 0.2rem; }
+.stat-hint  { font-size: 0.75rem; color: var(--muted); margin-top: 0.35rem; }
 `;

--- a/relay-worker/src/dashboards/ui.tsx
+++ b/relay-worker/src/dashboards/ui.tsx
@@ -59,6 +59,16 @@ export function Badge({ label, title }: { label: string; title: string }) {
   );
 }
 
+// The single explanation of what a "throttled" badge means, shared by the
+// errors dashboard (where it hangs off one error's total) and the overview
+// (where it hangs off the aggregate crash count). One constant rather than a
+// copy in each, so the two can never drift into describing the same
+// mechanism differently.
+export const FLOOR_TITLE =
+  "The ingest throttle saturated at least one hourly bucket at some point. " +
+  "Crashes beyond the per-hour cap were accepted but not counted, so this " +
+  "total is a permanent floor, not an exact count.";
+
 // A single-button POST form. Used for resolve/unresolve on the errors
 // dashboard and mark-read/archive on the feedback one. Kept as a real form
 // rather than a fetch() so the dashboards keep working with JS disabled,
@@ -90,5 +100,44 @@ export function Pager({ href }: { href: string | null }) {
     <p class="pager">
       <a href={href}>Next</a>
     </p>
+  );
+}
+
+// The overview's headline row. Purely a layout container: it applies no
+// meaning to its children and does not decide how many fit, which is
+// grid-template-columns' job in styles.ts.
+export function StatGrid({ children }: { children?: Child }) {
+  return <div class="stat-grid">{children}</div>;
+}
+
+// One number with its label. `value` arrives pre-formatted, so this component
+// never has to decide what an unreadable count should look like -- see
+// overview.tsx's count().
+//
+// `hint` renders as visible text rather than a title attribute. The two hints
+// this page actually uses both correct an assumption the number invites (that
+// "crash sources" means installs, that a crash total is exact), and a tooltip
+// on a div is neither keyboard-reachable nor visible to the reader who most
+// needs it.
+export function StatCard({
+  label,
+  value,
+  hint,
+  badge,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  badge?: Child;
+}) {
+  return (
+    <div class="stat-card">
+      <div class="stat-label">{label}</div>
+      <div class="stat-value">
+        {value}
+        {badge}
+      </div>
+      {hint && <div class="stat-hint">{hint}</div>}
+    </div>
   );
 }

--- a/relay-worker/src/index.ts
+++ b/relay-worker/src/index.ts
@@ -7,6 +7,7 @@ import { registerPassthroughRoutes } from "./proxy/passthrough";
 import { registerPairingRoutes } from "./pairing/routes";
 import { registerCrashRoutes } from "./crashes/ingest";
 import { registerErrorDashboard } from "./dashboards/errors";
+import { registerOverviewDashboard } from "./dashboards/overview";
 import { registerFeedbackRoutes } from "./feedback/ingest";
 import { registerFeedbackDashboard } from "./dashboards/feedback";
 import { adminHostnameBlocked } from "./dashboards/hostname-guard";
@@ -96,6 +97,11 @@ app.get("/stats", (c) =>
 // Registered before the dashboards it guards, since app.use() only wraps
 // routes registered after it (same composition rule as the two middlewares
 // above).
+//
+// The wildcard also guards the bare /admin route registered below, not just
+// the /admin/* subpaths: Hono's `/admin/*` was measured against 4.13.7 and
+// does match `/admin` itself, so the overview page is covered here too, with
+// no separate registration.
 app.use("/admin/*", async (c, next) => {
   const hostname = new URL(c.req.url).hostname;
   if (adminHostnameBlocked(hostname, c.env.ADMIN_ACCESS_HOSTNAME)) {
@@ -122,6 +128,12 @@ registerCrashRoutes(app);
 // still a manual step; until it exists, this route has no auth at all on any
 // hostname Access does not cover -- which is why the workers.dev deny above
 // exists, and why it is not a substitute for doing Step 1.
+// GET /admin -- the maintainer overview, and the landing page the other two
+// dashboards link back to. It is under the same /admin/* middleware above:
+// Hono's wildcard was measured against 4.13.7 and does match the bare path,
+// so this inherits the workers.dev deny with no separate registration, and
+// Cloudflare Access's own /admin* scope already covers it too.
+registerOverviewDashboard(app);
 registerErrorDashboard(app);
 // POST /feedback is the public ingest endpoint every mydia install calls --
 // a wire contract that must never move. registerFeedbackDashboard below

--- a/relay-worker/src/obs/sweep.ts
+++ b/relay-worker/src/obs/sweep.ts
@@ -51,18 +51,66 @@ export async function sweepStaleIngestBuckets(env: Env): Promise<number> {
   return result.meta.changes;
 }
 
+// Seven days of hourly runs, so this table holds roughly 168 rows. The sweep
+// that writes a row deletes the expired ones in the same batch, which is what
+// keeps this from becoming the fourth table here to need an eviction path
+// added after the fact.
+export const SWEEP_RUN_RETENTION_SECONDS = 604_800;
+
+// Bookkeeping, wrapped so it cannot fail the sweep. Before this the hourly
+// Cron Trigger left no durable trace at all, so "is the cron actually
+// running" had no answer short of reading Workers Logs.
+async function recordSweepRun(
+  env: Env,
+  ranAt: number,
+  deleted: { rateLimits: number; ingestBuckets: number; pairingClaims: number },
+  durationMs: number,
+): Promise<void> {
+  try {
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO sweep_runs (ran_at, feedback_rate_limits_deleted,
+                                 ingest_buckets_deleted, pairing_claims_deleted, duration_ms)
+         VALUES (?, ?, ?, ?, ?)`,
+      ).bind(
+        ranAt,
+        deleted.rateLimits,
+        deleted.ingestBuckets,
+        deleted.pairingClaims,
+        durationMs,
+      ),
+      env.DB.prepare("DELETE FROM sweep_runs WHERE ran_at < ?").bind(
+        ranAt - SWEEP_RUN_RETENTION_SECONDS,
+      ),
+    ]);
+  } catch (error) {
+    // Deliberately swallowed. A rethrow here would mark a Cron Trigger
+    // invocation failed even though all three sweeps completed, and
+    // Cloudflare reports that as a broken schedule.
+    console.log(
+      JSON.stringify({ event: "sweep_run_record_failed", message: String(error) }),
+    );
+  }
+}
+
 // Runs all three sweeps under one Cron Trigger. pairing/store.ts's
 // purgeExpiredClaims was written when pairing landed and then never wired to
 // anything -- the identical defect (a table with no eviction path) in a
-// different table, closed here in the same commit rather than left to be
-// rediscovered a third time.
-// readClaim already refuses an expired row on read, so this, like the
-// feedback sweep above, is housekeeping (bounding table growth), not a
-// correctness fix.
+// different table, closed here rather than left to be rediscovered a third
+// time. readClaim already refuses an expired row on read, so that one, like
+// the feedback sweep, is housekeeping and not a correctness fix.
 export async function runScheduledSweep(env: Env): Promise<void> {
-  await Promise.all([
+  const startedAt = Date.now();
+  const [rateLimits, ingestBuckets, pairingClaims] = await Promise.all([
     sweepStaleFeedbackRateLimits(env),
     sweepStaleIngestBuckets(env),
     purgeExpiredClaims(env),
   ]);
+
+  await recordSweepRun(
+    env,
+    Math.floor(startedAt / 1000),
+    { rateLimits, ingestBuckets, pairingClaims },
+    Date.now() - startedAt,
+  );
 }

--- a/relay-worker/src/pairing/store.ts
+++ b/relay-worker/src/pairing/store.ts
@@ -33,12 +33,13 @@ export async function deleteClaim(env: Env, key: string): Promise<void> {
   await env.DB.prepare("DELETE FROM pairing_claims WHERE key = ?").bind(key).run();
 }
 
-// Not wired to a scheduled trigger yet -- no cron handler exists in this
-// Worker as of this task. Kept as the obvious hook for one later, exactly as
-// the module-level comment above says: housekeeping, not correctness, since
-// readClaim already refuses an expired row on its own.
-export async function purgeExpiredClaims(env: Env): Promise<void> {
-  await env.DB.prepare("DELETE FROM pairing_claims WHERE expires_at <= ?")
+// Returns the delete count so runScheduledSweep (src/obs/sweep.ts) can record
+// it alongside the other two sweeps, exactly as the module-level comment
+// above says: housekeeping, not correctness, since readClaim already refuses
+// an expired row on its own.
+export async function purgeExpiredClaims(env: Env): Promise<number> {
+  const result = await env.DB.prepare("DELETE FROM pairing_claims WHERE expires_at <= ?")
     .bind(Math.floor(Date.now() / 1000))
     .run();
+  return result.meta.changes;
 }

--- a/relay-worker/src/stats/queries.ts
+++ b/relay-worker/src/stats/queries.ts
@@ -1,0 +1,30 @@
+// The three windows GET /admin offers. Values are seconds, subtracted from
+// the current unix second to produce the `since` bound every windowed query
+// binds. The key never reaches a query as text: it selects one of these
+// integers, which is why parseWindow below is about rendering a coherent page
+// and not about injection.
+export const WINDOWS = {
+  "24h": 86_400,
+  "7d": 604_800,
+  "30d": 2_592_000,
+} as const;
+
+export type WindowKey = keyof typeof WINDOWS;
+
+// Landing on the overview with no explicit window shows a week, which is wide
+// enough that a quiet relay still has something on the page and narrow enough
+// that a spike from three weeks ago does not read as current.
+export const DEFAULT_WINDOW: WindowKey = "7d";
+
+// Same shape of guard as layout.tsx's parsePage, for the same reason: this is
+// arbitrary caller-supplied text on a route whose page must render regardless.
+//
+// hasOwnProperty rather than `raw in WINDOWS`: the `in` operator walks the
+// prototype chain, so "toString" and "constructor" would both pass and return
+// a WindowKey that WINDOWS[key] cannot resolve to a number.
+export function parseWindow(raw: string | undefined): WindowKey {
+  if (raw !== undefined && Object.prototype.hasOwnProperty.call(WINDOWS, raw)) {
+    return raw as WindowKey;
+  }
+  return DEFAULT_WINDOW;
+}

--- a/relay-worker/src/stats/queries.ts
+++ b/relay-worker/src/stats/queries.ts
@@ -1,3 +1,5 @@
+import type { Env } from "../env";
+
 // The three windows GET /admin offers. Values are seconds, subtracted from
 // the current unix second to produce the `since` bound every windowed query
 // binds. The key never reaches a query as text: it selects one of these
@@ -27,4 +29,181 @@ export function parseWindow(raw: string | undefined): WindowKey {
     return raw as WindowKey;
   }
   return DEFAULT_WINDOW;
+}
+
+export interface VersionRow {
+  version: string;
+  occurrences: number;
+  sources: number;
+}
+
+export interface TopErrorRow {
+  fingerprint: string;
+  kind: string;
+  message: string;
+  count_is_floor: number;
+  last_seen_at: number;
+  recent: number;
+}
+
+export interface TableCounts {
+  errors: number;
+  occurrences: number;
+  feedback_submissions: number;
+  ingest_buckets: number;
+  feedback_rate_limits: number;
+  pairing_claims: number;
+}
+
+export interface SweepRunRow {
+  id: number;
+  ran_at: number;
+  feedback_rate_limits_deleted: number;
+  ingest_buckets_deleted: number;
+  pairing_claims_deleted: number;
+  duration_ms: number;
+}
+
+export interface OverviewStats {
+  window: WindowKey;
+  crashes: number;
+  crashSources: number;
+  unresolvedGroups: number;
+  throttledGroups: number;
+  feedbackByState: Record<string, number>;
+  feedbackByType: Record<string, number>;
+  versions: VersionRow[];
+  topErrors: TopErrorRow[];
+  livePairingClaims: number;
+  tableCounts: TableCounts;
+  lastSweep: SweepRunRow | null;
+}
+
+const VERSION_LIMIT = 10;
+const TOP_ERROR_LIMIT = 5;
+
+// The batch's statement order. Reading results back by index is fragile, so
+// these names are the single place the order is written down; every accessor
+// below indexes through one of them.
+const enum Q {
+  Crashes = 0,
+  CrashSources = 1,
+  UnresolvedGroups = 2,
+  ThrottledGroups = 3,
+  FeedbackByState = 4,
+  FeedbackByType = 5,
+  Versions = 6,
+  TopErrors = 7,
+  LivePairingClaims = 8,
+  TableCounts = 9,
+  LastSweep = 10,
+}
+
+function rows<T>(result: D1Result | undefined): T[] {
+  return (result?.results as T[] | undefined) ?? [];
+}
+
+// A count that cannot be read comes back 0 rather than undefined, so a single
+// missing aggregate cannot propagate NaN through the page. The dashboard has
+// its own placeholder for a value it genuinely cannot render; this keeps the
+// type honest before it ever gets there.
+function scalar(result: D1Result | undefined): number {
+  const value = rows<{ n: unknown }>(result)[0]?.n;
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function grouped(result: D1Result | undefined, key: string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of rows<Record<string, unknown>>(result)) {
+    const label = row[key];
+    const n = row.n;
+    if (typeof label === "string" && typeof n === "number") out[label] = n;
+  }
+  return out;
+}
+
+// Every aggregate on GET /admin, as ONE batch. Eleven sequential
+// prepare()/first() calls would be eleven round trips to build one page; D1's
+// batch runs them in a single transaction and one trip.
+export async function loadOverviewStats(
+  env: Env,
+  window: WindowKey,
+): Promise<OverviewStats> {
+  const now = Math.floor(Date.now() / 1000);
+  const since = now - WINDOWS[window];
+
+  const results = await env.DB.batch([
+    env.DB.prepare("SELECT COUNT(*) AS n FROM occurrences WHERE occurred_at >= ?").bind(since),
+    env.DB.prepare(
+      "SELECT COUNT(DISTINCT instance_key) AS n FROM occurrences WHERE occurred_at >= ?",
+    ).bind(since),
+    env.DB.prepare("SELECT COUNT(*) AS n FROM errors WHERE status = 'unresolved'"),
+    // Drives the "throttled" badge on the crash card. Reads count_is_floor,
+    // the sticky flag ingest sets and never clears, and NOT
+    // ingest_buckets.saturated, which resets on the next hour and would show
+    // a precise-looking number at exactly the moment after a storm when
+    // someone is most likely to be looking. See 0002_crash_reports.sql.
+    env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM errors WHERE status = 'unresolved' AND count_is_floor = 1",
+    ),
+    env.DB.prepare("SELECT state, COUNT(*) AS n FROM feedback_submissions GROUP BY state"),
+    env.DB.prepare(
+      "SELECT type, COUNT(*) AS n FROM feedback_submissions WHERE inserted_at >= ? GROUP BY type",
+    ).bind(since),
+    env.DB.prepare(
+      `SELECT COALESCE(version, 'unknown') AS version,
+              COUNT(*) AS occurrences,
+              COUNT(DISTINCT instance_key) AS sources
+       FROM occurrences WHERE occurred_at >= ?
+       GROUP BY 1 ORDER BY 2 DESC LIMIT ?`,
+    ).bind(since, VERSION_LIMIT),
+    env.DB.prepare(
+      `SELECT e.fingerprint, e.kind, e.message, e.count_is_floor, e.last_seen_at,
+              COUNT(o.id) AS recent
+       FROM errors e
+       JOIN occurrences o ON o.fingerprint = e.fingerprint AND o.occurred_at >= ?
+       WHERE e.status = 'unresolved'
+       GROUP BY e.fingerprint
+       ORDER BY recent DESC, e.last_seen_at DESC LIMIT ?`,
+    ).bind(since, TOP_ERROR_LIMIT),
+    env.DB.prepare("SELECT COUNT(*) AS n FROM pairing_claims WHERE expires_at > ?").bind(now),
+    // Six counts as one statement of scalar subqueries rather than six more
+    // entries in this batch. Nothing here is windowed: these are "how big is
+    // the database right now".
+    env.DB.prepare(
+      `SELECT (SELECT COUNT(*) FROM errors)               AS errors,
+              (SELECT COUNT(*) FROM occurrences)          AS occurrences,
+              (SELECT COUNT(*) FROM feedback_submissions) AS feedback_submissions,
+              (SELECT COUNT(*) FROM ingest_buckets)       AS ingest_buckets,
+              (SELECT COUNT(*) FROM feedback_rate_limits) AS feedback_rate_limits,
+              (SELECT COUNT(*) FROM pairing_claims)       AS pairing_claims`,
+    ),
+    env.DB.prepare("SELECT * FROM sweep_runs ORDER BY ran_at DESC LIMIT 1"),
+  ]);
+
+  const counts = rows<Partial<TableCounts>>(results[Q.TableCounts])[0] ?? {};
+  const zeroed = (value: number | undefined): number =>
+    typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+  return {
+    window,
+    crashes: scalar(results[Q.Crashes]),
+    crashSources: scalar(results[Q.CrashSources]),
+    unresolvedGroups: scalar(results[Q.UnresolvedGroups]),
+    throttledGroups: scalar(results[Q.ThrottledGroups]),
+    feedbackByState: grouped(results[Q.FeedbackByState], "state"),
+    feedbackByType: grouped(results[Q.FeedbackByType], "type"),
+    versions: rows<VersionRow>(results[Q.Versions]),
+    topErrors: rows<TopErrorRow>(results[Q.TopErrors]),
+    livePairingClaims: scalar(results[Q.LivePairingClaims]),
+    tableCounts: {
+      errors: zeroed(counts.errors),
+      occurrences: zeroed(counts.occurrences),
+      feedback_submissions: zeroed(counts.feedback_submissions),
+      ingest_buckets: zeroed(counts.ingest_buckets),
+      feedback_rate_limits: zeroed(counts.feedback_rate_limits),
+      pairing_claims: zeroed(counts.pairing_claims),
+    },
+    lastSweep: rows<SweepRunRow>(results[Q.LastSweep])[0] ?? null,
+  };
 }

--- a/relay-worker/src/stats/queries.ts
+++ b/relay-worker/src/stats/queries.ts
@@ -53,6 +53,7 @@ export interface TableCounts {
   ingest_buckets: number;
   feedback_rate_limits: number;
   pairing_claims: number;
+  sweep_runs: number;
 }
 
 export interface SweepRunRow {
@@ -167,16 +168,23 @@ export async function loadOverviewStats(
        ORDER BY recent DESC, e.last_seen_at DESC LIMIT ?`,
     ).bind(since, TOP_ERROR_LIMIT),
     env.DB.prepare("SELECT COUNT(*) AS n FROM pairing_claims WHERE expires_at > ?").bind(now),
-    // Six counts as one statement of scalar subqueries rather than six more
-    // entries in this batch. Nothing here is windowed: these are "how big is
-    // the database right now".
+    // Seven counts as one statement of scalar subqueries rather than seven
+    // more entries in this batch. Nothing here is windowed: these are "how big
+    // is the database right now".
+    //
+    // sweep_runs belongs here even though it is bounded: the count is how you
+    // see that its self-eviction still works. Three tables in this Worker
+    // needed an eviction path retrofitted, so a sweep_runs count far above the
+    // ~168 the retention window implies is the signal that a fourth has
+    // started growing without one.
     env.DB.prepare(
       `SELECT (SELECT COUNT(*) FROM errors)               AS errors,
               (SELECT COUNT(*) FROM occurrences)          AS occurrences,
               (SELECT COUNT(*) FROM feedback_submissions) AS feedback_submissions,
               (SELECT COUNT(*) FROM ingest_buckets)       AS ingest_buckets,
               (SELECT COUNT(*) FROM feedback_rate_limits) AS feedback_rate_limits,
-              (SELECT COUNT(*) FROM pairing_claims)       AS pairing_claims`,
+              (SELECT COUNT(*) FROM pairing_claims)       AS pairing_claims,
+              (SELECT COUNT(*) FROM sweep_runs)           AS sweep_runs`,
     ),
     env.DB.prepare("SELECT * FROM sweep_runs ORDER BY ran_at DESC LIMIT 1"),
   ]);
@@ -203,6 +211,7 @@ export async function loadOverviewStats(
       ingest_buckets: zeroed(counts.ingest_buckets),
       feedback_rate_limits: zeroed(counts.feedback_rate_limits),
       pairing_claims: zeroed(counts.pairing_claims),
+      sweep_runs: zeroed(counts.sweep_runs),
     },
     lastSweep: rows<SweepRunRow>(results[Q.LastSweep])[0] ?? null,
   };

--- a/relay-worker/test/dashboards/hostname.test.ts
+++ b/relay-worker/test/dashboards/hostname.test.ts
@@ -18,7 +18,13 @@ beforeAll(async () => {
 // This is not authentication and these tests do not claim it is. It removes
 // unprotected hostnames from reach; Access still decides who may look.
 describe("/admin/* on a workers.dev hostname", () => {
-  const ADMIN_PATHS = ["/admin/errors", "/admin/feedback"];
+  // `/admin` is in this list deliberately. Hono's `/admin/*` wildcard was
+  // measured against 4.13.7 and does match a bare `/admin`, so the overview
+  // inherits the deny with no extra registration. That behaviour is
+  // load-bearing: if a router upgrade ever changed it, the overview would
+  // start serving on production's workers.dev host and on every versioned
+  // preview URL. These cases are what would catch it.
+  const ADMIN_PATHS = ["/admin", "/admin/errors", "/admin/feedback"];
 
   // Mirrors vitest.config.ts's miniflare binding. The deliberately different
   // worker name (`-staging`) is what keeps every pre-existing case in this

--- a/relay-worker/test/dashboards/overview.test.ts
+++ b/relay-worker/test/dashboards/overview.test.ts
@@ -1,0 +1,147 @@
+import { env, SELF, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+
+const FP = "dd00000000000000000000000000view";
+const now = Math.floor(Date.now() / 1000);
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+
+  await env.DB.prepare(
+    `INSERT INTO errors (fingerprint, kind, message, status, first_seen_at,
+                         last_seen_at, occurrence_count, count_is_floor)
+     VALUES (?, 'RuntimeError', 'Nebula Drift scan failed', 'unresolved', ?, ?, 9, 1)`,
+  )
+    .bind(FP, now - 86_400, now - 3_600)
+    .run();
+
+  await env.DB.prepare(
+    `INSERT INTO occurrences (id, fingerprint, occurred_at, version, instance_key)
+     VALUES ('view-occ-1', ?, ?, '1.4.0', '198.51.100.7')`,
+  )
+    .bind(FP, now - 3_600)
+    .run();
+
+  await env.DB.prepare(
+    `INSERT INTO feedback_submissions (id, type, message, state, inserted_at, updated_at)
+     VALUES ('view-fb-1', 'bug', 'Scanner skipped a folder', 'unread', ?, ?)`,
+  )
+    .bind(now - 3_600, now - 3_600)
+    .run();
+});
+
+describe("GET /admin overview", () => {
+  it("renders the headline cards", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/admin");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+
+    const html = await res.text();
+    expect(html).toContain("Crashes");
+    expect(html).toContain("Crash sources");
+    expect(html).toContain("Unresolved groups");
+    expect(html).toContain("Unread feedback");
+    expect(html).toContain("Live pairing claims");
+  });
+
+  it("says the crash-source count is IP-derived rather than an install count", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin")).text();
+    expect(html).toContain("stat-hint");
+    expect(html.toLowerCase()).toContain("ip-derived");
+    // The number is a count of instance_key values, and instance_key holds a
+    // client IP. The IPs themselves must never reach the page.
+    expect(html).not.toContain("198.51.100.7");
+  });
+
+  it("marks a throttled crash total rather than showing it as exact", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin")).text();
+    expect(html).toContain("throttled");
+  });
+
+  it("shows the version breakdown and links the top errors", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin")).text();
+    expect(html).toContain("1.4.0");
+    expect(html).toContain("Nebula Drift scan failed");
+    expect(html).toContain(`href="/admin/errors/${FP}"`);
+  });
+
+  it("shows service health", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin")).text();
+    expect(html).toContain("Service health");
+    expect(html).toContain("occurrences");
+    expect(html).toContain("Last sweep");
+  });
+
+  // The active tab is the whole assertion, and "7d" appears as a tab label
+  // whichever window is active, so a bare toContain("7d") would pass against
+  // a page that had defaulted to the wrong one. Match the anchor itself.
+  const ACTIVE_7D = '<a href="/admin?window=7d" aria-current="page">';
+  const ACTIVE_24H = '<a href="/admin?window=24h" aria-current="page">';
+
+  it("offers all three windows and marks 7d active by default", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin")).text();
+    expect(html).toContain('href="/admin?window=24h"');
+    expect(html).toContain('href="/admin?window=30d"');
+    expect(html).toContain(ACTIVE_7D);
+    expect(html).not.toContain(ACTIVE_24H);
+  });
+
+  it("falls back to the default window for a garbage query param", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/admin?window=%00bogus");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain(ACTIVE_7D);
+  });
+
+  it("honours an explicit window", async () => {
+    const res = await SELF.fetch("https://relay.mydia.dev/admin?window=24h");
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain(ACTIVE_24H);
+  });
+
+  it("escapes a version string a remote install controls", async () => {
+    await env.DB.prepare(
+      `INSERT INTO occurrences (id, fingerprint, occurred_at, version, instance_key)
+       VALUES ('view-occ-xss', ?, ?, '<script>alert(1)</script>', '198.51.100.8')`,
+    )
+      .bind(FP, now - 3_600)
+      .run();
+
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin")).text();
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("links to all three dashboards from the nav", async () => {
+    const html = await (await SELF.fetch("https://relay.mydia.dev/admin")).text();
+    expect(html).toContain('href="/admin"');
+    expect(html).toContain('href="/admin/errors"');
+    expect(html).toContain('href="/admin/feedback"');
+  });
+});
+
+// Deletes the fixtures, so this must stay the last describe in the file.
+// Vitest runs suites in declaration order within a file.
+//
+// A fresh deploy shows exactly this page. The overview renders every card
+// unconditionally, so a zero that arrives as undefined would reach the
+// formatter, and a missing lastSweep row would reach LastSweep.
+describe("GET /admin on an empty database", () => {
+  it("renders the page rather than 500ing", async () => {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM occurrences"),
+      env.DB.prepare("DELETE FROM errors"),
+      env.DB.prepare("DELETE FROM feedback_submissions"),
+      env.DB.prepare("DELETE FROM pairing_claims"),
+      env.DB.prepare("DELETE FROM sweep_runs"),
+    ]);
+
+    const res = await SELF.fetch("https://relay.mydia.dev/admin");
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain("Crashes");
+    expect(html).toContain("Last sweep: never");
+    expect(html).not.toContain("NaN");
+    expect(html).not.toContain("undefined");
+  });
+});

--- a/relay-worker/test/dashboards/shell.test.ts
+++ b/relay-worker/test/dashboards/shell.test.ts
@@ -31,8 +31,9 @@ describe("page shell", () => {
     expect(html).toContain("color-scheme: light dark");
   });
 
-  it("renders both nav links", () => {
+  it("renders all three nav links", () => {
     const html = render(page("Errors", "body"));
+    expect(html).toContain('href="/admin"');
     expect(html).toContain('href="/admin/errors"');
     expect(html).toContain('href="/admin/feedback"');
   });

--- a/relay-worker/test/dashboards/ui.test.ts
+++ b/relay-worker/test/dashboards/ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { Tabs, DataTable, Badge, PostButton, Pager } from "../../src/dashboards/ui";
+import { Tabs, DataTable, Badge, PostButton, Pager, StatGrid, StatCard, FLOOR_TITLE } from "../../src/dashboards/ui";
+import { css } from "../../src/dashboards/styles";
 
 // A component that renders nothing returns null, and null has no toString.
 // Verified against hono/jsx 4.13.7: `Pager({ href: null })` is literally
@@ -81,5 +82,83 @@ describe("Pager", () => {
     const html = render(Pager({ href: "/admin/errors?page=1" }));
     expect(html).toContain('href="/admin/errors?page=1"');
     expect(html).toContain("Next");
+  });
+});
+
+describe("StatCard", () => {
+  it("renders its label and value", () => {
+    const html = render(StatCard({ label: "Crashes", value: "42" }));
+    expect(html).toContain("Crashes");
+    expect(html).toContain("42");
+    expect(html).toContain('class="stat-card"');
+  });
+
+  // A hint is a visible line rather than a title tooltip: the reader has to
+  // see that "crash sources" is IP-derived without hovering a div, which is
+  // not reachable by keyboard anyway.
+  it("renders a hint as visible text when given one", () => {
+    const html = render(
+      StatCard({ label: "Crash sources", value: "8", hint: "IP-derived" }),
+    );
+    expect(html).toContain('class="stat-hint"');
+    expect(html).toContain("IP-derived");
+  });
+
+  it("emits no hint element when no hint is given", () => {
+    const html = render(StatCard({ label: "Crashes", value: "42" }));
+    expect(html).not.toContain("stat-hint");
+  });
+
+  it("escapes a label and value it is handed", () => {
+    const html = render(
+      StatCard({ label: "<script>alert(1)</script>", value: "<b>x</b>" }),
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).not.toContain("<b>x</b>");
+  });
+
+  it("renders a badge alongside the value", () => {
+    const html = render(
+      StatCard({
+        label: "Crashes",
+        value: "42",
+        badge: Badge({ label: "throttled", title: "why" }),
+      }),
+    );
+    expect(html).toContain("throttled");
+  });
+});
+
+describe("StatGrid", () => {
+  it("wraps its children in the grid container", () => {
+    const html = render(StatGrid({ children: "CARDS-MARKER" }));
+    expect(html).toContain('class="stat-grid"');
+    expect(html).toContain("CARDS-MARKER");
+  });
+});
+
+describe("stat card styles", () => {
+  it("defines every class the components emit", () => {
+    for (const selector of [
+      ".stat-grid",
+      ".stat-card",
+      ".stat-label",
+      ".stat-value",
+      ".stat-hint",
+    ]) {
+      expect(css).toContain(selector);
+    }
+  });
+});
+
+describe("FLOOR_TITLE", () => {
+  // The badge itself only says "throttled". This constant is the entire
+  // explanation of what that means, so a version that just restates the label
+  // would be useless to the maintainer reading it.
+  it("explains the mechanism, not just the label", () => {
+    expect(FLOOR_TITLE).toContain("hourly bucket");
+    expect(FLOOR_TITLE).toContain("floor");
+    expect(FLOOR_TITLE.length).toBeGreaterThan(80);
   });
 });

--- a/relay-worker/test/obs/sweep.test.ts
+++ b/relay-worker/test/obs/sweep.test.ts
@@ -10,6 +10,8 @@ import worker from "../../src/index";
 import {
   sweepStaleFeedbackRateLimits,
   sweepStaleIngestBuckets,
+  SWEEP_RUN_RETENTION_SECONDS,
+  runScheduledSweep,
 } from "../../src/obs/sweep";
 
 beforeAll(async () => {
@@ -177,5 +179,84 @@ describe("scheduled() handler", () => {
     // eviction path" defect in a different table.
     expect(await pairingClaimExists("sweep-scheduled:expired")).toBe(false);
     expect(await pairingClaimExists("sweep-scheduled:live")).toBe(true);
+  });
+});
+
+async function latestSweepRun(): Promise<Record<string, number> | null> {
+  return await env.DB.prepare("SELECT * FROM sweep_runs ORDER BY ran_at DESC LIMIT 1")
+    .first<Record<string, number>>();
+}
+
+describe("sweep run bookkeeping", () => {
+  it("records one row carrying each sweep's delete count", async () => {
+    await env.DB.prepare("DELETE FROM sweep_runs").run();
+
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    const now = Math.floor(Date.now() / 1000);
+    await insertRateLimitBucket("sweep-record:stale", currentHour - 10, 5);
+    await insertIngestBucket("sweep-record-fp", "stale-instance", currentHour - 10);
+    await insertPairingClaim("sweep-record:expired", now - 3600);
+
+    await runScheduledSweep(env);
+
+    const run = await latestSweepRun();
+    expect(run).not.toBeNull();
+    expect(run!.feedback_rate_limits_deleted).toBeGreaterThanOrEqual(1);
+    expect(run!.ingest_buckets_deleted).toBeGreaterThanOrEqual(1);
+    expect(run!.pairing_claims_deleted).toBeGreaterThanOrEqual(1);
+    expect(run!.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(run!.ran_at).toBeGreaterThan(now - 60);
+  });
+
+  // The fourth table in this Worker to need bounding, and the first to do it
+  // in the same batch that writes the row instead of waiting to be
+  // retrofitted.
+  it("evicts its own rows past the retention window", async () => {
+    await env.DB.prepare("DELETE FROM sweep_runs").run();
+    const now = Math.floor(Date.now() / 1000);
+
+    await env.DB.prepare(
+      `INSERT INTO sweep_runs (ran_at, feedback_rate_limits_deleted,
+                               ingest_buckets_deleted, pairing_claims_deleted, duration_ms)
+       VALUES (?, 0, 0, 0, 1)`,
+    )
+      .bind(now - SWEEP_RUN_RETENTION_SECONDS - 3600)
+      .run();
+
+    await runScheduledSweep(env);
+
+    const remaining = await env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM sweep_runs WHERE ran_at < ?",
+    )
+      .bind(now - SWEEP_RUN_RETENTION_SECONDS)
+      .first<{ n: number }>();
+    expect(remaining?.n).toBe(0);
+  });
+
+  // Losing one bookkeeping row must never turn a successful sweep into a
+  // failed cron invocation Cloudflare then reports as a broken schedule. The
+  // sweeps are the work; the record is bookkeeping.
+  it("still completes the sweeps when recording the run fails", async () => {
+    const currentHour = Math.floor(Date.now() / 3_600_000);
+    await insertRateLimitBucket("sweep-broken:stale", currentHour - 10, 5);
+
+    // Proxy rather than a spread: D1Database's methods live on its prototype
+    // and need the real receiver, so every non-overridden call is rebound to
+    // the genuine target.
+    const brokenDb = new Proxy(env.DB, {
+      get(target, prop) {
+        if (prop === "batch") {
+          return () => Promise.reject(new Error("D1 batch is down"));
+        }
+        const value = Reflect.get(target, prop, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    await expect(
+      runScheduledSweep({ ...env, DB: brokenDb } as unknown as Parameters<typeof runScheduledSweep>[0]),
+    ).resolves.toBeUndefined();
+
+    expect(await rateLimitBucketExists("sweep-broken:stale")).toBe(false);
   });
 });

--- a/relay-worker/test/stats/queries.test.ts
+++ b/relay-worker/test/stats/queries.test.ts
@@ -199,6 +199,7 @@ describe("loadOverviewStats", () => {
       "ingest_buckets",
       "feedback_rate_limits",
       "pairing_claims",
+      "sweep_runs",
     ] as const) {
       expect(typeof stats.tableCounts[key]).toBe("number");
     }

--- a/relay-worker/test/stats/queries.test.ts
+++ b/relay-worker/test/stats/queries.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { parseWindow, WINDOWS, DEFAULT_WINDOW } from "../../src/stats/queries";
+import { env, applyD1Migrations } from "cloudflare:test";
+import { beforeAll } from "vitest";
+import { parseWindow, WINDOWS, DEFAULT_WINDOW, loadOverviewStats } from "../../src/stats/queries";
 
 describe("parseWindow", () => {
   it("accepts each known key", () => {
@@ -31,5 +33,214 @@ describe("parseWindow", () => {
 
   it("defaults to 7d", () => {
     expect(DEFAULT_WINDOW).toBe("7d");
+  });
+});
+
+// Every fixture id is prefixed so these rows cannot collide with another test
+// file's, and every title is invented rather than a real show or film.
+const FP_HOT = "aa00000000000000000000000000stat";
+const FP_COLD = "bb00000000000000000000000000stat";
+const FP_DONE = "cc00000000000000000000000000stat";
+
+const now = Math.floor(Date.now() / 1000);
+const HOUR = 3_600;
+const DAY = 86_400;
+
+async function seed(): Promise<void> {
+  await env.DB.batch([
+    env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, status, first_seen_at,
+                           last_seen_at, occurrence_count, count_is_floor)
+       VALUES (?, 'RuntimeError', 'Nebula Drift scan failed', 'unresolved', ?, ?, 9, 1)`,
+    ).bind(FP_HOT, now - 10 * DAY, now - HOUR),
+    env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, status, first_seen_at,
+                           last_seen_at, occurrence_count, count_is_floor)
+       VALUES (?, 'ArgumentError', 'Harbour Lights probe failed', 'unresolved', ?, ?, 2, 0)`,
+    ).bind(FP_COLD, now - 10 * DAY, now - 2 * HOUR),
+    env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, status, first_seen_at,
+                           last_seen_at, occurrence_count, count_is_floor)
+       VALUES (?, 'KeyError', 'Resolved already', 'resolved', ?, ?, 40, 0)`,
+    ).bind(FP_DONE, now - 10 * DAY, now - HOUR),
+  ]);
+
+  // FP_HOT: 3 in-window occurrences from 2 distinct sources, on two versions.
+  // FP_COLD: 1 in-window occurrence.
+  // FP_DONE: 5 in-window occurrences, but the group is resolved.
+  // One FP_HOT occurrence sits 40 days back, outside every window.
+  const occurrences: [string, number, string | null, string][] = [
+    [FP_HOT, now - HOUR, "1.4.0", "198.51.100.1"],
+    [FP_HOT, now - 2 * HOUR, "1.4.0", "198.51.100.2"],
+    [FP_HOT, now - 3 * HOUR, "1.5.0", "198.51.100.1"],
+    [FP_HOT, now - 40 * DAY, "1.0.0", "198.51.100.9"],
+    [FP_COLD, now - HOUR, null, "198.51.100.3"],
+    ...Array.from({ length: 5 }, (_, i): [string, number, string | null, string] => [
+      FP_DONE,
+      now - HOUR,
+      "1.4.0",
+      `198.51.100.1${i}`,
+    ]),
+  ];
+
+  await env.DB.batch(
+    occurrences.map(([fingerprint, occurredAt, version, instanceKey], i) =>
+      env.DB.prepare(
+        `INSERT INTO occurrences (id, fingerprint, occurred_at, version, instance_key)
+         VALUES (?, ?, ?, ?, ?)`,
+      ).bind(`stat-occ-${i}`, fingerprint, occurredAt, version, instanceKey),
+    ),
+  );
+
+  await env.DB.batch([
+    env.DB.prepare(
+      `INSERT INTO feedback_submissions (id, type, message, state, inserted_at, updated_at)
+       VALUES ('stat-fb-1', 'bug', 'Scanner skipped a folder', 'unread', ?, ?)`,
+    ).bind(now - HOUR, now - HOUR),
+    env.DB.prepare(
+      `INSERT INTO feedback_submissions (id, type, message, state, inserted_at, updated_at)
+       VALUES ('stat-fb-2', 'idea', 'Add a compact list view', 'read', ?, ?)`,
+    ).bind(now - 2 * HOUR, now - 2 * HOUR),
+    env.DB.prepare(
+      `INSERT INTO pairing_claims (key, value, expires_at) VALUES ('stat:live', 'v', ?)`,
+    ).bind(now + HOUR),
+    env.DB.prepare(
+      `INSERT INTO pairing_claims (key, value, expires_at) VALUES ('stat:dead', 'v', ?)`,
+    ).bind(now - HOUR),
+    env.DB.prepare(
+      `INSERT INTO sweep_runs (ran_at, feedback_rate_limits_deleted,
+                               ingest_buckets_deleted, pairing_claims_deleted, duration_ms)
+       VALUES (?, 4, 2, 1, 37)`,
+    ).bind(now - HOUR),
+  ]);
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+  await seed();
+});
+
+describe("loadOverviewStats", () => {
+  it("counts crashes and distinct sources inside the window only", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+
+    // 3 FP_HOT + 1 FP_COLD + 5 FP_DONE = 9. The 40-day-old row is excluded.
+    expect(stats.crashes).toBe(9);
+    // 198.51.100.1, .2, .3 plus the five .1x sources = 8 distinct, and the
+    // 40-day-old .9 is outside the window.
+    expect(stats.crashSources).toBe(8);
+  });
+
+  it("excludes rows outside a narrower window", async () => {
+    const wide = await loadOverviewStats(env, "30d");
+    const narrow = await loadOverviewStats(env, "24h");
+    expect(wide.crashes).toBe(narrow.crashes);
+
+    // Nothing here is between 30 and 40 days old, so 30d must still exclude
+    // the 40-day row. This is the assertion that catches a window constant
+    // being wrong by an order of magnitude.
+    expect(wide.crashes).toBe(9);
+  });
+
+  it("counts unresolved groups and the throttled subset of them", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    expect(stats.unresolvedGroups).toBe(2);
+    // Only FP_HOT has count_is_floor set, and FP_DONE is resolved.
+    expect(stats.throttledGroups).toBe(1);
+  });
+
+  it("groups versions, folding a NULL version into 'unknown'", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    const byVersion = Object.fromEntries(stats.versions.map((v) => [v.version, v]));
+
+    expect(byVersion["1.4.0"].occurrences).toBe(7);
+    expect(byVersion["1.4.0"].sources).toBe(7);
+    expect(byVersion["1.5.0"].occurrences).toBe(1);
+    expect(byVersion["unknown"].occurrences).toBe(1);
+  });
+
+  it("orders versions by occurrence count, most first", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    const counts = stats.versions.map((v) => v.occurrences);
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+  });
+
+  it("ranks unresolved errors by in-window occurrences and excludes resolved ones", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    const fingerprints = stats.topErrors.map((e) => e.fingerprint);
+
+    expect(fingerprints).toEqual([FP_HOT, FP_COLD]);
+    expect(fingerprints).not.toContain(FP_DONE);
+    expect(stats.topErrors[0].recent).toBe(3);
+    expect(stats.topErrors[0].count_is_floor).toBe(1);
+    expect(stats.topErrors[0].kind).toBe("RuntimeError");
+    expect(stats.topErrors[0].last_seen_at).toBe(now - HOUR);
+  });
+
+  it("counts only unexpired pairing claims as live", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    expect(stats.livePairingClaims).toBe(1);
+  });
+
+  it("reports feedback by state and by type", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    expect(stats.feedbackByState.unread).toBe(1);
+    expect(stats.feedbackByState.read).toBe(1);
+    expect(stats.feedbackByType.bug).toBe(1);
+    expect(stats.feedbackByType.idea).toBe(1);
+  });
+
+  it("reports a row count for every table", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    for (const key of [
+      "errors",
+      "occurrences",
+      "feedback_submissions",
+      "ingest_buckets",
+      "feedback_rate_limits",
+      "pairing_claims",
+    ] as const) {
+      expect(typeof stats.tableCounts[key]).toBe("number");
+    }
+    expect(stats.tableCounts.errors).toBeGreaterThanOrEqual(3);
+  });
+
+  it("returns the most recent sweep run", async () => {
+    const stats = await loadOverviewStats(env, "7d");
+    expect(stats.lastSweep?.feedback_rate_limits_deleted).toBe(4);
+    expect(stats.lastSweep?.duration_ms).toBe(37);
+  });
+
+  it("echoes the window it was asked for", async () => {
+    expect((await loadOverviewStats(env, "24h")).window).toBe("24h");
+  });
+});
+
+// An empty relay is the first thing a fresh deploy shows. Every field must be
+// a real zero or an empty collection, never undefined and never a throw,
+// because the page renders all of them unconditionally.
+describe("loadOverviewStats on an empty database", () => {
+  it("returns zeros and empty collections rather than throwing", async () => {
+    await env.DB.batch([
+      env.DB.prepare("DELETE FROM occurrences"),
+      env.DB.prepare("DELETE FROM errors"),
+      env.DB.prepare("DELETE FROM feedback_submissions"),
+      env.DB.prepare("DELETE FROM pairing_claims"),
+      env.DB.prepare("DELETE FROM sweep_runs"),
+    ]);
+
+    const stats = await loadOverviewStats(env, "7d");
+
+    expect(stats.crashes).toBe(0);
+    expect(stats.crashSources).toBe(0);
+    expect(stats.unresolvedGroups).toBe(0);
+    expect(stats.throttledGroups).toBe(0);
+    expect(stats.livePairingClaims).toBe(0);
+    expect(stats.versions).toEqual([]);
+    expect(stats.topErrors).toEqual([]);
+    expect(stats.feedbackByState).toEqual({});
+    expect(stats.feedbackByType).toEqual({});
+    expect(stats.lastSweep).toBeNull();
+    expect(stats.tableCounts.occurrences).toBe(0);
   });
 });

--- a/relay-worker/test/stats/queries.test.ts
+++ b/relay-worker/test/stats/queries.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { parseWindow, WINDOWS, DEFAULT_WINDOW } from "../../src/stats/queries";
+
+describe("parseWindow", () => {
+  it("accepts each known key", () => {
+    expect(parseWindow("24h")).toBe("24h");
+    expect(parseWindow("7d")).toBe("7d");
+    expect(parseWindow("30d")).toBe("30d");
+  });
+
+  it("falls back to the default for anything unrecognised", () => {
+    for (const raw of [undefined, "", "  ", "1d", "7D", "-7d", "1e300", "NaN"]) {
+      expect(parseWindow(raw)).toBe(DEFAULT_WINDOW);
+    }
+  });
+
+  // The lookup must not answer from Object.prototype. A plain `raw in WINDOWS`
+  // returns true for "toString" and "constructor", which would hand a
+  // WindowKey the rest of the module cannot map to a duration.
+  it("does not treat inherited object properties as windows", () => {
+    for (const raw of ["toString", "constructor", "hasOwnProperty", "__proto__"]) {
+      expect(parseWindow(raw)).toBe(DEFAULT_WINDOW);
+    }
+  });
+
+  it("maps every key to a distinct positive duration", () => {
+    const values = Object.values(WINDOWS);
+    expect(values.every((seconds) => Number.isInteger(seconds) && seconds > 0)).toBe(true);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("defaults to 7d", () => {
+    expect(DEFAULT_WINDOW).toBe("7d");
+  });
+});

--- a/relay-worker/test/stats/schema.test.ts
+++ b/relay-worker/test/stats/schema.test.ts
@@ -1,0 +1,69 @@
+import { env, applyD1Migrations } from "cloudflare:test";
+import { describe, it, expect, beforeAll } from "vitest";
+
+beforeAll(async () => {
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+});
+
+// The windowed overview queries filter on occurred_at alone. The only
+// pre-existing index is (fingerprint, occurred_at DESC), which cannot serve
+// that, so without a dedicated index every one of them full-scans the table
+// and reads every column of every row, which is exactly what D1 bills. The
+// three trailing columns exist so the scan never has to touch the table at
+// all.
+async function queryPlan(sql: string): Promise<string> {
+  const { results } = await env.DB.prepare(`EXPLAIN QUERY PLAN ${sql}`)
+    .bind(0)
+    .all<{ detail: string }>();
+  return results.map((row) => row.detail).join(" | ");
+}
+
+describe("0004_admin_overview migration", () => {
+  it("serves the windowed crash count from a covering index", async () => {
+    const plan = await queryPlan(
+      "SELECT COUNT(*) AS n FROM occurrences WHERE occurred_at >= ?",
+    );
+    expect(plan).toContain("COVERING INDEX occurrences_occurred_at_idx");
+  });
+
+  it("serves the distinct-sources count from the same covering index", async () => {
+    const plan = await queryPlan(
+      "SELECT COUNT(DISTINCT instance_key) AS n FROM occurrences WHERE occurred_at >= ?",
+    );
+    expect(plan).toContain("COVERING INDEX occurrences_occurred_at_idx");
+  });
+
+  it("serves the version breakdown from the same covering index", async () => {
+    const plan = await queryPlan(
+      `SELECT COALESCE(version, 'unknown') AS version, COUNT(*) AS occurrences,
+              COUNT(DISTINCT instance_key) AS sources
+       FROM occurrences WHERE occurred_at >= ? GROUP BY 1`,
+    );
+    expect(plan).toContain("COVERING INDEX occurrences_occurred_at_idx");
+  });
+
+  it("creates sweep_runs with every column the overview reads", async () => {
+    const { results } = await env.DB.prepare(
+      "SELECT name FROM pragma_table_info('sweep_runs')",
+    ).all<{ name: string }>();
+    const names = results.map((row) => row.name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        "id",
+        "ran_at",
+        "feedback_rate_limits_deleted",
+        "ingest_buckets_deleted",
+        "pairing_claims_deleted",
+        "duration_ms",
+      ]),
+    );
+  });
+
+  it("indexes sweep_runs by ran_at, which both the read and the eviction need", async () => {
+    const { results } = await env.DB.prepare(
+      "SELECT name FROM pragma_index_list('sweep_runs')",
+    ).all<{ name: string }>();
+    expect(results.map((row) => row.name)).toContain("sweep_runs_ran_at_idx");
+  });
+});


### PR DESCRIPTION
Typing `/admin` used to reach the JSON 404 catch-all. It now renders a maintainer overview built entirely from D1 tables that already exist.

## What the page shows

Crash volume and distinct crash sources over a selectable window, unresolved and throttled group counts, unread feedback, live pairing claims, a version breakdown, the top unresolved errors, D1 table row counts, and when the hourly sweep last ran. The other two dashboards are linked from the nav, and link back here.

Proxy request volume and cache hit rate are deliberately absent. Nothing counts them anywhere durable, and adding them needs an Analytics Engine binding plus an account API token.

## Two numbers that mean something narrower than they look

Both say so on the page itself, as visible text rather than a `title` attribute, since a tooltip on a div reaches neither the keyboard nor a screen reader.

- **Crash sources** counts distinct `occurrences.instance_key`, and that column holds `cf-connecting-ip` because it was chosen as a rate-limiting key. It undercounts installs behind one NAT and overcounts one install on a changing address, so it is not an install count. The addresses themselves never leave D1.
- **Crash totals** carry a `throttled` badge whenever any unresolved group has `errors.count_is_floor` set, because ingest stops writing occurrence rows once an hour's budget saturates. The badge reads that sticky flag rather than `ingest_buckets.saturated`, which resets on the next hour and would look precise exactly when it is not.

## Query cost

Eleven statements build the page, sent as one `DB.batch()` instead of eleven sequential round trips. Missing aggregates read back as `0` rather than `undefined`, so one failed count cannot propagate `NaN` through the page.

The windowed aggregates filter on `occurred_at` alone, which the pre-existing `(fingerprint, occurred_at DESC)` index cannot serve. Migration 0004 adds `(occurred_at DESC, instance_key, version)`; the trailing columns let the crash count, distinct-sources count and version breakdown be satisfied from the index without touching the table. `test/stats/schema.test.ts` pins that with `EXPLAIN QUERY PLAN` rather than trusting it, so dropping either trailing column fails the assertions.

## sweep_runs

The hourly Cron Trigger left no durable trace, so "is the cron actually running" had no answer short of reading Workers Logs. Each run now writes one row with its three delete counts and its duration.

The table evicts itself in the same `.batch()` that writes it, holding it at roughly 168 rows. Three tables in this Worker shipped with no eviction path and had to be retrofitted; a fourth will not repeat it. Recording is wrapped so that losing a bookkeeping row cannot mark the cron invocation failed when all three sweeps completed.

## Access

The overview needs no separate registration. Hono's `/admin/*` wildcard does match the bare `/admin` path (measured against 4.13.7), so the page inherits the existing workers.dev deny, and Cloudflare Access's application scope is `/admin*` rather than `/admin/*`, so it covers the bare path with no configuration change at cutover. `test/dashboards/hostname.test.ts` gains cases for the bare path, which is what would catch a router change that altered this.

## Verification

359 tests pass, 42 skipped, 0 failures. `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `/admin` overview dashboard with crash, feedback, pairing, version, error, database, and sweep metrics.
  - Added 24-hour, 7-day, and 30-day time-window filtering.
  - Added Overview navigation alongside the existing admin dashboards.
  - Added sweep history tracking, including deletion counts, run duration, and recent-run details.
  - Improved dashboard stat-card layout and presentation.

- **Documentation**
  - Updated admin dashboard, access configuration, verification, and maintenance documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->