### PR TITLE
feat(streaming): hardware-accelerated transcoding via VAAPI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -268,6 +268,12 @@ LABEL org.opencontainers.image.title="Mydia" \
 # openssl is needed for self-signed certificate generation
 # libstdc++ and ncurses-libs came from the erlang base this image used to use;
 # the bundled ERTS and the Rust NIFs link against them
+# VA drivers for hardware transcoding. ffmpeg links libva unconditionally and
+# advertises `vaapi` in -hwaccels whether or not a driver exists, so without
+# these the feature detects as present and then fails at vaInitialize.
+# mesa-va-gallium covers AMD and older Intel; intel-media-driver covers
+# Broadwell and newer; libva-utils provides vainfo, which the probe parses.
+# Adds roughly 30-50MB, mostly the Intel driver.
 RUN apk add --no-cache \
     sqlite \
     libpq \
@@ -276,6 +282,9 @@ RUN apk add --no-cache \
     ffmpeg \
     chromaprint \
     fdk-aac \
+    mesa-va-gallium \
+    intel-media-driver \
+    libva-utils \
     su-exec \
     tzdata \
     shadow \

--- a/Dockerfile
+++ b/Dockerfile
@@ -273,7 +273,11 @@ LABEL org.opencontainers.image.title="Mydia" \
 # these the feature detects as present and then fails at vaInitialize.
 # mesa-va-gallium covers AMD and older Intel; intel-media-driver covers
 # Broadwell and newer; libva-utils provides vainfo, which the probe parses.
-# Adds roughly 30-50MB, mostly the Intel driver.
+# Adds roughly 250MB uncompressed (measured: 154MB -> 407MB on this package
+# set), most of it llvm21-libs (~170MB), pulled in transitively by
+# mesa-va-gallium because its gallium driver compiles shaders through LLVM;
+# intel-media-driver itself is only ~38MB. The compressed layer delta will
+# be smaller, but on that order.
 RUN apk add --no-cache \
     sqlite \
     libpq \

--- a/devenv.nix
+++ b/devenv.nix
@@ -187,11 +187,19 @@ in
   #   inotify-tools  Phoenix live reload uses fs_events on darwin
   #   chromium/…     Wallaby feature tests are Linux/CI-only (see env below)
   #   gcc            NIFs build against the host clang from the Xcode CLT
+  #   libva-utils    VAAPI is Linux/DRM only; its libdrm dependency has no
+  #                  darwin meta.platforms entry, so this belongs here rather
+  #                  than beside ffmpeg above
   ++ lib.optionals pkgs.stdenv.isLinux (with pkgs; [
     gcc
     inotify-tools
     chromium
     chromedriver
+    # vainfo, which Mydia.Streaming.HardwareAccel.Probe shells out to when
+    # detecting VAAPI capabilities. libva alone (an ffmpeg dependency) does not
+    # provide the CLI; without it the opt-in hwaccel_live_test.exs suite could
+    # never run outside the production container.
+    libva-utils
   ]);
 
   env = {

--- a/docker-entrypoint-prod.sh
+++ b/docker-entrypoint-prod.sh
@@ -83,6 +83,38 @@ if [ -n "$TZ" ]; then
     fi
 fi
 
+# Give the app user access to the render node when one is bind-mounted.
+#
+# The gid that owns /dev/dri/renderD128 is assigned by the host and has no
+# stable name inside the container: on a NixOS host it appears as the bare
+# number 303, because Alpine has no matching /etc/group entry. So stat the
+# device and add the gid, rather than looking up a group called "render" or
+# "video" that may not exist.
+#
+# Many hosts ship the node 0666, where this is a no-op. Debian and Ubuntu
+# commonly ship 0660 root:render, where without this the probe fails with
+# Permission denied on a correctly configured host, and the operator reads
+# that as Mydia not supporting their GPU.
+#
+# A host with no GPU is the common case, so every step below fails soft:
+# nothing here may abort the entrypoint under `set -e`.
+if [ -e /dev/dri/renderD128 ]; then
+    RENDER_GID="$(stat -c '%g' /dev/dri/renderD128 2>/dev/null)" || RENDER_GID=""
+
+    if [ -n "$RENDER_GID" ]; then
+        if ! getent group "$RENDER_GID" >/dev/null 2>&1; then
+            addgroup -g "$RENDER_GID" render 2>/dev/null || true
+        fi
+
+        RENDER_GROUP="$(getent group "$RENDER_GID" 2>/dev/null | cut -d: -f1)"
+
+        if [ -n "$RENDER_GROUP" ]; then
+            addgroup mydia "$RENDER_GROUP" 2>/dev/null || true
+            echo "Granted mydia access to /dev/dri/renderD128 (group $RENDER_GROUP/$RENDER_GID)"
+        fi
+    fi
+fi
+
 echo "────────────────────────────────────────"
 echo "Starting Mydia..."
 echo "────────────────────────────────────────"

--- a/docker-entrypoint-prod.sh
+++ b/docker-entrypoint-prod.sh
@@ -85,11 +85,17 @@ fi
 
 # Give the app user access to the render node when one is bind-mounted.
 #
-# The gid that owns /dev/dri/renderD128 is assigned by the host and has no
-# stable name inside the container: on a NixOS host it appears as the bare
-# number 303, because Alpine has no matching /etc/group entry. So stat the
-# device and add the gid, rather than looking up a group called "render" or
-# "video" that may not exist.
+# The device path is configurable (HWACCEL_DEVICE, see Mydia.Config and
+# Mydia.Streaming.HardwareAccel.Probe) so an operator can pick a render node
+# on a multi-GPU host; default to the common single-GPU path when unset.
+# Resolve it once and use the same value throughout, so a grant on a
+# non-default device actually lands on the device the app will probe.
+#
+# The gid that owns the node is assigned by the host and has no stable name
+# inside the container: on a NixOS host it appears as the bare number 303,
+# because Alpine has no matching /etc/group entry. So stat the device and
+# add the gid, rather than looking up a group called "render" or "video"
+# that may not exist.
 #
 # Many hosts ship the node 0666, where this is a no-op. Debian and Ubuntu
 # commonly ship 0660 root:render, where without this the probe fails with
@@ -98,8 +104,10 @@ fi
 #
 # A host with no GPU is the common case, so every step below fails soft:
 # nothing here may abort the entrypoint under `set -e`.
-if [ -e /dev/dri/renderD128 ]; then
-    RENDER_GID="$(stat -c '%g' /dev/dri/renderD128 2>/dev/null)" || RENDER_GID=""
+RENDER_DEVICE="${HWACCEL_DEVICE:-/dev/dri/renderD128}"
+
+if [ -e "$RENDER_DEVICE" ]; then
+    RENDER_GID="$(stat -c '%g' "$RENDER_DEVICE" 2>/dev/null)" || RENDER_GID=""
 
     if [ -n "$RENDER_GID" ]; then
         if ! getent group "$RENDER_GID" >/dev/null 2>&1; then
@@ -110,8 +118,12 @@ if [ -e /dev/dri/renderD128 ]; then
 
         if [ -n "$RENDER_GROUP" ]; then
             addgroup mydia "$RENDER_GROUP" 2>/dev/null || true
-            echo "Granted mydia access to /dev/dri/renderD128 (group $RENDER_GROUP/$RENDER_GID)"
+            echo "Granted mydia access to $RENDER_DEVICE (group $RENDER_GROUP/$RENDER_GID)"
+        else
+            echo "Warning: found $RENDER_DEVICE but could not resolve or create its group (gid $RENDER_GID); skipping the grant"
         fi
+    else
+        echo "Warning: found $RENDER_DEVICE but could not read its gid; skipping the grant"
     fi
 fi
 

--- a/lib/mydia/application.ex
+++ b/lib/mydia/application.ex
@@ -124,80 +124,83 @@ defmodule Mydia.Application do
       # because it runs before this tree exists. Must sit after the migrator: on
       # a fresh install config_settings does not exist until the migrator has
       # run. Returns :ignore once done. See the module doc.
-      {Mydia.Config.Bootstrap, skip: skip_config_merge?()},
-      # Releases import runs whose coordinator died with the previous node.
-      # Must run after the migrator (it queries import_runs) and before the
-      # Oban child below, because "no queue has started yet" is exactly what
-      # lets it read a lingering `executing` job row as an orphan rather than
-      # as a healthy job this boot just picked up. Returns :ignore once done.
-      Mydia.Jobs.ImportRunReconciler,
-      {DNSCluster, query: Application.get_env(:mydia, :dns_cluster_query) || :ignore},
-      {Phoenix.PubSub, name: Mydia.PubSub},
-      # Owns every asynchronous event insert. Must sit after the repo and
-      # PubSub, which it uses, and therefore stops before them on shutdown so
-      # its terminate/2 has a chance to flush what is still buffered (best
-      # effort, not a guarantee; see the writer's moduledoc).
-      Mydia.Events.Writer,
-      Mydia.Downloads.Client.Registry,
-      # Owns the ETS table holding the derived set of client torrents Mydia
-      # does not manage. init/1 only creates the table (no I/O), so unlike
-      # ClientHealth this is safe to start in every environment.
-      Mydia.Downloads.ExternalTorrents,
-      Mydia.Indexers.Adapter.Registry,
-      Mydia.Indexers.RateLimiter,
-      # Passive circuit breaker for subtitle providers. In-memory only, no DB,
-      # so it is safe to start in every environment including tests.
-      Mydia.Subtitles.Health,
-      Mydia.Metadata.Provider.Registry,
-      Mydia.Metadata.Cache,
-      Mydia.Metadata.ProviderIDRegistry,
-      {Task.Supervisor, name: Mydia.TaskSupervisor},
-      # Supervises optimistic manual-grab pipelines (Mydia.Downloads.Grabber)
-      # so grabs survive the LiveView that started them.
-      {Task.Supervisor, name: Mydia.Downloads.GrabSupervisor},
-      # WASM plugin platform: per-plugin pools register here and live under
-      # the dynamic supervisor (see Mydia.Plugins.Host); the Agent registry
-      # holds installed plugin descriptors (see Mydia.Plugins.Registry).
-      Mydia.Plugins.Registry,
-      {Registry, keys: :unique, name: Mydia.Plugins.PoolRegistry},
-      {DynamicSupervisor, name: Mydia.Plugins.PoolSupervisor, strategy: :one_for_one},
-      # Per-plugin invocation single-flight lock (U4): serializes on-event /
-      # on-schedule / inline calls for one plugin so shared KV state is safe.
-      Mydia.Plugins.SingleFlight,
-      # Separate named lock instance serializing session subtitle extraction
-      # (see Mydia.Streaming.SessionSubtitles). A slow ffmpeg extraction must
-      # never make a plugin invocation wait behind it, hence its own instance
-      # rather than sharing the plugin host's lock above. The explicit :id
-      # disambiguates it from the SingleFlight child above: both default to
-      # the module name as their child id, which the supervisor rejects as
-      # a duplicate.
-      Supervisor.child_spec({Mydia.Plugins.SingleFlight, name: Mydia.Streaming.SubtitleLock},
-        id: Mydia.Streaming.SubtitleLock
-      ),
-      # Fans "events:all" out to subscribed plugins (U5). Replaces the Luerl
-      # hooks manager removed in U11.
-      Mydia.Plugins.Dispatcher,
-      {Registry, keys: :unique, name: Mydia.Streaming.HlsSessionRegistry},
-      Mydia.Streaming.HlsSessionSupervisor,
-      {Mydia.Streaming.SessionSampler,
-       Application.get_env(:mydia, Mydia.Streaming.SessionSampler, [])},
-      {Registry, keys: :unique, name: Mydia.Downloads.TranscodeRegistry},
-      {Registry, keys: :unique, name: Mydia.Downloads.Client.Debrid.FetcherRegistry},
-      {DynamicSupervisor,
-       name: Mydia.Downloads.Client.Debrid.FetcherSupervisor, strategy: :one_for_one},
-      Mydia.Downloads.Client.Debrid.RateLimiter,
-      {Registry, keys: :unique, name: Mydia.Downloads.Seedbox.FetcherRegistry},
-      {DynamicSupervisor,
-       name: Mydia.Downloads.Seedbox.FetcherSupervisor, strategy: :one_for_one},
-      Mydia.Downloads.JobManager,
-      Mydia.CrashReporter.Throttle,
-      Mydia.CrashReporter.Queue,
-      Mydia.RemoteAccess.ClaimRateLimiter,
-      Mydia.Accounts.ApiKeyRateLimiter,
-      {Registry, keys: :unique, name: Mydia.DynamicSupervisorRegistry},
-      {DynamicSupervisor,
-       name: {:via, Registry, {Mydia.DynamicSupervisorRegistry, :relay}}, strategy: :one_for_one}
+      {Mydia.Config.Bootstrap, skip: skip_config_merge?()}
     ] ++
+      hardware_accel_children() ++
+      [
+        # Releases import runs whose coordinator died with the previous node.
+        # Must run after the migrator (it queries import_runs) and before the
+        # Oban child below, because "no queue has started yet" is exactly what
+        # lets it read a lingering `executing` job row as an orphan rather than
+        # as a healthy job this boot just picked up. Returns :ignore once done.
+        Mydia.Jobs.ImportRunReconciler,
+        {DNSCluster, query: Application.get_env(:mydia, :dns_cluster_query) || :ignore},
+        {Phoenix.PubSub, name: Mydia.PubSub},
+        # Owns every asynchronous event insert. Must sit after the repo and
+        # PubSub, which it uses, and therefore stops before them on shutdown so
+        # its terminate/2 has a chance to flush what is still buffered (best
+        # effort, not a guarantee; see the writer's moduledoc).
+        Mydia.Events.Writer,
+        Mydia.Downloads.Client.Registry,
+        # Owns the ETS table holding the derived set of client torrents Mydia
+        # does not manage. init/1 only creates the table (no I/O), so unlike
+        # ClientHealth this is safe to start in every environment.
+        Mydia.Downloads.ExternalTorrents,
+        Mydia.Indexers.Adapter.Registry,
+        Mydia.Indexers.RateLimiter,
+        # Passive circuit breaker for subtitle providers. In-memory only, no DB,
+        # so it is safe to start in every environment including tests.
+        Mydia.Subtitles.Health,
+        Mydia.Metadata.Provider.Registry,
+        Mydia.Metadata.Cache,
+        Mydia.Metadata.ProviderIDRegistry,
+        {Task.Supervisor, name: Mydia.TaskSupervisor},
+        # Supervises optimistic manual-grab pipelines (Mydia.Downloads.Grabber)
+        # so grabs survive the LiveView that started them.
+        {Task.Supervisor, name: Mydia.Downloads.GrabSupervisor},
+        # WASM plugin platform: per-plugin pools register here and live under
+        # the dynamic supervisor (see Mydia.Plugins.Host); the Agent registry
+        # holds installed plugin descriptors (see Mydia.Plugins.Registry).
+        Mydia.Plugins.Registry,
+        {Registry, keys: :unique, name: Mydia.Plugins.PoolRegistry},
+        {DynamicSupervisor, name: Mydia.Plugins.PoolSupervisor, strategy: :one_for_one},
+        # Per-plugin invocation single-flight lock (U4): serializes on-event /
+        # on-schedule / inline calls for one plugin so shared KV state is safe.
+        Mydia.Plugins.SingleFlight,
+        # Separate named lock instance serializing session subtitle extraction
+        # (see Mydia.Streaming.SessionSubtitles). A slow ffmpeg extraction must
+        # never make a plugin invocation wait behind it, hence its own instance
+        # rather than sharing the plugin host's lock above. The explicit :id
+        # disambiguates it from the SingleFlight child above: both default to
+        # the module name as their child id, which the supervisor rejects as
+        # a duplicate.
+        Supervisor.child_spec({Mydia.Plugins.SingleFlight, name: Mydia.Streaming.SubtitleLock},
+          id: Mydia.Streaming.SubtitleLock
+        ),
+        # Fans "events:all" out to subscribed plugins (U5). Replaces the Luerl
+        # hooks manager removed in U11.
+        Mydia.Plugins.Dispatcher,
+        {Registry, keys: :unique, name: Mydia.Streaming.HlsSessionRegistry},
+        Mydia.Streaming.HlsSessionSupervisor,
+        {Mydia.Streaming.SessionSampler,
+         Application.get_env(:mydia, Mydia.Streaming.SessionSampler, [])},
+        {Registry, keys: :unique, name: Mydia.Downloads.TranscodeRegistry},
+        {Registry, keys: :unique, name: Mydia.Downloads.Client.Debrid.FetcherRegistry},
+        {DynamicSupervisor,
+         name: Mydia.Downloads.Client.Debrid.FetcherSupervisor, strategy: :one_for_one},
+        Mydia.Downloads.Client.Debrid.RateLimiter,
+        {Registry, keys: :unique, name: Mydia.Downloads.Seedbox.FetcherRegistry},
+        {DynamicSupervisor,
+         name: Mydia.Downloads.Seedbox.FetcherSupervisor, strategy: :one_for_one},
+        Mydia.Downloads.JobManager,
+        Mydia.CrashReporter.Throttle,
+        Mydia.CrashReporter.Queue,
+        Mydia.RemoteAccess.ClaimRateLimiter,
+        Mydia.Accounts.ApiKeyRateLimiter,
+        {Registry, keys: :unique, name: Mydia.DynamicSupervisorRegistry},
+        {DynamicSupervisor,
+         name: {:via, Registry, {Mydia.DynamicSupervisorRegistry, :relay}}, strategy: :one_for_one}
+      ] ++
       remote_access_children() ++
       client_health_children() ++
       indexer_health_children() ++
@@ -246,6 +249,26 @@ defmodule Mydia.Application do
         # Resume active pairing claims on startup
         Mydia.RemoteAccess.ResumeClaims
       ]
+    else
+      []
+    end
+  end
+
+  # Probes the host's video hardware once and caches the answer. Must sit after
+  # Config.Bootstrap, which merges the database layer carrying HWACCEL and
+  # HWACCEL_DEVICE. Probing costs one to three seconds and runs in
+  # handle_continue, so it delays only the first caller asking for
+  # capabilities, not the rest of the tree.
+  #
+  # Not started under `mix test`. A developer machine with a real render node
+  # would otherwise hand hardware capabilities to every streaming test, and
+  # those tests assert software arguments on purpose: they are what proves the
+  # accelerated path did not change the unaccelerated one. capabilities/0
+  # reports software when this process is absent, so nothing else needs to
+  # know.
+  defp hardware_accel_children do
+    if Application.get_env(:mydia, :start_health_monitors, true) do
+      [Mydia.Streaming.HardwareAccel]
     else
       []
     end

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -324,6 +324,12 @@ defmodule Mydia.Config.Loader do
       System.get_env("SUBTITLE_LANGUAGE"),
       &parse_string_list/1
     )
+    |> put_if_present(
+      :hwaccel,
+      System.get_env("HWACCEL"),
+      &parse_hwaccel/1
+    )
+    |> put_if_present(:hwaccel_device, System.get_env("HWACCEL_DEVICE"))
   end
 
   defp load_logging_env do
@@ -690,6 +696,26 @@ defmodule Mydia.Config.Loader do
   end
 
   defp parse_external_torrents(_), do: :error
+
+  # A dedicated fixed-enum parser. parse_atom/1 must not be reused here: it
+  # rescues into String.to_atom/1, which mints atoms from environment input.
+  #
+  # An unrecognised value becomes :invalid rather than :error. put_if_present/4
+  # drops the key on :error, which would make a typo silently resolve to the
+  # schema default of :auto; :invalid is not a member of the Ecto.Enum, so
+  # config validation rejects it by name.
+  defp parse_hwaccel(value) when is_atom(value), do: {:ok, value}
+
+  defp parse_hwaccel(value) when is_binary(value) do
+    case value |> String.trim() |> String.downcase() do
+      "auto" -> {:ok, :auto}
+      "off" -> {:ok, :off}
+      "vaapi" -> {:ok, :vaapi}
+      _unrecognised -> {:ok, :invalid}
+    end
+  end
+
+  defp parse_hwaccel(_), do: :error
 
   defp parse_string_list(value) when is_list(value), do: {:ok, value}
 

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -200,6 +200,21 @@ defmodule Mydia.Config.Schema do
       # languages to go and get, and resolving "original" per item would make
       # a bulk run's target set depend on metadata that may be absent.
       field :subtitle_language, {:array, :string}, default: ["en"]
+
+      # Which hardware video backend to use. :auto probes and uses whatever
+      # works; :off forces software even on a capable box; :vaapi names a
+      # backend explicitly, which skips auto-selection so the operator learns
+      # whether the one they asked for actually worked rather than silently
+      # receiving a different answer.
+      #
+      # :invalid is not selectable. It is what the env parser emits for an
+      # unrecognised value so that validation rejects it by name; see
+      # Mydia.Config.Loader.parse_hwaccel/1.
+      field :hwaccel, Ecto.Enum, values: [:auto, :off, :vaapi, :invalid], default: :auto
+
+      # Render node to use on a multi-GPU host. nil means "pick the first one
+      # that probes successfully".
+      field :hwaccel_device, :string
     end
 
     embeds_one :logging, Logging, on_replace: :update, primary_key: false do
@@ -486,7 +501,13 @@ defmodule Mydia.Config.Schema do
 
   defp streaming_changeset(schema, attrs) do
     schema
-    |> cast(attrs, [:max_transcode_height, :audio_language, :prefer_default_audio_track])
+    |> cast(attrs, [
+      :max_transcode_height,
+      :audio_language,
+      :prefer_default_audio_track,
+      :hwaccel,
+      :hwaccel_device
+    ])
     # cast/3's default empty_values ([""]) silently drops blank entries from
     # array fields before validate_subtitle_language/1 ever sees them, which
     # is also why validate_audio_language/1's blank-entry branch below is

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -207,10 +207,15 @@ defmodule Mydia.Config.Schema do
       # whether the one they asked for actually worked rather than silently
       # receiving a different answer.
       #
-      # :invalid is not selectable. It is what the env parser emits for an
-      # unrecognised value so that validation rejects it by name; see
-      # Mydia.Config.Loader.parse_hwaccel/1.
-      field :hwaccel, Ecto.Enum, values: [:auto, :off, :vaapi, :invalid], default: :auto
+      # :invalid is deliberately absent from `values:`. Mydia.Config.Loader's
+      # parse_hwaccel/1 emits {:ok, :invalid} for an unrecognised HWACCEL so
+      # that put_if_present/4 does not drop the key and fall back to :auto;
+      # Ecto.Enum then rejects that atom at cast time because it is not a
+      # member of this list. Adding :invalid here would make it a valid
+      # selection and defeat the whole mechanism -- see the
+      # DownloadClient.external_torrents field below (and
+      # parse_external_torrents/1 in the loader) for the working precedent.
+      field :hwaccel, Ecto.Enum, values: [:auto, :off, :vaapi], default: :auto
 
       # Render node to use on a multi-GPU host. nil means "pick the first one
       # that probes successfully".

--- a/lib/mydia/downloads/download_service.ex
+++ b/lib/mydia/downloads/download_service.ex
@@ -390,6 +390,7 @@ defmodule Mydia.Downloads.DownloadService do
                resolution: resolution_atom,
                input_path: input_path,
                output_path: output_path,
+               source_codec: media_file.codec,
                on_progress: on_progress,
                on_complete: on_complete,
                on_error: on_error

--- a/lib/mydia/downloads/ffmpeg_mp4_transcoder.ex
+++ b/lib/mydia/downloads/ffmpeg_mp4_transcoder.ex
@@ -16,12 +16,13 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
 
   ## FFmpeg Command Structure
 
-  The core FFmpeg command used:
+  The core FFmpeg command used (software tier shown; a VAAPI-capable host
+  swaps in `h264_vaapi` and a `scale_vaapi` filter instead):
 
       ffmpeg -i input.mkv \
         -c:v libx264 -preset medium -crf 23 \
         -pix_fmt yuv420p -profile:v high \
-        -s 1920x1080 \
+        -vf scale=-2:1080 \
         -c:a aac -b:a 128k -ar 48000 -ac 2 \
         -movflags +frag_keyframe+empty_moov+default_base_moof \
         -progress pipe:2 \
@@ -31,6 +32,19 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
   - `frag_keyframe`: Create a new fragment at each keyframe (enables seeking)
   - `empty_moov`: Write the moov atom immediately (enables playback before complete)
   - `default_base_moof`: Optimize fragment headers for seeking
+
+  ## Hardware Acceleration
+
+  The video encode goes through `Mydia.Streaming.HardwareAccel.Args`, the same
+  builder the HLS path uses, so a VAAPI-capable host encodes with `h264_vaapi`
+  instead of `libx264`. This is a background job rather than interactive
+  playback, so `init/1` takes a `:background` lease from
+  `Mydia.Streaming.HardwareAccel`, which is refused one slot early so an
+  interactive playback start never waits behind a batch download; a refusal
+  just means "encode in software". If the hardware encoder fails to
+  initialise, the whole job restarts once in software (there is no window or
+  segment grid to preserve here, unlike HLS) via `retry_in_software?/1` and
+  `Mydia.Streaming.FfmpegHlsTranscoder.hwaccel_failure?/1`.
 
   ## Usage
 
@@ -49,6 +63,11 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
 
   use GenServer
   require Logger
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+  alias Mydia.Streaming.HardwareAccel
+  alias Mydia.Streaming.HardwareAccel.Args, as: AccelArgs
+  alias Mydia.Streaming.HardwareAccel.Capabilities
 
   @type resolution :: :p1080 | :p720 | :p480
   @type transcode_opts :: [
@@ -75,7 +94,13 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
       :on_error,
       :buffer,
       :duration,
-      :started_at
+      :started_at,
+      :job_id,
+      :source_codec,
+      :opts,
+      :hwaccel_lease,
+      hwaccel_retried: false,
+      output_buffer: ""
     ]
 
     @type t :: %__MODULE__{
@@ -89,7 +114,13 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
             on_error: (String.t() -> any()) | nil,
             buffer: String.t(),
             duration: float() | nil,
-            started_at: DateTime.t()
+            started_at: DateTime.t(),
+            job_id: String.t() | nil,
+            source_codec: String.t() | nil,
+            opts: keyword(),
+            hwaccel_lease: reference() | nil,
+            hwaccel_retried: boolean(),
+            output_buffer: String.t()
           }
   end
 
@@ -175,6 +206,19 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
       on_complete = Keyword.get(opts, :on_complete)
       on_error = Keyword.get(opts, :on_error)
 
+      # A background lease is refused one slot early so an interactive
+      # playback start never waits behind a batch download transcode. A
+      # refusal means "encode in software", not an error -- fall back to the
+      # software capabilities so build_ffmpeg_args/4 never reaches for a
+      # device this job was refused.
+      {capabilities, lease} =
+        case HardwareAccel.lease(:background) do
+          {:ok, ref} -> {HardwareAccel.capabilities(), ref}
+          :refused -> {Capabilities.software("no hardware slot free for a background job"), nil}
+        end
+
+      opts = Keyword.put(opts, :capabilities, capabilities)
+
       # Build FFmpeg command
       args = build_ffmpeg_args(input_path, output_path, resolution, opts)
 
@@ -195,13 +239,20 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
             on_error: on_error,
             buffer: "",
             duration: nil,
-            started_at: DateTime.utc_now()
+            started_at: DateTime.utc_now(),
+            job_id: Keyword.get(opts, :media_file_id, input_path),
+            source_codec: Keyword.get(opts, :source_codec),
+            opts: opts,
+            hwaccel_lease: lease,
+            hwaccel_retried: false,
+            output_buffer: ""
           }
 
           {:ok, state}
 
         {:error, reason} ->
           Logger.error("Failed to start FFmpeg process: #{inspect(reason)}")
+          if lease, do: HardwareAccel.release(lease)
           {:stop, {:ffmpeg_start_failed, reason}}
       end
     else
@@ -234,6 +285,12 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
 
     # Accumulate output in buffer
     buffer = state.buffer <> data
+
+    # Separate, bounded accumulation of raw stderr so the hwaccel classifier
+    # sees the whole message rather than one chunk -- `buffer` above gets
+    # cleared as soon as parse_ffmpeg_output/1 recognizes a line, which would
+    # otherwise chop a multi-line VAAPI failure apart before it could match.
+    state = %{state | output_buffer: FfmpegHlsTranscoder.append_output(state.output_buffer, data)}
 
     # Parse FFmpeg output for progress and duration
     state =
@@ -297,7 +354,30 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
       state.on_error.(error_msg)
     end
 
-    {:stop, {:ffmpeg_failed, status}, state}
+    if retry_in_software?(state) do
+      Logger.warning(
+        "Download transcode hardware encode failed; restarting in software for job " <>
+          "#{state.job_id}"
+      )
+
+      HardwareAccel.report_failure(:vaapi, state.source_codec)
+
+      case restart_in_software(state) do
+        {:ok, new_state} ->
+          {:noreply, new_state}
+
+        {:error, reason} ->
+          Logger.error("Failed to restart FFmpeg in software: #{inspect(reason)}")
+          {:stop, {:ffmpeg_failed, status}, state}
+      end
+    else
+      # {:ffmpeg_failed, status}, not {:ffmpeg_exit, status}: JobManager
+      # pattern-matches on this exact reason (see
+      # lib/mydia/downloads/job_manager.ex) to drive download job failure
+      # handling, unlike the HLS transcoder's equivalent reason which nothing
+      # matches on.
+      {:stop, {:ffmpeg_failed, status}, state}
+    end
   end
 
   def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
@@ -313,6 +393,11 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
   @impl true
   def terminate(reason, state) do
     Logger.info("Terminating FFmpeg MP4 transcoder, reason: #{inspect(reason)}")
+
+    # Release the hardware slot on every exit path -- normal completion,
+    # ffmpeg failure, or a crash -- so a leaked background lease never starves
+    # playback of a slot it was never using.
+    if state.hwaccel_lease, do: HardwareAccel.release(state.hwaccel_lease)
 
     # Stop FFmpeg process if still running
     if is_port(state.ffmpeg_port) && Port.info(state.ffmpeg_port) do
@@ -356,57 +441,117 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
     _ -> false
   end
 
-  # Build FFmpeg command arguments for progressive MP4 transcoding
-  defp build_ffmpeg_args(input_path, output_path, resolution, opts) do
-    preset = Keyword.get(opts, :preset, "medium")
-    crf = Keyword.get(opts, :crf, 23)
+  # Build FFmpeg command arguments for progressive MP4 transcoding.
+  #
+  # `-s WxH` is deliberately gone: it forces exact dimensions with no aspect
+  # handling and cannot coexist with a hardware filter chain -- it would force
+  # a software scale after the frames are already on the GPU. The height
+  # reaches AccelArgs as :max_height instead, so one filter expression
+  # (software scale, or scale_vaapi on the hardware tiers) handles every
+  # resolution preset.
+  @doc false
+  # Public only so the argument construction can be unit-tested directly,
+  # without spawning ffmpeg; nothing outside this module should call it.
+  def build_ffmpeg_args(input_path, output_path, resolution, opts) do
+    %{height: height} = @resolution_presets[resolution]
 
-    # Get resolution dimensions
-    %{width: width, height: height} = @resolution_presets[resolution]
+    capabilities =
+      Keyword.get_lazy(opts, :capabilities, fn ->
+        HardwareAccel.capabilities()
+      end)
 
-    # Build FFmpeg arguments
-    [
-      # Input
-      "-i",
-      input_path,
-      # Video encoding
-      "-c:v",
-      "libx264",
-      "-preset",
-      preset,
-      "-crf",
-      to_string(crf),
-      "-pix_fmt",
-      "yuv420p",
-      "-profile:v",
-      "high",
-      "-s",
-      "#{width}x#{height}",
-      # Audio encoding
-      "-c:a",
-      "aac",
-      "-b:a",
-      "128k",
-      "-ar",
-      "48000",
-      "-ac",
-      "2",
-      # Fragmented MP4 output flags for progressive playback
-      # - frag_keyframe: Create new fragment at each keyframe (enables seeking)
-      # - empty_moov: Write moov atom immediately (enables playback before complete)
-      # - default_base_moof: Optimize fragment headers
-      "-movflags",
-      "+frag_keyframe+empty_moov+default_base_moof",
-      # Progress reporting (FFmpeg writes to stderr)
-      "-progress",
-      "pipe:2",
-      # Format and output
-      "-f",
-      "mp4",
-      "-loglevel",
-      "info",
-      output_path
-    ]
+    accel =
+      AccelArgs.build(capabilities,
+        source_codec: Keyword.get(opts, :source_codec),
+        max_height: height,
+        crf: Keyword.get(opts, :crf, 23),
+        preset: Keyword.get(opts, :preset, "medium")
+      )
+
+    # -hwaccel flags must precede -i. After it, ffmpeg has already selected a
+    # decoder and silently ignores them.
+    accel.input ++
+      ["-i", input_path] ++
+      accel.video ++
+      [
+        # Audio encoding
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-ar",
+        "48000",
+        "-ac",
+        "2",
+        # Fragmented MP4 output flags for progressive playback -- these are
+        # what make the file playable before the download completes; losing
+        # them breaks progressive playback silently, with no error.
+        # - frag_keyframe: Create new fragment at each keyframe (enables seeking)
+        # - empty_moov: Write moov atom immediately (enables playback before complete)
+        # - default_base_moof: Optimize fragment headers
+        "-movflags",
+        "+frag_keyframe+empty_moov+default_base_moof",
+        # Progress reporting (FFmpeg writes to stderr)
+        "-progress",
+        "pipe:2",
+        # Format and output
+        "-f",
+        "mp4",
+        output_path
+      ]
+  end
+
+  # Whether a non-zero ffmpeg exit should be retried once in software.
+  #
+  # Public so the branch decision is testable without spawning ffmpeg,
+  # mirroring FfmpegHlsTranscoder.hwaccel_failure?/1. A hardware failure is
+  # only worth retrying the first time -- retrying a genuine encode error
+  # would just hide a bug behind a second, slower failure -- so a job that
+  # already retried always answers false here regardless of what the output
+  # looks like.
+  @doc false
+  @spec retry_in_software?(map()) :: boolean()
+  def retry_in_software?(%{hwaccel_retried: true}), do: false
+
+  def retry_in_software?(%{output_buffer: output}) do
+    FfmpegHlsTranscoder.hwaccel_failure?(output)
+  end
+
+  # Restarts the whole job in software after a hardware initialisation
+  # failure. There is no window or segment grid to preserve here, unlike the
+  # HLS session, so this rebuilds the arguments from scratch and spawns a
+  # fresh port rather than relocating anything.
+  defp restart_in_software(state) do
+    if state.hwaccel_lease, do: HardwareAccel.release(state.hwaccel_lease)
+
+    opts =
+      Keyword.put(
+        state.opts,
+        :capabilities,
+        Capabilities.software("fell back after a hardware failure")
+      )
+
+    args = build_ffmpeg_args(state.input_path, state.output_path, state.resolution, opts)
+
+    Logger.debug("FFmpeg args (software fallback): #{inspect(args)}")
+
+    case start_ffmpeg_process(args) do
+      {:ok, port, pid} ->
+        {:ok,
+         %{
+           state
+           | ffmpeg_pid: pid,
+             ffmpeg_port: port,
+             buffer: "",
+             output_buffer: "",
+             opts: opts,
+             hwaccel_lease: nil,
+             hwaccel_retried: true
+         }}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   # Start FFmpeg process using Port

--- a/lib/mydia/downloads/ffmpeg_mp4_transcoder.ex
+++ b/lib/mydia/downloads/ffmpeg_mp4_transcoder.ex
@@ -350,10 +350,15 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
     error_msg = "FFmpeg exited with status #{status}#{error_details}"
     Logger.error(error_msg)
 
-    if state.on_error do
-      state.on_error.(error_msg)
-    end
-
+    # on_error is deliberately NOT called here unconditionally. JobManager
+    # drives download job failure straight from this callback (see
+    # DownloadService.maybe_start_transcode/2, which wires on_error to
+    # Downloads.fail_job/2), so calling it on every non-zero exit -- including
+    # a hardware-init failure this process is about to retry in software --
+    # marked the job failed while a software retry was still starting behind
+    # it, racing JobManager against that retry's own eventual on_complete or
+    # on_error. It is only called below, on the two branches that are
+    # actually terminal for this job.
     if retry_in_software?(state) do
       Logger.warning(
         "Download transcode hardware encode failed; restarting in software for job " <>
@@ -368,9 +373,17 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
 
         {:error, reason} ->
           Logger.error("Failed to restart FFmpeg in software: #{inspect(reason)}")
+
+          # Terminal: the software retry itself never started, so no later
+          # callback will ever report this job's outcome.
+          if state.on_error, do: state.on_error.(error_msg)
           {:stop, {:ffmpeg_failed, status}, state}
       end
     else
+      # Terminal: not retrying, so this exit is the job's one and only
+      # outcome.
+      if state.on_error, do: state.on_error.(error_msg)
+
       # {:ffmpeg_failed, status}, not {:ffmpeg_exit, status}: JobManager
       # pattern-matches on this exact reason (see
       # lib/mydia/downloads/job_manager.ex) to drive download job failure
@@ -523,6 +536,18 @@ defmodule Mydia.Downloads.FfmpegMp4Transcoder do
   # fresh port rather than relocating anything.
   defp restart_in_software(state) do
     if state.hwaccel_lease, do: HardwareAccel.release(state.hwaccel_lease)
+
+    # The failed hardware attempt already left a file at output_path:
+    # -movflags +empty_moov (see build_ffmpeg_args/4) writes the moov atom
+    # immediately, before a single frame is encoded, so the file exists even
+    # though the hardware attempt produced no usable output. build_ffmpeg_args/4
+    # never emits -y, so without this the software retry would stop at
+    # ffmpeg's interactive overwrite prompt -- with no terminal attached to
+    # answer it -- and hang forever instead of retrying. Removing the
+    # known-dead partial is narrower than adding -y globally, which would
+    # also silently paper over a genuine "output already exists" bug
+    # elsewhere.
+    File.rm(state.output_path)
 
     opts =
       Keyword.put(

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -71,7 +71,9 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       :duration,
       :started_at,
       ready_notified: false,
-      seen_segments: MapSet.new()
+      seen_segments: MapSet.new(),
+      accel_tier: :software,
+      output_buffer: ""
     ]
 
     @type t :: %__MODULE__{
@@ -89,7 +91,9 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
             buffer: String.t(),
             duration: float() | nil,
             started_at: DateTime.t(),
-            ready_notified: boolean()
+            ready_notified: boolean(),
+            accel_tier: AccelArgs.tier(),
+            output_buffer: String.t()
           }
   end
 
@@ -204,6 +208,19 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     # Build FFmpeg command
     args = build_ffmpeg_args(input_path, output_dir, opts)
 
+    # Derived from the argument list rather than by calling AccelArgs.build/2
+    # again: re-deriving from inputs risks drift, and build_ffmpeg_args/3's
+    # return shape can't change without breaking the six regression test
+    # files that assert its exact output. The gate below only needs to know
+    # whether this was a hardware attempt at all, but deriving the precise
+    # tier costs nothing and keeps the log line below accurate.
+    accel_tier =
+      cond do
+        "-hwaccel" in args -> :full_hardware
+        "-init_hw_device" in args -> :hybrid
+        true -> :software
+      end
+
     Logger.info("Starting FFmpeg HLS transcoding: #{input_path}")
     Logger.debug("FFmpeg args: #{inspect(args)}")
 
@@ -226,7 +243,9 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           playlist_path: playlist_path,
           buffer: "",
           duration: nil,
-          started_at: DateTime.utc_now()
+          started_at: DateTime.utc_now(),
+          accel_tier: accel_tier,
+          output_buffer: ""
         }
 
         # One timer drives both signals. Readiness is just "the playlist
@@ -265,6 +284,12 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
 
     # Accumulate output in buffer
     buffer = state.buffer <> data
+
+    # Separate, bounded accumulation of raw stderr so the hwaccel classifier
+    # sees the whole message rather than one chunk — `buffer` above gets
+    # cleared as soon as parse_ffmpeg_output/1 recognizes a line, which would
+    # otherwise chop a multi-line VAAPI failure apart before it could match.
+    state = %{state | output_buffer: String.slice(state.output_buffer <> data, -4_000, 4_000)}
 
     # Parse FFmpeg output for progress and duration
     state =
@@ -347,7 +372,19 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       state.on_error.(error_msg)
     end
 
-    {:stop, {:ffmpeg_failed, status}, state}
+    reason =
+      if state.accel_tier != :software and hwaccel_failure?(state.output_buffer) do
+        Logger.warning(
+          "Hardware encode failed to initialise (tier #{state.accel_tier}); " <>
+            "the session will retry in software"
+        )
+
+        {:hwaccel_failed, state.output_buffer}
+      else
+        {:ffmpeg_exit, status}
+      end
+
+    {:stop, reason, state}
   end
 
   def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
@@ -782,6 +819,34 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
         {:error, e}
     end
   end
+
+  # Matched against ffmpeg's stderr to tell a hardware initialisation failure
+  # from an ordinary encode error. Only the former is worth retrying in
+  # software: retrying a genuine error would hide a bug behind a second, slower
+  # failure. The first pattern is captured verbatim from a container whose
+  # ffmpeg links libva with no driver installed.
+  @hwaccel_failure_patterns [
+    ~r/Failed to initialise VAAPI connection/i,
+    ~r/No VA display found/i,
+    ~r/Device creation failed/i,
+    ~r/Function not implemented/i,
+    ~r/Failed to open .*\/dev\/dri\/.*Permission denied/i,
+    ~r/for option 'init_hw_device'/i,
+    ~r/for option 'hwaccel_device'/i
+  ]
+
+  @doc """
+  Whether ffmpeg's output describes a hardware initialisation failure.
+
+  Public so the classifier can be tested against captured output without
+  starting a transcoder.
+  """
+  @spec hwaccel_failure?(String.t()) :: boolean()
+  def hwaccel_failure?(output) when is_binary(output) do
+    Enum.any?(@hwaccel_failure_patterns, &Regex.match?(&1, output))
+  end
+
+  def hwaccel_failure?(_), do: false
 
   # Parse FFmpeg output for duration, progress, and errors
   defp parse_ffmpeg_output(output) do

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -289,7 +289,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     # sees the whole message rather than one chunk — `buffer` above gets
     # cleared as soon as parse_ffmpeg_output/1 recognizes a line, which would
     # otherwise chop a multi-line VAAPI failure apart before it could match.
-    state = %{state | output_buffer: String.slice(state.output_buffer <> data, -4_000, 4_000)}
+    state = %{state | output_buffer: append_output(state.output_buffer, data)}
 
     # Parse FFmpeg output for progress and duration
     state =
@@ -825,11 +825,20 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # software: retrying a genuine error would hide a bug behind a second, slower
   # failure. The first pattern is captured verbatim from a container whose
   # ffmpeg links libva with no driver installed.
+  #
+  # Deliberately NOT included: a standalone `Function not implemented`
+  # pattern. That string is the literal strerror(ENOSYS) text ffmpeg prints
+  # via av_strerror for ANY AVERROR(ENOSYS) — an unsupported muxer, protocol,
+  # or codec feature, not only hardware device init. Matching it on its own
+  # would classify an unrelated encode-time ENOSYS as a hardware failure and
+  # retry it in software, which is exactly the over-matching this classifier
+  # exists to avoid. The real VAAPI case is still caught: it always appears
+  # as the parenthetical on the connection line, which
+  # `Failed to initialise VAAPI connection` already matches.
   @hwaccel_failure_patterns [
     ~r/Failed to initialise VAAPI connection/i,
     ~r/No VA display found/i,
     ~r/Device creation failed/i,
-    ~r/Function not implemented/i,
     ~r/Failed to open .*\/dev\/dri\/.*Permission denied/i,
     ~r/for option 'init_hw_device'/i,
     ~r/for option 'hwaccel_device'/i
@@ -847,6 +856,35 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   end
 
   def hwaccel_failure?(_), do: false
+
+  # Bound in bytes, not graphemes. String.slice/3 counts grapheme clusters,
+  # so slicing a buffer full of multi-byte characters to "the last 4,000"
+  # keeps 4,000 *graphemes* — up to 3x @output_buffer_bytes for 3-byte UTF-8
+  # sequences (common CJK/accented text, realistic here since this is a
+  # self-hosted media server with arbitrary international file paths). This
+  # buffer lives for the whole session, so that growth is exactly what the
+  # bound exists to prevent.
+  @output_buffer_bytes 4_000
+
+  @doc false
+  # Public only so the byte bound can be unit-tested directly, without
+  # starting a transcoder; nothing outside this module should call it.
+  def append_output(buffer, data) do
+    combined = buffer <> data
+    size = byte_size(combined)
+
+    if size > @output_buffer_bytes do
+      # A byte-based cut can land inside a multi-byte character, leaving
+      # invalid UTF-8 at the start of the buffer. That's fine here: the
+      # buffer is only ever regex-matched, and @hwaccel_failure_patterns are
+      # plain ASCII without the `u` modifier, so the regex engine matches
+      # against raw bytes and never raises on the malformed prefix.
+      # Scrubbing it back to valid UTF-8 would cost more than it buys.
+      binary_part(combined, size - @output_buffer_bytes, @output_buffer_bytes)
+    else
+      combined
+    end
+  end
 
   # Parse FFmpeg output for duration, progress, and errors
   defp parse_ffmpeg_output(output) do

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -36,6 +36,8 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
 
   alias Mydia.Library.Structs.StreamInfo
   alias Mydia.Streaming.AudioTrackSelector
+  alias Mydia.Streaming.HardwareAccel
+  alias Mydia.Streaming.HardwareAccel.Args, as: AccelArgs
 
   @type transcode_opts :: [
           input_path: String.t(),
@@ -614,55 +616,43 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
         _ -> []
       end
 
-    base_args =
-      seek_args ++
-        [
-          "-i",
-          input_path
-        ]
-
-    # Build video encoding args
-    video_args =
+    # Acceleration is decided only on the encode branch. A stream copy returns
+    # empty argument lists, so nothing here can turn a copy into a transcode.
+    accel =
       if video_codec == "copy" do
-        # Stream copy - no encoding parameters needed
-        ["-c:v", "copy"]
+        %AccelArgs{tier: :software, input: [], video: []}
       else
-        # Base encoding parameters shared by CRF and ABR modes
-        base_video = [
-          "-c:v",
-          video_codec,
-          "-preset",
-          preset,
-          "-pix_fmt",
-          "yuv420p",
-          "-profile:v",
-          "high",
-          "-g",
-          "60",
-          "-bf",
-          "0"
-        ]
+        capabilities =
+          Keyword.get_lazy(opts, :capabilities, fn -> HardwareAccel.capabilities() end)
 
-        # Rate control: ABR when max_bitrate is set, CRF otherwise
-        rate_control =
+        video_bitrate_kbps =
           if max_bitrate do
-            video_kbps = max(max_bitrate - @audio_bitrate_kbps, 100)
-
-            Logger.info("Using ABR mode: video=#{video_kbps}kbps, total_cap=#{max_bitrate}kbps")
-
-            [
-              "-b:v",
-              "#{video_kbps}k",
-              "-maxrate",
-              "#{video_kbps}k",
-              "-bufsize",
-              "#{video_kbps * 2}k"
-            ]
-          else
-            ["-crf", to_string(crf)]
+            kbps = max(max_bitrate - @audio_bitrate_kbps, 100)
+            Logger.info("Using ABR mode: video=#{kbps}kbps, total_cap=#{max_bitrate}kbps")
+            kbps
           end
 
-        base_video ++ scale_args(max_height) ++ rate_control
+        AccelArgs.build(capabilities,
+          source_codec: media_file && media_file.codec,
+          max_height: max_height,
+          video_bitrate_kbps: video_bitrate_kbps,
+          crf: crf,
+          preset: preset,
+          video_codec: video_codec
+        )
+      end
+
+    Logger.info("Encoding tier: #{accel.tier}")
+
+    # -hwaccel flags must precede -i. After it, ffmpeg has already selected a
+    # decoder and silently ignores them.
+    base_args = seek_args ++ accel.input ++ ["-i", input_path]
+
+    video_args =
+      if video_codec == "copy" do
+        ["-c:v", "copy"]
+      else
+        accel.video
       end
 
     # Build audio encoding args
@@ -826,63 +816,6 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
         :no_match
     end
   end
-
-  # Builds the video scale filter. Every encode gets one; only the ceiling is
-  # optional.
-  #
-  # `-2` keeps the width proportional to the source and divisible by two,
-  # which H.264 requires; hardcoding both dimensions (the previous `-s
-  # WxH`) distorted anything that was not 16:9. `min(h, ih)` clamps against
-  # the *input* height so a rung above the source never upscales, which
-  # would burn CPU to produce a larger, blurrier picture.
-  #
-  # The comma inside `min()` is backslash-escaped because FFmpeg reads a
-  # bare comma in a filtergraph as a filter separator. The usual shell form
-  # `-vf scale=-2:'min(720,ih)'` is wrong here: these arguments go straight
-  # to a port with no shell, so the quotes would arrive literally and the
-  # filter would fail to parse.
-  #
-  # `2*trunc(.../2)` rounds the height down to an even number, and it is the
-  # reason the uncapped clause emits a filter at all rather than nothing. An
-  # odd frame height makes libx264 with `-pix_fmt yuv420p` refuse to open the
-  # encoder outright ("height not divisible by 2", exit 187): the transcode
-  # dies before writing a playlist, the client's playlist wait times out, and
-  # the viewer gets a generic playback error with nothing in it pointing here.
-  #
-  # That is reachable on the DEFAULT path, not just under a cap. The old
-  # hardcoded `-s 1280x720` evened every transcode as a side effect; removing
-  # it (correctly, since it also squished everything that was not 16:9) took
-  # the evening with it. VP9 and AV1 both permit odd frame heights and are
-  # exactly the codecs this module force-transcodes, and ordinary rips like
-  # 720x405 and 848x477 are odd too. Rounding down rather than up is what
-  # keeps the no-upscale guarantee; `-2` then tracks the width to it, which is
-  # what preserves the aspect ratio.
-  #
-  # Only ever reached on the encode branch — a stream copy returns before
-  # this, so no filter can turn a copy into a transcode.
-  defp scale_args(height) when is_integer(height) and height > 0 do
-    ["-vf", "scale=-2:2*trunc(min(#{height}\\,ih)/2)"]
-  end
-
-  # A zero or negative ceiling would scale to nothing. It can only arrive from
-  # a misconfigured `streaming.max_transcode_height` (the schema rejects it,
-  # but a stale cached runtime config could still carry one), so say so rather
-  # than silently ignoring it and leaving the operator to wonder why their cap
-  # does nothing. The encode still gets the evening filter: a bad ceiling is
-  # no reason to hand libx264 an odd height.
-  defp scale_args(height) when is_integer(height) do
-    Logger.warning(
-      "Ignoring a non-positive transcode height ceiling (#{height}); " <>
-        "encoding at the source resolution"
-    )
-
-    even_height_args()
-  end
-
-  defp scale_args(_), do: even_height_args()
-
-  # No ceiling: keep the source resolution, rounded down to an even height.
-  defp even_height_args, do: ["-vf", "scale=-2:2*trunc(ih/2)"]
 
   @doc """
   Composes a requested output height with the operator's configured ceiling

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -45,6 +45,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           on_progress: (map() -> any()) | nil,
           on_complete: (-> any()) | nil,
           on_error: (String.t() -> any()) | nil,
+          on_hwaccel_failed: (String.t() -> any()) | nil,
           media_file: Mydia.Library.MediaFile.t() | nil,
           video_codec: String.t(),
           audio_codec: String.t(),
@@ -66,6 +67,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       :on_error,
       :on_ready,
       :on_segments,
+      :on_hwaccel_failed,
       :playlist_path,
       :buffer,
       :duration,
@@ -86,6 +88,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
             on_error: (String.t() -> any()) | nil,
             on_ready: (-> any()) | nil,
             on_segments: ([non_neg_integer()] -> any()) | nil,
+            on_hwaccel_failed: (String.t() -> any()) | nil,
             seen_segments: MapSet.t(non_neg_integer()),
             playlist_path: String.t() | nil,
             buffer: String.t(),
@@ -110,6 +113,11 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     * `:on_progress` - (optional) Callback function called with progress updates
     * `:on_complete` - (optional) Callback function called when transcoding completes
     * `:on_error` - (optional) Callback function called when an error occurs
+    * `:on_hwaccel_failed` - (optional) Callback called with the buffered FFmpeg
+      output when a hardware initialisation failure is detected. The process
+      then stops with reason `:normal` (recoverable, not a crash) instead of
+      `{:ffmpeg_exit, status}`; the callback is the only way the caller learns
+      why.
     * `:video_codec` - (optional) Video codec (default: auto-detect from media_file or "libx264")
     * `:audio_codec` - (optional) Audio codec (default: auto-detect from media_file or "aac")
     * `:preset` - (optional) FFmpeg preset (default: "medium")
@@ -204,6 +212,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     on_error = Keyword.get(opts, :on_error)
     on_ready = Keyword.get(opts, :on_ready)
     on_segments = Keyword.get(opts, :on_segments)
+    on_hwaccel_failed = Keyword.get(opts, :on_hwaccel_failed)
 
     # Build FFmpeg command
     args = build_ffmpeg_args(input_path, output_dir, opts)
@@ -240,6 +249,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
           on_error: on_error,
           on_ready: on_ready,
           on_segments: on_segments,
+          on_hwaccel_failed: on_hwaccel_failed,
           playlist_path: playlist_path,
           buffer: "",
           duration: nil,
@@ -372,19 +382,26 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
       state.on_error.(error_msg)
     end
 
-    reason =
-      if state.accel_tier != :software and hwaccel_failure?(state.output_buffer) do
-        Logger.warning(
-          "Hardware encode failed to initialise (tier #{state.accel_tier}); " <>
-            "the session will retry in software"
-        )
+    if state.accel_tier != :software and hwaccel_failure?(state.output_buffer) do
+      Logger.warning(
+        "Hardware encode failed to initialise (tier #{state.accel_tier}); " <>
+          "the session will retry in software"
+      )
 
-        {:hwaccel_failed, state.output_buffer}
-      else
-        {:ffmpeg_exit, status}
+      if state.on_hwaccel_failed do
+        state.on_hwaccel_failed.(state.output_buffer)
       end
 
-    {:stop, reason, state}
+      # :normal, not {:hwaccel_failed, output}: HlsSession links to this
+      # process (see the comment on HlsSession.relocate/2), and a link to a
+      # non-trapping process only kills it for a non-normal exit. A hardware
+      # init failure is recoverable and must not take the session down the
+      # same way a genuine crash does; on_hwaccel_failed above is what tells
+      # the session to actually recover it.
+      {:stop, :normal, state}
+    else
+      {:stop, {:ffmpeg_exit, status}, state}
+    end
   end
 
   def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do

--- a/lib/mydia/streaming/hardware_accel.ex
+++ b/lib/mydia/streaming/hardware_accel.ex
@@ -1,0 +1,173 @@
+defmodule Mydia.Streaming.HardwareAccel do
+  @moduledoc """
+  Holds the hardware probe result and rations access to the device.
+
+  The probe runs in `handle_continue/2`, so `capabilities/1` is an ordinary
+  `GenServer.call/3` that queues behind it: callers arriving during the probe
+  block until it finishes, and callers after it get a cached struct. There is no
+  `:probing` state for the encode paths to handle.
+
+  When this process is not running, `capabilities/0` reports software rather
+  than raising. That is the normal state in `test` and on any install where the
+  supervisor child is skipped, and it is what lets every pre-existing streaming
+  test keep asserting software arguments.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+  alias Mydia.Streaming.HardwareAccel.Probe
+
+  # Household scale, not a hardware limit. Deliberately not configurable: a knob
+  # added before anyone hits the ceiling is surface without evidence. If leases
+  # are refused in practice, that is the signal to raise it.
+  @default_cap 3
+
+  # How many failures for one {backend, codec} pair before that codec drops out
+  # of the decode list.
+  @default_demote_after 3
+
+  defmodule State do
+    @moduledoc false
+    defstruct [:capabilities, :cap, :demote_after, :probe, leases: %{}, failures: %{}]
+  end
+
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "The probe result, or software capabilities when no probe is running."
+  @spec capabilities(GenServer.server()) :: Capabilities.t()
+  def capabilities(server \\ __MODULE__) do
+    case GenServer.whereis(server) do
+      nil -> Capabilities.software("hardware acceleration probe is not running")
+      pid -> GenServer.call(pid, :capabilities, 30_000)
+    end
+  end
+
+  @doc """
+  Claims a hardware slot. `:background` is refused one slot early so an
+  interactive playback start never waits behind a batch download transcode. A
+  refusal means "encode in software", not an error.
+  """
+  @spec lease(GenServer.server(), :playback | :background) :: {:ok, reference()} | :refused
+  def lease(server \\ __MODULE__, priority) do
+    case GenServer.whereis(server) do
+      nil -> :refused
+      pid -> GenServer.call(pid, {:lease, priority})
+    end
+  end
+
+  @spec release(GenServer.server(), reference()) :: :ok
+  def release(server \\ __MODULE__, ref) do
+    case GenServer.whereis(server) do
+      nil -> :ok
+      pid -> GenServer.cast(pid, {:release, ref})
+    end
+  end
+
+  @doc "Records that a hardware encode failed for a source codec."
+  @spec report_failure(GenServer.server(), atom(), String.t() | atom() | nil) :: :ok
+  def report_failure(server \\ __MODULE__, backend, source_codec) do
+    case GenServer.whereis(server) do
+      nil -> :ok
+      pid -> GenServer.call(pid, {:report_failure, backend, source_codec})
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    state = %State{
+      cap: Keyword.get(opts, :cap, @default_cap),
+      demote_after: Keyword.get(opts, :demote_after, @default_demote_after),
+      probe: Keyword.get(opts, :probe, &Probe.run/1)
+    }
+
+    {:ok, state, {:continue, :probe}}
+  end
+
+  @impl true
+  def handle_continue(:probe, state) do
+    config = Mydia.Config.get()
+    streaming = Map.get(config || %{}, :streaming) || %{}
+
+    opts = [
+      hwaccel: Map.get(streaming, :hwaccel, :auto),
+      device: Map.get(streaming, :hwaccel_device)
+    ]
+
+    capabilities = state.probe.(opts)
+
+    log_result(capabilities)
+
+    {:noreply, %{state | capabilities: capabilities}}
+  end
+
+  defp log_result(%Capabilities{backend: :none, reason: reason}) do
+    Logger.info("Hardware transcoding unavailable: #{reason}. Encoding in software.")
+  end
+
+  defp log_result(%Capabilities{} = caps) do
+    Logger.info(
+      "Hardware transcoding enabled: #{caps.backend} on #{caps.device}, " <>
+        "decodes #{inspect(caps.decode_profiles)}, encodes #{inspect(caps.encoders)}"
+    )
+  end
+
+  @impl true
+  def handle_call(:capabilities, _from, state), do: {:reply, state.capabilities, state}
+
+  def handle_call({:lease, _priority}, _from, %State{capabilities: %{backend: :none}} = state) do
+    {:reply, :refused, state}
+  end
+
+  def handle_call({:lease, priority}, _from, state) do
+    if map_size(state.leases) < limit_for(priority, state.cap) do
+      ref = make_ref()
+      {:reply, {:ok, ref}, %{state | leases: Map.put(state.leases, ref, priority)}}
+    else
+      {:reply, :refused, state}
+    end
+  end
+
+  def handle_call({:report_failure, backend, source_codec}, _from, state) do
+    case Capabilities.codec_atom(source_codec) do
+      nil ->
+        {:reply, :ok, state}
+
+      codec ->
+        key = {backend, codec}
+        count = Map.get(state.failures, key, 0) + 1
+        state = %{state | failures: Map.put(state.failures, key, count)}
+
+        {:reply, :ok, maybe_demote(state, codec, count)}
+    end
+  end
+
+  # Demotion is per codec, never per backend. Losing the whole device because
+  # one advertised profile is broken would throw away every other codec it
+  # handles correctly.
+  defp maybe_demote(state, codec, count) do
+    if count >= state.demote_after and codec in state.capabilities.decode_profiles do
+      Logger.warning(
+        "Hardware decode of #{codec} failed #{count} times; dropping it to the hybrid tier"
+      )
+
+      profiles = List.delete(state.capabilities.decode_profiles, codec)
+      %{state | capabilities: %{state.capabilities | decode_profiles: profiles}}
+    else
+      state
+    end
+  end
+
+  defp limit_for(:background, cap), do: max(cap - 1, 0)
+  defp limit_for(_playback, cap), do: cap
+
+  @impl true
+  def handle_cast({:release, ref}, state) do
+    {:noreply, %{state | leases: Map.delete(state.leases, ref)}}
+  end
+end

--- a/lib/mydia/streaming/hardware_accel.ex
+++ b/lib/mydia/streaming/hardware_accel.ex
@@ -29,6 +29,16 @@ defmodule Mydia.Streaming.HardwareAccel do
   # of the decode list.
   @default_demote_after 3
 
+  # Every call below queues behind handle_continue's :probe message, which can
+  # legitimately run for a few seconds (a hung vainfo or driver ioctl makes
+  # that worse, not better). The default GenServer.call/3 timeout of 5s would
+  # then raise exit(:timeout) in the caller instead of returning :refused,
+  # turning a slow probe into a crash in the playback path -- exactly what
+  # this module's "a refusal means encode in software, not an error" contract
+  # promises callers it won't do. One shared value so lease/2 and
+  # report_failure/3 cannot drift from capabilities/1's timeout again.
+  @call_timeout 30_000
+
   defmodule State do
     @moduledoc false
     defstruct [:capabilities, :cap, :demote_after, :probe, leases: %{}, failures: %{}]
@@ -44,7 +54,7 @@ defmodule Mydia.Streaming.HardwareAccel do
   def capabilities(server \\ __MODULE__) do
     case GenServer.whereis(server) do
       nil -> Capabilities.software("hardware acceleration probe is not running")
-      pid -> GenServer.call(pid, :capabilities, 30_000)
+      pid -> GenServer.call(pid, :capabilities, @call_timeout)
     end
   end
 
@@ -52,12 +62,17 @@ defmodule Mydia.Streaming.HardwareAccel do
   Claims a hardware slot. `:background` is refused one slot early so an
   interactive playback start never waits behind a batch download transcode. A
   refusal means "encode in software", not an error.
+
+  Monitors the calling process for the lifetime of the lease: if the holder
+  dies without calling `release/2` (an ffmpeg-wrapping session killed by OOM
+  or a timeout, the realistic failure mode here), the slot is reclaimed on the
+  resulting `:DOWN` rather than leaking until this process restarts.
   """
   @spec lease(GenServer.server(), :playback | :background) :: {:ok, reference()} | :refused
   def lease(server \\ __MODULE__, priority) do
     case GenServer.whereis(server) do
       nil -> :refused
-      pid -> GenServer.call(pid, {:lease, priority})
+      pid -> GenServer.call(pid, {:lease, priority}, @call_timeout)
     end
   end
 
@@ -74,7 +89,7 @@ defmodule Mydia.Streaming.HardwareAccel do
   def report_failure(server \\ __MODULE__, backend, source_codec) do
     case GenServer.whereis(server) do
       nil -> :ok
-      pid -> GenServer.call(pid, {:report_failure, backend, source_codec})
+      pid -> GenServer.call(pid, {:report_failure, backend, source_codec}, @call_timeout)
     end
   end
 
@@ -124,9 +139,13 @@ defmodule Mydia.Streaming.HardwareAccel do
     {:reply, :refused, state}
   end
 
-  def handle_call({:lease, priority}, _from, state) do
+  def handle_call({:lease, priority}, {pid, _tag}, state) do
     if map_size(state.leases) < limit_for(priority, state.cap) do
-      ref = make_ref()
+      # The monitor reference doubles as the lease reference handed back to
+      # the caller: it is already unique, and using it directly means the
+      # :DOWN handler below needs no separate index to find which lease a
+      # dead holder held.
+      ref = Process.monitor(pid)
       {:reply, {:ok, ref}, %{state | leases: Map.put(state.leases, ref, priority)}}
     else
       {:reply, :refused, state}
@@ -168,6 +187,25 @@ defmodule Mydia.Streaming.HardwareAccel do
 
   @impl true
   def handle_cast({:release, ref}, state) do
+    # Flush so a DOWN that already fired (or fires concurrently with this
+    # cast) for a ref we're about to forget cannot land in the mailbox and be
+    # treated as a live message later.
+    Process.demonitor(ref, [:flush])
     {:noreply, %{state | leases: Map.delete(state.leases, ref)}}
+  end
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    case Map.pop(state.leases, ref) do
+      {nil, _leases} ->
+        {:noreply, state}
+
+      {priority, leases} ->
+        Logger.info(
+          "Reclaimed a leaked #{priority} hardware lease: holder exited (#{inspect(reason)})"
+        )
+
+        {:noreply, %{state | leases: leases}}
+    end
   end
 end

--- a/lib/mydia/streaming/hardware_accel.ex
+++ b/lib/mydia/streaming/hardware_accel.ex
@@ -52,9 +52,11 @@ defmodule Mydia.Streaming.HardwareAccel do
   @doc "The probe result, or software capabilities when no probe is running."
   @spec capabilities(GenServer.server()) :: Capabilities.t()
   def capabilities(server \\ __MODULE__) do
+    fallback = Capabilities.software("hardware acceleration probe is not running")
+
     case GenServer.whereis(server) do
-      nil -> Capabilities.software("hardware acceleration probe is not running")
-      pid -> GenServer.call(pid, :capabilities, @call_timeout)
+      nil -> fallback
+      pid -> call_or(pid, :capabilities, fallback)
     end
   end
 
@@ -72,7 +74,7 @@ defmodule Mydia.Streaming.HardwareAccel do
   def lease(server \\ __MODULE__, priority) do
     case GenServer.whereis(server) do
       nil -> :refused
-      pid -> GenServer.call(pid, {:lease, priority}, @call_timeout)
+      pid -> call_or(pid, {:lease, priority}, :refused)
     end
   end
 
@@ -89,8 +91,25 @@ defmodule Mydia.Streaming.HardwareAccel do
   def report_failure(server \\ __MODULE__, backend, source_codec) do
     case GenServer.whereis(server) do
       nil -> :ok
-      pid -> GenServer.call(pid, {:report_failure, backend, source_codec}, @call_timeout)
+      pid -> call_or(pid, {:report_failure, backend, source_codec}, :ok)
     end
+  end
+
+  # GenServer.whereis/1 resolves a pid, but the probe process can exit in the
+  # gap between that lookup and this call actually being handled (a probe
+  # crash and its supervisor restart are the realistic version of this,
+  # boot-time or not). A plain GenServer.call/3 turns that race into an exit
+  # in the CALLER -- an admin LiveView mount, or a playback session -- which
+  # contradicts this module's documented contract that it never raises and
+  # instead reports software/refused/ok, the same as when the process was
+  # never running at all. Every call site above already has that fallback
+  # value on hand for the "not running" branch; a mid-call exit gets the
+  # identical one.
+  @spec call_or(pid(), term(), term()) :: term()
+  defp call_or(pid, message, fallback) do
+    GenServer.call(pid, message, @call_timeout)
+  catch
+    :exit, _ -> fallback
   end
 
   @impl true

--- a/lib/mydia/streaming/hardware_accel/args.ex
+++ b/lib/mydia/streaming/hardware_accel/args.ex
@@ -1,0 +1,150 @@
+defmodule Mydia.Streaming.HardwareAccel.Args do
+  @moduledoc """
+  Builds the ffmpeg arguments that differ between software and hardware
+  encoding. Pure: it takes a `Capabilities` and encode parameters and returns
+  argument lists, so every tier and rate-control combination is testable without
+  a GPU or an ffmpeg binary.
+
+  The software tier reproduces exactly the arguments this pipeline emitted
+  before hardware acceleration existed. The scale tests in
+  `test/mydia/streaming/ffmpeg_scale*_test.exs` assert that composed output
+  through `FfmpegHlsTranscoder.build_ffmpeg_args/3` and are the regression guard.
+
+  ## Why the scale expression is shared
+
+  `scale_vaapi` accepts the same expression syntax as `scale`, escaped comma
+  included. Verified on Intel iHD 25.4.6 with ffmpeg 8.1.2:
+  `scale_vaapi=w=-2:h=2*trunc(min(720\\,ih)/2):format=nv12` produced 1280x720
+  from a 1080p source. So the no-upscale clamp and even-height rounding are
+  written once in `height_expression/1` and reused by all three tiers.
+  """
+
+  require Logger
+
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+
+  # Measured against libx264 -crf 23 on a 1080p sample: qp 23 costs 1.29x the
+  # bitrate for SSIM 0.9923 against x264's 0.9949. See the rate-control table in
+  # the design spec before changing this.
+  @vaapi_qp 23
+
+  defstruct tier: :software, input: [], video: []
+
+  @type tier :: :software | :hybrid | :full_hardware
+  @type t :: %__MODULE__{tier: tier(), input: [String.t()], video: [String.t()]}
+
+  @spec build(Capabilities.t(), keyword()) :: t()
+  def build(%Capabilities{} = caps, opts) do
+    tier = tier(caps, Keyword.get(opts, :source_codec))
+    height = Keyword.get(opts, :max_height)
+    bitrate = Keyword.get(opts, :video_bitrate_kbps)
+
+    %__MODULE__{
+      tier: tier,
+      input: input_args(tier, caps.device),
+      video:
+        codec_args(tier, opts) ++
+          filter_args(tier, height) ++
+          rate_control_args(tier, bitrate, Keyword.get(opts, :crf, 23))
+    }
+  end
+
+  # A device that cannot encode H.264 is useless to this pipeline regardless of
+  # what it can decode, so it degrades to software rather than to hybrid.
+  defp tier(%Capabilities{backend: :none}, _source), do: :software
+
+  defp tier(%Capabilities{} = caps, source) do
+    cond do
+      not Capabilities.can_encode?(caps, :h264) -> :software
+      Capabilities.can_decode?(caps, source) -> :full_hardware
+      true -> :hybrid
+    end
+  end
+
+  defp input_args(:software, _device), do: []
+
+  defp input_args(:full_hardware, device) do
+    ["-hwaccel", "vaapi", "-hwaccel_device", device, "-hwaccel_output_format", "vaapi"]
+  end
+
+  # hwupload needs a filter device, which -hwaccel alone does not establish.
+  defp input_args(:hybrid, device) do
+    ["-init_hw_device", "vaapi=hw:#{device}", "-filter_hw_device", "hw"]
+  end
+
+  defp codec_args(:software, opts) do
+    [
+      "-c:v",
+      Keyword.get(opts, :video_codec, "libx264"),
+      "-preset",
+      Keyword.get(opts, :preset, "medium"),
+      "-pix_fmt",
+      "yuv420p",
+      "-profile:v",
+      "high",
+      "-g",
+      "60",
+      "-bf",
+      "0"
+    ]
+  end
+
+  # No -preset (VAAPI has none) and no -pix_fmt (the filter chain sets nv12;
+  # leaving it in forces a download/upload round trip).
+  defp codec_args(_hardware, _opts) do
+    ["-c:v", "h264_vaapi", "-profile:v", "high", "-g", "60", "-bf", "0"]
+  end
+
+  defp filter_args(:software, height) do
+    ["-vf", "scale=-2:#{height_expression(height)}"]
+  end
+
+  defp filter_args(:full_hardware, height) do
+    ["-vf", "scale_vaapi=w=-2:h=#{height_expression(height)}:format=nv12"]
+  end
+
+  defp filter_args(:hybrid, height) do
+    ["-vf", "scale=-2:#{height_expression(height)},format=nv12,hwupload"]
+  end
+
+  # `min(h, ih)` clamps against the input height so a rung above the source
+  # never upscales. The comma is backslash-escaped because ffmpeg reads a bare
+  # comma in a filtergraph as a filter separator, and these arguments reach a
+  # port with no shell, so shell quoting would arrive literally.
+  #
+  # `2*trunc(.../2)` rounds down to an even height. An odd height makes libx264
+  # with -pix_fmt yuv420p refuse to open the encoder (exit 187), which kills the
+  # transcode before a playlist exists and surfaces as a generic playback error.
+  defp height_expression(height) when is_integer(height) and height > 0 do
+    "2*trunc(min(#{height}\\,ih)/2)"
+  end
+
+  defp height_expression(height) when is_integer(height) do
+    Logger.warning(
+      "Ignoring a non-positive transcode height ceiling (#{height}); " <>
+        "encoding at the source resolution"
+    )
+
+    "2*trunc(ih/2)"
+  end
+
+  defp height_expression(_), do: "2*trunc(ih/2)"
+
+  defp rate_control_args(:software, nil, crf), do: ["-crf", to_string(crf)]
+
+  defp rate_control_args(:software, kbps, _crf) do
+    ["-b:v", "#{kbps}k", "-maxrate", "#{kbps}k", "-bufsize", "#{kbps * 2}k"]
+  end
+
+  defp rate_control_args(_hardware, nil, _crf) do
+    ["-rc_mode", "CQP", "-qp", to_string(@vaapi_qp)]
+  end
+
+  # VAAPI's default rc_mode is `auto`, which resolves by driver. Measured on iHD
+  # 25.4.6 it honours -b:v without this flag, so pinning VBR is defensive rather
+  # than a fix: it removes a driver-dependent variable from a client's bandwidth
+  # cap.
+  defp rate_control_args(_hardware, kbps, _crf) do
+    ["-rc_mode", "VBR", "-b:v", "#{kbps}k", "-maxrate", "#{kbps}k", "-bufsize", "#{kbps * 2}k"]
+  end
+end

--- a/lib/mydia/streaming/hardware_accel/args.ex
+++ b/lib/mydia/streaming/hardware_accel/args.ex
@@ -130,6 +130,10 @@ defmodule Mydia.Streaming.HardwareAccel.Args do
 
   defp height_expression(_), do: "2*trunc(ih/2)"
 
+  # :crf is software-only. The hardware tiers ignore it entirely and rate-control
+  # off -qp (unmetered) or -rc_mode/-b:v (capped) instead, set by the two
+  # `rate_control_args(_hardware, ...)` clauses below -- a caller that raises
+  # :crf expecting it to affect a hardware encode's quality is a no-op.
   defp rate_control_args(:software, nil, crf), do: ["-crf", to_string(crf)]
 
   defp rate_control_args(:software, kbps, _crf) do

--- a/lib/mydia/streaming/hardware_accel/capabilities.ex
+++ b/lib/mydia/streaming/hardware_accel/capabilities.ex
@@ -1,0 +1,78 @@
+defmodule Mydia.Streaming.HardwareAccel.Capabilities do
+  @moduledoc """
+  What the host's video hardware can actually do, as measured by
+  `Mydia.Streaming.HardwareAccel.Probe`.
+
+  `backend: :none` is the normal, supported state: most installs have no usable
+  device, and every consumer must treat software as the default rather than as a
+  failure. `reason` is what separates "no GPU here", "a GPU is present but its
+  driver is missing", and "an operator turned this off", which lead to three
+  different actions and must not collapse into a bare `:none`.
+  """
+
+  @known_codecs %{
+    "h264" => :h264,
+    "hevc" => :hevc,
+    "h265" => :hevc,
+    "av1" => :av1,
+    "vp9" => :vp9,
+    "vp8" => :vp8,
+    "mpeg2video" => :mpeg2video,
+    "vc1" => :vc1
+  }
+
+  defstruct backend: :none, device: nil, encoders: [], decode_profiles: [], reason: nil
+
+  @type backend :: :vaapi | :none
+  @type codec :: :h264 | :hevc | :av1 | :vp9 | :vp8 | :mpeg2video | :vc1
+
+  @type t :: %__MODULE__{
+          backend: backend(),
+          device: String.t() | nil,
+          encoders: [codec()],
+          decode_profiles: [codec()],
+          reason: String.t() | nil
+        }
+
+  @doc "Capabilities meaning 'encode in software', carrying why."
+  @spec software(String.t()) :: t()
+  def software(reason) when is_binary(reason), do: %__MODULE__{backend: :none, reason: reason}
+
+  @spec accelerated?(t()) :: boolean()
+  def accelerated?(%__MODULE__{backend: :none}), do: false
+  def accelerated?(%__MODULE__{}), do: true
+
+  @doc """
+  Whether the device can decode `codec` in hardware.
+
+  Accepts the atom or the string ffprobe reported. An unrecognised string is
+  never a hardware decode: the lookup table is closed so that a codec name
+  arriving from file metadata cannot mint an atom.
+  """
+  @spec can_decode?(t(), codec() | String.t() | nil) :: boolean()
+  def can_decode?(caps, codec), do: member?(caps, :decode_profiles, codec)
+
+  @spec can_encode?(t(), codec() | String.t() | nil) :: boolean()
+  def can_encode?(caps, codec), do: member?(caps, :encoders, codec)
+
+  @doc "Maps an ffprobe codec name onto a known atom, or nil."
+  @spec codec_atom(codec() | String.t() | nil) :: codec() | nil
+  def codec_atom(codec) when is_atom(codec) and not is_nil(codec) do
+    if codec in Map.values(@known_codecs), do: codec, else: nil
+  end
+
+  def codec_atom(codec) when is_binary(codec) do
+    Map.get(@known_codecs, String.downcase(codec))
+  end
+
+  def codec_atom(_), do: nil
+
+  defp member?(%__MODULE__{backend: :none}, _field, _codec), do: false
+
+  defp member?(%__MODULE__{} = caps, field, codec) do
+    case codec_atom(codec) do
+      nil -> false
+      atom -> atom in Map.fetch!(caps, field)
+    end
+  end
+end

--- a/lib/mydia/streaming/hardware_accel/probe.ex
+++ b/lib/mydia/streaming/hardware_accel/probe.ex
@@ -260,14 +260,25 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
             nil -> nil
           end
 
-        collect_bounded(port, os_pid, "", timeout)
+        # An absolute deadline, not a per-receive timeout. `after` applies to
+        # each `receive`, so passing the bound straight down would restart the
+        # whole window on every {:data, _} chunk, and a child that hangs while
+        # still writing output would run indefinitely -- exactly the case this
+        # bound exists to stop.
+        deadline =
+          case timeout do
+            :infinity -> :infinity
+            ms -> System.monotonic_time(:millisecond) + ms
+          end
+
+        collect_bounded(port, os_pid, "", deadline)
     end
   end
 
-  defp collect_bounded(port, os_pid, buffer, timeout) do
+  defp collect_bounded(port, os_pid, buffer, deadline) do
     receive do
       {^port, {:data, data}} ->
-        collect_bounded(port, os_pid, buffer <> data, timeout)
+        collect_bounded(port, os_pid, buffer <> data, deadline)
 
       {^port, {:exit_status, 0}} ->
         {:ok, buffer}
@@ -275,11 +286,16 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
       {^port, {:exit_status, code}} ->
         {:error, {:exit, code, buffer}}
     after
-      timeout ->
+      remaining_ms(deadline) ->
         kill_bounded(port, os_pid)
         {:error, :timeout}
     end
   end
+
+  defp remaining_ms(:infinity), do: :infinity
+
+  defp remaining_ms(deadline),
+    do: max(deadline - System.monotonic_time(:millisecond), 0)
 
   # Closing the port stops it relaying further messages, but does not by
   # itself terminate a running child -- Erlang's default port behaviour on

--- a/lib/mydia/streaming/hardware_accel/probe.ex
+++ b/lib/mydia/streaming/hardware_accel/probe.ex
@@ -55,12 +55,22 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
         Capabilities.software(no_device_reason(opts))
 
       devices ->
-        Enum.find_value(devices, Capabilities.software(last_failure_reason(devices)), fn device ->
+        devices
+        |> Enum.reduce_while({:error, []}, fn device, {:error, failures} ->
           case probe_device(device) do
-            {:ok, caps} -> forced_note(caps, backend)
-            {:error, _reason} -> nil
+            {:ok, caps} -> {:halt, {:ok, forced_note(caps, backend)}}
+            {:error, reason} -> {:cont, {:error, [{device, reason} | failures]}}
           end
         end)
+        |> case do
+          {:ok, caps} ->
+            caps
+
+          {:error, failures} ->
+            reason = failure_reason(Enum.reverse(failures))
+            Logger.warning("No usable VAAPI device: #{reason}")
+            Capabilities.software(reason)
+        end
     end
   end
 
@@ -78,8 +88,14 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
     end
   end
 
-  defp last_failure_reason(devices) do
-    "no usable VAAPI device among #{Enum.join(devices, ", ")}"
+  # Each device's actual failure text is preserved. Discarding it and reporting
+  # a generic "no usable device" collapses "the driver package is missing" into
+  # the same bucket as "vainfo is not installed" and "the test encode failed",
+  # and those lead an operator to three different actions. The driver-missing
+  # case is the one measured on real hardware, so it is exactly the one that
+  # must survive.
+  defp failure_reason(failures) do
+    Enum.map_join(failures, "; ", fn {device, reason} -> "#{device}: #{reason}" end)
   end
 
   # An explicitly requested backend is recorded in the reason so the settings

--- a/lib/mydia/streaming/hardware_accel/probe.ex
+++ b/lib/mydia/streaming/hardware_accel/probe.ex
@@ -1,0 +1,180 @@
+defmodule Mydia.Streaming.HardwareAccel.Probe do
+  @moduledoc """
+  Detects what the host's video hardware can do.
+
+  Three steps, in order, because each rules out a different false positive:
+
+  1. Enumerate `/dev/dri/renderD*`. No node means no device.
+  2. Parse `vainfo` for the profile and entrypoint matrix. This is what fills
+     the decode and encode lists without synthesizing a test clip per codec.
+  3. Run one real throwaway encode.
+
+  Step 3 is not redundant. `ffmpeg -hwaccels` lists `vaapi` whenever the API was
+  compiled in, and the stock Alpine image ships `libva.so.2` with no driver in
+  `/usr/lib/dri`, so ffmpeg advertises VAAPI and then fails at `vaInitialize`.
+  Steps 1 and 2 alone would reproduce exactly that false positive.
+  """
+
+  require Logger
+
+  alias Mydia.Library.Ffmpeg
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+
+  @device_glob "/dev/dri/renderD*"
+
+  # VAProfile names map onto codec atoms. Profile variants (Main, Main10,
+  # High, Profile0) collapse onto the codec, because the tier decision only
+  # asks "can this device decode av1 at all".
+  @profile_patterns [
+    {~r/VAProfileH264/, :h264},
+    {~r/VAProfileHEVC/, :hevc},
+    {~r/VAProfileAV1/, :av1},
+    {~r/VAProfileVP9/, :vp9},
+    {~r/VAProfileVP8/, :vp8},
+    {~r/VAProfileMPEG2/, :mpeg2video},
+    {~r/VAProfileVC1/, :vc1}
+  ]
+
+  @spec run(keyword()) :: Capabilities.t()
+  def run(opts \\ []) do
+    case Keyword.get(opts, :hwaccel, :auto) do
+      :off ->
+        Capabilities.software("disabled by HWACCEL=off")
+
+      :invalid ->
+        Capabilities.software("HWACCEL is set to an unrecognised value")
+
+      backend when backend in [:auto, :vaapi] ->
+        probe_devices(backend, opts)
+    end
+  end
+
+  defp probe_devices(backend, opts) do
+    case candidate_devices(opts) do
+      [] ->
+        Capabilities.software(no_device_reason(opts))
+
+      devices ->
+        Enum.find_value(devices, Capabilities.software(last_failure_reason(devices)), fn device ->
+          case probe_device(device) do
+            {:ok, caps} -> forced_note(caps, backend)
+            {:error, _reason} -> nil
+          end
+        end)
+    end
+  end
+
+  defp candidate_devices(opts) do
+    case Keyword.get(opts, :device) do
+      nil -> Path.wildcard(Keyword.get(opts, :device_glob, @device_glob))
+      device -> if File.exists?(device), do: [device], else: []
+    end
+  end
+
+  defp no_device_reason(opts) do
+    case Keyword.get(opts, :device) do
+      nil -> "no render node present under /dev/dri"
+      device -> "requested device #{device} does not exist"
+    end
+  end
+
+  defp last_failure_reason(devices) do
+    "no usable VAAPI device among #{Enum.join(devices, ", ")}"
+  end
+
+  # An explicitly requested backend is recorded in the reason so the settings
+  # page can say the operator asked for it, which matters once Spec B adds a
+  # second backend and `auto` could have chosen differently.
+  defp forced_note(caps, :auto), do: caps
+  defp forced_note(caps, backend), do: %{caps | reason: "selected by HWACCEL=#{backend}"}
+
+  defp probe_device(device) do
+    with {:ok, matrix} <- vainfo(device),
+         :ok <- test_encode(device) do
+      {:ok,
+       %Capabilities{
+         backend: :vaapi,
+         device: device,
+         encoders: matrix.encoders,
+         decode_profiles: matrix.decode_profiles
+       }}
+    end
+  end
+
+  defp vainfo(device) do
+    case System.cmd("vainfo", ["--display", "drm", "--device", device], stderr_to_stdout: true) do
+      {output, 0} ->
+        matrix = parse_vainfo(output)
+
+        if matrix.encoders == [] do
+          {:error, "vainfo reported no encoders on #{device}"}
+        else
+          {:ok, matrix}
+        end
+
+      {output, _code} ->
+        {:error, "vainfo failed on #{device}: #{String.trim(output)}"}
+    end
+  rescue
+    ErlangError -> {:error, "vainfo is not installed"}
+  end
+
+  @doc """
+  Extracts the codec matrix from `vainfo` output.
+
+  `VAEntrypointVLD` is decode. `VAEntrypointEncSlice` and `VAEntrypointEncSliceLP`
+  are encode. Reading VLD as encode support would select an encoder the device
+  does not have: this hardware decodes AV1 and cannot encode it.
+  """
+  @spec parse_vainfo(String.t()) :: %{encoders: [atom()], decode_profiles: [atom()]}
+  def parse_vainfo(output) do
+    lines = String.split(output, "\n")
+
+    %{
+      decode_profiles: codecs_for(lines, ~r/VAEntrypointVLD\s*$/),
+      encoders: codecs_for(lines, ~r/VAEntrypointEncSlice(LP)?\s*$/)
+    }
+  end
+
+  defp codecs_for(lines, entrypoint) do
+    lines
+    |> Enum.filter(&Regex.match?(entrypoint, &1))
+    |> Enum.flat_map(fn line ->
+      Enum.filter(@profile_patterns, fn {pattern, _codec} -> Regex.match?(pattern, line) end)
+    end)
+    |> Enum.map(fn {_pattern, codec} -> codec end)
+    |> Enum.uniq()
+  end
+
+  # The definitive check. Encodes two seconds of generated video through the
+  # hybrid path, which exercises device creation, the filter device and the
+  # encoder in one go.
+  defp test_encode(device) do
+    args = [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-init_hw_device",
+      "vaapi=hw:#{device}",
+      "-filter_hw_device",
+      "hw",
+      "-f",
+      "lavfi",
+      "-i",
+      "testsrc=size=320x240:duration=1:rate=15",
+      "-vf",
+      "format=nv12,hwupload",
+      "-c:v",
+      "h264_vaapi",
+      "-f",
+      "null",
+      "-"
+    ]
+
+    case Ffmpeg.run(args) do
+      {:ok, _output} -> :ok
+      {:error, {:ffmpeg_error, _code, output}} -> {:error, String.trim(output)}
+      {:error, :ffmpeg_not_found} -> {:error, "ffmpeg is not installed"}
+    end
+  end
+end

--- a/lib/mydia/streaming/hardware_accel/probe.ex
+++ b/lib/mydia/streaming/hardware_accel/probe.ex
@@ -17,10 +17,17 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
 
   require Logger
 
-  alias Mydia.Library.Ffmpeg
   alias Mydia.Streaming.HardwareAccel.Capabilities
 
   @device_glob "/dev/dri/renderD*"
+
+  # `HardwareAccel.handle_continue(:probe, ...)` runs before any queued
+  # capabilities/1, lease/2 or report_failure/3 call is answered (they queue
+  # behind it in the mailbox), so a wedged vainfo or ffmpeg here blocks every
+  # one of those callers until the 30s GenServer.call timeout instead of the
+  # software fallback this module promises. A probe that legitimately takes
+  # more than a few seconds is already broken hardware.
+  @probe_timeout_ms 5_000
 
   # VAProfile names map onto codec atoms. Profile variants (Main, Main10,
   # High, Profile0) collapse onto the codec, because the tier decision only
@@ -118,8 +125,8 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
   end
 
   defp vainfo(device) do
-    case System.cmd("vainfo", ["--display", "drm", "--device", device], stderr_to_stdout: true) do
-      {output, 0} ->
+    case run_bounded("vainfo", ["--display", "drm", "--device", device]) do
+      {:ok, output} ->
         matrix = parse_vainfo(output)
 
         if matrix.encoders == [] do
@@ -128,11 +135,15 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
           {:ok, matrix}
         end
 
-      {output, _code} ->
+      {:error, {:exit, _code, output}} ->
         {:error, "vainfo failed on #{device}: #{String.trim(output)}"}
+
+      {:error, :timeout} ->
+        {:error, "vainfo did not finish within #{@probe_timeout_ms}ms on #{device}"}
+
+      {:error, :not_found} ->
+        {:error, "vainfo is not installed"}
     end
-  rescue
-    ErlangError -> {:error, "vainfo is not installed"}
   end
 
   @doc """
@@ -187,10 +198,104 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
       "-"
     ]
 
-    case Ffmpeg.run(args) do
-      {:ok, _output} -> :ok
-      {:error, {:ffmpeg_error, _code, output}} -> {:error, String.trim(output)}
-      {:error, :ffmpeg_not_found} -> {:error, "ffmpeg is not installed"}
+    # Deliberately not Mydia.Library.Ffmpeg.run/2: that wraps System.cmd/3,
+    # which blocks this process until the OS process exits with no way to
+    # bound or interrupt it. run_bounded/3 below is the same
+    # :spawn_executable + tracked-os_pid pattern FfmpegHlsTranscoder and
+    # FfmpegMp4Transcoder already use to actually kill a wedged ffmpeg
+    # instead of merely giving up on waiting for it.
+    case run_bounded(executable(:ffmpeg_path, "ffmpeg"), args) do
+      {:ok, _output} ->
+        :ok
+
+      {:error, {:exit, _code, output}} ->
+        {:error, String.trim(output)}
+
+      {:error, :timeout} ->
+        {:error, "ffmpeg test encode did not finish within #{@probe_timeout_ms}ms"}
+
+      {:error, :not_found} ->
+        {:error, "ffmpeg is not installed"}
     end
+  end
+
+  # Same executable-override convention as Mydia.Library.Ffmpeg: an
+  # application-env path (used by tests) falls back to resolving the bare
+  # name on PATH.
+  defp executable(env_key, default_name) do
+    Application.get_env(:mydia, env_key) || default_name
+  end
+
+  @doc false
+  # Runs `name` as a Port with a tracked OS pid, the same shape
+  # FfmpegHlsTranscoder.start_ffmpeg_process/1 uses, so a timeout can
+  # actually SIGKILL the child instead of merely abandoning a handle to it --
+  # Task.shutdown/2 around System.cmd/3 cannot do that, since System.cmd/3
+  # never gives the caller an OS pid to kill.
+  #
+  # Public only so the timeout and kill behaviour can be exercised directly
+  # against a generic command (`sleep`, `sh`) without depending on vainfo or
+  # ffmpeg being installed, and without a test having to wait out a real
+  # multi-second probe; nothing outside this module should call it.
+  @spec run_bounded(String.t(), [String.t()], timeout()) ::
+          {:ok, binary()} | {:error, {:exit, integer(), binary()} | :timeout | :not_found}
+  def run_bounded(name, args, timeout \\ @probe_timeout_ms) do
+    case System.find_executable(name) do
+      nil ->
+        {:error, :not_found}
+
+      path ->
+        port =
+          Port.open({:spawn_executable, path}, [
+            :binary,
+            :exit_status,
+            :stderr_to_stdout,
+            :hide,
+            args: args
+          ])
+
+        os_pid =
+          case Port.info(port, :os_pid) do
+            {:os_pid, os_pid} -> os_pid
+            nil -> nil
+          end
+
+        collect_bounded(port, os_pid, "", timeout)
+    end
+  end
+
+  defp collect_bounded(port, os_pid, buffer, timeout) do
+    receive do
+      {^port, {:data, data}} ->
+        collect_bounded(port, os_pid, buffer <> data, timeout)
+
+      {^port, {:exit_status, 0}} ->
+        {:ok, buffer}
+
+      {^port, {:exit_status, code}} ->
+        {:error, {:exit, code, buffer}}
+    after
+      timeout ->
+        kill_bounded(port, os_pid)
+        {:error, :timeout}
+    end
+  end
+
+  # Closing the port stops it relaying further messages, but does not by
+  # itself terminate a running child -- Erlang's default port behaviour on
+  # close is to keep the OS process alive when the driver was opened with
+  # :spawn_executable. SIGKILL via the same `kill -9` mechanism the
+  # transcoders use is what actually ends it, leaving no orphaned vainfo or
+  # ffmpeg process behind.
+  defp kill_bounded(port, os_pid) do
+    if os_pid, do: System.cmd("kill", ["-9", to_string(os_pid)], stderr_to_stdout: true)
+
+    try do
+      Port.close(port)
+    rescue
+      ArgumentError -> :ok
+    end
+
+    :ok
   end
 end

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -235,6 +235,20 @@ defmodule Mydia.Streaming.HlsSession do
     GenServer.cast(pid, {:segments_ready, generation, indices})
   end
 
+  @doc """
+  Notifies the session that its backend failed to initialise hardware
+  acceleration and stopped (with reason `:normal`) rather than crashing.
+
+  `generation` guards against this exact race the same way `notify_segments/3`
+  does: a backend the session has already relocated away from (a viewer seeked
+  before this notification arrived) must not be allowed to restart a window
+  that no longer exists.
+  """
+  @spec notify_hwaccel_failed(pid(), non_neg_integer(), String.t()) :: :ok
+  def notify_hwaccel_failed(pid, generation, output) do
+    GenServer.cast(pid, {:hwaccel_failed, generation, output})
+  end
+
   ## Server Callbacks
 
   @impl true
@@ -672,30 +686,25 @@ defmodule Mydia.Streaming.HlsSession do
     {:noreply, %{state | window: window, segment_waiters: remaining}}
   end
 
-  @impl true
-  def handle_info(:check_timeout, state) do
-    now = DateTime.utc_now()
-    inactive_duration = DateTime.diff(now, state.last_activity, :millisecond)
-
-    if inactive_duration >= @session_timeout do
-      Logger.info("Session #{state.session_id} inactive for #{inactive_duration}ms, terminating")
-
-      {:stop, :timeout, state}
-    else
-      # Still active, schedule next check
-      state = schedule_timeout_check(state)
-      {:noreply, state}
-    end
+  def handle_cast({:hwaccel_failed, generation, _output}, %{window_generation: current} = state)
+      when generation != current do
+    # A dead backend's failure report for a window the session has already
+    # relocated away from (a viewer seeked before the notification arrived).
+    # Mirrors the identical guard on {:segments_ready, ...} above.
+    {:noreply, state}
   end
 
   # A hardware initialisation failure is recoverable: re-encode the same window
   # in software rather than taking the session down. Reuses relocate/2, which
   # already knows how to stop a backend, restart it at a target segment number,
-  # and bump window_generation so the dead backend's late polls are discarded.
-  def handle_info(
-        {:DOWN, _ref, :process, pid, {:hwaccel_failed, output}},
-        %{backend_pid: pid} = state
-      ) do
+  # and bump window_generation so a late report from this same dead backend
+  # (were it to somehow arrive twice) is discarded by the guard clause above.
+  #
+  # FfmpegHlsTranscoder stops itself with reason :normal for this case
+  # specifically so the link from this session to its backend does not take
+  # the session down before this callback can run (see the comment on
+  # relocate/2, and on FfmpegHlsTranscoder's exit-status handler).
+  def handle_cast({:hwaccel_failed, _generation, output}, state) do
     Mydia.Streaming.HardwareAccel.report_failure(
       :vaapi,
       state.media_file && state.media_file.codec
@@ -715,6 +724,22 @@ defmodule Mydia.Streaming.HlsSession do
       :stop ->
         Logger.error("Session #{state.session_id}: hardware fallback already used; giving up")
         {:stop, {:backend_terminated, {:hwaccel_failed, output}}, state}
+    end
+  end
+
+  @impl true
+  def handle_info(:check_timeout, state) do
+    now = DateTime.utc_now()
+    inactive_duration = DateTime.diff(now, state.last_activity, :millisecond)
+
+    if inactive_duration >= @session_timeout do
+      Logger.info("Session #{state.session_id} inactive for #{inactive_duration}ms, terminating")
+
+      {:stop, :timeout, state}
+    else
+      # Still active, schedule next check
+      state = schedule_timeout_check(state)
+      {:noreply, state}
     end
   end
 
@@ -948,6 +973,9 @@ defmodule Mydia.Streaming.HlsSession do
           end,
           on_error: fn error ->
             Logger.error("FFmpeg transcoding error for #{absolute_path}: #{error}")
+          end,
+          on_hwaccel_failed: fn output ->
+            __MODULE__.notify_hwaccel_failed(session_pid, generation, output)
           end
         ] ++
         if Keyword.get(opts, :playlist_mode) == :full do

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -33,6 +33,8 @@ defmodule Mydia.Streaming.HlsSession do
 
   alias Mydia.Library
   alias Mydia.Streaming.FfmpegHlsTranscoder
+  alias Mydia.Streaming.HardwareAccel
+  alias Mydia.Streaming.HardwareAccel.Capabilities
   alias Mydia.Streaming.SegmentPlan
   alias Mydia.Streaming.TranscodeWindow
   alias Mydia.Repo
@@ -67,6 +69,7 @@ defmodule Mydia.Streaming.HlsSession do
       :db_job_id,
       :segment_plan,
       :backend_opts,
+      :hwaccel_lease,
       playlist_mode: :window,
       window: nil,
       segment_waiters: %{},
@@ -93,6 +96,7 @@ defmodule Mydia.Streaming.HlsSession do
             db_job_id: binary() | nil,
             segment_plan: Mydia.Streaming.SegmentPlan.t() | nil,
             backend_opts: keyword(),
+            hwaccel_lease: reference() | nil,
             playlist_mode: :full | :window,
             window: Mydia.Streaming.TranscodeWindow.t() | nil,
             segment_waiters: %{non_neg_integer() => [GenServer.from()]},
@@ -416,9 +420,17 @@ defmodule Mydia.Streaming.HlsSession do
         Logger.info("Temp directory: #{temp_dir}")
         Logger.info("Starting HLS transcoding with FFmpeg backend")
 
+        # A :playback lease is claimed once for the whole session, not once
+        # per FfmpegHlsTranscoder process -- see acquire_hwaccel_lease/0 for
+        # why.
+        {capabilities, hwaccel_lease} = maybe_acquire_hwaccel_lease(media_file, max_bitrate)
+
         # The keyword list a relocation reuses verbatim (see relocate/2), so it
         # has to carry everything start_backend/6 needs beyond the offset and
-        # start number, which relocate overwrites per-call.
+        # start number, which relocate overwrites per-call. :capabilities is
+        # carried the same way: decided once here (or by hwaccel_fallback/2
+        # after a failure), never re-derived per relocation, so a seek never
+        # has to contact HardwareAccel again.
         backend_opts = [
           max_bitrate: max_bitrate,
           max_height: max_height,
@@ -428,7 +440,8 @@ defmodule Mydia.Streaming.HlsSession do
           absolute_timestamps: playlist_mode == :full,
           playlist_mode: playlist_mode,
           audio_language: playback.audio_language,
-          show_audio_language: playback.show_audio_language
+          show_audio_language: playback.show_audio_language,
+          capabilities: capabilities
         ]
 
         # Start FFmpeg backend
@@ -454,7 +467,8 @@ defmodule Mydia.Streaming.HlsSession do
               segment_plan: segment_plan,
               playlist_mode: playlist_mode,
               window: if(playlist_mode == :full, do: TranscodeWindow.new(first_index), else: nil),
-              backend_opts: backend_opts
+              backend_opts: backend_opts,
+              hwaccel_lease: hwaccel_lease
             }
 
             # Schedule initial timeout check
@@ -469,6 +483,7 @@ defmodule Mydia.Streaming.HlsSession do
               "Failed to start FFmpeg backend for session #{session_id}: #{inspect(reason)}"
             )
 
+            if hwaccel_lease, do: HardwareAccel.release(hwaccel_lease)
             File.rm_rf!(temp_dir)
             {:stop, {:backend_start_failed, reason}}
         end
@@ -476,6 +491,55 @@ defmodule Mydia.Streaming.HlsSession do
       {:error, reason} ->
         Logger.error("Failed to create temp directory #{temp_dir}: #{inspect(reason)}")
         {:stop, {:temp_dir_creation_failed, reason}}
+    end
+  end
+
+  # Decides whether this session is worth leasing a hardware slot for at all.
+  # Only a re-encoding session ever reaches the hardware encoder --
+  # reencodes_video?/2 is the exact same decision build_ffmpeg_args/3 makes
+  # between "copy" and "libx264"/"h264_vaapi" -- so a stream-copy session
+  # leasing a slot it will never use would only starve a session that does.
+  #
+  # Public only so the gating decision can be asserted directly against a
+  # plain MediaFile struct, without a live HardwareAccel process, a DB row, or
+  # a real init/1; nothing outside this module should call it.
+  @doc false
+  @spec maybe_acquire_hwaccel_lease(Mydia.Library.MediaFile.t() | nil, integer() | nil) ::
+          {Capabilities.t() | nil, reference() | nil}
+  def maybe_acquire_hwaccel_lease(media_file, max_bitrate) do
+    if FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate) do
+      acquire_hwaccel_lease()
+    else
+      {nil, nil}
+    end
+  end
+
+  # Claims a :playback hardware lease for the life of this session.
+  #
+  # Deliberately a session-level call, not one made by FfmpegHlsTranscoder
+  # itself on every start (which is how FfmpegMp4Transcoder's :background
+  # lease works -- see its init/1). FfmpegHlsTranscoder is restarted on every
+  # window relocation (a seek: see relocate/2) and on every hardware-failure
+  # fallback (see hwaccel_fallback/2 below), and stop_and_start_backend/3
+  # deliberately overlaps the old and new backend by roughly 100ms so the
+  # relocation itself never blocks the session's mailbox. A per-transcoder
+  # lease would have to hold two slots during that overlap on every single
+  # seek, and would be refused near the cap -- turning an ordinary seek on a
+  # session that already holds a slot into a spurious software fallback.
+  # Leasing once here and carrying the result through backend_opts (reused
+  # verbatim by both relocate/2 and restart_backend_in_place/1) means a seek
+  # never contacts HardwareAccel at all: only session start, session end, and
+  # a permanent hardware-failure fallback do.
+  #
+  # Public only so the "not leased" fallback shape can be asserted directly
+  # without a live HardwareAccel process; nothing outside this module should
+  # call it.
+  @doc false
+  @spec acquire_hwaccel_lease() :: {Capabilities.t(), reference() | nil}
+  def acquire_hwaccel_lease do
+    case HardwareAccel.lease(:playback) do
+      {:ok, ref} -> {HardwareAccel.capabilities(), ref}
+      :refused -> {Capabilities.software("no hardware slot free for playback"), nil}
     end
   end
 
@@ -523,10 +587,14 @@ defmodule Mydia.Streaming.HlsSession do
   def hwaccel_fallback(%State{accel_fallbacks: n}, _target) when n >= 1, do: :stop
 
   def hwaccel_fallback(%State{} = state, target) do
+    # This session is about to encode in software for the rest of its life
+    # (only one fallback is ever allowed -- see the clause above), so
+    # continuing to hold a hardware slot would waste it: another session could
+    # be leasing it instead.
+    if state.hwaccel_lease, do: HardwareAccel.release(state.hwaccel_lease)
+
     software =
-      Mydia.Streaming.HardwareAccel.Capabilities.software(
-        "fell back to software after a hardware failure in this session"
-      )
+      Capabilities.software("fell back to software after a hardware failure in this session")
 
     backend_opts =
       state.backend_opts
@@ -538,7 +606,8 @@ defmodule Mydia.Streaming.HlsSession do
        state
        | accel: :none,
          accel_fallbacks: state.accel_fallbacks + 1,
-         backend_opts: backend_opts
+         backend_opts: backend_opts,
+         hwaccel_lease: nil
      }}
   end
 
@@ -799,6 +868,12 @@ defmodule Mydia.Streaming.HlsSession do
   @impl true
   def terminate(reason, state) do
     Logger.info("Terminating HLS session #{state.session_id}, reason: #{inspect(reason)}")
+
+    # Release the hardware slot on every exit path -- normal termination,
+    # timeout, backend crash -- so a session that leased one at start never
+    # leaks it. Already nil after a permanent software fallback (see
+    # hwaccel_fallback/2), so this is a no-op then.
+    if state.hwaccel_lease, do: HardwareAccel.release(state.hwaccel_lease)
 
     Phoenix.PubSub.broadcast(Mydia.PubSub, "hls_sessions", :session_ended)
 

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -694,11 +694,22 @@ defmodule Mydia.Streaming.HlsSession do
     {:noreply, state}
   end
 
-  # A hardware initialisation failure is recoverable: re-encode the same window
-  # in software rather than taking the session down. Reuses relocate/2, which
-  # already knows how to stop a backend, restart it at a target segment number,
-  # and bump window_generation so a late report from this same dead backend
-  # (were it to somehow arrive twice) is discarded by the guard clause above.
+  # A hardware initialisation failure is recoverable: re-encode in software
+  # rather than taking the session down, and bump window_generation so a late
+  # report from this same dead backend (were it to somehow arrive twice) is
+  # discarded by the guard clause above.
+  #
+  # A :full session reuses relocate/2, which already knows how to stop a
+  # backend and restart it at a target segment number while preserving the
+  # segment grid. A :window session has no segment grid -- both segment_plan
+  # and window are nil (see start_registered_session/7) -- and never reaches
+  # relocate/2 any other way (it is only ever called from
+  # {:request_segment, index}, which a :window session's handle_call answers
+  # with {:error, :window_mode} before relocate/2 could run). Calling
+  # relocate/2 for a :window session would crash on
+  # SegmentPlan.start_time(nil, _), so it gets the simpler
+  # restart_backend_in_place/1 instead: same backend_opts (already forced to
+  # software by hwaccel_fallback/2 below), no grid to advance.
   #
   # FfmpegHlsTranscoder stops itself with reason :normal for this case
   # specifically so the link from this session to its backend does not take
@@ -719,7 +730,13 @@ defmodule Mydia.Streaming.HlsSession do
             "at segment #{target}"
         )
 
-        {:noreply, relocate(%{state | backend_pid: nil}, target)}
+        new_state =
+          case state.playlist_mode do
+            :full -> relocate(%{state | backend_pid: nil}, target)
+            :window -> restart_backend_in_place(%{state | backend_pid: nil})
+          end
+
+        {:noreply, new_state}
 
       :stop ->
         Logger.error("Session #{state.session_id}: hardware fallback already used; giving up")
@@ -837,15 +854,15 @@ defmodule Mydia.Streaming.HlsSession do
     :exit, _reason -> :ok
   end
 
-  # Moves the encoder to `target`, keeping every segment already on disk.
+  # Stops the current backend (unlinked first, so its exit doesn't take this
+  # session down) if it is still alive, then starts a new one at
+  # `opts`/`generation`. Returns exactly what start_backend/6 returns.
   #
-  # The backend is unlinked before it is stopped. HlsSession links to its
-  # backend so a crashed encoder takes the session down; without the unlink, a
-  # deliberate stop would do the same thing and every seek would kill the
-  # session.
-  defp relocate(state, target) do
-    generation = state.window_generation + 1
-
+  # Shared by relocate/2 and restart_backend_in_place/1 below: both need
+  # "replace the running backend with a new one," and only differ in what
+  # session state to update once that succeeds (relocate/2 also advances the
+  # segment window; a :window session has no window to advance).
+  defp stop_and_start_backend(state, opts, generation) do
     if is_pid(state.backend_pid) and Process.alive?(state.backend_pid) do
       Process.unlink(state.backend_pid)
 
@@ -864,27 +881,27 @@ defmodule Mydia.Streaming.HlsSession do
       #
       # This does mean the old and new encoders overlap for roughly 100ms.
       # That is safe: the old backend is already unlinked and about to stop
-      # producing segments, and any {:segments_ready, ...} it still manages
-      # to send in that window carries the old generation, which the guard
-      # clause on that handle_cast discards.
+      # producing segments, and any {:segments_ready, ...} or
+      # {:hwaccel_failed, ...} it still manages to send in that window
+      # carries the old generation, which the matching guard clause discards.
       backend_pid = state.backend_pid
       backend = state.backend
       Task.start(fn -> stop_backend(backend, backend_pid) end)
     end
+
+    start_backend(:ffmpeg, state.media_file, state.temp_dir, state.db_job_id, opts, generation)
+  end
+
+  # Moves the encoder to `target`, keeping every segment already on disk.
+  defp relocate(state, target) do
+    generation = state.window_generation + 1
 
     opts =
       state.backend_opts
       |> Keyword.put(:start_position, trunc(SegmentPlan.start_time(state.segment_plan, target)))
       |> Keyword.put(:start_number, target)
 
-    case start_backend(
-           :ffmpeg,
-           state.media_file,
-           state.temp_dir,
-           state.db_job_id,
-           opts,
-           generation
-         ) do
+    case stop_and_start_backend(state, opts, generation) do
       {:ok, backend_pid} ->
         Process.link(backend_pid)
 
@@ -904,6 +921,27 @@ defmodule Mydia.Streaming.HlsSession do
             window: TranscodeWindow.stopped(state.window),
             window_generation: generation
         }
+    end
+  end
+
+  # The :window-mode counterpart to relocate/2, used only for the
+  # hardware-failure fallback. A :window session has no SegmentPlan and no
+  # TranscodeWindow to advance (both nil -- see start_registered_session/7),
+  # so there is nothing to seek to: it just restarts the backend with its
+  # existing backend_opts, which hwaccel_fallback/2 has already forced to
+  # software, at a bumped window_generation so a stray late report from the
+  # old backend is discarded the same way a stale relocation is.
+  defp restart_backend_in_place(state) do
+    generation = state.window_generation + 1
+
+    case stop_and_start_backend(state, state.backend_opts, generation) do
+      {:ok, backend_pid} ->
+        Process.link(backend_pid)
+        %{state | backend_pid: backend_pid, window_generation: generation}
+
+      {:error, reason} ->
+        Logger.error("Failed to restart backend in software: #{inspect(reason)}")
+        %{state | backend_pid: nil, window_generation: generation}
     end
   end
 

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -72,7 +72,9 @@ defmodule Mydia.Streaming.HlsSession do
       segment_waiters: %{},
       window_generation: 0,
       ready: false,
-      ready_waiters: []
+      ready_waiters: [],
+      accel: :auto,
+      accel_fallbacks: 0
     ]
 
     @type t :: %__MODULE__{
@@ -96,7 +98,9 @@ defmodule Mydia.Streaming.HlsSession do
             segment_waiters: %{non_neg_integer() => [GenServer.from()]},
             window_generation: non_neg_integer(),
             ready: boolean(),
-            ready_waiters: list()
+            ready_waiters: list(),
+            accel: :auto | :none,
+            accel_fallbacks: non_neg_integer()
           }
   end
 
@@ -494,6 +498,36 @@ defmodule Mydia.Streaming.HlsSession do
     playlist_mode == :full and FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate)
   end
 
+  @doc """
+  Decides what to do when the backend died of a hardware initialisation failure.
+
+  Returns `{:retry, state}` with acceleration disabled for the rest of the
+  session, or `:stop` when this session has already fallen back once. Public so
+  the decision is testable without starting a backend.
+  """
+  @spec hwaccel_fallback(State.t(), non_neg_integer()) :: {:retry, State.t()} | :stop
+  def hwaccel_fallback(%State{accel_fallbacks: n}, _target) when n >= 1, do: :stop
+
+  def hwaccel_fallback(%State{} = state, target) do
+    software =
+      Mydia.Streaming.HardwareAccel.Capabilities.software(
+        "fell back to software after a hardware failure in this session"
+      )
+
+    backend_opts =
+      state.backend_opts
+      |> Keyword.put(:capabilities, software)
+      |> Keyword.put(:start_number, target)
+
+    {:retry,
+     %{
+       state
+       | accel: :none,
+         accel_fallbacks: state.accel_fallbacks + 1,
+         backend_opts: backend_opts
+     }}
+  end
+
   @impl true
   def handle_call(:get_info, _from, state) do
     # Getting info counts as activity
@@ -651,6 +685,36 @@ defmodule Mydia.Streaming.HlsSession do
       # Still active, schedule next check
       state = schedule_timeout_check(state)
       {:noreply, state}
+    end
+  end
+
+  # A hardware initialisation failure is recoverable: re-encode the same window
+  # in software rather than taking the session down. Reuses relocate/2, which
+  # already knows how to stop a backend, restart it at a target segment number,
+  # and bump window_generation so the dead backend's late polls are discarded.
+  def handle_info(
+        {:DOWN, _ref, :process, pid, {:hwaccel_failed, output}},
+        %{backend_pid: pid} = state
+      ) do
+    Mydia.Streaming.HardwareAccel.report_failure(
+      :vaapi,
+      state.media_file && state.media_file.codec
+    )
+
+    target = Keyword.get(state.backend_opts, :start_number, 0)
+
+    case hwaccel_fallback(state, target) do
+      {:retry, state} ->
+        Logger.warning(
+          "Session #{state.session_id}: hardware encode failed, restarting in software " <>
+            "at segment #{target}"
+        )
+
+        {:noreply, relocate(%{state | backend_pid: nil}, target)}
+
+      :stop ->
+        Logger.error("Session #{state.session_id}: hardware fallback already used; giving up")
+        {:stop, {:backend_terminated, {:hwaccel_failed, output}}, state}
     end
   end
 
@@ -844,7 +908,8 @@ defmodule Mydia.Streaming.HlsSession do
         if(opts[:show_audio_language],
           do: [show_audio_language: opts[:show_audio_language]],
           else: []
-        )
+        ) ++
+        if(opts[:capabilities], do: [capabilities: opts[:capabilities]], else: [])
 
     # Only a :full session has a TranscodeWindow to mark ready, so only wire
     # the callback that reports segment completion for that mode. A :window

--- a/lib/mydia_web/live/admin_settings_live/components.ex
+++ b/lib/mydia_web/live/admin_settings_live/components.ex
@@ -5,6 +5,7 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
   attr :config_settings_with_sources, :map, required: true
   attr :crash_report_stats, :map, required: true
   attr :invalid_config_settings, :list, default: []
+  attr :hwaccel, Mydia.Streaming.HardwareAccel.Capabilities, required: true
 
   def general_settings_tab(assigns) do
     ~H"""
@@ -70,6 +71,39 @@ defmodule MydiaWeb.AdminSettingsLive.Components do
                       category={category}
                       editable={Map.get(setting, :editable, setting.source != :env)}
                     />
+                  </div>
+                </div>
+              </div>
+            <% end %>
+            <%= if category == "Streaming" do %>
+              <div id="hwaccel-status" class="p-3 sm:p-4">
+                <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+                  <div class="flex-1 min-w-0">
+                    <div class="font-medium flex items-center gap-2 flex-wrap">
+                      Hardware transcoding
+                    </div>
+                    <div class="text-xs opacity-60 mt-1">
+                      <%= if @hwaccel.backend == :none do %>
+                        Unavailable: {@hwaccel.reason}
+                      <% else %>
+                        {@hwaccel.backend} on {@hwaccel.device || "unknown device"}
+                        <%= if @hwaccel.decode_profiles != [] do %>
+                          &middot; decodes {Enum.map_join(
+                            @hwaccel.decode_profiles,
+                            ", ",
+                            &to_string/1
+                          )}
+                        <% end %>
+                      <% end %>
+                    </div>
+                  </div>
+                  <div class="sm:ml-auto">
+                    <span class={[
+                      "badge",
+                      if(@hwaccel.backend == :none, do: "badge-ghost", else: "badge-success")
+                    ]}>
+                      {if @hwaccel.backend == :none, do: "Software", else: "Accelerated"}
+                    </span>
                   </div>
                 </div>
               </div>

--- a/lib/mydia_web/live/admin_settings_live/index.ex
+++ b/lib/mydia_web/live/admin_settings_live/index.ex
@@ -348,6 +348,7 @@ defmodule MydiaWeb.AdminSettingsLive.Index do
     |> assign(:config_settings_with_sources, get_all_settings_with_sources())
     |> assign(:crash_report_stats, Mydia.CrashReporter.stats())
     |> assign(:invalid_config_settings, Settings.invalid_config_settings())
+    |> assign(:hwaccel, Mydia.Streaming.HardwareAccel.capabilities())
   end
 
   defp get_all_settings_with_sources do

--- a/lib/mydia_web/live/admin_settings_live/index.html.heex
+++ b/lib/mydia_web/live/admin_settings_live/index.html.heex
@@ -4,6 +4,7 @@
       config_settings_with_sources={@config_settings_with_sources}
       crash_report_stats={@crash_report_stats}
       invalid_config_settings={@invalid_config_settings}
+      hwaccel={@hwaccel}
     />
   </.admin_page>
 </Layouts.app>

--- a/test/mydia/config/hwaccel_config_test.exs
+++ b/test/mydia/config/hwaccel_config_test.exs
@@ -1,0 +1,37 @@
+defmodule Mydia.Config.HwaccelConfigTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Config.Schema
+
+  defp changeset(attrs) do
+    Schema.changeset(%Schema{}, %{"streaming" => attrs})
+  end
+
+  describe "hwaccel" do
+    test "defaults to auto" do
+      assert %Schema{streaming: %{hwaccel: :auto}} = Schema.defaults()
+    end
+
+    test "accepts the supported backends" do
+      for value <- ["auto", "off", "vaapi"] do
+        assert changeset(%{"hwaccel" => value}).valid?, "expected #{value} to be accepted"
+      end
+    end
+
+    test "rejects an unknown backend by name rather than defaulting" do
+      # An operator who typos a safety-relevant setting must get an error, not
+      # silently get `auto`. :invalid is not a member of the Ecto.Enum, so
+      # validation rejects it.
+      refute changeset(%{"hwaccel" => "vappi"}).valid?
+    end
+  end
+
+  describe "hwaccel_device" do
+    test "accepts a render node path" do
+      cs = changeset(%{"hwaccel_device" => "/dev/dri/renderD129"})
+
+      assert cs.valid?
+      assert Ecto.Changeset.get_field(cs, :streaming).hwaccel_device == "/dev/dri/renderD129"
+    end
+  end
+end

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -47,7 +47,9 @@ defmodule Mydia.Config.LoaderTest do
         "AUTO_SEARCH_MIN_SEEDERS",
         "TRASH_RETENTION_DAYS",
         "SUBTITLE_LANGUAGE",
-        "DEFAULT_SEASON_MONITORING"
+        "DEFAULT_SEASON_MONITORING",
+        "HWACCEL",
+        "HWACCEL_DEVICE"
       ] ++ download_client_vars ++ library_path_vars
 
     # Store original values
@@ -760,6 +762,80 @@ defmodule Mydia.Config.LoaderTest do
       {:ok, config} = Loader.load(config_file: "nonexistent.yml")
 
       assert config.streaming.subtitle_language == ["en", "es"]
+    end
+
+    test "HWACCEL defaults to auto when the env var is absent" do
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.streaming.hwaccel == :auto
+    end
+
+    test "reads HWACCEL as an atom" do
+      System.put_env("HWACCEL", "vaapi")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.streaming.hwaccel == :vaapi
+    end
+
+    test "accepts HWACCEL case-insensitively with surrounding whitespace" do
+      System.put_env("HWACCEL", "  Off ")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.streaming.hwaccel == :off
+    end
+
+    test "a blank HWACCEL is treated as unset and leaves the default in place" do
+      System.put_env("HWACCEL", "")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.streaming.hwaccel == :auto
+    end
+
+    test "rejects an unrecognised HWACCEL rather than falling back to auto" do
+      # Dropping the key would silently fall back to :auto, so an operator who
+      # typed "vappi" would get software transcoding while believing they had
+      # forced (or disabled) hardware acceleration. Failing loudly matches how
+      # a bad DOWNLOAD_CLIENT_<N>_EXTERNAL_TORRENTS already behaves.
+      #
+      # This is the regression test for the review finding that :invalid must
+      # NOT be a member of Streaming.hwaccel's Ecto.Enum values: including it
+      # there would make Ecto.Enum accept the atom parse_hwaccel/1 emits for a
+      # typo, producing a *valid* config carrying the sentinel with no error
+      # anywhere.
+      System.put_env("HWACCEL", "vappi")
+
+      assert {:error, _reason} = Loader.load(config_file: "nonexistent.yml")
+    end
+
+    test "an unrecognised HWACCEL does not mint a new atom" do
+      # parse_atom/1 falls back to String.to_atom/1, and atoms are never
+      # garbage collected. The dedicated parser must never reach that path.
+      System.put_env("HWACCEL", "definitely_not_a_backend_atom")
+
+      {:error, _reason} = Loader.load(config_file: "nonexistent.yml")
+
+      assert_raise ArgumentError, fn ->
+        String.to_existing_atom("definitely_not_a_backend_atom")
+      end
+    end
+
+    test "HWACCEL_DEVICE round-trips a render node path" do
+      System.put_env("HWACCEL_DEVICE", "/dev/dri/renderD129")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.streaming.hwaccel_device == "/dev/dri/renderD129"
+    end
+
+    test "a blank HWACCEL_DEVICE is treated as unset" do
+      System.put_env("HWACCEL_DEVICE", "")
+
+      {:ok, config} = Loader.load(config_file: "nonexistent.yml")
+
+      assert config.streaming.hwaccel_device == nil
     end
 
     test "the automatic-search seeder floor is reachable from every layer" do

--- a/test/mydia/downloads/ffmpeg_mp4_hwaccel_test.exs
+++ b/test/mydia/downloads/ffmpeg_mp4_hwaccel_test.exs
@@ -63,4 +63,91 @@ defmodule Mydia.Downloads.FfmpegMp4HwaccelTest do
              output_buffer: "Invalid data found when processing input"
            })
   end
+
+  describe "the non-zero exit handler" do
+    # handle_info/2 is a GenServer callback, so it is already a public
+    # function -- called directly here the same way retry_in_software?/1's
+    # tests above call a decision function directly, without a live
+    # GenServer. input_path points nowhere on purpose: it makes whatever
+    # ffmpeg process handle_info/2 spawns for the software retry fail almost
+    # instantly (the codebase already assumes ffmpeg is on PATH for the
+    # default `mix test` run -- see test/mydia/library/ffmpeg_test.exs).
+    # These tests only care what handle_info/2 itself does synchronously,
+    # never what that spawned process eventually reports.
+    defp state(output_path, on_error, output_buffer) do
+      opts = [
+        input_path: "/nonexistent/definitely-not-here.mkv",
+        output_path: output_path,
+        resolution: :p720
+      ]
+
+      %FfmpegMp4Transcoder.State{
+        input_path: "/nonexistent/definitely-not-here.mkv",
+        output_path: output_path,
+        resolution: :p720,
+        ffmpeg_pid: 999_999,
+        ffmpeg_port: make_ref(),
+        on_error: on_error,
+        buffer: "",
+        job_id: "job-1",
+        source_codec: "hevc",
+        opts: opts,
+        hwaccel_lease: nil,
+        hwaccel_retried: false,
+        output_buffer: output_buffer
+      }
+    end
+
+    setup do
+      output_path =
+        Path.join(System.tmp_dir!(), "mp4_hwaccel_test_#{System.unique_integer([:positive])}.mp4")
+
+      on_exit(fn -> File.rm(output_path) end)
+
+      %{output_path: output_path}
+    end
+
+    test "a retryable hardware failure does not report on_error before the software restart",
+         %{output_path: output_path} do
+      # Stands in for -movflags +empty_moov having already written a moov atom
+      # for the failed hardware attempt (see restart_in_software/1's comment):
+      # a real file sits at output_path before the retry runs.
+      File.write!(output_path, "partial hardware output")
+
+      test_pid = self()
+      on_error = fn msg -> send(test_pid, {:on_error_called, msg}) end
+
+      state = state(output_path, on_error, "Device creation failed: -5.")
+
+      assert {:noreply, new_state} =
+               FfmpegMp4Transcoder.handle_info({state.ffmpeg_port, {:exit_status, 1}}, state)
+
+      # The bug: on_error used to fire unconditionally before this branch was
+      # even chosen, marking the download job failed while this software
+      # restart was still starting behind it.
+      refute_received {:on_error_called, _}
+
+      assert new_state.hwaccel_retried
+      assert is_port(new_state.ffmpeg_port)
+
+      # The partial hardware output must be gone before the software retry's
+      # ffmpeg process starts, or that process would stop at ffmpeg's
+      # interactive overwrite prompt (no -y in the argument list) and hang.
+      refute File.exists?(output_path)
+    end
+
+    test "a non-retryable failure still reports on_error and stops the job",
+         %{output_path: output_path} do
+      test_pid = self()
+      on_error = fn msg -> send(test_pid, {:on_error_called, msg}) end
+
+      state = state(output_path, on_error, "Invalid data found when processing input")
+
+      assert {:stop, {:ffmpeg_failed, 1}, ^state} =
+               FfmpegMp4Transcoder.handle_info({state.ffmpeg_port, {:exit_status, 1}}, state)
+
+      assert_received {:on_error_called, msg}
+      assert msg =~ "FFmpeg exited with status 1"
+    end
+  end
 end

--- a/test/mydia/downloads/ffmpeg_mp4_hwaccel_test.exs
+++ b/test/mydia/downloads/ffmpeg_mp4_hwaccel_test.exs
@@ -1,0 +1,66 @@
+defmodule Mydia.Downloads.FfmpegMp4HwaccelTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Downloads.FfmpegMp4Transcoder
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+
+  @vaapi %Capabilities{
+    backend: :vaapi,
+    device: "/dev/dri/renderD128",
+    encoders: [:h264],
+    decode_profiles: [:hevc]
+  }
+
+  defp args(opts) do
+    FfmpegMp4Transcoder.build_ffmpeg_args("/tmp/in.mkv", "/tmp/out.mp4", :p1080, opts)
+  end
+
+  test "without capabilities the arguments are unchanged" do
+    result = args([])
+
+    assert "libx264" in result
+    refute "-hwaccel" in result
+  end
+
+  test "a decodable source uses the hardware encoder" do
+    result = args(capabilities: @vaapi, source_codec: "hevc")
+
+    assert "h264_vaapi" in result
+    assert Enum.find_index(result, &(&1 == "-hwaccel")) < Enum.find_index(result, &(&1 == "-i"))
+  end
+
+  test "the fragmented MP4 flags survive acceleration" do
+    # These are what make the file playable before the download completes;
+    # losing them would break progressive playback silently.
+    result = args(capabilities: @vaapi, source_codec: "hevc")
+
+    assert "+frag_keyframe+empty_moov+default_base_moof" in result
+  end
+
+  test "the resolution preset is applied through the filter, not -s" do
+    # -s and a hardware filter chain cannot both set geometry; -s would force a
+    # software scale after the frames are already on the GPU.
+    result = args(capabilities: @vaapi, source_codec: "hevc")
+
+    refute "-s" in result
+    assert Enum.any?(result, &String.contains?(&1, "scale_vaapi"))
+  end
+
+  test "retries a hardware failure once and no more" do
+    output = "Device creation failed: -5."
+
+    assert FfmpegMp4Transcoder.retry_in_software?(%{
+             hwaccel_retried: false,
+             output_buffer: output
+           })
+
+    refute FfmpegMp4Transcoder.retry_in_software?(%{hwaccel_retried: true, output_buffer: output})
+  end
+
+  test "an ordinary encode failure is never retried" do
+    refute FfmpegMp4Transcoder.retry_in_software?(%{
+             hwaccel_retried: false,
+             output_buffer: "Invalid data found when processing input"
+           })
+  end
+end

--- a/test/mydia/downloads/transcoder_opts_wiring_test.exs
+++ b/test/mydia/downloads/transcoder_opts_wiring_test.exs
@@ -1,0 +1,179 @@
+defmodule Mydia.Downloads.TranscoderOptsWiringTest do
+  @moduledoc """
+  Pins the wiring that carries `:source_codec` from the source media file all
+  the way to the ffmpeg transcoder, rather than only asserting on end-to-end
+  behaviour.
+
+  Without `:source_codec`, `Mydia.Streaming.HardwareAccel.Args.build/2` never
+  sees a decodable source, `Capabilities.can_decode?/2` fails closed, and
+  every download resolves to the `:hybrid` tier forever -- even on hardware
+  that can decode the source -- which is a large, silent performance
+  regression, not a crash. A prior task in this plan shipped exactly this
+  shape of bug (a key silently dropped by a function that rebuilt its options
+  from a fixed whitelist) with every existing test passing, because nothing
+  asserted on the opts a downstream collaborator actually received.
+  """
+
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Downloads.CapturingTranscoder
+  alias Mydia.Downloads.DownloadService
+  alias Mydia.Downloads.JobManager
+
+  setup do
+    previous = Application.get_env(:mydia, :transcoder_module)
+    Application.put_env(:mydia, :transcoder_module, CapturingTranscoder)
+
+    cleanup_jobs()
+    CapturingTranscoder.collect()
+
+    on_exit(fn ->
+      cleanup_jobs()
+
+      case previous do
+        nil -> Application.delete_env(:mydia, :transcoder_module)
+        mod -> Application.put_env(:mydia, :transcoder_module, mod)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "JobManager.start_or_queue_job/1" do
+    test "the immediate-start path forwards opts to the transcoder unchanged" do
+      {:ok, pid} =
+        JobManager.start_or_queue_job(
+          media_file_id: "wiring-immediate",
+          resolution: :p720,
+          input_path: "/tmp/in.mkv",
+          output_path: "/tmp/out.mp4",
+          source_codec: "hevc"
+        )
+
+      assert_receive {:transcoder_opts, opts}
+      assert Keyword.get(opts, :source_codec) == "hevc"
+
+      JobManager.cancel_job("wiring-immediate", :p720)
+      assert is_pid(pid)
+    end
+
+    test "a job promoted from the queue still carries :source_codec" do
+      # Fill capacity (default max_concurrent: 2) with jobs that stay alive
+      # until told to finish, so the third job is forced into the queue --
+      # queued_job.opts is a separate storage path from the immediate-start
+      # one, and both must preserve the same keys.
+      {:ok, pid1} =
+        JobManager.start_or_queue_job(
+          media_file_id: "wiring-fill-1",
+          resolution: :p720,
+          input_path: "/tmp/in1.mkv",
+          output_path: "/tmp/out1.mp4",
+          source_codec: "h264"
+        )
+
+      {:ok, _pid2} =
+        JobManager.start_or_queue_job(
+          media_file_id: "wiring-fill-2",
+          resolution: :p720,
+          input_path: "/tmp/in2.mkv",
+          output_path: "/tmp/out2.mp4",
+          source_codec: "h264"
+        )
+
+      # Drain the two capture messages from the immediate starts above before
+      # asserting on the queued job's message below.
+      assert_receive {:transcoder_opts, _fill_1}
+      assert_receive {:transcoder_opts, _fill_2}
+
+      {:ok, :queued} =
+        JobManager.start_or_queue_job(
+          media_file_id: "wiring-queued",
+          resolution: :p720,
+          input_path: "/tmp/in3.mkv",
+          output_path: "/tmp/out3.mp4",
+          source_codec: "hevc"
+        )
+
+      refute_receive {:transcoder_opts, _}, 100
+
+      # Free a slot so the queued job is promoted.
+      CapturingTranscoder.finish(pid1)
+
+      assert_receive {:transcoder_opts, promoted_opts}, 5_000
+      assert Keyword.get(promoted_opts, :source_codec) == "hevc"
+
+      JobManager.cancel_job("wiring-fill-2", :p720)
+      JobManager.cancel_job("wiring-queued", :p720)
+    end
+  end
+
+  describe "DownloadService.prepare_by_file/2" do
+    setup do
+      library = insert(:library_path, type: :movies, path: "/movies")
+      media_item = insert(:media_item, type: "movie")
+
+      media_file =
+        insert(:media_file,
+          media_item: media_item,
+          library_path: library,
+          relative_path: "movie.mkv",
+          size: 1_000_000_000,
+          resolution: "1080p",
+          codec: "hevc"
+        )
+
+      %{media_file: media_file}
+    end
+
+    test "threads the source media file's codec through to the transcoder", %{
+      media_file: media_file
+    } do
+      assert {:ok, _job_info} = DownloadService.prepare_by_file(media_file.id, "720p")
+
+      assert_receive {:transcoder_opts, opts}, 5_000
+      assert Keyword.get(opts, :source_codec) == "hevc"
+
+      # cleanup_jobs/0 in on_exit cancels this via JobManager (keyed on
+      # media_file_id + resolution, same as DownloadService used to start
+      # it); no need to cancel it here.
+    end
+  end
+
+  defp cleanup_jobs do
+    %{active: active, queued: queued} = JobManager.list_active_jobs()
+
+    Enum.each(active ++ queued, fn job ->
+      JobManager.cancel_job(job.media_file_id, job.resolution)
+    end)
+
+    wait_for_registry_cleanup()
+  end
+
+  defp wait_for_registry_cleanup(attempts_left \\ 20)
+
+  defp wait_for_registry_cleanup(0) do
+    registry_entries()
+    |> Enum.each(fn [_key, pid, _value] ->
+      if Process.alive?(pid) do
+        GenServer.stop(pid, :normal)
+      end
+    end)
+
+    Process.sleep(100)
+  end
+
+  defp wait_for_registry_cleanup(attempts_left) do
+    case registry_entries() do
+      [] ->
+        :ok
+
+      _entries ->
+        Process.sleep(50)
+        wait_for_registry_cleanup(attempts_left - 1)
+    end
+  end
+
+  defp registry_entries do
+    Registry.select(Mydia.Downloads.TranscodeRegistry, [{{:"$1", :"$2", :"$3"}, [], [:"$$"]}])
+  end
+end

--- a/test/mydia/streaming/ffmpeg_hwaccel_args_test.exs
+++ b/test/mydia/streaming/ffmpeg_hwaccel_args_test.exs
@@ -1,0 +1,83 @@
+defmodule Mydia.Streaming.FfmpegHwaccelArgsTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+
+  @vaapi %Capabilities{
+    backend: :vaapi,
+    device: "/dev/dri/renderD128",
+    encoders: [:h264],
+    decode_profiles: [:hevc]
+  }
+
+  defp args(opts), do: FfmpegHlsTranscoder.build_ffmpeg_args("/tmp/in.mkv", "/tmp/out", opts)
+
+  defp media_file(codec), do: %MediaFile{codec: codec, audio_codec: "aac"}
+
+  defp index_of(args, value), do: Enum.find_index(args, &(&1 == value))
+
+  describe "with no capabilities available" do
+    test "produces exactly today's software arguments" do
+      result = args(video_codec: "libx264")
+
+      assert "libx264" in result
+      refute "h264_vaapi" in result
+      refute "-hwaccel" in result
+      assert "yuv420p" in result
+    end
+  end
+
+  describe "with a VAAPI device" do
+    test "hwaccel flags precede the input" do
+      # -hwaccel after -i is silently ignored: ffmpeg has already chosen a
+      # decoder by then.
+      result = args(capabilities: @vaapi, media_file: media_file("hevc"))
+
+      assert index_of(result, "-hwaccel") < index_of(result, "-i")
+    end
+
+    test "a decodable source uses the full hardware tier" do
+      result = args(capabilities: @vaapi, media_file: media_file("hevc"))
+
+      assert "h264_vaapi" in result
+      assert "-hwaccel_output_format" in result
+      refute "libx264" in result
+      refute "yuv420p" in result
+    end
+
+    test "an undecodable source uses the hybrid tier" do
+      result = args(capabilities: @vaapi, media_file: media_file("av1"))
+
+      assert "h264_vaapi" in result
+      assert "-init_hw_device" in result
+      refute "-hwaccel_output_format" in result
+    end
+
+    test "a stream copy is never accelerated" do
+      # Acceleration must not turn a copy into a transcode.
+      result = args(capabilities: @vaapi, media_file: media_file("h264"), video_codec: "copy")
+
+      assert "copy" in result
+      refute "-hwaccel" in result
+      refute "h264_vaapi" in result
+    end
+
+    test "the HLS muxing arguments are untouched" do
+      result = args(capabilities: @vaapi, media_file: media_file("hevc"))
+
+      assert "-hls_time" in result
+      assert "temp_file" in result
+      assert index_of(result, "-f") < index_of(result, "/tmp/out/index.m3u8")
+    end
+
+    test "a bitrate cap still reaches the encoder" do
+      result = args(capabilities: @vaapi, media_file: media_file("hevc"), max_bitrate: 3000)
+
+      assert "-rc_mode" in result
+      assert "VBR" in result
+      assert "2872k" in result
+    end
+  end
+end

--- a/test/mydia/streaming/hardware_accel/args_test.exs
+++ b/test/mydia/streaming/hardware_accel/args_test.exs
@@ -1,0 +1,203 @@
+defmodule Mydia.Streaming.HardwareAccel.ArgsTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Mydia.Streaming.HardwareAccel.Args
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+
+  defp vaapi(decode_profiles) do
+    %Capabilities{
+      backend: :vaapi,
+      device: "/dev/dri/renderD128",
+      encoders: [:h264],
+      decode_profiles: decode_profiles
+    }
+  end
+
+  defp software, do: Capabilities.software("no device")
+
+  defp filter(%Args{video: video}), do: Enum.at(video, Enum.find_index(video, &(&1 == "-vf")) + 1)
+
+  describe "tier selection" do
+    test "software capabilities give the software tier" do
+      assert %Args{tier: :software} = Args.build(software(), source_codec: "hevc")
+    end
+
+    test "a decodable source gives the full hardware tier" do
+      assert %Args{tier: :full_hardware} = Args.build(vaapi([:hevc, :av1]), source_codec: "hevc")
+    end
+
+    test "an undecodable source gives the hybrid tier" do
+      assert %Args{tier: :hybrid} = Args.build(vaapi([:hevc]), source_codec: "av1")
+    end
+
+    test "a device that cannot encode h264 gives software" do
+      caps = %Capabilities{
+        backend: :vaapi,
+        device: "/dev/dri/renderD128",
+        encoders: [],
+        decode_profiles: [:hevc]
+      }
+
+      assert %Args{tier: :software} = Args.build(caps, source_codec: "hevc")
+    end
+
+    test "an unknown source codec gives hybrid, never full hardware" do
+      # Failing open here would hand the GPU a stream it cannot decode and
+      # produce a dead session rather than a slow one.
+      assert %Args{tier: :hybrid} = Args.build(vaapi([:hevc]), source_codec: "some_new_codec")
+    end
+  end
+
+  describe "software arguments are unchanged from today" do
+    test "the full uncapped CRF argument list" do
+      args = Args.build(software(), source_codec: "av1")
+
+      assert args.input == []
+
+      assert args.video == [
+               "-c:v",
+               "libx264",
+               "-preset",
+               "medium",
+               "-pix_fmt",
+               "yuv420p",
+               "-profile:v",
+               "high",
+               "-g",
+               "60",
+               "-bf",
+               "0",
+               "-vf",
+               "scale=-2:2*trunc(ih/2)",
+               "-crf",
+               "23"
+             ]
+    end
+
+    test "the capped ABR argument list" do
+      args =
+        Args.build(software(), source_codec: "av1", max_height: 720, video_bitrate_kbps: 2872)
+
+      assert args.video == [
+               "-c:v",
+               "libx264",
+               "-preset",
+               "medium",
+               "-pix_fmt",
+               "yuv420p",
+               "-profile:v",
+               "high",
+               "-g",
+               "60",
+               "-bf",
+               "0",
+               "-vf",
+               "scale=-2:2*trunc(min(720\\,ih)/2)",
+               "-b:v",
+               "2872k",
+               "-maxrate",
+               "2872k",
+               "-bufsize",
+               "5744k"
+             ]
+    end
+  end
+
+  describe "full hardware arguments" do
+    test "hwaccel input args name the probed device" do
+      args = Args.build(vaapi([:hevc]), source_codec: "hevc")
+
+      assert args.input == [
+               "-hwaccel",
+               "vaapi",
+               "-hwaccel_device",
+               "/dev/dri/renderD128",
+               "-hwaccel_output_format",
+               "vaapi"
+             ]
+    end
+
+    test "uses scale_vaapi with the same expression as the software filter" do
+      args = Args.build(vaapi([:hevc]), source_codec: "hevc", max_height: 720)
+
+      assert filter(args) == "scale_vaapi=w=-2:h=2*trunc(min(720\\,ih)/2):format=nv12"
+    end
+
+    test "drops -pix_fmt yuv420p" do
+      # The filter chain already lands frames in nv12. Leaving the flag in makes
+      # ffmpeg insert a download and re-upload that costs more than it saves.
+      args = Args.build(vaapi([:hevc]), source_codec: "hevc")
+
+      refute "-pix_fmt" in args.video
+    end
+
+    test "constant quality is CQP at the measured qp" do
+      args = Args.build(vaapi([:hevc]), source_codec: "hevc")
+
+      assert args.video == [
+               "-c:v",
+               "h264_vaapi",
+               "-profile:v",
+               "high",
+               "-g",
+               "60",
+               "-bf",
+               "0",
+               "-vf",
+               "scale_vaapi=w=-2:h=2*trunc(ih/2):format=nv12",
+               "-rc_mode",
+               "CQP",
+               "-qp",
+               "23"
+             ]
+    end
+
+    test "a bitrate cap pins rc_mode to VBR" do
+      args = Args.build(vaapi([:hevc]), source_codec: "hevc", video_bitrate_kbps: 2872)
+
+      assert Enum.chunk_every(args.video, 2) |> Enum.member?(["-rc_mode", "VBR"])
+      assert Enum.chunk_every(args.video, 2) |> Enum.member?(["-b:v", "2872k"])
+      refute "-qp" in args.video
+    end
+  end
+
+  describe "hybrid arguments" do
+    test "init_hw_device and filter_hw_device are required for hwupload" do
+      args = Args.build(vaapi([:hevc]), source_codec: "av1")
+
+      assert args.input == [
+               "-init_hw_device",
+               "vaapi=hw:/dev/dri/renderD128",
+               "-filter_hw_device",
+               "hw"
+             ]
+    end
+
+    test "keeps the software scale filter and appends the upload" do
+      args = Args.build(vaapi([:hevc]), source_codec: "av1", max_height: 720)
+
+      assert filter(args) == "scale=-2:2*trunc(min(720\\,ih)/2),format=nv12,hwupload"
+    end
+
+    test "encodes with the hardware encoder" do
+      args = Args.build(vaapi([:hevc]), source_codec: "av1")
+
+      assert "h264_vaapi" in args.video
+      refute "libx264" in args.video
+    end
+  end
+
+  describe "a non-positive height ceiling" do
+    test "warns and falls back to the source resolution on every tier" do
+      log =
+        capture_log(fn ->
+          assert filter(Args.build(software(), source_codec: "av1", max_height: 0)) ==
+                   "scale=-2:2*trunc(ih/2)"
+        end)
+
+      assert log =~ "non-positive transcode height ceiling"
+    end
+  end
+end

--- a/test/mydia/streaming/hardware_accel/capabilities_test.exs
+++ b/test/mydia/streaming/hardware_accel/capabilities_test.exs
@@ -1,0 +1,48 @@
+defmodule Mydia.Streaming.HardwareAccel.CapabilitiesTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+
+  describe "software/1" do
+    test "carries the reason so the settings page can explain itself" do
+      caps = Capabilities.software("no render node present")
+
+      assert caps.backend == :none
+      assert caps.device == nil
+      assert caps.reason == "no render node present"
+      refute Capabilities.accelerated?(caps)
+    end
+  end
+
+  describe "can_decode?/2" do
+    test "matches a codec the device advertises" do
+      caps = %Capabilities{backend: :vaapi, decode_profiles: [:hevc, :av1]}
+
+      assert Capabilities.can_decode?(caps, :hevc)
+      assert Capabilities.can_decode?(caps, "av1")
+      refute Capabilities.can_decode?(caps, :vp9)
+    end
+
+    test "an unknown codec string is not a decode profile" do
+      # A source codec ffprobe reported but we have no atom for must never
+      # resolve to a hardware decode path, and must never mint an atom.
+      caps = %Capabilities{backend: :vaapi, decode_profiles: [:hevc]}
+
+      refute Capabilities.can_decode?(caps, "prores_raw_9000")
+      refute Capabilities.can_decode?(caps, nil)
+    end
+
+    test "software capabilities decode nothing" do
+      refute Capabilities.can_decode?(Capabilities.software("off"), :hevc)
+    end
+  end
+
+  describe "can_encode?/2" do
+    test "reflects the advertised encoders" do
+      caps = %Capabilities{backend: :vaapi, encoders: [:h264]}
+
+      assert Capabilities.can_encode?(caps, :h264)
+      refute Capabilities.can_encode?(caps, :hevc)
+    end
+  end
+end

--- a/test/mydia/streaming/hardware_accel/probe_test.exs
+++ b/test/mydia/streaming/hardware_accel/probe_test.exs
@@ -90,4 +90,57 @@ defmodule Mydia.Streaming.HardwareAccel.ProbeTest do
       refute caps.reason =~ "no usable VAAPI device among"
     end
   end
+
+  describe "run_bounded/3" do
+    test "returns the child's combined output on a normal exit" do
+      assert {:ok, output} = Probe.run_bounded("echo", ["hello"])
+      assert String.trim(output) == "hello"
+    end
+
+    test "reports the exit code and output on a non-zero exit" do
+      assert {:error, {:exit, 7, _output}} = Probe.run_bounded("sh", ["-c", "exit 7"])
+    end
+
+    test "reports :not_found for a missing executable" do
+      assert {:error, :not_found} =
+               Probe.run_bounded("definitely-not-a-real-mydia-probe-binary", [])
+    end
+
+    test "a wedged command times out instead of blocking the caller" do
+      started_at = System.monotonic_time(:millisecond)
+
+      assert {:error, :timeout} = Probe.run_bounded("sleep", ["5"], 100)
+
+      elapsed = System.monotonic_time(:millisecond) - started_at
+      # Generous margin over the 100ms bound: the assertion that matters is
+      # "did not wait anywhere near sleep's actual 5s", not a tight bound on
+      # scheduler jitter.
+      assert elapsed < 2_000
+    end
+
+    test "the timeout actually kills the OS process rather than abandoning it" do
+      # A fingerprinted duration so pgrep -f finds only the child this call
+      # spawned, never some unrelated sleep left over by another test running
+      # concurrently (this module is async: true).
+      unique_secs = to_string(100_000 + System.unique_integer([:positive]))
+
+      assert {:error, :timeout} = Probe.run_bounded("sleep", [unique_secs], 100)
+
+      # The SIGKILL in kill_bounded/2 is sent synchronously before
+      # run_bounded/3 returns, but the kernel reaping it is not instant.
+      Process.sleep(200)
+
+      case System.find_executable("pgrep") do
+        nil ->
+          :ok
+
+        _found ->
+          {output, _status} =
+            System.cmd("pgrep", ["-f", "sleep #{unique_secs}"], stderr_to_stdout: true)
+
+          assert String.trim(output) == "",
+                 "sleep #{unique_secs} was still running after its timeout killed it"
+      end
+    end
+  end
 end

--- a/test/mydia/streaming/hardware_accel/probe_test.exs
+++ b/test/mydia/streaming/hardware_accel/probe_test.exs
@@ -1,6 +1,7 @@
 defmodule Mydia.Streaming.HardwareAccel.ProbeTest do
   use ExUnit.Case, async: true
 
+  alias Mydia.Streaming.HardwareAccel.Capabilities
   alias Mydia.Streaming.HardwareAccel.Probe
 
   defp fixture(name), do: File.read!("test/support/fixtures/#{name}")
@@ -66,6 +67,27 @@ defmodule Mydia.Streaming.HardwareAccel.ProbeTest do
 
       assert caps.backend == :none
       assert caps.reason =~ "/nonexistent/renderD128"
+    end
+
+    test "a device that exists but is not a working render node reports its own failure, not a generic one" do
+      # File.touch!/1 creates something that satisfies File.exists?/1 but is
+      # not a real render node, so vainfo (or, absent that binary, the
+      # rescue ErlangError clause) fails on it. In this devenv vainfo is not
+      # installed, so this also exercises the boot-safety path where
+      # System.cmd/3 raises: the probe must degrade to software capabilities
+      # rather than crash the caller.
+      tmp_path = Path.join(System.tmp_dir!(), "probe_test_#{System.unique_integer([:positive])}")
+      File.touch!(tmp_path)
+      on_exit(fn -> File.rm(tmp_path) end)
+
+      caps = Probe.run(hwaccel: :vaapi, device: tmp_path)
+
+      assert %Capabilities{backend: :none} = caps
+      # The reason names this specific device and its actual failure, not the
+      # generic "no usable VAAPI device among ..." that discards which device
+      # failed and why.
+      assert caps.reason =~ tmp_path
+      refute caps.reason =~ "no usable VAAPI device among"
     end
   end
 end

--- a/test/mydia/streaming/hardware_accel/probe_test.exs
+++ b/test/mydia/streaming/hardware_accel/probe_test.exs
@@ -1,0 +1,71 @@
+defmodule Mydia.Streaming.HardwareAccel.ProbeTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.HardwareAccel.Probe
+
+  defp fixture(name), do: File.read!("test/support/fixtures/#{name}")
+
+  describe "parse_vainfo/1" do
+    test "reads decode profiles from VLD entrypoints" do
+      %{decode_profiles: decode} = Probe.parse_vainfo(fixture("vainfo_intel_raptor_lake.txt"))
+
+      assert :h264 in decode
+      assert :hevc in decode
+      assert :av1 in decode
+      assert :vp9 in decode
+      assert :vp8 in decode
+      assert :mpeg2video in decode
+      assert :vc1 in decode
+    end
+
+    test "reads encoders from EncSlice entrypoints" do
+      %{encoders: encoders} = Probe.parse_vainfo(fixture("vainfo_intel_raptor_lake.txt"))
+
+      assert :h264 in encoders
+      assert :hevc in encoders
+    end
+
+    test "AV1 has no encode entrypoint on this device" do
+      # Raptor Lake decodes AV1 and cannot encode it. Reading VLD as encode
+      # support would pick an encoder that does not exist.
+      %{encoders: encoders} = Probe.parse_vainfo(fixture("vainfo_intel_raptor_lake.txt"))
+
+      refute :av1 in encoders
+    end
+
+    test "a driver-less vainfo yields nothing" do
+      assert %{encoders: [], decode_profiles: []} =
+               Probe.parse_vainfo(fixture("vainfo_no_driver.txt"))
+    end
+
+    test "results are deduplicated" do
+      # H264High and H264Main both map to :h264 and both advertise EncSlice.
+      %{encoders: encoders} = Probe.parse_vainfo(fixture("vainfo_intel_raptor_lake.txt"))
+
+      assert length(encoders) == length(Enum.uniq(encoders))
+    end
+  end
+
+  describe "run/1" do
+    test "returns software capabilities when hwaccel is off" do
+      caps = Probe.run(hwaccel: :off)
+
+      assert caps.backend == :none
+      assert caps.reason =~ "HWACCEL=off"
+    end
+
+    test "returns software capabilities when no render node exists" do
+      caps = Probe.run(hwaccel: :auto, device_glob: "/nonexistent/renderD*")
+
+      assert caps.backend == :none
+      assert caps.reason =~ "no render node"
+    end
+
+    test "an explicitly requested device that does not exist is reported as such" do
+      caps = Probe.run(hwaccel: :vaapi, device: "/nonexistent/renderD128")
+
+      assert caps.backend == :none
+      assert caps.reason =~ "/nonexistent/renderD128"
+    end
+  end
+end

--- a/test/mydia/streaming/hardware_accel_test.exs
+++ b/test/mydia/streaming/hardware_accel_test.exs
@@ -107,12 +107,16 @@ defmodule Mydia.Streaming.HardwareAccelTest do
           end
         end)
 
-      assert_receive {:leased, _ref}
+      # Explicit budget rather than ExUnit's 100ms default: the PostgreSQL CI
+      # job runs the suite concurrently (max_cases: System.schedulers_online()
+      # in test_helper.exs, against 1 for SQLite), where a cross-process
+      # handoff can exceed 100ms without anything being wrong.
+      assert_receive {:leased, _ref}, 2_000
       assert :refused = HardwareAccel.lease(name, :playback)
 
       holder_monitor = Process.monitor(holder)
       send(holder, :die)
-      assert_receive {:DOWN, ^holder_monitor, :process, ^holder, :normal}
+      assert_receive {:DOWN, ^holder_monitor, :process, ^holder, :normal}, 2_000
 
       assert eventually(fn -> match?({:ok, _}, HardwareAccel.lease(name, :playback)) end)
     end
@@ -203,7 +207,7 @@ defmodule Mydia.Streaming.HardwareAccelTest do
          end}
       )
 
-      assert_receive {:probe_opts, opts}
+      assert_receive {:probe_opts, opts}, 2_000
 
       streaming = Mydia.Config.get().streaming
       assert Keyword.fetch!(opts, :hwaccel) == streaming.hwaccel

--- a/test/mydia/streaming/hardware_accel_test.exs
+++ b/test/mydia/streaming/hardware_accel_test.exs
@@ -49,6 +49,53 @@ defmodule Mydia.Streaming.HardwareAccelTest do
     end
   end
 
+  describe "surviving the process exiting mid-call" do
+    # GenServer.whereis/1 resolves a pid before the call is made, but the
+    # process can die in the gap -- realistically the probe crashing and the
+    # supervisor restarting it. :sys.suspend/1 makes that race deterministic:
+    # the suspended process still queues the call message but never answers
+    # it, so killing it while a caller is blocked on GenServer.call/3
+    # reliably reproduces "exited while a call was in flight" instead of
+    # "was already gone before the call was made" (which capabilities/0's
+    # own "without a running process" test above already covers).
+    test "capabilities/1 reports software instead of crashing the caller" do
+      name = start_with(@vaapi)
+      pid = GenServer.whereis(name)
+
+      :sys.suspend(pid)
+      task = Task.async(fn -> HardwareAccel.capabilities(name) end)
+      Process.sleep(50)
+      Process.exit(pid, :kill)
+
+      assert %Capabilities{backend: :none, reason: reason} = Task.await(task)
+      assert reason =~ "not running"
+    end
+
+    test "lease/2 is refused instead of crashing the caller" do
+      name = start_with(@vaapi)
+      pid = GenServer.whereis(name)
+
+      :sys.suspend(pid)
+      task = Task.async(fn -> HardwareAccel.lease(name, :playback) end)
+      Process.sleep(50)
+      Process.exit(pid, :kill)
+
+      assert :refused = Task.await(task)
+    end
+
+    test "report_failure/3 reports ok instead of crashing the caller" do
+      name = start_with(@vaapi)
+      pid = GenServer.whereis(name)
+
+      :sys.suspend(pid)
+      task = Task.async(fn -> HardwareAccel.report_failure(name, :vaapi, "hevc") end)
+      Process.sleep(50)
+      Process.exit(pid, :kill)
+
+      assert :ok = Task.await(task)
+    end
+  end
+
   describe "leases" do
     test "playback takes slots up to the cap" do
       name = start_with(@vaapi, cap: 2)

--- a/test/mydia/streaming/hardware_accel_test.exs
+++ b/test/mydia/streaming/hardware_accel_test.exs
@@ -18,6 +18,18 @@ defmodule Mydia.Streaming.HardwareAccelTest do
     name
   end
 
+  # A dead lease holder's :DOWN reaches HardwareAccel independently of any
+  # :DOWN the test process set up for its own synchronization, so there is no
+  # ordering guarantee between "test observed the holder die" and "server
+  # finished reclaiming the slot". Poll briefly instead of asserting once.
+  defp eventually(fun, attempts \\ 50) do
+    cond do
+      fun.() -> true
+      attempts > 0 -> Process.sleep(5) && eventually(fun, attempts - 1)
+      true -> false
+    end
+  end
+
   describe "capabilities/0 without a running process" do
     test "reports software rather than crashing" do
       # Every existing streaming test runs with no probe process. They must keep
@@ -76,6 +88,47 @@ defmodule Mydia.Streaming.HardwareAccelTest do
 
       assert :refused = HardwareAccel.lease(name, :playback)
     end
+
+    test "reclaims a lease when its holder dies without releasing it" do
+      # The realistic failure mode this feature will meet: an ffmpeg-wrapping
+      # session gets OOM-killed or times out and never calls release/2. The
+      # slot must come back on its own rather than leaking until HardwareAccel
+      # itself restarts.
+      name = start_with(@vaapi, cap: 1)
+      test_pid = self()
+
+      holder =
+        spawn(fn ->
+          {:ok, ref} = HardwareAccel.lease(name, :playback)
+          send(test_pid, {:leased, ref})
+
+          receive do
+            :die -> :ok
+          end
+        end)
+
+      assert_receive {:leased, _ref}
+      assert :refused = HardwareAccel.lease(name, :playback)
+
+      holder_monitor = Process.monitor(holder)
+      send(holder, :die)
+      assert_receive {:DOWN, ^holder_monitor, :process, ^holder, :normal}
+
+      assert eventually(fn -> match?({:ok, _}, HardwareAccel.lease(name, :playback)) end)
+    end
+
+    test "a normal release demonitors, so a late DOWN cannot double-free the slot" do
+      name = start_with(@vaapi, cap: 1)
+
+      {:ok, ref} = HardwareAccel.lease(name, :playback)
+      :ok = HardwareAccel.release(name, ref)
+
+      # Two independent leases now fit in the cap-1 slot: proof the release
+      # path leaves no stray monitor that could otherwise reclaim a slot a
+      # second, unrelated holder is legitimately using.
+      assert {:ok, _} = HardwareAccel.lease(name, :playback)
+      assert :refused = HardwareAccel.lease(name, :playback)
+    end
   end
 
   describe "report_failure/3" do
@@ -101,6 +154,60 @@ defmodule Mydia.Streaming.HardwareAccelTest do
       HardwareAccel.report_failure(name, :vaapi, "not_a_codec")
 
       assert HardwareAccel.capabilities(name).decode_profiles == [:hevc, :av1]
+    end
+  end
+
+  describe "call timeout hardening" do
+    test "lease/2 and report_failure/3 wait out a slow probe instead of racing the default GenServer timeout" do
+      name = :"hwaccel_#{System.unique_integer([:positive])}"
+
+      start_supervised!({HardwareAccel,
+       name: name,
+       cap: 3,
+       probe: fn _ ->
+         # Longer than the default GenServer.call/3 timeout (5s). Before
+         # this fix, lease/2 and report_failure/3 used that default while
+         # queued behind this same handle_continue, so both would raise
+         # exit(:timeout) here instead of simply waiting the probe out the
+         # way capabilities/1 already does.
+         Process.sleep(5_300)
+         @vaapi
+       end})
+
+      lease_task = Task.async(fn -> HardwareAccel.lease(name, :playback) end)
+      failure_task = Task.async(fn -> HardwareAccel.report_failure(name, :vaapi, "hevc") end)
+
+      assert {:ok, _ref} = Task.await(lease_task, 10_000)
+      assert :ok = Task.await(failure_task, 10_000)
+    end
+  end
+
+  describe "the config wiring" do
+    test "passes the configured hwaccel and device through to the probe" do
+      # Every other test here injects a probe stub that ignores its argument,
+      # so nothing exercises handle_continue's read of Mydia.Config.get().
+      # Pin it: a future rename of the streaming.hwaccel/hwaccel_device schema
+      # fields would otherwise make handle_continue's Map.get/3 calls fall
+      # back to :auto/nil silently, disabling the feature while the rest of
+      # the suite stayed green.
+      test_pid = self()
+      name = :"hwaccel_#{System.unique_integer([:positive])}"
+
+      start_supervised!(
+        {HardwareAccel,
+         name: name,
+         cap: 3,
+         probe: fn opts ->
+           send(test_pid, {:probe_opts, opts})
+           Capabilities.software("stub")
+         end}
+      )
+
+      assert_receive {:probe_opts, opts}
+
+      streaming = Mydia.Config.get().streaming
+      assert Keyword.fetch!(opts, :hwaccel) == streaming.hwaccel
+      assert Keyword.fetch!(opts, :device) == streaming.hwaccel_device
     end
   end
 

--- a/test/mydia/streaming/hardware_accel_test.exs
+++ b/test/mydia/streaming/hardware_accel_test.exs
@@ -1,0 +1,112 @@
+defmodule Mydia.Streaming.HardwareAccelTest do
+  use ExUnit.Case, async: false
+
+  alias Mydia.Streaming.HardwareAccel
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+
+  @vaapi %Capabilities{
+    backend: :vaapi,
+    device: "/dev/dri/renderD128",
+    encoders: [:h264],
+    decode_profiles: [:hevc, :av1]
+  }
+
+  defp start_with(caps, opts \\ []) do
+    name = :"hwaccel_#{System.unique_integer([:positive])}"
+    opts = Keyword.merge([name: name, probe: fn _ -> caps end, cap: 3], opts)
+    start_supervised!({HardwareAccel, opts})
+    name
+  end
+
+  describe "capabilities/0 without a running process" do
+    test "reports software rather than crashing" do
+      # Every existing streaming test runs with no probe process. They must keep
+      # asserting software arguments, so absence is a supported state.
+      caps = HardwareAccel.capabilities()
+
+      assert caps.backend == :none
+      assert caps.reason =~ "not running"
+    end
+  end
+
+  describe "capabilities/1" do
+    test "returns what the probe found" do
+      name = start_with(@vaapi)
+
+      assert HardwareAccel.capabilities(name).backend == :vaapi
+    end
+  end
+
+  describe "leases" do
+    test "playback takes slots up to the cap" do
+      name = start_with(@vaapi, cap: 2)
+
+      assert {:ok, _} = HardwareAccel.lease(name, :playback)
+      assert {:ok, _} = HardwareAccel.lease(name, :playback)
+      assert :refused = HardwareAccel.lease(name, :playback)
+    end
+
+    test "background is refused one slot early so playback keeps headroom" do
+      name = start_with(@vaapi, cap: 2)
+
+      assert {:ok, _} = HardwareAccel.lease(name, :background)
+      assert :refused = HardwareAccel.lease(name, :background)
+      assert {:ok, _} = HardwareAccel.lease(name, :playback)
+    end
+
+    test "a cap of one refuses background entirely" do
+      name = start_with(@vaapi, cap: 1)
+
+      assert :refused = HardwareAccel.lease(name, :background)
+      assert {:ok, _} = HardwareAccel.lease(name, :playback)
+    end
+
+    test "releasing frees the slot" do
+      name = start_with(@vaapi, cap: 1)
+
+      {:ok, ref} = HardwareAccel.lease(name, :playback)
+      assert :refused = HardwareAccel.lease(name, :playback)
+
+      :ok = HardwareAccel.release(name, ref)
+      assert {:ok, _} = HardwareAccel.lease(name, :playback)
+    end
+
+    test "software capabilities refuse every lease" do
+      name = start_with(Capabilities.software("no device"))
+
+      assert :refused = HardwareAccel.lease(name, :playback)
+    end
+  end
+
+  describe "report_failure/3" do
+    test "demotes only the failing codec, keeping the rest on full hardware" do
+      # A device whose AV1 decode is advertised but broken must not lose HEVC,
+      # which is 94.5% of the library.
+      name = start_with(@vaapi, demote_after: 2)
+
+      HardwareAccel.report_failure(name, :vaapi, "av1")
+      assert Capabilities.can_decode?(HardwareAccel.capabilities(name), :av1)
+
+      HardwareAccel.report_failure(name, :vaapi, "av1")
+      caps = HardwareAccel.capabilities(name)
+
+      refute Capabilities.can_decode?(caps, :av1)
+      assert Capabilities.can_decode?(caps, :hevc)
+      assert caps.backend == :vaapi
+    end
+
+    test "an unknown codec name never demotes anything" do
+      name = start_with(@vaapi, demote_after: 1)
+
+      HardwareAccel.report_failure(name, :vaapi, "not_a_codec")
+
+      assert HardwareAccel.capabilities(name).decode_profiles == [:hevc, :av1]
+    end
+  end
+
+  test "the supervisor does not start the probe under mix test" do
+    # If this fails, every streaming test that asserts software arguments is
+    # now at the mercy of whether the developer's machine has a GPU.
+    assert GenServer.whereis(Mydia.Streaming.HardwareAccel) == nil
+  end
+end

--- a/test/mydia/streaming/hardware_accel_test.exs
+++ b/test/mydia/streaming/hardware_accel_test.exs
@@ -22,7 +22,11 @@ defmodule Mydia.Streaming.HardwareAccelTest do
   # :DOWN the test process set up for its own synchronization, so there is no
   # ordering guarantee between "test observed the holder die" and "server
   # finished reclaiming the slot". Poll briefly instead of asserting once.
-  defp eventually(fun, attempts \\ 50) do
+  # 400 attempts at 5ms is a 2s ceiling, matching the explicit budgets on the
+  # assert_receive calls beside it. The holder's :DOWN and HardwareAccel's
+  # reclamation of its slot are independently ordered, so a shorter wait can
+  # still lose the race under the concurrent PostgreSQL CI job.
+  defp eventually(fun, attempts \\ 400) do
     cond do
       fun.() -> true
       attempts > 0 -> Process.sleep(5) && eventually(fun, attempts - 1)

--- a/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
+++ b/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
@@ -1,0 +1,148 @@
+defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Settings.LibraryPath
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+  alias Mydia.Streaming.{HlsSession, SegmentPlan, TranscodeWindow}
+
+  describe "hwaccel_fallback/2" do
+    test "flips the session to software and keeps the segment index" do
+      state = %HlsSession.State{
+        session_id: "s1",
+        temp_dir: "/tmp/s1",
+        backend: :ffmpeg,
+        backend_opts: [start_number: 42, grid_aligned: true],
+        window_generation: 3,
+        accel: :auto,
+        accel_fallbacks: 0
+      }
+
+      {:retry, next} = HlsSession.hwaccel_fallback(state, 42)
+
+      assert next.accel == :none
+      assert next.accel_fallbacks == 1
+      assert Keyword.get(next.backend_opts, :start_number) == 42
+      # Every other backend option survives: the fallback re-encodes the same
+      # window, it does not reconfigure the session.
+      assert Keyword.get(next.backend_opts, :grid_aligned) == true
+
+      caps = Keyword.fetch!(next.backend_opts, :capabilities)
+      assert caps.backend == :none
+      assert caps.reason =~ "fell back"
+    end
+
+    test "only one fallback per session" do
+      # A persistently broken device must not spin the session in a restart
+      # loop; the second failure is a real failure.
+      state = %HlsSession.State{
+        session_id: "s1",
+        temp_dir: "/tmp/s1",
+        backend: :ffmpeg,
+        backend_opts: [],
+        accel: :none,
+        accel_fallbacks: 1
+      }
+
+      assert :stop = HlsSession.hwaccel_fallback(state, 42)
+    end
+  end
+
+  # ---------------------------------------------------------------------
+  # The trap this task calls out explicitly: start_backend/6 rebuilds its
+  # transcoder opts from an explicit whitelist, so a :capabilities key placed
+  # in backend_opts is silently dropped unless start_backend/6 itself forwards
+  # it. hwaccel_fallback/2 returning a State with :capabilities in
+  # backend_opts (asserted above) is necessary but not sufficient — this
+  # drives the real handle_info :DOWN clause through relocate/2 and
+  # start_backend/6 and inspects what actually reached the (fake) transcoder,
+  # which is the only way to catch that key being dropped.
+  # ---------------------------------------------------------------------
+
+  defmodule Harness do
+    @moduledoc false
+    use GenServer
+
+    def start_link(state), do: GenServer.start_link(__MODULE__, state)
+
+    @impl true
+    def init(state), do: {:ok, state}
+
+    @impl true
+    def handle_info(msg, state), do: HlsSession.handle_info(msg, state)
+  end
+
+  defmodule CapturingBackend do
+    @moduledoc """
+    Stands in for FfmpegHlsTranscoder. Stores the full opts it was started
+    with (the same opts start_backend/6 built from backend_opts) as its own
+    state, so a test can read back exactly what reached the transcoder.
+    """
+    use GenServer
+
+    def start_transcoding(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts), do: {:ok, opts}
+  end
+
+  describe "restarting the backend after a hardware failure (:DOWN handling)" do
+    test "the software capabilities set by hwaccel_fallback/2 reach the restarted backend" do
+      {:ok, plan} = SegmentPlan.build(600.0, 4)
+
+      {:ok, dead_backend_pid} = CapturingBackend.start_transcoding([])
+
+      state = %HlsSession.State{
+        session_id: "hwaccel-fallback-restart-test",
+        media_file: %MediaFile{
+          codec: "h264",
+          relative_path: "movie.mkv",
+          library_path: %LibraryPath{path: "/tmp"}
+        },
+        media_file_id: 1,
+        user_id: 1,
+        mode: :transcode,
+        start_position: 0,
+        backend: :ffmpeg,
+        backend_pid: dead_backend_pid,
+        temp_dir: "/tmp/mydia-hls-hwaccel-fallback-test",
+        db_job_id: nil,
+        segment_plan: plan,
+        backend_opts: [
+          transcoder_module: CapturingBackend,
+          start_number: 7,
+          grid_aligned: true
+        ],
+        playlist_mode: :full,
+        window: TranscodeWindow.new(7),
+        window_generation: 0,
+        accel: :auto,
+        accel_fallbacks: 0
+      }
+
+      {:ok, harness_pid} = Harness.start_link(state)
+
+      send(
+        harness_pid,
+        {:DOWN, make_ref(), :process, dead_backend_pid, {:hwaccel_failed, "vaapi init failed"}}
+      )
+
+      # :sys.get_state/1 is a synchronous system message, so it is only
+      # answered after the :DOWN message above has been handled.
+      new_state = :sys.get_state(harness_pid)
+
+      assert new_state.accel == :none
+      assert new_state.accel_fallbacks == 1
+      refute new_state.backend_pid == dead_backend_pid
+
+      transcoder_opts = :sys.get_state(new_state.backend_pid)
+
+      assert Keyword.has_key?(transcoder_opts, :capabilities),
+             ":capabilities from backend_opts never reached start_backend/6's transcoder opts"
+
+      caps = Keyword.fetch!(transcoder_opts, :capabilities)
+      assert caps.backend == :none
+      assert caps.reason =~ "fell back"
+    end
+  end
+end

--- a/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
+++ b/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
@@ -49,34 +49,65 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
   end
 
   # ---------------------------------------------------------------------
-  # The trap this task calls out explicitly: start_backend/6 rebuilds its
-  # transcoder opts from an explicit whitelist, so a :capabilities key placed
-  # in backend_opts is silently dropped unless start_backend/6 itself forwards
-  # it. hwaccel_fallback/2 returning a State with :capabilities in
-  # backend_opts (asserted above) is necessary but not sufficient — this
-  # drives the real handle_info :DOWN clause through relocate/2 and
-  # start_backend/6 and inspects what actually reached the (fake) transcoder,
-  # which is the only way to catch that key being dropped.
+  # Two things a test that only exercises hwaccel_fallback/2 in isolation
+  # cannot distinguish a live mechanism from a dead one:
+  #
+  #   1. HlsSession only ever Process.link/1s to its backend_pid, never
+  #      Process.monitor/1s it, and never traps exits (confirmed by reading
+  #      start_registered_session/7 and relocate/2). A link to a
+  #      non-trapping process only kills it for a non-normal exit reason,
+  #      which is exactly why FfmpegHlsTranscoder now stops with :normal
+  #      (plus an on_hwaccel_failed callback) instead of
+  #      {:hwaccel_failed, output} for this specific failure: the old
+  #      {:hwaccel_failed, output} stop reason would have killed the
+  #      linked session before any handle_info/handle_cast clause could
+  #      ever run.
+  #   2. start_backend/6 rebuilds its transcoder opts from an explicit
+  #      whitelist, so a :capabilities key placed in backend_opts is
+  #      silently dropped unless start_backend/6 itself forwards it.
+  #
+  # This drives the real link + notification + relocate/2 + start_backend/6
+  # chain: a real backend process, really linked to the session the way
+  # start_registered_session/7 links it, really exiting with :normal, and
+  # asserts the session is still alive and has relocated onto a new backend
+  # carrying :capabilities -- the only way to catch either class of bug.
   # ---------------------------------------------------------------------
 
   defmodule Harness do
-    @moduledoc false
+    @moduledoc """
+    Stands in for the live HlsSession GenServer. set_backend/2 links to a
+    backend pid from *within* the harness process (Process.link/1 always
+    acts on the calling process), exactly mirroring the
+    `Process.link(backend_pid)` call in start_registered_session/7 -- the
+    only way to exercise the real link semantics this test is about.
+    """
     use GenServer
 
     def start_link(state), do: GenServer.start_link(__MODULE__, state)
+
+    def set_backend(harness_pid, backend_pid) do
+      GenServer.call(harness_pid, {:set_backend, backend_pid})
+    end
 
     @impl true
     def init(state), do: {:ok, state}
 
     @impl true
-    def handle_info(msg, state), do: HlsSession.handle_info(msg, state)
+    def handle_call({:set_backend, pid}, _from, state) do
+      Process.link(pid)
+      {:reply, :ok, %{state | backend_pid: pid}}
+    end
+
+    @impl true
+    def handle_cast(msg, state), do: HlsSession.handle_cast(msg, state)
   end
 
   defmodule CapturingBackend do
     @moduledoc """
-    Stands in for FfmpegHlsTranscoder. Stores the full opts it was started
-    with (the same opts start_backend/6 built from backend_opts) as its own
-    state, so a test can read back exactly what reached the transcoder.
+    Stands in for FfmpegHlsTranscoder in its ordinary running state. Stores
+    the full opts it was started with (the same opts start_backend/6 built
+    from backend_opts) as its own state, so a test can read back exactly
+    what reached the transcoder.
     """
     use GenServer
 
@@ -86,11 +117,35 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
     def init(opts), do: {:ok, opts}
   end
 
-  describe "restarting the backend after a hardware failure (:DOWN handling)" do
-    test "the software capabilities set by hwaccel_fallback/2 reach the restarted backend" do
-      {:ok, plan} = SegmentPlan.build(600.0, 4)
+  defmodule FailingHwaccelBackend do
+    @moduledoc """
+    Stands in for FfmpegHlsTranscoder's hardware-failure exit path: on
+    trigger_failure/2, invokes the on_hwaccel_failed callback it was
+    started with, then stops with reason :normal -- precisely what the real
+    exit-status handler now does. trigger_failure/2 is a synchronous call
+    (the process replies before it stops) so a test can be certain the
+    on_hwaccel_failed callback -- and whatever cast it sends -- has already
+    run by the time the call returns.
+    """
+    use GenServer
 
-      {:ok, dead_backend_pid} = CapturingBackend.start_transcoding([])
+    def start_transcoding(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    def trigger_failure(pid, output), do: GenServer.call(pid, {:fail, output})
+
+    @impl true
+    def init(opts), do: {:ok, opts}
+
+    @impl true
+    def handle_call({:fail, output}, _from, opts) do
+      if cb = Keyword.get(opts, :on_hwaccel_failed), do: cb.(output)
+      {:stop, :normal, :ok, opts}
+    end
+  end
+
+  describe "restarting the backend after a hardware failure" do
+    test "the session survives the backend's :normal exit, relocates, and forwards :capabilities" do
+      {:ok, plan} = SegmentPlan.build(600.0, 4)
 
       state = %HlsSession.State{
         session_id: "hwaccel-fallback-restart-test",
@@ -104,7 +159,7 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
         mode: :transcode,
         start_position: 0,
         backend: :ffmpeg,
-        backend_pid: dead_backend_pid,
+        backend_pid: nil,
         temp_dir: "/tmp/mydia-hls-hwaccel-fallback-test",
         db_job_id: nil,
         segment_plan: plan,
@@ -122,18 +177,42 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
 
       {:ok, harness_pid} = Harness.start_link(state)
 
-      send(
-        harness_pid,
-        {:DOWN, make_ref(), :process, dead_backend_pid, {:hwaccel_failed, "vaapi init failed"}}
-      )
+      # Wired exactly the way start_backend/6 wires on_hwaccel_failed: the
+      # session's pid and this backend's generation (0, matching state above).
+      {:ok, dying_backend_pid} =
+        FailingHwaccelBackend.start_transcoding(
+          on_hwaccel_failed: fn output ->
+            HlsSession.notify_hwaccel_failed(harness_pid, 0, output)
+          end
+        )
 
-      # :sys.get_state/1 is a synchronous system message, so it is only
-      # answered after the :DOWN message above has been handled.
+      :ok = Harness.set_backend(harness_pid, dying_backend_pid)
+
+      assert Process.alive?(harness_pid)
+
+      # Synchronous: by the time this returns, the on_hwaccel_failed callback
+      # has already run and its cast to harness_pid is already in its mailbox
+      # (a local GenServer.cast enqueues before returning). :sys.get_state/1
+      # below, issued afterward from this same process, is therefore only
+      # answered once that cast has been handled -- the same guarantee this
+      # codebase already relies on elsewhere for cast-then-:sys.get_state
+      # synchronization (see hls_session_segments_test.exs).
+      :ok = FailingHwaccelBackend.trigger_failure(dying_backend_pid, "vaapi init failed")
+
+      refute Process.alive?(dying_backend_pid)
+
+      # The whole point: a :normal exit over a plain Process.link does not
+      # kill the linked, non-trapping session. Before this task's fix (when
+      # FfmpegHlsTranscoder stopped with {:hwaccel_failed, output} instead),
+      # this assertion is exactly what would have failed.
+      assert Process.alive?(harness_pid),
+             "the session died from the backend's exit instead of surviving it and relocating"
+
       new_state = :sys.get_state(harness_pid)
 
       assert new_state.accel == :none
       assert new_state.accel_fallbacks == 1
-      refute new_state.backend_pid == dead_backend_pid
+      refute new_state.backend_pid == dying_backend_pid
 
       transcoder_opts = :sys.get_state(new_state.backend_pid)
 

--- a/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
+++ b/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
@@ -49,7 +49,7 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
   end
 
   # ---------------------------------------------------------------------
-  # Two things a test that only exercises hwaccel_fallback/2 in isolation
+  # Three things a test that only exercises hwaccel_fallback/2 in isolation
   # cannot distinguish a live mechanism from a dead one:
   #
   #   1. HlsSession only ever Process.link/1s to its backend_pid, never
@@ -65,12 +65,23 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
   #   2. start_backend/6 rebuilds its transcoder opts from an explicit
   #      whitelist, so a :capabilities key placed in backend_opts is
   #      silently dropped unless start_backend/6 itself forwards it.
+  #   3. relocate/2 assumes :full-mode state (SegmentPlan, TranscodeWindow)
+  #      and is only ever reachable, outside this task, through
+  #      {:request_segment, index}, which a :window session's handle_call
+  #      answers with {:error, :window_mode} before relocate/2 could run.
+  #      handle_cast({:hwaccel_failed, ...}) is a second path into it, and a
+  #      :window session (segment_plan: nil, window: nil, and the DEFAULT
+  #      playlist mode -- see @default_playlist_mode in
+  #      hls_session_supervisor.ex) must not be routed through it, or
+  #      SegmentPlan.start_time(nil, _) crashes the session instead of
+  #      falling back.
   #
-  # This drives the real link + notification + relocate/2 + start_backend/6
-  # chain: a real backend process, really linked to the session the way
-  # start_registered_session/7 links it, really exiting with :normal, and
-  # asserts the session is still alive and has relocated onto a new backend
-  # carrying :capabilities -- the only way to catch either class of bug.
+  # run_hwaccel_failure_scenario/1 below drives the real link + notification
+  # + start_backend/6 chain -- a real backend process, really linked to the
+  # session the way start_registered_session/7 links it, really exiting with
+  # :normal -- for both playlist_mode values through one shared body, so
+  # :full and :window cannot silently drift apart the way they did to
+  # introduce the :window crash this describe block was rewritten to catch.
   # ---------------------------------------------------------------------
 
   defmodule Harness do
@@ -102,30 +113,20 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
     def handle_cast(msg, state), do: HlsSession.handle_cast(msg, state)
   end
 
-  defmodule CapturingBackend do
-    @moduledoc """
-    Stands in for FfmpegHlsTranscoder in its ordinary running state. Stores
-    the full opts it was started with (the same opts start_backend/6 built
-    from backend_opts) as its own state, so a test can read back exactly
-    what reached the transcoder.
-    """
-    use GenServer
-
-    def start_transcoding(opts), do: GenServer.start_link(__MODULE__, opts)
-
-    @impl true
-    def init(opts), do: {:ok, opts}
-  end
-
   defmodule FailingHwaccelBackend do
     @moduledoc """
-    Stands in for FfmpegHlsTranscoder's hardware-failure exit path: on
-    trigger_failure/2, invokes the on_hwaccel_failed callback it was
-    started with, then stops with reason :normal -- precisely what the real
-    exit-status handler now does. trigger_failure/2 is a synchronous call
-    (the process replies before it stops) so a test can be certain the
-    on_hwaccel_failed callback -- and whatever cast it sends -- has already
-    run by the time the call returns.
+    Stands in for FfmpegHlsTranscoder, both as the initially-running backend
+    and as the backend start_backend/6 restarts after a fallback (via
+    `transcoder_module: FailingHwaccelBackend` in backend_opts) -- the same
+    module plays both roles because a real transcoder does too.
+
+    Its own GenServer state *is* the opts it was started with, so a test can
+    read back exactly what start_backend/6 built (the :capabilities check).
+    trigger_failure/2 invokes the on_hwaccel_failed callback it was started
+    with, then stops with reason :normal -- precisely what the real
+    exit-status handler now does -- via a synchronous call (the process
+    replies before it stops) so a test can be certain the callback, and
+    whatever cast it sends, has already run by the time the call returns.
     """
     use GenServer
 
@@ -143,85 +144,172 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
     end
   end
 
+  # Builds the state a real session would have right before a hardware
+  # failure, for each playlist_mode. segment_plan/window exist only in :full
+  # mode, matching start_registered_session/7 exactly (a :window session
+  # never gets a SegmentPlan or a TranscodeWindow).
+  defp build_state(:full) do
+    {:ok, plan} = SegmentPlan.build(600.0, 4)
+
+    %HlsSession.State{
+      session_id: "hwaccel-fallback-full-test",
+      media_file: %MediaFile{
+        codec: "h264",
+        relative_path: "movie.mkv",
+        library_path: %LibraryPath{path: "/tmp"}
+      },
+      media_file_id: 1,
+      user_id: 1,
+      mode: :transcode,
+      start_position: 0,
+      backend: :ffmpeg,
+      backend_pid: nil,
+      temp_dir: "/tmp/mydia-hls-hwaccel-fallback-full-test",
+      db_job_id: nil,
+      segment_plan: plan,
+      backend_opts: [
+        transcoder_module: FailingHwaccelBackend,
+        start_number: 7,
+        grid_aligned: true
+      ],
+      playlist_mode: :full,
+      window: TranscodeWindow.new(7),
+      window_generation: 0,
+      accel: :auto,
+      accel_fallbacks: 0
+    }
+  end
+
+  defp build_state(:window) do
+    %HlsSession.State{
+      session_id: "hwaccel-fallback-window-test",
+      media_file: %MediaFile{
+        codec: "h264",
+        relative_path: "movie.mkv",
+        library_path: %LibraryPath{path: "/tmp"}
+      },
+      media_file_id: 1,
+      user_id: 1,
+      mode: :transcode,
+      start_position: 0,
+      backend: :ffmpeg,
+      backend_pid: nil,
+      temp_dir: "/tmp/mydia-hls-hwaccel-fallback-window-test",
+      db_job_id: nil,
+      segment_plan: nil,
+      backend_opts: [
+        transcoder_module: FailingHwaccelBackend,
+        start_number: 0,
+        grid_aligned: false
+      ],
+      playlist_mode: :window,
+      window: nil,
+      window_generation: 0,
+      accel: :auto,
+      accel_fallbacks: 0
+    }
+  end
+
+  # Starts a harness in `playlist_mode`, links it to a real FailingHwaccelBackend
+  # exactly the way start_registered_session/7 would, triggers a real
+  # hardware-init failure, and asserts the session survives, restarts, and
+  # forwards :capabilities to the new backend. Returns the harness pid and
+  # the new backend pid so a caller can drive a second failure for the
+  # one-fallback-per-session test below.
+  defp run_hwaccel_failure_scenario(playlist_mode) do
+    state = build_state(playlist_mode)
+    {:ok, harness_pid} = Harness.start_link(state)
+
+    # Wired exactly the way start_backend/6 wires on_hwaccel_failed: the
+    # session's pid and this backend's generation (0, matching state above).
+    {:ok, dying_backend_pid} =
+      FailingHwaccelBackend.start_transcoding(
+        on_hwaccel_failed: fn output ->
+          HlsSession.notify_hwaccel_failed(harness_pid, 0, output)
+        end
+      )
+
+    :ok = Harness.set_backend(harness_pid, dying_backend_pid)
+
+    assert Process.alive?(harness_pid)
+
+    # Synchronous: by the time this returns, the on_hwaccel_failed callback
+    # has already run and its cast to harness_pid is already in its mailbox
+    # (a local GenServer.cast enqueues before returning). :sys.get_state/1
+    # below, issued afterward from this same process, is therefore only
+    # answered once that cast has been handled -- the same guarantee this
+    # codebase already relies on elsewhere for cast-then-:sys.get_state
+    # synchronization (see hls_session_segments_test.exs).
+    :ok = FailingHwaccelBackend.trigger_failure(dying_backend_pid, "vaapi init failed")
+
+    refute Process.alive?(dying_backend_pid)
+
+    # The whole point: a :normal exit over a plain Process.link does not
+    # kill the linked, non-trapping session, AND (for :window) the fallback
+    # does not route through relocate/2, which would crash on
+    # SegmentPlan.start_time(nil, _). Before the respective fixes, this
+    # assertion is exactly what would have failed.
+    assert Process.alive?(harness_pid),
+           "the #{playlist_mode} session died from the backend's exit instead of " <>
+             "surviving it and restarting"
+
+    new_state = :sys.get_state(harness_pid)
+
+    assert new_state.accel == :none
+    assert new_state.accel_fallbacks == 1
+    assert new_state.window_generation == 1
+    refute new_state.backend_pid == dying_backend_pid
+
+    transcoder_opts = :sys.get_state(new_state.backend_pid)
+
+    assert Keyword.has_key?(transcoder_opts, :capabilities),
+           ":capabilities from backend_opts never reached start_backend/6's transcoder opts"
+
+    caps = Keyword.fetch!(transcoder_opts, :capabilities)
+    assert caps.backend == :none
+    assert caps.reason =~ "fell back"
+
+    %{harness_pid: harness_pid, new_backend_pid: new_state.backend_pid}
+  end
+
   describe "restarting the backend after a hardware failure" do
-    test "the session survives the backend's :normal exit, relocates, and forwards :capabilities" do
-      {:ok, plan} = SegmentPlan.build(600.0, 4)
+    test "a :full session survives the backend's :normal exit, relocates, and forwards :capabilities" do
+      run_hwaccel_failure_scenario(:full)
+    end
 
-      state = %HlsSession.State{
-        session_id: "hwaccel-fallback-restart-test",
-        media_file: %MediaFile{
-          codec: "h264",
-          relative_path: "movie.mkv",
-          library_path: %LibraryPath{path: "/tmp"}
-        },
-        media_file_id: 1,
-        user_id: 1,
-        mode: :transcode,
-        start_position: 0,
-        backend: :ffmpeg,
-        backend_pid: nil,
-        temp_dir: "/tmp/mydia-hls-hwaccel-fallback-test",
-        db_job_id: nil,
-        segment_plan: plan,
-        backend_opts: [
-          transcoder_module: CapturingBackend,
-          start_number: 7,
-          grid_aligned: true
-        ],
-        playlist_mode: :full,
-        window: TranscodeWindow.new(7),
-        window_generation: 0,
-        accel: :auto,
-        accel_fallbacks: 0
-      }
+    test "a :window session survives the backend's :normal exit, restarts, and forwards :capabilities" do
+      # The regression this test exists for: :window is @default_playlist_mode
+      # (hls_session_supervisor.ex), so this is the common path, not an edge
+      # case -- a hardware-init failure on it must not crash the session.
+      run_hwaccel_failure_scenario(:window)
+    end
 
-      {:ok, harness_pid} = Harness.start_link(state)
+    for playlist_mode <- [:full, :window] do
+      test "only one fallback per session, in #{playlist_mode} mode" do
+        %{harness_pid: harness_pid, new_backend_pid: new_backend_pid} =
+          run_hwaccel_failure_scenario(unquote(playlist_mode))
 
-      # Wired exactly the way start_backend/6 wires on_hwaccel_failed: the
-      # session's pid and this backend's generation (0, matching state above).
-      {:ok, dying_backend_pid} =
-        FailingHwaccelBackend.start_transcoding(
-          on_hwaccel_failed: fn output ->
-            HlsSession.notify_hwaccel_failed(harness_pid, 0, output)
-          end
-        )
+        # Harness.start_link/1 links this test process to the harness (every
+        # GenServer.start_link/2 call links to its caller), same as
+        # start_registered_session/7 links a real session's owning process.
+        # This second failure is expected to stop the harness for real (a
+        # non-:normal reason), which would otherwise crash this test process
+        # right along with it -- see the identical trap_exit comment in
+        # hls_session_segments_test.exs. Process.monitor/1 below is
+        # unaffected either way; it is what actually observes the stop.
+        Process.flag(:trap_exit, true)
+        ref = Process.monitor(harness_pid)
 
-      :ok = Harness.set_backend(harness_pid, dying_backend_pid)
+        # The restarted backend is itself a FailingHwaccelBackend, so it can
+        # report a second hardware failure exactly like the first one did.
+        # accel_fallbacks is now 1, so hwaccel_fallback/2 must answer :stop
+        # this time: a persistently broken device must not spin the session
+        # in a restart loop.
+        :ok = FailingHwaccelBackend.trigger_failure(new_backend_pid, "vaapi init failed again")
 
-      assert Process.alive?(harness_pid)
-
-      # Synchronous: by the time this returns, the on_hwaccel_failed callback
-      # has already run and its cast to harness_pid is already in its mailbox
-      # (a local GenServer.cast enqueues before returning). :sys.get_state/1
-      # below, issued afterward from this same process, is therefore only
-      # answered once that cast has been handled -- the same guarantee this
-      # codebase already relies on elsewhere for cast-then-:sys.get_state
-      # synchronization (see hls_session_segments_test.exs).
-      :ok = FailingHwaccelBackend.trigger_failure(dying_backend_pid, "vaapi init failed")
-
-      refute Process.alive?(dying_backend_pid)
-
-      # The whole point: a :normal exit over a plain Process.link does not
-      # kill the linked, non-trapping session. Before this task's fix (when
-      # FfmpegHlsTranscoder stopped with {:hwaccel_failed, output} instead),
-      # this assertion is exactly what would have failed.
-      assert Process.alive?(harness_pid),
-             "the session died from the backend's exit instead of surviving it and relocating"
-
-      new_state = :sys.get_state(harness_pid)
-
-      assert new_state.accel == :none
-      assert new_state.accel_fallbacks == 1
-      refute new_state.backend_pid == dying_backend_pid
-
-      transcoder_opts = :sys.get_state(new_state.backend_pid)
-
-      assert Keyword.has_key?(transcoder_opts, :capabilities),
-             ":capabilities from backend_opts never reached start_backend/6's transcoder opts"
-
-      caps = Keyword.fetch!(transcoder_opts, :capabilities)
-      assert caps.backend == :none
-      assert caps.reason =~ "fell back"
+        assert_receive {:DOWN, ^ref, :process, ^harness_pid,
+                        {:backend_terminated, {:hwaccel_failed, "vaapi init failed again"}}}
+      end
     end
   end
 end

--- a/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
+++ b/test/mydia/streaming/hls_session_hwaccel_fallback_test.exs
@@ -307,8 +307,17 @@ defmodule Mydia.Streaming.HlsSessionHwaccelFallbackTest do
         # in a restart loop.
         :ok = FailingHwaccelBackend.trigger_failure(new_backend_pid, "vaapi init failed again")
 
+        # Explicit budget rather than ExUnit's 100ms default. Reaching this
+        # DOWN spans several process hops (backend classifies, casts to the
+        # session, the session decides :stop and terminates), and the
+        # PostgreSQL CI job is the only one that runs the suite concurrently
+        # (`max_cases: System.schedulers_online()` in test_helper.exs, against
+        # 1 for SQLite). 100ms is comfortable when serial and marginal under
+        # that load, which is exactly the timeout-budget flake shape
+        # .github/ci-flakes.md warns about.
         assert_receive {:DOWN, ^ref, :process, ^harness_pid,
-                        {:backend_terminated, {:hwaccel_failed, "vaapi init failed again"}}}
+                        {:backend_terminated, {:hwaccel_failed, "vaapi init failed again"}}},
+                       2_000
       end
     end
   end

--- a/test/mydia/streaming/hls_session_hwaccel_lease_test.exs
+++ b/test/mydia/streaming/hls_session_hwaccel_lease_test.exs
@@ -1,0 +1,143 @@
+defmodule Mydia.Streaming.HlsSessionHwaccelLeaseTest do
+  @moduledoc """
+  Covers the fix for HLS playback never taking a `:playback` hardware lease
+  (CodeRabbit finding on PR #751): before this, `FfmpegHlsTranscoder` could
+  ask for the hardware encoder without ever going through
+  `Mydia.Streaming.HardwareAccel`'s lease accounting, so the concurrency cap
+  did not constrain playback at all.
+
+  The lease is claimed once per `HlsSession`, not once per
+  `FfmpegHlsTranscoder` process (see `acquire_hwaccel_lease/0`'s comment for
+  why: the transcoder is restarted on every seek, and a per-transcoder lease
+  would churn HardwareAccel on every one of them). That means the meaningful
+  units to test are: the gating decision
+  (`maybe_acquire_hwaccel_lease/2`, whether a session bothers leasing at
+  all), the "not running" fallback shape (`acquire_hwaccel_lease/0`, which
+  `mix test` always exercises since `HardwareAccel` is never started in this
+  suite), and the two release sites (`hwaccel_fallback/2` and `terminate/2`).
+  Exercising a real lease being GRANTED would need a `HardwareAccel` process
+  registered under its literal global name, which risks colliding with every
+  other `async: true` test that assumes that name is never registered (see
+  `hardware_accel_test.exs`'s own "the supervisor does not start the probe
+  under mix test" guard) -- deliberately not attempted here.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Settings.LibraryPath
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+  alias Mydia.Streaming.HlsSession
+
+  @reencode_media_file %MediaFile{
+    codec: "hevc",
+    relative_path: "movie.mkv",
+    library_path: %LibraryPath{path: "/tmp"}
+  }
+
+  @copy_media_file %MediaFile{
+    codec: "h264",
+    relative_path: "movie.mkv",
+    library_path: %LibraryPath{path: "/tmp"}
+  }
+
+  describe "maybe_acquire_hwaccel_lease/2" do
+    test "a session that will re-encode attempts a lease" do
+      # HardwareAccel is never started under mix test (see
+      # hardware_accel_test.exs), so this exercises the refusal branch: a
+      # session that WOULD lease still gets software capabilities rather than
+      # nil, so build_ffmpeg_args/3 never reaches for hardware it was refused.
+      assert {%Capabilities{backend: :none, reason: reason}, nil} =
+               HlsSession.maybe_acquire_hwaccel_lease(@reencode_media_file, nil)
+
+      assert reason =~ "no hardware slot free"
+    end
+
+    test "a bitrate cap forces a re-encode and therefore a lease attempt" do
+      # max_bitrate forces reencodes_video?/2 to true regardless of codec --
+      # even an already-compatible h264 source is transcoded to control the
+      # output bitrate.
+      assert {%Capabilities{backend: :none}, nil} =
+               HlsSession.maybe_acquire_hwaccel_lease(@copy_media_file, 2000)
+    end
+
+    test "a stream-copy session never attempts a lease" do
+      assert {nil, nil} = HlsSession.maybe_acquire_hwaccel_lease(@copy_media_file, nil)
+    end
+
+    test "no media file (mode unknown) is treated as re-encoding, matching build_ffmpeg_args/3" do
+      assert {%Capabilities{backend: :none}, nil} =
+               HlsSession.maybe_acquire_hwaccel_lease(nil, nil)
+    end
+  end
+
+  describe "acquire_hwaccel_lease/0" do
+    test "reports software with no lease when HardwareAccel is not running" do
+      assert {%Capabilities{backend: :none, reason: reason}, nil} =
+               HlsSession.acquire_hwaccel_lease()
+
+      assert reason =~ "no hardware slot free for playback"
+    end
+  end
+
+  describe "hwaccel_fallback/2 releases the session's lease" do
+    test "clears hwaccel_lease from state so terminate/2 cannot double-release it" do
+      state = %HlsSession.State{
+        session_id: "s1",
+        temp_dir: "/tmp/s1",
+        backend: :ffmpeg,
+        backend_opts: [start_number: 42, grid_aligned: true],
+        window_generation: 3,
+        accel: :auto,
+        accel_fallbacks: 0,
+        # A throwaway ref stands in for a real lease: HardwareAccel is not
+        # running under mix test, so HardwareAccel.release/2 is a documented
+        # no-op regardless of what this holds. The behaviour under test is
+        # that hwaccel_fallback/2 calls it at all and clears the field, not
+        # what the (absent) server does with it.
+        hwaccel_lease: make_ref()
+      }
+
+      {:retry, next} = HlsSession.hwaccel_fallback(state, 42)
+
+      assert next.hwaccel_lease == nil
+    end
+
+    test "a session with no lease (stream-copy, or already refused) is unaffected" do
+      state = %HlsSession.State{
+        session_id: "s1",
+        temp_dir: "/tmp/s1",
+        backend: :ffmpeg,
+        backend_opts: [start_number: 0, grid_aligned: false],
+        window_generation: 0,
+        accel: :auto,
+        accel_fallbacks: 0,
+        hwaccel_lease: nil
+      }
+
+      {:retry, next} = HlsSession.hwaccel_fallback(state, 0)
+
+      assert next.hwaccel_lease == nil
+    end
+  end
+
+  describe "terminate/2 releases the session's lease" do
+    test "does not crash when a lease is present" do
+      tmp_dir =
+        Path.join(System.tmp_dir!(), "hls-lease-terminate-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(tmp_dir)
+
+      state = %HlsSession.State{
+        session_id: "terminate-lease-test",
+        temp_dir: tmp_dir,
+        backend: :ffmpeg,
+        backend_pid: nil,
+        db_job_id: nil,
+        hwaccel_lease: make_ref()
+      }
+
+      assert :ok = HlsSession.terminate(:normal, state)
+      refute File.exists?(tmp_dir)
+    end
+  end
+end

--- a/test/mydia/streaming/hwaccel_failure_classifier_test.exs
+++ b/test/mydia/streaming/hwaccel_failure_classifier_test.exs
@@ -40,5 +40,45 @@ defmodule Mydia.Streaming.HwaccelFailureClassifierTest do
       refute FfmpegHlsTranscoder.hwaccel_failure?("height not divisible by 2")
       refute FfmpegHlsTranscoder.hwaccel_failure?("No such file or directory")
     end
+
+    test "a bare ENOSYS string with no VAAPI context is not a hardware failure" do
+      # "Function not implemented" is the literal strerror(ENOSYS) text ffmpeg
+      # prints for ANY AVERROR(ENOSYS) -- an unsupported muxer, protocol, or
+      # codec feature, not only hardware device init. Matching it standalone
+      # would retry an unrelated encode-time ENOSYS in software, hiding a real
+      # bug behind a second, slower failure. Paired with the test above ("an
+      # unimplemented driver function"), which proves the real VAAPI case
+      # (the same text inside the connection line) is still caught.
+      refute FfmpegHlsTranscoder.hwaccel_failure?("Function not implemented")
+    end
+  end
+
+  describe "append_output/2" do
+    test "leaves a buffer under the cap untouched" do
+      assert FfmpegHlsTranscoder.append_output("", "short") == "short"
+      assert FfmpegHlsTranscoder.append_output("abc", "def") == "abcdef"
+    end
+
+    test "bounds cumulative multi-byte input to the byte cap, not the grapheme cap" do
+      # Regression for a defect where the bound was applied with
+      # String.slice/3, which counts grapheme clusters: a buffer of 3-byte
+      # UTF-8 characters (CJK is realistic here -- this is a self-hosted
+      # media server with arbitrary international file paths) sliced to
+      # "the last 4,000" kept 4,000 *characters*, up to 3x the intended byte
+      # cap.
+      chunk = String.duplicate("界", 1_000)
+
+      buffer =
+        Enum.reduce(1..5, "", fn _, acc -> FfmpegHlsTranscoder.append_output(acc, chunk) end)
+
+      assert byte_size(buffer) <= 4_000
+    end
+
+    test "keeps the most recent bytes when trimming" do
+      buffer = FfmpegHlsTranscoder.append_output(String.duplicate("a", 4_990), "MARKER_END")
+
+      assert byte_size(buffer) == 4_000
+      assert String.ends_with?(buffer, "MARKER_END")
+    end
   end
 end

--- a/test/mydia/streaming/hwaccel_failure_classifier_test.exs
+++ b/test/mydia/streaming/hwaccel_failure_classifier_test.exs
@@ -1,0 +1,44 @@
+defmodule Mydia.Streaming.HwaccelFailureClassifierTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+
+  describe "hwaccel_failure?/1" do
+    test "the driver-less container failure, captured from production" do
+      output = """
+      [VAAPI @ 0x75537df49d40] Failed to initialise VAAPI connection: -1 (unknown libva error).
+      Device creation failed: -5.
+      Failed to set value 'vaapi=hw:/dev/dri/renderD128' for option 'init_hw_device': I/O error
+      Error parsing global options: I/O error
+      """
+
+      assert FfmpegHlsTranscoder.hwaccel_failure?(output)
+    end
+
+    test "no VA display" do
+      assert FfmpegHlsTranscoder.hwaccel_failure?(
+               "[AVHWDeviceContext] No VA display found for device /dev/dri/renderD128."
+             )
+    end
+
+    test "an unimplemented driver function" do
+      assert FfmpegHlsTranscoder.hwaccel_failure?(
+               "Failed to initialise VAAPI connection: -1 (Function not implemented)."
+             )
+    end
+
+    test "permission denied on the render node" do
+      assert FfmpegHlsTranscoder.hwaccel_failure?(
+               "Failed to open /dev/dri/renderD128: Permission denied"
+             )
+    end
+
+    test "an ordinary encode error is not a hardware failure" do
+      # Falling back to software here would hide a real bug behind a slow
+      # transcode that also fails.
+      refute FfmpegHlsTranscoder.hwaccel_failure?("Invalid data found when processing input")
+      refute FfmpegHlsTranscoder.hwaccel_failure?("height not divisible by 2")
+      refute FfmpegHlsTranscoder.hwaccel_failure?("No such file or directory")
+    end
+  end
+end

--- a/test/mydia/streaming/hwaccel_live_test.exs
+++ b/test/mydia/streaming/hwaccel_live_test.exs
@@ -1,0 +1,130 @@
+defmodule Mydia.Streaming.HwaccelLiveTest do
+  @moduledoc """
+  Exercises real hardware. Skipped unless run with `--include hwaccel` on a host
+  with a working VA device.
+
+  Every other hwaccel test in this directory (`hardware_accel_test.exs`,
+  `ffmpeg_hwaccel_args_test.exs`, `hwaccel_failure_classifier_test.exs`) asserts
+  on argument lists as strings. This is the one place those strings are actually
+  handed to ffmpeg: the whole value of this suite is proving that what
+  `Mydia.Streaming.HardwareAccel.Args.build/2` emits is something ffmpeg
+  accepts, not merely something that looks right.
+
+  Requires `vainfo` (from `libva-utils`) and a usable `/dev/dri/renderD*` node.
+  Tagged `:hwaccel`, a tag distinct from `:ffmpeg`: the latter needs only the
+  ffmpeg binary, this needs a working GPU, so a developer with ffmpeg but no
+  render node can run one without the other. Excluded by default in
+  test_helper.exs; run explicitly with `--include hwaccel`.
+  """
+  use ExUnit.Case, async: false
+
+  @moduletag :hwaccel
+
+  alias Mydia.Streaming.HardwareAccel.Args
+  alias Mydia.Streaming.HardwareAccel.Probe
+
+  setup_all do
+    caps = Probe.run(hwaccel: :auto)
+
+    if caps.backend == :none do
+      raise "no hardware device available: #{caps.reason}"
+    end
+
+    {:ok, caps: caps}
+  end
+
+  defp run(args) do
+    System.cmd(System.find_executable("ffmpeg"), args, stderr_to_stdout: true)
+  end
+
+  defp source(codec, pix_fmt) do
+    path = Path.join(System.tmp_dir!(), "hwaccel_src_#{codec}.mkv")
+
+    {_out, 0} =
+      run([
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        "testsrc=size=640x480:duration=2:rate=24",
+        "-pix_fmt",
+        pix_fmt,
+        "-c:v",
+        codec,
+        path
+      ])
+
+    on_exit(fn -> File.rm(path) end)
+    path
+  end
+
+  test "the probe reports a device that can encode h264", %{caps: caps} do
+    assert caps.backend == :vaapi
+    assert :h264 in caps.encoders
+    assert caps.device =~ "/dev/dri/renderD"
+  end
+
+  test "the full hardware argument list encodes a real file", %{caps: caps} do
+    path = source("libx264", "yuv420p")
+    accel = Args.build(caps, source_codec: "h264", max_height: 360)
+
+    assert accel.tier == :full_hardware
+
+    {output, status} =
+      run(
+        ["-hide_banner", "-loglevel", "error"] ++
+          accel.input ++ ["-i", path] ++ accel.video ++ ["-f", "null", "-"]
+      )
+
+    assert status == 0, "hardware encode failed: #{output}"
+  end
+
+  test "the hybrid argument list encodes a real file", %{caps: caps} do
+    # Forced by claiming the device decodes nothing, which is how this tier gets
+    # exercised on hardware that does not need it.
+    path = source("libx264", "yuv420p")
+    accel = Args.build(%{caps | decode_profiles: []}, source_codec: "h264", max_height: 360)
+
+    assert accel.tier == :hybrid
+
+    {output, status} =
+      run(
+        ["-hide_banner", "-loglevel", "error"] ++
+          accel.input ++ ["-i", path] ++ accel.video ++ ["-f", "null", "-"]
+      )
+
+    assert status == 0, "hybrid encode failed: #{output}"
+  end
+
+  test "a bitrate cap is honoured by the hardware encoder", %{caps: caps} do
+    path = source("libx264", "yuv420p")
+    accel = Args.build(caps, source_codec: "h264", video_bitrate_kbps: 500)
+    out = Path.join(System.tmp_dir!(), "hwaccel_capped.mp4")
+    on_exit(fn -> File.rm(out) end)
+
+    {output, status} =
+      run(
+        ["-hide_banner", "-loglevel", "error", "-y"] ++
+          accel.input ++ ["-i", path] ++ accel.video ++ [out]
+      )
+
+    assert status == 0, "capped encode failed: #{output}"
+
+    {probe, 0} =
+      System.cmd(System.find_executable("ffprobe"), [
+        "-v",
+        "error",
+        "-show_entries",
+        "format=bit_rate",
+        "-of",
+        "csv=p=0",
+        out
+      ])
+
+    bitrate = probe |> String.trim() |> String.to_integer()
+    assert bitrate < 900_000, "expected the 500k cap to hold, got #{bitrate}"
+  end
+end

--- a/test/mydia/streaming/hwaccel_live_test.exs
+++ b/test/mydia/streaming/hwaccel_live_test.exs
@@ -30,15 +30,30 @@ defmodule Mydia.Streaming.HwaccelLiveTest do
       raise "no hardware device available: #{caps.reason}"
     end
 
-    {:ok, caps: caps}
+    # Shared by the full-hardware and hybrid tests below: both only assert
+    # that ffmpeg accepts the argument list, so a plain testsrc clip is
+    # enough, and building it once instead of once per test avoids encoding
+    # the same file three times.
+    source = build_source("testsrc=size=640x480:rate=24", "plain")
+
+    {:ok, caps: caps, source: source}
   end
 
   defp run(args) do
     System.cmd(System.find_executable("ffmpeg"), args, stderr_to_stdout: true)
   end
 
-  defp source(codec, pix_fmt) do
-    path = Path.join(System.tmp_dir!(), "hwaccel_src_#{codec}.mkv")
+  # Cleanup is registered before the encode runs, not after a successful
+  # pattern match on its result: a generation failure must not leave a
+  # partial file behind uncleaned.
+  defp build_source(lavfi_filter, tag) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "hwaccel_src_#{tag}_#{System.unique_integer([:positive])}.mkv"
+      )
+
+    on_exit(fn -> File.rm(path) end)
 
     {_out, 0} =
       run([
@@ -49,69 +64,39 @@ defmodule Mydia.Streaming.HwaccelLiveTest do
         "-f",
         "lavfi",
         "-i",
-        "testsrc=size=640x480:duration=2:rate=24",
+        lavfi_filter,
+        "-t",
+        "2",
         "-pix_fmt",
-        pix_fmt,
+        "yuv420p",
         "-c:v",
-        codec,
+        "libx264",
         path
       ])
 
-    on_exit(fn -> File.rm(path) end)
     path
   end
 
-  test "the probe reports a device that can encode h264", %{caps: caps} do
-    assert caps.backend == :vaapi
-    assert :h264 in caps.encoders
-    assert caps.device =~ "/dev/dri/renderD"
-  end
-
-  test "the full hardware argument list encodes a real file", %{caps: caps} do
-    path = source("libx264", "yuv420p")
-    accel = Args.build(caps, source_codec: "h264", max_height: 360)
-
-    assert accel.tier == :full_hardware
-
-    {output, status} =
-      run(
-        ["-hide_banner", "-loglevel", "error"] ++
-          accel.input ++ ["-i", path] ++ accel.video ++ ["-f", "null", "-"]
+  # Encodes `source` through `accel`'s argument list and returns the
+  # resulting file's measured bitrate, per ffprobe. Used by the bitrate-cap
+  # test to compare a capped encode against an uncapped control from the
+  # same source and tier, rather than against a hardcoded ceiling.
+  defp encode_and_measure(source, accel, tag) do
+    out =
+      Path.join(
+        System.tmp_dir!(),
+        "hwaccel_bitrate_#{tag}_#{System.unique_integer([:positive])}.mp4"
       )
 
-    assert status == 0, "hardware encode failed: #{output}"
-  end
-
-  test "the hybrid argument list encodes a real file", %{caps: caps} do
-    # Forced by claiming the device decodes nothing, which is how this tier gets
-    # exercised on hardware that does not need it.
-    path = source("libx264", "yuv420p")
-    accel = Args.build(%{caps | decode_profiles: []}, source_codec: "h264", max_height: 360)
-
-    assert accel.tier == :hybrid
-
-    {output, status} =
-      run(
-        ["-hide_banner", "-loglevel", "error"] ++
-          accel.input ++ ["-i", path] ++ accel.video ++ ["-f", "null", "-"]
-      )
-
-    assert status == 0, "hybrid encode failed: #{output}"
-  end
-
-  test "a bitrate cap is honoured by the hardware encoder", %{caps: caps} do
-    path = source("libx264", "yuv420p")
-    accel = Args.build(caps, source_codec: "h264", video_bitrate_kbps: 500)
-    out = Path.join(System.tmp_dir!(), "hwaccel_capped.mp4")
     on_exit(fn -> File.rm(out) end)
 
     {output, status} =
       run(
         ["-hide_banner", "-loglevel", "error", "-y"] ++
-          accel.input ++ ["-i", path] ++ accel.video ++ [out]
+          accel.input ++ ["-i", source] ++ accel.video ++ [out]
       )
 
-    assert status == 0, "capped encode failed: #{output}"
+    assert status == 0, "#{tag} encode failed: #{output}"
 
     {probe, 0} =
       System.cmd(System.find_executable("ffprobe"), [
@@ -124,7 +109,70 @@ defmodule Mydia.Streaming.HwaccelLiveTest do
         out
       ])
 
-    bitrate = probe |> String.trim() |> String.to_integer()
-    assert bitrate < 900_000, "expected the 500k cap to hold, got #{bitrate}"
+    probe |> String.trim() |> String.to_integer()
+  end
+
+  test "the probe reports a device that can encode h264", %{caps: caps} do
+    assert caps.backend == :vaapi
+    assert :h264 in caps.encoders
+    assert caps.device =~ "/dev/dri/renderD"
+  end
+
+  test "the full hardware argument list encodes a real file", %{caps: caps, source: source} do
+    accel = Args.build(caps, source_codec: "h264", max_height: 360)
+
+    assert accel.tier == :full_hardware
+
+    {output, status} =
+      run(
+        ["-hide_banner", "-loglevel", "error"] ++
+          accel.input ++ ["-i", source] ++ accel.video ++ ["-f", "null", "-"]
+      )
+
+    assert status == 0, "hardware encode failed: #{output}"
+  end
+
+  test "the hybrid argument list encodes a real file", %{caps: caps, source: source} do
+    # Forced by claiming the device decodes nothing, which is how this tier gets
+    # exercised on hardware that does not need it.
+    accel = Args.build(%{caps | decode_profiles: []}, source_codec: "h264", max_height: 360)
+
+    assert accel.tier == :hybrid
+
+    {output, status} =
+      run(
+        ["-hide_banner", "-loglevel", "error"] ++
+          accel.input ++ ["-i", source] ++ accel.video ++ ["-f", "null", "-"]
+      )
+
+    assert status == 0, "hybrid encode failed: #{output}"
+  end
+
+  test "a bitrate cap is honoured by the hardware encoder", %{caps: caps} do
+    # A plain testsrc clip compresses so well under CQP that its natural
+    # bitrate can already sit below any cap worth testing, which would let a
+    # threshold assertion pass even if -b:v/-maxrate/-rc_mode VBR silently
+    # dropped out of rate_control_args/3. mandelbrot is a standard
+    # torture-test source for exactly this: it has no static regions and its
+    # detail keeps increasing as it zooms, so a CQP-23 encode of it lands far
+    # above the 500k cap this test requests, guaranteeing the capped run has
+    # real headroom to shrink into. The assertions below compare the capped
+    # encode against an uncapped control from the same source and tier
+    # instead of a bare threshold, so a regression that stops applying the
+    # cap fails regardless of how compressible the source turns out to be.
+    source = build_source("mandelbrot=size=640x480:rate=24", "entropy")
+
+    control = Args.build(caps, source_codec: "h264")
+    capped = Args.build(caps, source_codec: "h264", video_bitrate_kbps: 500)
+
+    control_bitrate = encode_and_measure(source, control, "control")
+    capped_bitrate = encode_and_measure(source, capped, "capped")
+
+    assert capped_bitrate < control_bitrate * 0.6,
+           "expected the 500k cap to shrink the output materially: " <>
+             "control=#{control_bitrate}, capped=#{capped_bitrate}"
+
+    assert capped_bitrate < 900_000,
+           "expected the 500k cap to land near its target, got #{capped_bitrate}"
   end
 end

--- a/test/mydia_web/live/admin_settings_hwaccel_test.exs
+++ b/test/mydia_web/live/admin_settings_hwaccel_test.exs
@@ -1,0 +1,44 @@
+defmodule MydiaWeb.AdminSettingsHwaccelTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Mydia.Accounts
+
+  setup %{conn: conn} do
+    unique_id = System.unique_integer([:positive])
+
+    {:ok, user} =
+      Accounts.create_user(%{
+        email: "admin_#{unique_id}@example.com",
+        username: "admin_#{unique_id}",
+        password_hash: "$2b$12$test",
+        role: "admin"
+      })
+
+    {:ok, token, _claims} = Mydia.Auth.Guardian.encode_and_sign(user)
+
+    conn =
+      conn
+      |> init_test_session(%{})
+      |> put_session(:guardian_default_token, token)
+      |> put_req_header("authorization", "Bearer #{token}")
+
+    %{conn: conn, user: user}
+  end
+
+  test "the streaming section reports the hardware status", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
+
+    assert has_element?(view, "#hwaccel-status")
+  end
+
+  test "explains why acceleration is unavailable rather than only that it is", %{conn: conn} do
+    # With no probe running in test, capabilities/0 reports software with a
+    # reason. An operator must be able to tell "no GPU" from "driver missing"
+    # from "you turned it off" without reading logs.
+    {:ok, view, _html} = live(conn, ~p"/admin/config/settings")
+
+    assert render(view) =~ "not running"
+  end
+end

--- a/test/support/capturing_transcoder.ex
+++ b/test/support/capturing_transcoder.ex
@@ -1,0 +1,76 @@
+defmodule Mydia.Downloads.CapturingTranscoder do
+  @moduledoc """
+  Deterministic stand-in for `Mydia.Downloads.FfmpegMp4Transcoder`, combining
+  `Mydia.Downloads.BlockingTranscoder`'s job-manager-friendly lifecycle (stays
+  alive, occupying a capacity slot, until told to finish or stopped) with
+  capturing the exact opts `start_transcoding/1` was called with.
+
+  Exists to pin the *wiring* between `DownloadService`, `JobManager`, and the
+  real transcoder: a test can assert on the opts a transcoder actually
+  received, rather than only on end-to-end behaviour that could pass for the
+  wrong reason (e.g. a dropped `:source_codec` silently degrading hardware
+  acceleration to a slower tier while still producing correct video). A prior
+  task in this plan shipped exactly this shape of bug -- a key placed in an
+  opts keyword list silently dropped because a downstream function rebuilt
+  its options from a fixed whitelist -- and every behavioural test still
+  passed, because nothing asserted on the opts themselves.
+
+  Call `collect/0` from the test process before triggering a job to receive
+  `{:transcoder_opts, opts}` for every subsequent `start_transcoding/1` call,
+  immediate or promoted from the queue.
+  """
+
+  use GenServer
+
+  @collector_name Mydia.Downloads.CapturingTranscoder.Collector
+
+  @doc "Starts a transcoder that captures its opts and stays alive until stopped."
+  @spec start_transcoding(keyword()) :: GenServer.on_start()
+  def start_transcoding(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc "Stops the transcoder process (simulates a cancelled job)."
+  @spec stop_transcoding(pid()) :: :ok
+  def stop_transcoding(pid) do
+    GenServer.stop(pid, :normal)
+  end
+
+  @doc """
+  Simulates a finished transcode: invokes `:on_complete` (if any) and exits
+  normally, so `JobManager` frees the slot and starts the next queued job.
+  """
+  @spec finish(pid()) :: :ok
+  def finish(pid) do
+    GenServer.cast(pid, :finish)
+  end
+
+  @doc """
+  Registers the calling process under a fixed name so every subsequent
+  `start_transcoding/1` call sends it `{:transcoder_opts, opts}`.
+
+  Registration is torn down automatically when the calling (test) process
+  exits, so no explicit cleanup is required between tests.
+  """
+  @spec collect() :: :ok
+  def collect do
+    Process.register(self(), @collector_name)
+    :ok
+  end
+
+  @impl true
+  def init(opts) do
+    case Process.whereis(@collector_name) do
+      nil -> :ok
+      pid -> send(pid, {:transcoder_opts, opts})
+    end
+
+    {:ok, %{on_complete: Keyword.get(opts, :on_complete)}}
+  end
+
+  @impl true
+  def handle_cast(:finish, %{on_complete: on_complete} = state) do
+    if is_function(on_complete, 0), do: on_complete.()
+    {:stop, :normal, state}
+  end
+end

--- a/test/support/fixtures/vainfo_intel_raptor_lake.txt
+++ b/test/support/fixtures/vainfo_intel_raptor_lake.txt
@@ -1,0 +1,23 @@
+libva info: VA-API version 1.22.0
+libva info: Trying to open /usr/lib/dri/iHD_drv_video.so
+libva info: Found init function __vaDriverInit_1_22
+libva info: va_openDriver() returns 0
+vainfo: VA-API version: 1.22 (libva 2.22.0)
+vainfo: Driver version: Intel iHD driver for Intel(R) Gen Graphics - 25.4.6 ()
+vainfo: Supported profile and entrypoints
+      VAProfileNone                   :	VAEntrypointVideoProc
+      VAProfileMPEG2Simple            :	VAEntrypointVLD
+      VAProfileH264Main               :	VAEntrypointVLD
+      VAProfileH264Main               :	VAEntrypointEncSlice
+      VAProfileH264High               :	VAEntrypointVLD
+      VAProfileH264High               :	VAEntrypointEncSlice
+      VAProfileVC1Advanced            :	VAEntrypointVLD
+      VAProfileJPEGBaseline           :	VAEntrypointVLD
+      VAProfileVP8Version0_3          :	VAEntrypointVLD
+      VAProfileHEVCMain               :	VAEntrypointVLD
+      VAProfileHEVCMain               :	VAEntrypointEncSlice
+      VAProfileHEVCMain10             :	VAEntrypointVLD
+      VAProfileHEVCMain10             :	VAEntrypointEncSliceLP
+      VAProfileVP9Profile0            :	VAEntrypointVLD
+      VAProfileVP9Profile2            :	VAEntrypointVLD
+      VAProfileAV1Profile0            :	VAEntrypointVLD

--- a/test/support/fixtures/vainfo_no_driver.txt
+++ b/test/support/fixtures/vainfo_no_driver.txt
@@ -1,0 +1,5 @@
+libva info: VA-API version 1.22.0
+libva info: User environment variable requested driver 'iHD'
+libva info: Trying to open /usr/lib/dri/iHD_drv_video.so
+libva info: va_openDriver() returns -1
+vaInitialize failed with error code -1 (unknown libva error),exit

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,6 +5,7 @@
 # Exclude feature tests by default (require chromedriver)
 # Exclude relay tests by default (require connected relay service)
 # Exclude ffmpeg integration tests by default (run real ffmpeg, seconds not ms)
+# Exclude hardware transcoding tests by default (require a VA device at /dev/dri)
 # Run specific tests explicitly with: mix test --include <tag>
 max_cases =
   if System.get_env("DATABASE_TYPE") == "postgres" do
@@ -13,7 +14,11 @@ max_cases =
     1
   end
 
-ExUnit.start(max_cases: max_cases, exclude: [:external, :feature, :requires_relay, :ffmpeg])
+ExUnit.start(
+  max_cases: max_cases,
+  exclude: [:external, :feature, :requires_relay, :ffmpeg, :hwaccel]
+)
+
 Ecto.Adapters.SQL.Sandbox.mode(Mydia.Repo, :manual)
 
 # Refuse outbound HTTP. Nothing else stops a test reaching the production


### PR DESCRIPTION
Every transcode Mydia performs runs on the CPU. `lib/mydia/streaming/` contained no hardware-acceleration code at all, so a file with an incompatible codec pinned roughly 1050% CPU on a box whose Intel iGPU sat idle with `/dev/dri/renderD128` already bind-mounted into the container.

This adds VAAPI hardware transcoding to both encode paths, detected automatically, with a software fallback whenever the hardware turns out not to work.

## Measured on real hardware

Intel Raptor Lake-P UHD Graphics (Gen12.2), 16 cores. 60 seconds of 1080p content, 1439 frames in every run, encoding to H.264 with the rest of the pipeline's arguments held constant. CPU is `(user + sys) / real`.

| source | tier | fps | realtime | CPU |
| --- | --- | --- | --- | --- |
| AV1 10-bit | software (today) | 166 | 6.92x | 1047% |
| AV1 10-bit | hybrid | 169 | 7.04x | 546% |
| AV1 10-bit | full hardware | 218 | 9.08x | 112% |
| HEVC 10-bit | software (today) | 191 | 7.98x | 1153% |
| HEVC 10-bit | full hardware | 350 | 14.6x | 115% |

The win is CPU headroom rather than wall clock. Full hardware is 1.3x faster on AV1 and 1.8x on HEVC, but it uses about one core where software uses eleven. On a 16-core box that moves the ceiling from roughly one concurrent transcode to about a dozen, and it stops a single playback session from degrading everything else the server is doing.

## Why the container could not do this before

`ffmpeg -hwaccels` listing `vaapi` only means the API was compiled in. The runtime image ships `libva.so.2` with no driver in `/usr/lib/dri`, so ffmpeg advertised VAAPI and then died at `Failed to initialise VAAPI connection: -1`. Detection that trusts `-hwaccels` would report the feature as working when it cannot work at all, which is why the probe ends with a real throwaway encode rather than a capability string.

## What is here

**Detection.** `HardwareAccel.Probe` enumerates `/dev/dri/renderD*`, parses `vainfo` for the decode/encode matrix, then confirms with an actual encode. `HardwareAccel` caches the result in a GenServer, hands out concurrency leases, and narrows its own capability map when a device turns out to advertise a profile it mishandles. Failure reasons stay specific, because "no render node", "driver missing" and "disabled by HWACCEL=off" lead an operator to three different actions.

**Three tiers.** Full hardware when the device can decode the source, hybrid (software decode, `hwupload`, hardware encode) when it cannot, software otherwise. Tier selection fails closed: an unrecognised codec never resolves to a hardware decode path.

**Fallback.** A boot probe cannot prove a particular file's profile will decode, so a hardware encode that dies at initialisation is classified distinctly from an ordinary encode error and the session restarts in software at the same position, once per session. Both playlist modes are covered.

**Configuration.** `HWACCEL` (`auto`, `off`, `vaapi`) and `HWACCEL_DEVICE` flow through the layered yaml/db/env config. Auto by default: a working setup needs no configuration. The admin settings page gains a read-only row reporting what was detected, or why nothing was.

**Packaging.** `mesa-va-gallium`, `intel-media-driver` and `libva-utils` join the runtime image, and the entrypoint grants the app user the render node's gid, which has no stable name inside the container.

## Notable decisions

**VAAPI only.** QSV is not implementable on this image: Alpine ships `libvpl` (the dispatcher) but no `onevpl-intel-gpu` runtime, so `h264_qsv` fails at `Error creating a MFX session: -9` regardless of code. NVENC is absent from Alpine's ffmpeg entirely, and `nvidia-container-toolkit` injection does not work on musl, so it needs a base-image migration and is deferred.

**Quality target is measured, not assumed.** On a 1080p sample, `h264_vaapi -qp 23` costs 1.29x the bitrate of `libx264 -crf 23` for SSIM 0.9923 against x264's 0.9949. Even at qp 22, spending 45% more bits, VAAPI does not reach x264's SSIM, so visual parity is not available at an acceptable bandwidth cost. The full curve is recorded in the design notes so the choice stays revisable.

**The image grows about 250MB uncompressed**, dominated by `llvm21-libs` (~170MB) pulled in transitively by `mesa-va-gallium`, not by the Intel driver (~38MB). `mesa-va-gallium` is kept because covering Intel and AMD in one code path is the reason VAAPI was chosen over an NVENC-first design; dropping it would halve the cost and leave AMD users with nothing.

## Testing

Argument construction is a pure module, so every tier, rate-control mode and scale combination is unit tested without a GPU. The probe is tested against captured `vainfo` output including the driver-less case. The stderr classifier is tested against the real production failure text, with negative cases proving an ordinary encode error is not misread as a hardware failure. The session fallback is exercised through a real process link and a real exit, asserting the session survives.

An opt-in `:hwaccel`-tagged suite exercises real hardware and is excluded by default (`mix test --include hwaccel` to run it). It requires `vainfo` and a render node whose driver matches the local libva.

The six pre-existing test files that assert the exact software ffmpeg arguments pass unmodified. That was the safety condition for the integration: they prove the accelerated path did not change the unaccelerated one.

Full suite: 10957 tests, 0 failures. Precommit green.

## Follow-ups not in this PR

Verifying the measured CPU improvement end to end on a deployed instance. NVENC, which needs the runtime image moved off Alpine to glibc. QSV, if `onevpl-intel-gpu` ever reaches Alpine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional VA-API hardware transcoding with automatic, disabled, or explicitly selected modes.
  * Added capability-aware hardware, hybrid, and software transcoding for streaming and MP4 conversion.
  * Added hardware acceleration status details, including device and supported profiles, to admin settings.
  * Added automatic GPU device permission setup when available.

* **Bug Fixes**
  * Streaming now falls back to software encoding when hardware initialization fails.
  * Transcoding jobs retry once in software after hardware-specific failures.
  * Improved handling of unavailable, disconnected, or unsupported hardware acceleration services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->