### PR TITLE
fix(player): stop a failed candidates call from forcing a transcode

### DIFF
--- a/lib/mydia_web/schema/resolvers/streaming_resolver.ex
+++ b/lib/mydia_web/schema/resolvers/streaming_resolver.ex
@@ -36,11 +36,12 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
         case Candidates.resolve_media_file(content_type, id) do
           {:ok, media_file} ->
             media_file = Candidates.ensure_codec_info(media_file)
+            device_profile = context[:device_profile]
 
             candidates =
               Candidates.build_streaming_candidates(
                 media_file,
-                context[:device_profile] || DeviceProfile.browser_default()
+                device_profile || DeviceProfile.browser_default()
               )
 
             metadata = Candidates.build_metadata_response(media_file, user_id: user.id)
@@ -59,6 +60,25 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
               Enum.map(candidates, fn candidate ->
                 %{candidate | strategy: strategy_to_atom(candidate.strategy)}
               end)
+
+            # The leading strategy is the whole answer: the client reads it as
+            # the compatibility verdict and will not direct play behind a
+            # leading TRANSCODE or HLS_COPY. Logging it with the two inputs that
+            # decide it turns "why did this transcode?" into one grep. Both
+            # inputs were invisible before, and answering that question on
+            # 2026-09-08 meant ruling out three hypotheses by hand.
+            leading =
+              case candidates do
+                [%{strategy: strategy} | _] -> strategy
+                _ -> nil
+              end
+
+            Logger.info(
+              "Streaming candidates for file #{media_file.id}: " <>
+                "leading=#{inspect(leading)} " <>
+                "device_profile=#{if device_profile, do: "client", else: "absent (assuming browser)"} " <>
+                "connection=#{context[:peer_connection_type] || "unknown"}"
+            )
 
             {:ok, %{file_id: media_file.id, candidates: candidates, metadata: metadata}}
 
@@ -307,9 +327,14 @@ defmodule MydiaWeb.Schema.Resolvers.StreamingResolver do
       reported_start_position =
         if info.playlist_mode == :full, do: 0, else: info.start_position
 
+      # max_height is here because its absence cost three ruled-out hypotheses
+      # on 2026-09-08. A capped height is the one thing that vetoes direct play
+      # from the client side, and without it in the log there is no way to tell
+      # a viewer who picked a quality rung from one who did not.
       Logger.info(
         "Started streaming session #{info.session_id} for file #{file_id}, user #{user_id}" <>
           if(max_bitrate, do: " (max_bitrate: #{max_bitrate}kbps)", else: "") <>
+          if(max_height, do: " (max_height: #{max_height}p)", else: "") <>
           if(session_start_position > 0,
             do: " (start_position: #{session_start_position}s)",
             else: ""

--- a/player/lib/domain/models/quality_delivery_subtitle.dart
+++ b/player/lib/domain/models/quality_delivery_subtitle.dart
@@ -48,6 +48,16 @@ String cappedRungDeliverySubtitle(int? maxBitrateKbps) {
 /// compatibility check already found acceptable into a different
 /// container.
 ///
+/// This guard used to stay permissive on the theory that the native device
+/// profile the server checks against hadn't been validated on real hardware
+/// and might under-report a device's true decoder support. That hedge no
+/// longer applies: `android_codec_capabilities.dart`'s `MediaCodecList` probe
+/// against a Fire HD 10 confirmed its decoder is exactly as limited as the
+/// server's verdict assumed — `video/hevc` capped at 8-bit, `video/vp9` capped
+/// at 10-bit — so a `:needs_transcoding` verdict for a codec this device
+/// cannot decode is trustworthy, and HLS_COPY must not be used to second-guess
+/// it.
+///
 /// Platform gating (`!kIsWeb`) is intentionally left to the caller — this
 /// only inspects strategy ordering.
 bool firstStrategyAllowsDirectPlay(Iterable<String> strategyValues) {
@@ -55,6 +65,34 @@ bool firstStrategyAllowsDirectPlay(Iterable<String> strategyValues) {
   if (!iterator.moveNext()) return false;
   final first = iterator.current;
   return first == 'DIRECT_PLAY' || first == 'REMUX';
+}
+
+/// Whether a native client may hand the file to mpv untouched.
+///
+/// [strategyValues] is null when the candidates call gave no answer. That is a
+/// transport failure, not a verdict: `PlayerScreen` throws before reaching this
+/// on both paths that would leave it without a usable file id, so the id in
+/// hand is still the route's own. Unknown therefore means direct play, because
+/// the alternative is asking a server we just failed to reach to run an encode
+/// first, and mpv decodes very nearly everything a transcode would produce.
+///
+/// Observed 2026-09-08: a 15s `StreamingCandidates` call surfaced as a failure
+/// and downgraded an AV1/Opus MKV that had direct-played 22 minutes earlier
+/// into a software transcode, which then died on a malformed Opus header. The
+/// cautious branch produced no playback where the cheap one would have worked.
+///
+/// A non-Original rung still vetoes. Direct play hands the file over untouched,
+/// so there is no encoder to give a height or bitrate cap to, and honouring the
+/// viewer's choice means going through an HLS session instead.
+///
+/// Platform gating (`!kIsWeb`) is left to the caller, as above.
+bool nativeDirectPlayAllowed({
+  required List<String>? strategyValues,
+  required bool isOriginalQuality,
+}) {
+  if (!isOriginalQuality) return false;
+  if (strategyValues == null) return true;
+  return firstStrategyAllowsDirectPlay(strategyValues);
 }
 
 /// Whether any candidate is a no-re-encode delivery (HLS_COPY or REMUX).

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1279,10 +1279,17 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
       // choice means going through a transcoded HLS session instead. Original
       // is the only rung with nothing to ask for, so it is the only one that
       // leaves the cheap path available.
+      // A null `candidatesResult` here can only be a transport failure against
+      // the route's own file id: both paths that would leave us without a
+      // usable id throw at `playFileId` above. See `nativeDirectPlayAllowed`
+      // for why unknown means direct play rather than a transcode.
       final canDirect = !kIsWeb &&
-          candidatesResult != null &&
-          _canDirectPlay(candidatesResult.candidates) &&
-          _selectedQuality.isOriginal;
+          nativeDirectPlayAllowed(
+            strategyValues: candidatesResult?.candidates
+                .map((c) => c.strategy.toJson())
+                .toList(),
+            isOriginalQuality: _selectedQuality.isOriginal,
+          );
 
       _isDirectPlay = canDirect;
 
@@ -1861,40 +1868,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     return null;
   }
 
-  /// Check if the first candidate supports direct play on native.
-  ///
-  /// Delegates to [firstStrategyAllowsDirectPlay], which accepts only
-  /// DIRECT_PLAY and REMUX. HLS_COPY is deliberately excluded even when it
-  /// leads the list: the server only ever leads with HLS_COPY from its
-  /// `:needs_transcoding` branch, and HLS_COPY repackages the stream
-  /// without re-encoding it, so it still carries the exact video codec the
-  /// server just said this device cannot decode. Treating a leading
-  /// HLS_COPY as direct-playable is what let a Fire HD 10 — whose HEVC
-  /// decoder is Main 8-bit only, with no Main 10 support — stream an HEVC
-  /// Main 10 file untouched, straight into mpv's "Could not open codec.".
-  ///
-  /// This guard used to stay permissive on the theory that the native
-  /// device profile the server checks against hadn't been validated on real
-  /// hardware and might under-report a device's true decoder support. That
-  /// hedge no longer applies: `android_codec_capabilities.dart`'s
-  /// `MediaCodecList` probe against a Fire HD 10 confirmed its decoder is
-  /// exactly as limited as the server's verdict assumed — `video/hevc`
-  /// capped at 8-bit, `video/vp9` capped at 10-bit — so a
-  /// `:needs_transcoding` verdict for a codec this device cannot decode is
-  /// trustworthy, and HLS_COPY must not be used to second-guess it. REMUX
-  /// stays accepted because it only repackages a codec the compatibility
-  /// check already found acceptable into a different container — an
-  /// unrelated case.
-  bool _canDirectPlay(
-    List<Query$StreamingCandidates$streamingCandidates$candidates> candidates,
-  ) {
-    final values = candidates.map((c) => c.strategy.toJson()).toList();
-    return firstStrategyAllowsDirectPlay(values);
-  }
-
   /// Cache the Original-rung delivery subtitle from resolved candidates.
   ///
-  /// Labels only — does not change the [_canDirectPlay] playback gate.
+  /// Labels only — does not change the [nativeDirectPlayAllowed] playback gate.
   void _rememberOriginalDeliverySubtitle(
     List<Query$StreamingCandidates$streamingCandidates$candidates>? candidates,
   ) {

--- a/player/test/domain/models/quality_delivery_subtitle_test.dart
+++ b/player/test/domain/models/quality_delivery_subtitle_test.dart
@@ -103,4 +103,65 @@ void main() {
       );
     });
   });
+
+  group('nativeDirectPlayAllowed', () {
+    test('unknown candidates mean direct play, not a transcode', () {
+      // A null list is a transport failure, not a verdict. Falling back to a
+      // transcode asks a server we just failed to reach to do more work, and
+      // on 2026-09-08 that produced no playback at all for a file mpv decodes.
+      expect(
+        nativeDirectPlayAllowed(strategyValues: null, isOriginalQuality: true),
+        isTrue,
+      );
+    });
+
+    test('a chosen rung still vetoes, known candidates or not', () {
+      // Direct play hands the file over untouched, so there is no encoder to
+      // give the rung's height and bitrate caps to.
+      expect(
+        nativeDirectPlayAllowed(strategyValues: null, isOriginalQuality: false),
+        isFalse,
+      );
+      expect(
+        nativeDirectPlayAllowed(
+          strategyValues: const ['DIRECT_PLAY', 'TRANSCODE'],
+          isOriginalQuality: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('known candidates are still judged on their leading strategy', () {
+      expect(
+        nativeDirectPlayAllowed(
+          strategyValues: const ['DIRECT_PLAY', 'TRANSCODE'],
+          isOriginalQuality: true,
+        ),
+        isTrue,
+      );
+      expect(
+        nativeDirectPlayAllowed(
+          strategyValues: const ['REMUX', 'HLS_COPY', 'TRANSCODE'],
+          isOriginalQuality: true,
+        ),
+        isTrue,
+      );
+      // A leading HLS_COPY is the server's :needs_transcoding verdict. Unknown
+      // meaning direct play must not become a way to smuggle past it.
+      expect(
+        nativeDirectPlayAllowed(
+          strategyValues: const ['HLS_COPY', 'TRANSCODE'],
+          isOriginalQuality: true,
+        ),
+        isFalse,
+      );
+      expect(
+        nativeDirectPlayAllowed(
+          strategyValues: const [],
+          isOriginalQuality: true,
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
Follow-up to #749. That PR fixed the timeouts around a cold transcode; this one
addresses why the transcode happened at all, which turned out to be a separate
bug on the player side.

## What happened

On 2026-09-08 an AV1/Opus MKV was server-transcoded on macOS. The same file, same
encode, had direct-played 22 minutes earlier as the preceding episode of the same
show. The transcode then failed on `Error parsing Opus packet header`, so the
viewer got nothing.

Three explanations were ruled out against the live server:

| hypothesis | why not |
|---|---|
| device profile missing | Even with no profile the server answers `[REMUX, HLS_COPY, TRANSCODE]`, and `firstStrategyAllowsDirectPlay` accepts a leading `REMUX`. With the native profile it answers `[DIRECT_PLAY, TRANSCODE]`. Both permit direct play. |
| relay connection | The relay path filters to `TRANSCODE` only, but also forces a 2000 kbps cap. The session log carries no `max_bitrate`. |
| a chosen quality rung | A non-Original rung does veto direct play, by design. Every rung carries a bitrate cap (8000/4000/1500/800) and the log shows none, so the rung was Original. |

What remained is the direct-play gate itself. It required `candidatesResult != null`,
and `_fetchStreamingCandidates` returns null on any exception. With null candidates
`_pickHlsStrategy` falls through to `TRANSCODE`.

That candidates call took 14,955 ms, the same unexplained stall #749 documented. So
the stall did not merely delay playback, it silently changed the playback decision.

## The fix

An unanswered candidates query is a transport failure, not a compatibility verdict.
By the time the gate runs, a null result can only mean a transport failure against
the route's own file id: both paths that would leave the screen without a usable id
already throw at `playFileId`. So the real choice is between handing mpv a file it
almost certainly decodes and asking a server we just failed to reach to run an
encode first.

Unknown now means direct play on native. A chosen rung still vetoes, and a leading
`HLS_COPY` still blocks, so unknown does not become a way around the server's
`:needs_transcoding` verdict.

The gate moves to `nativeDirectPlayAllowed` so it can be tested directly. That left
`PlayerScreen._canDirectPlay` unused, so it goes, and the one paragraph of its docs
not already duplicated on `firstStrategyAllowsDirectPlay` (the Fire HD 10
`MediaCodecList` probe) moves there.

## Logging

Answering the question above meant ruling out three hypotheses by hand, because
every input to the decision was invisible. `streaming_candidates/3` now logs the
leading strategy with the device profile and connection type that produce it, and
the session-start line carries `max_height` beside the `max_bitrate` it already had.
Neither changes a decision.

## Verification

`./dev mix precommit`: 10876 tests, 0 failures. `flutter analyze` on the changed
files is clean apart from two pre-existing `info`s at lines this PR does not touch.

Four new cases cover the gate: unknown means direct play, a rung vetoes with or
without candidates, and known candidates are still judged on their leading strategy
(including that a leading `HLS_COPY` and an empty list both still block).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved native direct playback decisions for Original-quality media.
  - Prevented incompatible direct-play strategies from bypassing codec compatibility checks.
  - Improved playback behavior when delivery strategy information is unavailable or cannot be retrieved, reducing unnecessary fallback to transcoded streaming.
  - Added safeguards for selected quality levels and HLS copy strategies to ensure playback uses compatible delivery options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->