### PR TITLE
fix(player): keep Hive boxes out of the user's Documents folder

### DIFF
--- a/player/CLAUDE.md
+++ b/player/CLAUDE.md
@@ -20,7 +20,10 @@ Deeper reference lives alongside this file in `player/docs/`:
 - **State Management**: Riverpod with code generation
 - **Routing**: go_router with hash-based URLs
 - **Data Layer**: GraphQL via graphql_flutter with codegen
-- **Storage**: flutter_secure_storage (credentials), Hive (cache)
+- **Storage**: flutter_secure_storage (credentials), Hive (cache). Open Hive
+  through `initAppHive()` in `core/storage/app_hive.dart`, never
+  `Hive.initFlutter()` or `initHiveForFlutter()` -- those put boxes in the
+  user's Documents folder. A new box also needs adding to `kMydiaHiveBoxes`.
 
 ## Development Commands
 

--- a/player/integration_test/helpers/test_bootstrap.dart
+++ b/player/integration_test/helpers/test_bootstrap.dart
@@ -6,6 +6,7 @@ import 'package:media_kit/media_kit.dart';
 import 'package:player/app.dart';
 import 'package:player/core/cast/cast_providers.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
+import 'package:player/core/storage/app_hive.dart';
 import 'package:player/native/frb_generated.dart';
 
 /// One-time initialization shared by every integration test file.
@@ -23,7 +24,11 @@ Future<void> ensureTestBootstrap() {
 Future<void> _runBootstrap() async {
   await RustLib.init();
   MediaKit.ensureInitialized();
-  await initHiveForFlutter();
+  // The same pair `main` runs, and for the same reason: `initHiveForFlutter`
+  // would put every box in the user's Documents folder, which under the E2E
+  // container is `/root`. See `core/storage/app_hive.dart`.
+  await initAppHive();
+  await HiveStore.open();
 }
 
 /// Replaces the app with an empty widget, after giving its startup work time

--- a/player/lib/core/downloads/download_database.dart
+++ b/player/lib/core/downloads/download_database.dart
@@ -1,5 +1,6 @@
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import '../../domain/models/download.dart';
+import '../storage/app_hive.dart';
 import 'download_recovery.dart';
 
 class DownloadDatabase {
@@ -10,7 +11,7 @@ class DownloadDatabase {
   late Box<DownloadedMedia> _mediaBox;
 
   Future<void> initialize() async {
-    await Hive.initFlutter();
+    await initAppHive();
 
     // Register adapters if not already registered
     if (!Hive.isAdapterRegistered(0)) {

--- a/player/lib/core/downloads/download_service_native.dart
+++ b/player/lib/core/downloads/download_service_native.dart
@@ -16,6 +16,7 @@ import '../../domain/models/download.dart';
 import '../../domain/models/download_option.dart';
 import '../../domain/models/download_settings.dart';
 import '../../domain/models/storage_settings.dart';
+import '../storage/app_hive.dart';
 import 'download_notification_service.dart';
 import 'download_recovery.dart';
 import 'download_service.dart';
@@ -56,7 +57,7 @@ class _NativeDownloadDatabase implements DownloadDatabase {
 
   @override
   Future<void> initialize() async {
-    await Hive.initFlutter();
+    await initAppHive();
 
     // Register adapters if not already registered
     if (!Hive.isAdapterRegistered(0)) {

--- a/player/lib/core/graphql/watch/fetch_log.dart
+++ b/player/lib/core/graphql/watch/fetch_log.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 
+import '../../storage/app_hive.dart';
 import 'query_key.dart';
 
 /// When each query last reached the network.
@@ -66,7 +67,7 @@ class HiveFetchLog implements FetchLog {
   static const String boxName = 'mydia_fetch_log';
 
   static Future<HiveFetchLog> open() async {
-    await Hive.initFlutter();
+    await initAppHive();
     return HiveFetchLog(await Hive.openBox<int>(boxName));
   }
 

--- a/player/lib/core/player/subtitle_language_prefs.dart
+++ b/player/lib/core/player/subtitle_language_prefs.dart
@@ -4,6 +4,8 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:hive_ce_flutter/hive_flutter.dart';
 
+import '../storage/app_hive.dart';
+
 /// Remembers which languages the user last searched subtitles for.
 ///
 /// Local only, on purpose: subtitle acquisition is manual, so there is no
@@ -68,7 +70,7 @@ class SubtitleLanguagePrefs {
 
   static Future<Box<List>> _box() async {
     if (Hive.isBoxOpen(boxName)) return Hive.box<List>(boxName);
-    await Hive.initFlutter();
+    await initAppHive();
     return Hive.openBox<List>(boxName);
   }
 }

--- a/player/lib/core/storage/app_hive.dart
+++ b/player/lib/core/storage/app_hive.dart
@@ -60,8 +60,17 @@ Future<void> _initHive() async {
 
     // Ahead of `Hive.init`, so the boxes are in place before anything opens
     // one. Best-effort by contract: `migrateHiveBoxes` never throws.
+    //
+    // `Hive.isBoxOpen` covers the case this ordering does not: a caller that
+    // opened a box at the old path before reaching here. Hive holds a box's
+    // lock file open and deletes it itself on close, so moving the files out
+    // from under it turns `box.close()` into a `PathNotFoundException`.
     final documents = await getApplicationDocumentsDirectory();
-    await migrateHiveBoxes(from: documents.path, to: support.path);
+    await migrateHiveBoxes(
+      from: documents.path,
+      to: support.path,
+      isBoxOpen: Hive.isBoxOpen,
+    );
 
     Hive.init(support.path);
   }

--- a/player/lib/core/storage/app_hive.dart
+++ b/player/lib/core/storage/app_hive.dart
@@ -15,7 +15,7 @@
 /// first launch; see `hive_box_migration.dart`.
 library;
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import 'package:flutter/widgets.dart';
 import 'package:hive_ce_flutter/adapters.dart';
 import 'package:path_provider/path_provider.dart';
@@ -57,25 +57,49 @@ Future<void> _initHive() async {
     Hive.init(null);
   } else {
     final support = await getApplicationSupportDirectory();
-
-    // Ahead of `Hive.init`, so the boxes are in place before anything opens
-    // one. Best-effort by contract: `migrateHiveBoxes` never throws.
-    //
-    // `Hive.isBoxOpen` covers the case this ordering does not: a caller that
-    // opened a box at the old path before reaching here. Hive holds a box's
-    // lock file open and deletes it itself on close, so moving the files out
-    // from under it turns `box.close()` into a `PathNotFoundException`.
-    final documents = await getApplicationDocumentsDirectory();
-    await migrateHiveBoxes(
-      from: documents.path,
-      to: support.path,
-      isBoxOpen: Hive.isBoxOpen,
-    );
-
+    await _migrateFromDocuments(support.path);
     Hive.init(support.path);
   }
 
   _registerFlutterAdapters();
+}
+
+/// Moves any boxes left in the old location, if that location can be found.
+///
+/// Runs ahead of `Hive.init` so the boxes are in place before anything opens
+/// one, and passes `Hive.isBoxOpen` to cover the case that ordering does not:
+/// a caller that opened a box at the old path before reaching here. Hive holds
+/// a box's lock file open and deletes it itself on close, so moving the files
+/// out from under it turns `box.close()` into a `PathNotFoundException`.
+///
+/// Resolving Documents is allowed to fail, and failing costs only the
+/// migration. On Linux `getApplicationDocumentsDirectory()` is
+/// `xdg.getUserDirectory('DOCUMENTS')`, and path_provider turns a null answer
+/// into a thrown `MissingPlatformDirectoryException` -- so a machine with no
+/// `user-dirs.dirs`, or an XDG setup that simply declares no Documents
+/// folder, throws here through no fault of the app. Letting that reach
+/// [initAppHive] would leave `Hive.init` uncalled and every box unopenable,
+/// which trades all of the app's persistence for a directory it only wanted
+/// to read old files out of. There is nothing to migrate from a directory
+/// that is not there, and nothing to abandon Hive over.
+///
+/// This is defence, not a fix for anything observed: the Flatpak sandbox
+/// resolves Documents fine despite granting no `--filesystem`, which its
+/// smoke-test log confirms by initializing Hive with no complaint.
+Future<void> _migrateFromDocuments(String supportPath) async {
+  final String documentsPath;
+  try {
+    documentsPath = (await getApplicationDocumentsDirectory()).path;
+  } catch (e) {
+    debugPrint('[Hive] No documents directory to migrate from: $e');
+    return;
+  }
+
+  await migrateHiveBoxes(
+    from: documentsPath,
+    to: supportPath,
+    isBoxOpen: Hive.isBoxOpen,
+  );
 }
 
 /// The `Color` and `TimeOfDay` adapters `Hive.initFlutter()` registers.

--- a/player/lib/core/storage/app_hive.dart
+++ b/player/lib/core/storage/app_hive.dart
@@ -1,0 +1,90 @@
+/// The one place Mydia Player decides where its Hive boxes live.
+///
+/// Call [initAppHive] instead of `Hive.initFlutter()` or graphql_flutter's
+/// `initHiveForFlutter()`. Both of those default their base path to
+/// `getApplicationDocumentsDirectory()` with no subdirectory, which on every
+/// desktop platform is the user's own Documents folder -- so the app used to
+/// drop fifteen boxes' worth of loose `.hive` and `.lock` files straight into
+/// it. On Windows that folder is normally redirected into OneDrive, which then
+/// syncs live database files while Hive is writing them.
+///
+/// Boxes now live under `getApplicationSupportDirectory()`: a per-app folder
+/// in `%APPDATA%` on Windows, under `~/Library/Application Support` on macOS,
+/// under `$XDG_DATA_HOME` on Linux, and the app's private support directory on
+/// Android and iOS. [initAppHive] moves an existing install's boxes there on
+/// first launch; see `hive_box_migration.dart`.
+library;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/widgets.dart';
+import 'package:hive_ce_flutter/adapters.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'hive_box_migration.dart';
+
+Future<void>? _init;
+
+/// Initializes Hive under the app's private support directory, once.
+///
+/// Memoized rather than merely idempotent: several independent startup steps
+/// need Hive ready before they open their own box -- window geometry (before
+/// the first frame), the GraphQL cache, the fetch log, the download database
+/// -- and the subtitle sheet opens one lazily from `initState` with no
+/// container in reach. They all call this and only the first does any work.
+///
+/// A failure is not cached. Whatever went wrong (an unavailable platform
+/// directory, a plugin not yet registered) may not still be true on the next
+/// attempt, and every caller already treats a failure here as "this feature
+/// does not persist for the session" rather than as fatal.
+Future<void> initAppHive() => _init ??= _initOnce();
+
+Future<void> _initOnce() async {
+  try {
+    await _initHive();
+  } catch (_) {
+    _init = null;
+    rethrow;
+  }
+}
+
+Future<void> _initHive() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  if (kIsWeb) {
+    // Hive's web backend is IndexedDB, keyed by box name and scoped to the
+    // origin. There is no path to choose and no litter to clean up, so this
+    // is the whole of the web story.
+    Hive.init(null);
+  } else {
+    final support = await getApplicationSupportDirectory();
+
+    // Ahead of `Hive.init`, so the boxes are in place before anything opens
+    // one. Best-effort by contract: `migrateHiveBoxes` never throws.
+    final documents = await getApplicationDocumentsDirectory();
+    await migrateHiveBoxes(from: documents.path, to: support.path);
+
+    Hive.init(support.path);
+  }
+
+  _registerFlutterAdapters();
+}
+
+/// The `Color` and `TimeOfDay` adapters `Hive.initFlutter()` registers.
+///
+/// Replicated here because [initAppHive] replaces that call and these two
+/// registrations are the rest of what it did. Nothing in the app persists
+/// either type today, but they sit at type IDs 200 and 201, far above the
+/// app's own adapters, so keeping them costs nothing and dropping them would
+/// be a silent behaviour change waiting to bite whoever first puts a `Color`
+/// in a box.
+void _registerFlutterAdapters() {
+  final color = ColorAdapter();
+  if (!Hive.isAdapterRegistered(color.typeId)) {
+    Hive.registerAdapter(color);
+  }
+
+  const timeOfDay = TimeOfDayAdapter();
+  if (!Hive.isAdapterRegistered(timeOfDay.typeId)) {
+    Hive.registerAdapter(timeOfDay);
+  }
+}

--- a/player/lib/core/storage/hive_box_migration.dart
+++ b/player/lib/core/storage/hive_box_migration.dart
@@ -125,13 +125,40 @@ Future<void> _migrateBox(String from, String to, String name) async {
 Future<void> _move(File source, File destination) async {
   try {
     await source.rename(destination.path);
+    return;
   } on FileSystemException {
     // `rename` cannot cross a filesystem boundary, and these two paths
     // routinely sit on different ones -- a Documents folder redirected to
-    // another volume, or to a OneDrive reparse point. Copy instead, and drop
-    // the original only once the copy is on disk.
-    await source.copy(destination.path);
+    // another volume, or to a OneDrive reparse point.
+  }
+
+  // Copy through a staging file in the destination directory rather than
+  // straight onto `destination`. `File.copy` promises no atomicity, so an
+  // interrupted copy would leave a truncated `.hive` at the destination while
+  // the source is still intact -- and the next launch reads that as a
+  // completed migration, because [_migrateBox] treats any existing
+  // destination as authoritative. Hive would then open the fragment and its
+  // crash recovery would accept it as a short box, silently losing whatever
+  // had not been written. Renaming within one directory is atomic, so the
+  // destination only ever appears complete.
+  //
+  // The pid keeps two instances racing this from writing each other's
+  // staging file. A hard kill can strand one, which is inert: it lives in the
+  // app's own support directory and nothing but this function looks for it.
+  final staging = File('${destination.path}.$pid.migrating');
+  try {
+    await source.copy(staging.path);
+    await staging.rename(destination.path);
     await source.delete();
+  } catch (_) {
+    if (staging.existsSync()) {
+      try {
+        await staging.delete();
+      } catch (e) {
+        debugPrint('[Hive] Could not clean up ${staging.path}: $e');
+      }
+    }
+    rethrow;
   }
 }
 

--- a/player/lib/core/storage/hive_box_migration.dart
+++ b/player/lib/core/storage/hive_box_migration.dart
@@ -145,6 +145,20 @@ Future<void> _move(File source, File destination) async {
   // The pid keeps two instances racing this from writing each other's
   // staging file. A hard kill can strand one, which is inert: it lives in the
   // app's own support directory and nothing but this function looks for it.
+  //
+  // Promotion replaces whatever is at the destination, and two instances
+  // migrating at once can both get past [_migrateBox]'s existence check. That
+  // is deliberately not locked against. Both racers copy the same bytes from
+  // the same untouched source, so the promoted file is identical either way;
+  // losing a record needs the other instance to finish its own copy, run
+  // `Hive.init`, open the box and write, all inside this copy. Two live
+  // instances are already the state `isLockContentionError` and
+  // `StartupErrorApp.alreadyRunning` exist to refuse. Closing the window
+  // properly would need an interprocess lock with stale-lock recovery on the
+  // startup path, because `dart:io` exposes no no-replace rename, and
+  // claiming the destination with `create(exclusive: true)` would put an
+  // empty `.hive` there that a crash turns into the very "already migrated,
+  // now empty" outcome this staging exists to prevent.
   final staging = File('${destination.path}.$pid.migrating');
   try {
     await source.copy(staging.path);

--- a/player/lib/core/storage/hive_box_migration.dart
+++ b/player/lib/core/storage/hive_box_migration.dart
@@ -1,0 +1,137 @@
+/// Moving Hive boxes out of the directory the app used to keep them in.
+///
+/// Until this landed, every Hive box was opened under
+/// `getApplicationDocumentsDirectory()` with no subdirectory, because both
+/// `Hive.initFlutter()` and graphql_flutter's `initHiveForFlutter()` default
+/// their base path to exactly that. On desktop that is the user's real
+/// Documents folder, so an install scattered thirty loose `.hive`/`.lock`
+/// files across it. On Windows it is worse than untidy: Documents is normally
+/// redirected into OneDrive, which then syncs live database files mid-write.
+///
+/// [migrateHiveBoxes] moves an existing install's boxes to their new home on
+/// first launch, so nobody loses playback progress, window geometry or -- the
+/// one that would really hurt -- the `downloaded_media` records that point at
+/// media files already on disk.
+library;
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show debugPrint;
+
+/// Every Hive box Mydia Player opens, by the name passed to `openBox`.
+///
+/// Hive derives a box's filenames from a lowercased box name (`<name>.hive`
+/// and `<name>.lock`, see `hive_ce`'s `BackendManager`), which is why
+/// `graphqlClientStore` is listed in its declared casing and lowercased at
+/// use. A box missing from this list keeps its old file in Documents forever
+/// and silently starts empty in the new location, so
+/// `hive_box_migration_test.dart` asserts this list against the box-name
+/// constants declared across `lib/`.
+const kMydiaHiveBoxes = <String>[
+  // graphql_flutter's normalized cache. `HiveStore.defaultBoxName`, spelled
+  // out rather than imported so this list stays a plain data declaration.
+  'graphqlClientStore',
+  'mydia_fetch_log',
+  'window_geometry',
+  'sidebar_layout',
+  'playback_progress',
+  'cast_session',
+  'subtitle_search_languages',
+  'remote_control_settings',
+  'update_dismissals',
+  'compatibility_dismissals',
+  'download_tasks',
+  'downloaded_media',
+  'download_settings',
+  'storage_settings',
+  'collection_sync',
+];
+
+/// Moves each of [boxes] from [from] to [to], best-effort.
+///
+/// Never throws. This runs on the startup path ahead of `Hive.init`, and a box
+/// that cannot be moved must cost that box its history, never the launch:
+/// Hive simply creates a fresh empty box at the new path. Each box is isolated
+/// in its own guard so one unreadable file cannot strand the other fourteen.
+///
+/// Safe to run on every launch. Once a box has moved there is nothing left at
+/// [from] to find, and a box whose data file already exists at [to] is left
+/// strictly alone rather than overwritten.
+Future<void> migrateHiveBoxes({
+  required String from,
+  required String to,
+  Iterable<String> boxes = kMydiaHiveBoxes,
+}) async {
+  if (_normalize(from) == _normalize(to)) return;
+
+  try {
+    if (!Directory(from).existsSync()) return;
+    await Directory(to).create(recursive: true);
+  } catch (e) {
+    debugPrint('[Hive] Cannot prepare box migration $from -> $to: $e');
+    return;
+  }
+
+  for (final box in boxes) {
+    try {
+      await _migrateBox(from, to, box.toLowerCase());
+    } catch (e) {
+      debugPrint('[Hive] Failed to migrate box "$box": $e');
+    }
+  }
+}
+
+Future<void> _migrateBox(String from, String to, String name) async {
+  final source = File(_join(from, '$name.hive'));
+  final destination = File(_join(to, '$name.hive'));
+
+  if (source.existsSync()) {
+    // A box already at the destination is the live one. Leaving the whole
+    // pair behind is the conservative read of an ambiguous state -- it costs
+    // an install that downgraded and re-upgraded a tidy Documents folder,
+    // where overwriting would cost it the newer data.
+    if (destination.existsSync()) return;
+    await _move(source, destination);
+  }
+
+  // The lock file is a mutual-exclusion artifact Hive recreates whenever it
+  // opens the box. It holds no records, so it is deleted rather than moved.
+  // That is also what clears the last of the litter for a box that was only
+  // ever opened and never written, which leaves a `.lock` and no `.hive`.
+  final lock = File(_join(from, '$name.lock'));
+  if (lock.existsSync()) {
+    try {
+      await lock.delete();
+    } catch (e) {
+      // On Windows a lock file another process still holds open cannot be
+      // deleted. Nothing is lost by leaving it.
+      debugPrint('[Hive] Could not remove stale lock for "$name": $e');
+    }
+  }
+}
+
+Future<void> _move(File source, File destination) async {
+  try {
+    await source.rename(destination.path);
+  } on FileSystemException {
+    // `rename` cannot cross a filesystem boundary, and these two paths
+    // routinely sit on different ones -- a Documents folder redirected to
+    // another volume, or to a OneDrive reparse point. Copy instead, and drop
+    // the original only once the copy is on disk.
+    await source.copy(destination.path);
+    await source.delete();
+  }
+}
+
+String _join(String directory, String name) =>
+    '${_normalize(directory)}${Platform.pathSeparator}$name';
+
+/// Strips trailing separators so `C:\Users\a\Documents\` and
+/// `C:\Users\a\Documents` compare equal and join identically.
+String _normalize(String path) {
+  var end = path.length;
+  while (end > 1 && path[end - 1] == Platform.pathSeparator) {
+    end--;
+  }
+  return path.substring(0, end);
+}

--- a/player/lib/core/storage/hive_box_migration.dart
+++ b/player/lib/core/storage/hive_box_migration.dart
@@ -57,10 +57,18 @@ const kMydiaHiveBoxes = <String>[
 /// Safe to run on every launch. Once a box has moved there is nothing left at
 /// [from] to find, and a box whose data file already exists at [to] is left
 /// strictly alone rather than overwritten.
+/// [isBoxOpen] reports whether a box is currently open, and any box it names
+/// is skipped entirely. Moving a box's files while Hive holds them is not
+/// survivable: Hive keeps the lock file open for the life of the box and
+/// deletes it itself on close, so deleting it first makes `box.close()` throw
+/// `PathNotFoundException` from inside Hive, far from here. Callers pass
+/// `Hive.isBoxOpen`; the default assumes nothing is open, which is what makes
+/// this function testable without a Hive instance.
 Future<void> migrateHiveBoxes({
   required String from,
   required String to,
   Iterable<String> boxes = kMydiaHiveBoxes,
+  bool Function(String name)? isBoxOpen,
 }) async {
   if (_normalize(from) == _normalize(to)) return;
 
@@ -73,6 +81,10 @@ Future<void> migrateHiveBoxes({
   }
 
   for (final box in boxes) {
+    if (isBoxOpen != null && isBoxOpen(box)) {
+      debugPrint('[Hive] Box "$box" is already open; leaving it where it is');
+      continue;
+    }
     try {
       await _migrateBox(from, to, box.toLowerCase());
     } catch (e) {

--- a/player/lib/core/window/desktop_window_native.dart
+++ b/player/lib/core/window/desktop_window_native.dart
@@ -24,12 +24,13 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-// Re-exports hive_ce, so this one import covers Hive, Box and initFlutter.
+// Re-exports hive_ce, so this one import covers both Hive and Box.
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:screen_retriever/screen_retriever.dart';
 import 'package:window_manager/window_manager.dart';
 
 import '../player/platform_features.dart';
+import '../storage/app_hive.dart';
 import 'player_window_sizer.dart';
 import 'player_window_sizer_native.dart';
 import 'window_controller_native.dart';
@@ -137,7 +138,7 @@ Future<List<WorkArea>> _readWorkAreas() async {
 
 Future<WindowGeometryStore> _openStore() async {
   try {
-    await Hive.initFlutter();
+    await initAppHive();
     return HiveWindowGeometryStore(
       await Hive.openBox<Map>(HiveWindowGeometryStore.boxName),
     );

--- a/player/lib/graphql/README.md
+++ b/player/lib/graphql/README.md
@@ -34,7 +34,7 @@ Initialize Hive for GraphQL caching in your app's main function:
 ```dart
 import 'package:graphql_flutter/graphql_flutter.dart';
 
-import '../core/storage/app_hive.dart';
+import 'core/storage/app_hive.dart';
 
 void main() async {
   await initAppHive();

--- a/player/lib/graphql/README.md
+++ b/player/lib/graphql/README.md
@@ -34,11 +34,18 @@ Initialize Hive for GraphQL caching in your app's main function:
 ```dart
 import 'package:graphql_flutter/graphql_flutter.dart';
 
+import '../core/storage/app_hive.dart';
+
 void main() async {
-  await initHiveForFlutter();
+  await initAppHive();
+  await HiveStore.open();
   runApp(MyApp());
 }
 ```
+
+`initAppHive` rather than graphql_flutter's `initHiveForFlutter`: the latter
+hard-wires its base path to `getApplicationDocumentsDirectory()`, which is the
+user's own Documents folder on desktop. See `core/storage/app_hive.dart`.
 
 ### 3. Code Generation
 

--- a/player/lib/main.dart
+++ b/player/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'core/graphql/watch/fetch_log.dart';
 import 'core/player/input_capabilities.dart';
 import 'core/navigation/sidebar_layout_providers.dart';
+import 'core/storage/app_hive.dart';
 import 'core/window/desktop_window.dart';
 import 'core/startup/startup_error_app.dart';
 import 'core/startup/startup_lock.dart';
@@ -177,8 +178,9 @@ Future<void> _startApp() async {
   // Best-effort and self-guarding: `initDesktopWindow` never throws and is a
   // no-op off desktop, so this cannot violate this function's invariant that
   // `runApp` is called exactly once on every path. It opens its own Hive box
-  // rather than depending on the `initHiveForFlutter` call further down, since
-  // geometry must be restored before the first frame.
+  // rather than depending on the GraphQL cache step further down, since
+  // geometry must be restored before the first frame. `initAppHive` is
+  // memoized, so whichever of the two runs first does the work.
   await initDesktopWindow();
 
   // Everything below persists to Hive boxes under the same per-user data
@@ -191,7 +193,14 @@ Future<void> _startApp() async {
   try {
     // Initialize GraphQL Hive cache for offline support. Best-effort: it's
     // an optimisation for offline support, not a requirement to run.
-    await initHiveForFlutter();
+    //
+    // `initAppHive` plus an explicit `HiveStore.open` rather than
+    // graphql_flutter's `initHiveForFlutter`, which is the same two steps
+    // with the base path hard-wired to `getApplicationDocumentsDirectory()`
+    // -- the user's Documents folder on every desktop platform. See
+    // `core/storage/app_hive.dart`.
+    await initAppHive();
+    await HiveStore.open();
   } catch (e, st) {
     debugPrint('[Hive] Failed to initialize GraphQL cache: $e');
     debugPrint('Stack trace: $st');

--- a/player/test/core/storage/hive_box_migration_test.dart
+++ b/player/test/core/storage/hive_box_migration_test.dart
@@ -122,6 +122,46 @@ void main() {
       expect(await _hive(to, 'download_tasks').readAsString(), 'tasks');
     });
 
+    test('leaves an open box completely alone', () async {
+      // Hive holds a box's lock file open for the life of the box and deletes
+      // it itself on close. Moving either file out from under it turns
+      // `box.close()` into a PathNotFoundException thrown from inside Hive,
+      // which is exactly what took out the E2E suite.
+      await _hive(from, 'cast_session').writeAsString('live');
+      await _lock(from, 'cast_session').writeAsString('held');
+      await _hive(from, 'sidebar_layout').writeAsString('closed');
+
+      await migrateHiveBoxes(
+        from: from.path,
+        to: to.path,
+        isBoxOpen: (name) => name == 'cast_session',
+      );
+
+      expect(await _hive(from, 'cast_session').readAsString(), 'live');
+      expect(_lock(from, 'cast_session').existsSync(), isTrue);
+      expect(_hive(to, 'cast_session').existsSync(), isFalse);
+      // The other boxes still move.
+      expect(await _hive(to, 'sidebar_layout').readAsString(), 'closed');
+    });
+
+    test('asks about the declared box name, not the lowercased filename',
+        () async {
+      await _hive(from, 'graphqlClientStore').writeAsString('cache');
+      final asked = <String>[];
+
+      await migrateHiveBoxes(
+        from: from.path,
+        to: to.path,
+        boxes: const ['graphqlClientStore'],
+        isBoxOpen: (name) {
+          asked.add(name);
+          return false;
+        },
+      );
+
+      expect(asked, ['graphqlClientStore']);
+    });
+
     test('one unmovable box does not strand the rest', () async {
       await _hive(from, 'cast_session').writeAsString('session');
       // A directory sitting where the destination file belongs. Both the
@@ -134,6 +174,41 @@ void main() {
 
       expect(await _hive(to, 'downloaded_media').readAsString(), 'media');
       expect(await _hive(from, 'cast_session').readAsString(), 'session');
+    });
+  });
+
+  group('Hive initialization', () {
+    test('nothing bypasses initAppHive', () async {
+      // Both of these default their base path to the user's Documents folder,
+      // which is the whole bug. `initAppHive` is the only sanctioned entry
+      // point. The E2E bootstrap was missed on the first pass and only
+      // surfaced as a PathNotFoundException deep inside Hive, so this looks
+      // everywhere source lives rather than just `lib/`.
+      //
+      // Built by concatenation so this file does not match its own scan.
+      final banned = ['Hive.init${'Flutter('}', 'init${'HiveForFlutter('}'];
+      final offenders = <String>[];
+
+      for (final root in ['lib', 'test', 'integration_test']) {
+        await for (final entity in Directory(root).list(recursive: true)) {
+          if (entity is! File || !entity.path.endsWith('.dart')) continue;
+          final lines = entity.readAsLinesSync();
+          for (var i = 0; i < lines.length; i++) {
+            final line = lines[i];
+            if (line.trimLeft().startsWith('//')) continue;
+            if (banned.any(line.contains)) {
+              offenders.add('${entity.path}:${i + 1}: ${line.trim()}');
+            }
+          }
+        }
+      }
+
+      expect(
+        offenders,
+        isEmpty,
+        reason: 'call initAppHive() from lib/core/storage/app_hive.dart '
+            'instead, so boxes stay out of the user Documents folder',
+      );
     });
   });
 

--- a/player/test/core/storage/hive_box_migration_test.dart
+++ b/player/test/core/storage/hive_box_migration_test.dart
@@ -1,0 +1,171 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/storage/hive_box_migration.dart';
+
+/// Hive names a box's files `<lowercased name>.hive` and `<lowercased
+/// name>.lock`, so these helpers mirror that rather than the declared casing.
+File _hive(Directory dir, String box) =>
+    File('${dir.path}${Platform.pathSeparator}${box.toLowerCase()}.hive');
+
+File _lock(Directory dir, String box) =>
+    File('${dir.path}${Platform.pathSeparator}${box.toLowerCase()}.lock');
+
+void main() {
+  late Directory from;
+  late Directory to;
+
+  setUp(() async {
+    from = await Directory.systemTemp.createTemp('mydia_docs_');
+    to = await Directory.systemTemp.createTemp('mydia_support_');
+  });
+
+  tearDown(() async {
+    for (final dir in [from, to]) {
+      if (dir.existsSync()) await dir.delete(recursive: true);
+    }
+  });
+
+  group('migrateHiveBoxes', () {
+    test('moves a box data file and drops the lock file behind it', () async {
+      await _hive(from, 'playback_progress').writeAsString('records');
+      await _lock(from, 'playback_progress').writeAsString('');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(await _hive(to, 'playback_progress').readAsString(), 'records');
+      expect(_hive(from, 'playback_progress').existsSync(), isFalse);
+      expect(_lock(from, 'playback_progress').existsSync(), isFalse);
+    });
+
+    test('lowercases the box name the way Hive does', () async {
+      await _hive(from, 'graphqlClientStore').writeAsString('cache');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(
+        File('${to.path}${Platform.pathSeparator}graphqlclientstore.hive')
+            .existsSync(),
+        isTrue,
+      );
+    });
+
+    test('leaves a box that already exists at the destination alone', () async {
+      await _hive(from, 'cast_session').writeAsString('old');
+      await _hive(to, 'cast_session').writeAsString('current');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(await _hive(to, 'cast_session').readAsString(), 'current');
+      expect(_hive(from, 'cast_session').existsSync(), isTrue);
+    });
+
+    test('removes an orphan lock left by a box that was never written',
+        () async {
+      await _lock(from, 'sidebar_layout').writeAsString('');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(_lock(from, 'sidebar_layout').existsSync(), isFalse);
+    });
+
+    test('never touches files it was not asked to move', () async {
+      final unrelated = File('${from.path}${Platform.pathSeparator}notes.txt');
+      await unrelated.writeAsString('a real document');
+      // Another Flutter app's box, sharing the same Documents folder.
+      final foreign =
+          File('${from.path}${Platform.pathSeparator}someotherapp.hive');
+      await foreign.writeAsString('not ours');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(await unrelated.readAsString(), 'a real document');
+      expect(await foreign.readAsString(), 'not ours');
+    });
+
+    test('is a no-op when the two paths are the same', () async {
+      await _hive(from, 'window_geometry').writeAsString('geometry');
+
+      await migrateHiveBoxes(
+        from: from.path,
+        to: '${from.path}${Platform.pathSeparator}',
+      );
+
+      expect(await _hive(from, 'window_geometry').readAsString(), 'geometry');
+    });
+
+    test('is a no-op when the source directory does not exist', () async {
+      final missing = '${from.path}${Platform.pathSeparator}gone';
+
+      await expectLater(
+        migrateHiveBoxes(from: missing, to: to.path),
+        completes,
+      );
+    });
+
+    test('creates the destination directory when it is missing', () async {
+      await to.delete();
+      await _hive(from, 'mydia_fetch_log').writeAsString('log');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(await _hive(to, 'mydia_fetch_log').readAsString(), 'log');
+    });
+
+    test('runs on every launch without disturbing an already-moved box',
+        () async {
+      await _hive(from, 'download_tasks').writeAsString('tasks');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(await _hive(to, 'download_tasks').readAsString(), 'tasks');
+    });
+
+    test('one unmovable box does not strand the rest', () async {
+      await _hive(from, 'cast_session').writeAsString('session');
+      // A directory sitting where the destination file belongs. Both the
+      // rename and its copy fallback fail on it, which is the cheapest way to
+      // drive a box into the per-box guard from a test.
+      await Directory(_hive(to, 'cast_session').path).create();
+      await _hive(from, 'downloaded_media').writeAsString('media');
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      expect(await _hive(to, 'downloaded_media').readAsString(), 'media');
+      expect(await _hive(from, 'cast_session').readAsString(), 'session');
+    });
+  });
+
+  group('kMydiaHiveBoxes', () {
+    test('lists every box name declared under lib/', () async {
+      // A box left out of the list keeps its file in Documents forever and
+      // silently starts empty at the new path, which is invisible until a user
+      // reports lost data. Cheaper to catch here, when the box is added.
+      final declaration = RegExp("[Bb]oxName\\s*=\\s*'([^']+)'");
+      final declared = <String, String>{};
+
+      await for (final entity in Directory('lib').list(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        for (final match in declaration.allMatches(entity.readAsStringSync())) {
+          declared[match.group(1)!] = entity.path;
+        }
+      }
+
+      expect(declared, isNotEmpty, reason: 'the scan found no box names');
+
+      final missing = {
+        for (final entry in declared.entries)
+          if (!kMydiaHiveBoxes.contains(entry.key)) entry.key: entry.value,
+      };
+
+      expect(
+        missing,
+        isEmpty,
+        reason: 'add these to kMydiaHiveBoxes in '
+            'lib/core/storage/hive_box_migration.dart so an upgrading install '
+            'carries them over',
+      );
+    });
+  });
+}

--- a/player/test/core/storage/hive_box_migration_test.dart
+++ b/player/test/core/storage/hive_box_migration_test.dart
@@ -162,6 +162,27 @@ void main() {
       expect(asked, ['graphqlClientStore']);
     });
 
+    test('a failed cross-device copy leaves no partial box behind', () async {
+      // The copy fallback runs when `rename` cannot cross a filesystem
+      // boundary. A directory at the destination path forces both to fail,
+      // standing in for an interrupted copy: what matters is that no
+      // half-written `.hive` and no staging file survive at the destination,
+      // since the next launch would read either as a completed migration.
+      await _hive(from, 'playback_progress').writeAsString('records');
+      await Directory(_hive(to, 'playback_progress').path).create();
+
+      await migrateHiveBoxes(from: from.path, to: to.path);
+
+      final leftovers = to
+          .listSync()
+          .map((e) => e.path.split(Platform.pathSeparator).last)
+          .where((name) => name.contains('migrating'))
+          .toList();
+      expect(leftovers, isEmpty, reason: 'staging files must be cleaned up');
+      // The source is still the only complete copy, so a later launch retries.
+      expect(await _hive(from, 'playback_progress').readAsString(), 'records');
+    });
+
     test('one unmovable box does not strand the rest', () async {
       await _hive(from, 'cast_session').writeAsString('session');
       // A directory sitting where the destination file belongs. Both the


### PR DESCRIPTION
Mydia Player scatters its Hive database files across the user's Documents folder. On Windows, where Documents is normally redirected into OneDrive, that means live database files get synced mid-write.

## The cause

Every box was opened under `getApplicationDocumentsDirectory()` with no subdirectory, which is what both `Hive.initFlutter()` and graphql_flutter's `initHiveForFlutter()` default to:

- `hive_ce_flutter/lib/src/hive_extensions.dart:25` — `join(appDir.path, subDir)` collapses to `appDir.path` when `subDir` is null.
- `graphql_flutter/lib/src/hive_init.dart:22` — same, `path = appDir.path`.
- `path_provider_windows/lib/src/path_provider_windows_real.dart:123` — `getApplicationDocumentsPath()` resolves `FOLDERID_Documents`.

Fifteen boxes, each a `.hive` plus a `.lock`, so up to thirty loose files. Linux and macOS get the same litter in `~/Documents`; Windows additionally gets OneDrive syncing files Hive holds open, and a box corrupted or locked that way surfaces as the "already running" startup screen.

## The fix

Boxes move to `getApplicationSupportDirectory()`, resolved in one place by `initAppHive()` in `core/storage/app_hive.dart`. All six init sites go through it: `main.dart`, the desktop window geometry store, the fetch log, both download databases, and the subtitle language prefs.

`initAppHive` is memoized (window geometry has to restore before the first frame, so it cannot wait for the GraphQL cache step), does not cache a failure, and re-registers the two Flutter type adapters `initFlutter` used to register on the app's behalf.

## Migration

Existing installs keep their data. `migrateHiveBoxes` runs before `Hive.init` on every launch and:

- renames each `<box>.hive` across, falling back to copy-then-delete when `rename` cannot cross a filesystem boundary — the normal case when Documents is redirected to another volume or a OneDrive reparse point;
- deletes the `.lock` rather than moving it, since Hive recreates it on open and it holds no records;
- leaves a box that already exists at the destination strictly alone;
- guards each box separately, and never throws into startup — a box that cannot move costs that box its history, not the launch.

Only the fifteen known box names are touched, so another Flutter app's `.hive` file sharing the same Documents folder is never picked up.

`kMydiaHiveBoxes` has to be complete for the migration to be, so a test scans `lib/` for box-name constants and fails naming any that is missing.

## Verification

Beyond the 11 unit tests: my own `~/Documents` had the real litter from a run on 2026-08-16. Copying those 16 files into a sandbox and running the migration over them moved all 8 `.hive` files, deleted all 8 `.lock` files, left the source directory empty, and produced a `graphqlclientstore.hive` that was byte-identical and reopened with its 81 real cache entries; `window_geometry` still yielded the saved window rect.

Full player suite: 3268 passed, 0 failed. `flutter analyze` adds no new issues.

## Deliberately not in scope

- **Downloaded media still lands in `Documents/downloads`.** That is gigabytes rather than kilobytes, `downloaded_media` rows store absolute paths that would all need rewriting, and the right destination is the user's Downloads folder with a real setting, not the app's support directory.
- **`download_manager.dart` and `download_database.dart` are dead code.** Nothing imports the former; only it imports the latter, whose `DownloadDatabase` class also shadows the live abstract interface of the same name in `download_service.dart`. Routed through `initAppHive()` for consistency rather than deleted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App data is now stored in the platform’s application-support location instead of the user’s Documents folder.
  * Existing storage files are migrated automatically on first launch, including cleanup of stale lock files.
  * Web storage continues to use the browser’s IndexedDB storage.

* **Bug Fixes**
  * Storage initialization can safely retry after a failure.
  * Migration preserves open storage and prevents incomplete files if a move is interrupted.
  * Missing platform Documents folders no longer prevent the app from starting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->