### PR TITLE
fix(streaming): stop a cold transcode from timing out playback

### DIFF
--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -242,6 +242,16 @@ defmodule Mydia.Application do
         # returns on its own schedule or never, and a bound whose slots never
         # come back just fails every later request instead.
         {Task.Supervisor, name: Mydia.P2p.RequestSupervisor, max_children: 512},
+        # HLS byte-serving, kept off RequestSupervisor on purpose. These tasks
+        # are long-lived where a request handler is not: one may sit in
+        # `HlsSession.await_ready/2` for the whole readiness budget waiting on a
+        # cold encoder, then stream a segment. Sharing the request pool would let
+        # a stalled encoder's backlog fill it and start refusing GraphQL, so the
+        # two get separate budgets and a stream backlog can only exhaust its own.
+        #
+        # One child per in-flight stream request here, not two, since nothing
+        # wraps these with a deadline: the readiness wait is the bound.
+        {Task.Supervisor, name: Mydia.P2p.StreamSupervisor, max_children: 256},
         Mydia.P2p.Server,
         # Resume active pairing claims on startup
         Mydia.RemoteAccess.ResumeClaims

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -609,9 +609,19 @@ defmodule Mydia.P2p.Server do
     :ok
   end
 
-  defp stream_hls_response(resource, stream_id, req) do
-    # Spawn a task to handle the streaming so we don't block the GenServer
-    Task.start(fn ->
+  # Public only so the regression test can fill the bound and drive the refusal
+  # without a live NIF resource, the same reason `serve_request/5` is public.
+  # Nothing outside this module should call it.
+  @doc false
+  def stream_hls_response(resource, stream_id, req) do
+    # Spawn a task to handle the streaming so we don't block the GenServer, under
+    # a supervisor that bounds how many can be in flight. A bare `Task.start`
+    # here was unbounded: iroh gates inbound connections on ALPN alone, and every
+    # request against a session still warming up parks a task for the whole
+    # `@session_ready_timeout` plus a waiter inside the session. Raising that
+    # budget to two minutes stretched the window in which a peer could pile them
+    # up, so the bound is what makes the longer wait safe to have.
+    task = fn ->
       t0 = System.monotonic_time(:millisecond)
       handle_hls_stream(resource, stream_id, req)
       elapsed = System.monotonic_time(:millisecond) - t0
@@ -619,7 +629,22 @@ defmodule Mydia.P2p.Server do
       Logger.info(
         "p2p_metrics_elixir: handler_complete total_ms=#{elapsed} session=#{req.session_id} path=#{req.path}"
       )
-    end)
+    end
+
+    case Task.Supervisor.start_child(Mydia.P2p.StreamSupervisor, task) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, :max_children} ->
+        # 503 rather than a silent drop: the peer can back off and retry, which
+        # is the behaviour it already has for a session that is not ready.
+        Logger.warning("P2P HLS stream refused: too many streams in flight")
+        send_hls_error(resource, stream_id, 503, "Too many streams in flight")
+
+      {:error, reason} ->
+        Logger.error("P2P HLS stream could not be started: #{inspect(reason)}")
+        send_hls_error(resource, stream_id, 503, "Stream failed to start")
+    end
 
     :ok
   end

--- a/lib/mydia/p2p/server.ex
+++ b/lib/mydia/p2p/server.ex
@@ -30,10 +30,24 @@ defmodule Mydia.P2p.Server do
   @opaque_failure "Request failed"
 
   # How long one peer request may run before its task is killed and its slot
-  # returned. Matches the Rust core's `RESPONSE_TIMEOUT`: past that the peer has
-  # already been handed a timeout error and stopped waiting, so anything still
-  # running is work whose result nothing will read.
-  @request_timeout :timer.seconds(30)
+  # returned. Deliberately *under* the Rust core's 30s `RESPONSE_TIMEOUT` rather
+  # than equal to it. Equal, the two deadlines race: a request that overruns is
+  # abandoned by the peer at the same instant the host decides to answer it, and
+  # the peer is left to infer a timeout from silence. Landing first means the
+  # host always gets to send the error, which is the whole point of the deadline
+  # (see `serve_request/5`). The gap has to cover sending that response back
+  # over the wire, so it is seconds, not milliseconds.
+  @request_timeout :timer.seconds(25)
+
+  # How long a peer's first HLS request waits for FFmpeg to write a playlist.
+  # This is not the request/response path and has no `RESPONSE_TIMEOUT` over it:
+  # the peer holds a QUIC stream open and waits as long as the host takes, so
+  # the only thing this bounds is how long a genuinely dead encoder ties up a
+  # slot. It used to be 30s, which a cold software transcode of an AV1 source
+  # missed by 400ms, turning a slow start into a 503 the player showed as a
+  # failure. Sized for the worst realistic cold start rather than the typical
+  # one, because being late costs a spinner and being early costs playback.
+  @session_ready_timeout :timer.minutes(2)
 
   @doc """
   Status information about the p2p host.
@@ -647,7 +661,7 @@ defmodule Mydia.P2p.Server do
     case lookup_hls_session(req.session_id) do
       {:ok, pid, session_info} ->
         # Wait for the session to be ready (FFmpeg has created initial files)
-        case HlsSession.await_ready(pid, 30_000) do
+        case HlsSession.await_ready(pid, @session_ready_timeout) do
           :ok ->
             case resolve_session_file(session_info, req.path) do
               {:ok, file_path} ->

--- a/lib/mydia/streaming/README.md
+++ b/lib/mydia/streaming/README.md
@@ -81,3 +81,74 @@ them, never a codec's mere absence from the allowlist. A codec missing from the
 lists means the client never claimed it, which still leaves stream-copy on the
 table for a browser that judges codec strings itself. Breaking that distinction
 would silently force Safari to transcode HEVC.
+
+## Four deadlines sit between "play" and the first segment
+
+Starting playback on a file that needs transcoding crosses four independent
+timeouts, in three languages. They are not redundant, and changing one without
+reading the others produces a failure that looks like the network.
+
+| budget | where | covers |
+| --- | --- | --- |
+| 25s | `@request_timeout`, `p2p/server.ex` | one GraphQL request, host side |
+| 30s | `RESPONSE_TIMEOUT`, `mydia_p2p_core/src/lib.rs` | one GraphQL request, peer side |
+| 2min | `@session_ready_timeout`, `p2p/server.ex` | FFmpeg writing its first playlist |
+| 60s | `:timeout`, `Mydia.Repo` config | one query, *excluding* the pool checkout |
+
+The database row is narrower than it looks. `:timeout` bounds the query itself.
+Waiting for a pool connection is governed separately, by `:queue_target` (50ms)
+and `:queue_interval` (2s), and neither is configured here. `:pool_timeout` does
+not exist in db_connection 2.x at all, so the `pool_timeout: 60_000` still sitting
+in `config/test.exs` is a dead option, not a longer budget.
+
+That distinction has diagnostic value: an exhausted pool does not stall quietly,
+it raises `connection not available and request was dropped from queue after Nms`.
+A slow query with no such error in the log was never waiting on a checkout.
+
+Two rules hold the p2p side together.
+
+**The host's request deadline must stay under the peer's.** They were both 30s,
+which raced: an overrunning request was abandoned by the peer at the same moment
+the host decided to answer it, so the peer inferred a timeout from silence
+instead of reading the error the host had prepared. `serve_request/5` exists to
+guarantee exactly one answer goes back; equal deadlines defeated it.
+
+**The readiness budget is not a request budget.** HLS bytes travel a separate
+QUIC stream path (`stream_hls_response/3`), not the request/response path, so no
+`RESPONSE_TIMEOUT` covers it and the peer waits as long as the host takes. That
+budget therefore bounds only how long a dead encoder ties up a slot, and is sized
+for the worst cold start rather than the typical one.
+
+Which is why it runs under `Mydia.P2p.StreamSupervisor` rather than a bare
+`Task.start`. iroh accepts an inbound connection on ALPN alone, so every request
+against a session still warming up parks a task for the whole readiness budget
+plus a waiter inside the session, and a two-minute budget is four times the
+window a thirty-second one gave a peer to pile them up. The bound is what makes
+the longer wait safe to have; stretch one without the other and the readiness
+budget becomes a denial-of-service budget.
+
+Observed on 2026-09-08 on the production instance: a viewer advanced to an AV1
+episode, which needs a full software encode. FFmpeg took 29.6s to write a
+playlist against the then-30s readiness budget, and `StartStreamingSession`
+returned in 29,728ms against the peer's 30s. Both missed by under half a second,
+in opposite directions.
+
+Something else stretched the two GraphQL calls in front of the encoder, and it is
+still unexplained. `StreamingCandidates` billed 14,955ms for work that measures
+1ms when the same resolver is driven directly on the live node, and every slow
+call that day finished within 30ms of a `media_import` commit. Three candidate
+mechanisms were checked and none survives: `CandidatePromotion.commit_group`
+opens a DB-only transaction, `MetadataEnricher` does its network work before the
+transaction opens, and the pool was never exhausted (zero queue-drop errors in
+24 hours, against a signature that cannot fail silently). `busy_timeout` reads 0
+on a pooled connection despite `config/runtime.exs` asking for 30,000, which is
+worth chasing on its own.
+
+Resist raising `pool_size` as a reflex here. It was tried and withdrawn: with no
+queue drops in the log there was no evidence the pool was ever the constraint,
+and the change would have been a guess wearing a measurement's clothes.
+
+The lasting lesson is that time-to-first-segment is a budget chain, not a single
+number, and that a transcode preset is part of it: `veryfast` is the default in
+`ffmpeg_hls_transcoder.ex` because a preset chosen for offline encoding spends
+wall clock the viewer is sitting through.

--- a/lib/mydia/streaming/direct_play_session.ex
+++ b/lib/mydia/streaming/direct_play_session.ex
@@ -152,7 +152,13 @@ defmodule Mydia.Streaming.DirectPlaySession do
         "Direct Play session #{state.session_id} inactive for #{inactive_duration}ms, terminating"
       )
 
-      {:stop, :timeout, state}
+      # `:normal`, not `:timeout`. Reaching the idle deadline is this process
+      # finishing its job, not failing at it, but OTP treats any reason other
+      # than :normal/:shutdown as a crash and prints a full error report with a
+      # stacktrace. Every routine session expiry was landing in the log as
+      # "** (stop) time out", which reads like a fault an operator should chase.
+      # The line above already records why the session ended.
+      {:stop, :normal, state}
     else
       state = schedule_timeout_check(state)
       {:noreply, state}

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -106,7 +106,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     * `:on_error` - (optional) Callback function called when an error occurs
     * `:video_codec` - (optional) Video codec (default: auto-detect from media_file or "libx264")
     * `:audio_codec` - (optional) Audio codec (default: auto-detect from media_file or "aac")
-    * `:preset` - (optional) FFmpeg preset (default: "medium")
+    * `:preset` - (optional) FFmpeg preset (default: "veryfast")
     * `:crf` - (optional) Constant Rate Factor for quality (default: 23)
     * `:max_bitrate` - (optional) Total kbps cap; forces a transcode when set
     * `:max_height` - (optional) Output height ceiling in pixels. Preserves
@@ -592,7 +592,13 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           codec
       end
 
-    preset = Keyword.get(opts, :preset, "medium")
+    # "veryfast", not x264's own "medium" default. This preset governs a live
+    # HLS encode a player is already waiting on, so the only quality that
+    # matters is the quality reachable before the viewer gives up. On an AV1
+    # source "medium" took 29.6s to write the first playlist against the 30s
+    # budget in `Mydia.P2p.Server`, which is a black screen, not better video.
+    # An operator who would rather spend the wall clock can still pass :preset.
+    preset = Keyword.get(opts, :preset, "veryfast")
     crf = Keyword.get(opts, :crf, 23)
 
     # Use index.m3u8 to match HLS controller expectations

--- a/test/mydia/p2p/server_stream_bound_test.exs
+++ b/test/mydia/p2p/server_stream_bound_test.exs
@@ -1,0 +1,88 @@
+defmodule Mydia.P2p.ServerStreamBoundTest do
+  @moduledoc """
+  HLS byte-serving runs under a bounded `Task.Supervisor`, separate from the one
+  serving GraphQL requests.
+
+  iroh accepts an inbound connection on ALPN alone, so a peer needs no
+  credential to make the host spawn one of these, and a request against a
+  session still warming up parks its task for the whole readiness budget plus a
+  waiter inside the session. That budget is two minutes, so an unbounded spawn
+  here is a denial-of-service hole that scales with how patient the host is
+  willing to be with a cold encoder.
+
+  These assert on whether the handler *ran*, not on log wording alone: a full
+  bound must refuse without starting one, and an available slot must actually
+  start one. The execution signal is `handle_hls_stream/3` rejecting the
+  unauthenticated fixture request, which only something inside the spawned
+  handler can emit.
+
+  Asserting the peer-visible 503 instead would need a seam over the P2P NIF,
+  and there is none: `Mydia.P2p.send_hls_header/3` is a bare
+  `:erlang.nif_error` stub with no behaviour or mock behind it. The sibling
+  `server_request_timeout_test.exs` drives `:fake_resource` the same way for
+  the same reason.
+  """
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Mydia.P2p.Server
+
+  setup do
+    # The real one starts only when remote access is enabled, which it is not in
+    # test. max_children: 1 so a single occupant fills it.
+    start_supervised!({Task.Supervisor, name: Mydia.P2p.StreamSupervisor, max_children: 1})
+    :ok
+  end
+
+  defp request do
+    %Mydia.P2p.HlsRequest{session_id: "session-under-test", path: "index.m3u8"}
+  end
+
+  defp children, do: Task.Supervisor.children(Mydia.P2p.StreamSupervisor)
+
+  # The handler runs concurrently, so its log lands after the call returns.
+  # Polls rather than sleeping a fixed span.
+  defp wait_until_settled(remaining, attempts \\ 400) do
+    cond do
+      length(children()) <= remaining -> :ok
+      attempts == 0 -> flunk("handler task never finished")
+      true -> Process.sleep(5) && wait_until_settled(remaining, attempts - 1)
+    end
+  end
+
+  test "starts a handler while the bound has room" do
+    log =
+      capture_log(fn ->
+        # `:fake_resource` never reaches the NIF: send_hls_error/4 rescues the
+        # ArgumentError a fake resource raises, which is the same guard that
+        # covers a peer disconnecting mid-response.
+        assert Server.stream_hls_response(:fake_resource, "stream-with-room", request()) == :ok
+        wait_until_settled(0)
+      end)
+
+    # The handler body ran. Without this the test would pass on an
+    # implementation that silently started nothing.
+    assert log =~ "HLS auth failed"
+    refute log =~ "too many streams in flight"
+  end
+
+  test "refuses without starting a handler once the bound is full" do
+    # Occupy the only slot. This stands in for a peer's request parked in
+    # await_ready/2 waiting on an encoder that has not written a playlist yet.
+    {:ok, occupant} =
+      Task.Supervisor.start_child(Mydia.P2p.StreamSupervisor, fn -> Process.sleep(:infinity) end)
+
+    log =
+      capture_log(fn ->
+        assert Server.stream_hls_response(:fake_resource, "stream-when-full", request()) == :ok
+      end)
+
+    assert log =~ "too many streams in flight"
+
+    # The point of the bound: no second handler was started. `start_child`
+    # refuses synchronously, so there is no race with a task still spawning.
+    refute log =~ "HLS auth failed"
+    assert children() == [occupant]
+  end
+end

--- a/test/mydia/streaming/direct_play_idle_stop_test.exs
+++ b/test/mydia/streaming/direct_play_idle_stop_test.exs
@@ -1,0 +1,40 @@
+defmodule Mydia.Streaming.DirectPlayIdleStopTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.DirectPlaySession
+  alias Mydia.Streaming.DirectPlaySession.State
+
+  # `init/1` inserts a TranscodeJob and broadcasts, so it needs a real
+  # media_file and user. The idle branch needs neither: it reads one timestamp
+  # off the state and decides. Driving the callback directly pins the exit
+  # reason without dragging the database into a test about a log line.
+  defp state_idle_for(milliseconds) do
+    %State{
+      session_id: "session-under-test",
+      media_file_id: Ecto.UUID.generate(),
+      user_id: Ecto.UUID.generate(),
+      mode: :direct,
+      last_activity: DateTime.add(DateTime.utc_now(), -milliseconds, :millisecond)
+    }
+  end
+
+  describe "reaching the idle deadline" do
+    test "stops with :normal, so routine expiry is not logged as a crash" do
+      # OTP reports any reason other than :normal/:shutdown as a crash, with a
+      # full error report. Returning :timeout here put "** (stop) time out"
+      # in the production log every time a viewer simply walked away, which
+      # reads like a fault worth chasing and is not one.
+      assert {:stop, :normal, _state} =
+               DirectPlaySession.handle_info(:check_timeout, state_idle_for(:timer.hours(1)))
+    end
+  end
+
+  describe "before the idle deadline" do
+    test "keeps running and rearms the check" do
+      assert {:noreply, %State{timeout_ref: ref}} =
+               DirectPlaySession.handle_info(:check_timeout, state_idle_for(0))
+
+      assert is_reference(ref)
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_preset_test.exs
+++ b/test/mydia/streaming/ffmpeg_preset_test.exs
@@ -1,0 +1,36 @@
+defmodule Mydia.Streaming.FfmpegPresetTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  defp args(opts) do
+    FfmpegHlsTranscoder.build_ffmpeg_args("/tmp/in.mkv", "/tmp/out", opts)
+  end
+
+  defp value_after(args, flag) do
+    case Enum.find_index(args, &(&1 == flag)) do
+      nil -> nil
+      i -> Enum.at(args, i + 1)
+    end
+  end
+
+  describe "preset" do
+    test "defaults to veryfast, because a player is waiting on the first segment" do
+      # x264's own default is "medium". On an AV1 source that took 29.6s to
+      # write a playlist, against the 2 minute ceiling in Mydia.P2p.Server and,
+      # before it was raised, a 30s one. A preset chosen for offline encoding
+      # spends the viewer's wall clock on quality they never get to see.
+      assert value_after(args([]), "-preset") == "veryfast"
+    end
+
+    test "an operator can still trade startup latency back for quality" do
+      assert value_after(args(preset: "slow"), "-preset") == "slow"
+    end
+
+    test "carries no preset when the video is stream-copied" do
+      # Nothing is being encoded, so a preset would be meaningless. This also
+      # pins that the default above cannot leak into the copy path.
+      assert value_after(args(video_codec: "copy"), "-preset") == nil
+    end
+  end
+end


### PR DESCRIPTION
## What happened

A player advancing to the next episode timed out. The episode was AV1 + Opus, so
it needed a full software transcode, and the startup crossed two independent
30 second deadlines with under half a second of margin on each.

Timeline from the production journal:

| Time | Event | Duration |
|---|---|---|
| 09:35:15 | `StreamingCandidates` | 14,955 ms |
| 09:35:30 | `StartStreamingSession` | 29,728 ms |
| 09:35:59 | FFmpeg starts | |
| 09:36:29 | playlist available | 29,633 ms |

Tap to playable: 75 seconds.

The walls it was up against:

* `RESPONSE_TIMEOUT` (30s, `mydia_p2p_core/src/lib.rs`). `StartStreamingSession`
  answered in 29,728 ms, 272 ms inside it.
* `await_ready` (30s, `p2p/server.ex`). The playlist appeared after 29,633 ms,
  367 ms inside it.

## Fixes

**Transcode preset `medium` to `veryfast`.** x264's default is tuned for offline
encoding. This preset drives a live encode a viewer is sitting through, where the
only quality that counts is the quality reachable before they give up. Callers can
still pass `:preset`.

**Host request deadline 30s to 25s.** It was equal to the peer's `RESPONSE_TIMEOUT`,
so the two raced: an overrunning request was abandoned by the peer at the same
instant the host decided to answer it, and the peer inferred a timeout from silence.
`serve_request/5` exists to guarantee exactly one answer goes back, and equal
deadlines defeated it. This is a one-sided change, so no player needs to ship first.

**HLS readiness budget 30s to 2 minutes.** That wait is not a request budget. HLS
bytes travel a separate QUIC stream path, so no `RESPONSE_TIMEOUT` covers it and the
peer waits as long as the host takes. It bounds only how long a dead encoder holds
a slot.

**HLS byte-serving now runs under a bounded supervisor.** `stream_hls_response/3`
used a bare `Task.start`, bypassing the `max_children` bound `RequestSupervisor`
exists to provide, and the longer readiness budget quadrupled the window a peer had
to pile tasks up in. It gets its own `Mydia.P2p.StreamSupervisor` rather than sharing
the request pool, so a stalled encoder's backlog cannot fill the pool and start
refusing GraphQL.

**Idle direct-play stop `:timeout` to `:normal`.** OTP treats any reason other than
`:normal`/`:shutdown` as a crash, so routine session expiry was printing
`** (stop) time out` with a full error report.

## What I got wrong, and removed

The first push of this branch raised the SQLite `pool_size` from 5 to 10, on the
theory that a concurrent library import had parked `StreamingCandidates` waiting for
a connection. Chasing CodeRabbit's second finding disproved it:

* `:pool_timeout` does not exist in db_connection 2.10.2. Checkout waiting is
  governed by `:queue_target` and `:queue_interval`, neither configured here. The
  `pool_timeout: 60_000` in `config/test.exs` is a dead option.
* An exhausted pool cannot stall quietly. It raises `connection not available and
  request was dropped from queue after Nms`.
* Production logged zero such errors in 24 hours.

So the pool was never the constraint. That commit is gone and `config/runtime.exs` is
untouched.

**The cause of the two slow GraphQL calls is still open.** `StreamingCandidates`
billed 14,955 ms for work that measures 1 ms when the resolver is driven directly on
the live node, and every slow call that day finished within 30 ms of a `media_import`
commit. Three mechanisms were checked and none survives: `commit_group` opens a
DB-only transaction, `MetadataEnricher` does its network work before the transaction
opens, and the pool was never exhausted. One loose thread worth pulling separately:
`busy_timeout` reads 0 on a pooled connection despite `config/runtime.exs` asking for
30,000.

The five fixes above all rest on directly measured numbers and do not depend on that
question being settled. `lib/mydia/streaming/README.md` records the open question and
the ruled-out candidates, so the next person to see a slow query beside a busy import
does not reach for `pool_size` as I did.

## Not in scope

Hardware-accelerated encoding is the real win and is being handled separately.
`/dev/dri/renderD128` is already passed into the container and its ffmpeg advertises
`vaapi`, `qsv`, `drm` and `vulkan`, so it is a code-only change; `lib/mydia/streaming/`
currently has no hwaccel references at all.

Also left alone: answering `StartStreamingSession` immediately so the client polls for
readiness instead of holding a request open.

## Verification

`./dev mix precommit`: 10875 tests, 0 failures.

All three new test files were checked against a reverted fix and fail without it:

* `ffmpeg_preset_test.exs` pins the default, the override, and that no preset leaks
  into the stream-copy path.
* `direct_play_idle_stop_test.exs` pins the exit reason on both branches.
* `server_stream_bound_test.exs` fills the bound and pins the refusal, plus the
  complement so an implementation that refused everything would not pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved HLS streaming startup with clearer handling when streaming capacity is reached or a stream cannot start.
  - Increased the time available for HLS sessions to become ready.

- **Performance**
  - New transcoding sessions now use the faster `veryfast` encoding preset by default, while still allowing custom presets.

- **Bug Fixes**
  - Direct Play sessions that expire due to inactivity now stop cleanly instead of being reported as crashes.

- **Documentation**
  - Added guidance explaining the separate deadlines involved in starting transcoded playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->