### PR TITLE
fix: Now Playing reports what FFmpeg is actually doing

### DIFF
--- a/lib/mydia/downloads/transcode_job.ex
+++ b/lib/mydia/downloads/transcode_job.ex
@@ -46,7 +46,7 @@ defmodule Mydia.Downloads.TranscodeJob do
 
   @valid_statuses ~w(pending transcoding playing ready failed)
   @valid_resolutions ~w(original 1080p 720p 480p)
-  @valid_types ~w(download stream direct)
+  @valid_types ~w(download stream direct remux)
 
   @doc """
   Changeset for creating or updating a transcode job.

--- a/lib/mydia/streaming.ex
+++ b/lib/mydia/streaming.ex
@@ -24,7 +24,8 @@ defmodule Mydia.Streaming do
       :bitrate_bps,
       :position_seconds,
       :duration_seconds,
-      :poster_path
+      :poster_path,
+      :plan
     ]
   end
 
@@ -66,6 +67,11 @@ defmodule Mydia.Streaming do
           Map.get(meta, :ready, false)
         end
 
+      # The registry's copy is the fallback for the window where the process
+      # died between the registry read and the get_info call, matching how
+      # started_at and ready are already resolved here.
+      plan = if info, do: Map.get(info, :plan), else: Map.get(meta, :plan)
+
       # Fetch User
       user = Repo.get(User, user_id)
 
@@ -98,7 +104,8 @@ defmodule Mydia.Streaming do
             bitrate_bps: media_file.bitrate,
             position_seconds: progress && progress.position_seconds,
             duration_seconds: progress && progress.duration_seconds,
-            poster_path: poster_path(artwork_item)
+            poster_path: poster_path(artwork_item),
+            plan: plan
           }
       end
     end)

--- a/lib/mydia/streaming/direct_play_session.ex
+++ b/lib/mydia/streaming/direct_play_session.ex
@@ -15,6 +15,8 @@ defmodule Mydia.Streaming.DirectPlaySession do
   alias Mydia.Repo
   alias Mydia.Downloads.TranscodeJob
 
+  @registry_name Mydia.Streaming.HlsSessionRegistry
+
   # Default timeout is 10 minutes
   @session_timeout Application.compile_env(
                      :mydia,
@@ -68,6 +70,22 @@ defmodule Mydia.Streaming.DirectPlaySession do
   """
   def stop(pid) do
     GenServer.stop(pid, :normal)
+  end
+
+  @doc """
+  Replaces this session's stream plan.
+
+  A remux tracker is reused across requests: a browser seek aborts the response
+  and immediately opens another, and `start_remux_session/3` hands back the
+  running session rather than starting a second one. A later request can
+  resolve a different audio track, and therefore a different plan, so the plan
+  the session was started with goes stale. Leaving it stale is the exact
+  failure this feature exists to remove — the dashboard describing an encode
+  that is not the one running.
+  """
+  @spec update_plan(pid(), Mydia.Streaming.StreamPlan.t()) :: :ok
+  def update_plan(pid, plan) do
+    GenServer.call(pid, {:update_plan, plan})
   end
 
   ## Server Callbacks
@@ -144,6 +162,21 @@ defmodule Mydia.Streaming.DirectPlaySession do
     {:reply, {:ok, info}, state}
   end
 
+  def handle_call({:update_plan, plan}, _from, state) do
+    # Both copies, deliberately. `Streaming.list_active_sessions/0` reads the
+    # live process when it can and falls back to the Registry metadata when
+    # that call races a shutdown, so a plan refreshed in only one place still
+    # leaves a path that reports the stale one.
+    #
+    # `Registry.update_value/3` may only be called by the key's owner. That is
+    # this process: the `:via` tuple in the child spec registered the key from
+    # inside `start_link`, so the call has to happen here rather than in the
+    # supervisor that asked for the refresh.
+    Registry.update_value(@registry_name, registry_key(state), &Map.put(&1, :plan, plan))
+
+    {:reply, :ok, %{state | plan: plan}}
+  end
+
   @impl true
   def handle_cast(:heartbeat, state) do
     state = update_activity(state)
@@ -188,6 +221,13 @@ defmodule Mydia.Streaming.DirectPlaySession do
   end
 
   ## Helpers
+
+  # Mirrors the keys HlsSessionSupervisor registers these sessions under.
+  defp registry_key(%State{kind: :remux, media_file_id: id, user_id: user_id}),
+    do: {:remux_session, id, user_id}
+
+  defp registry_key(%State{media_file_id: id, user_id: user_id}),
+    do: {:direct_session, id, user_id}
 
   defp update_activity(state) do
     if state.timeout_ref, do: Process.cancel_timer(state.timeout_ref)

--- a/lib/mydia/streaming/direct_play_session.ex
+++ b/lib/mydia/streaming/direct_play_session.ex
@@ -29,6 +29,8 @@ defmodule Mydia.Streaming.DirectPlaySession do
       :media_file_id,
       :user_id,
       :mode,
+      :kind,
+      :plan,
       :last_activity,
       :timeout_ref,
       :db_job_id
@@ -75,8 +77,10 @@ defmodule Mydia.Streaming.DirectPlaySession do
     media_file_id = Keyword.fetch!(opts, :media_file_id)
     user_id = Keyword.fetch!(opts, :user_id)
     started_at = Keyword.get(opts, :started_at, DateTime.utc_now())
+    kind = Keyword.get(opts, :kind, :direct)
+    plan = Keyword.get(opts, :plan)
 
-    Logger.info("Starting Direct Play session for file #{media_file_id}, user #{user_id}")
+    Logger.info("Starting #{kind} playback session for file #{media_file_id}, user #{user_id}")
 
     # Note: Registration in HlsSessionRegistry is handled by the :via tuple in start_link
     # passed from HlsSessionSupervisor.start_direct_session/2.
@@ -88,7 +92,7 @@ defmodule Mydia.Streaming.DirectPlaySession do
       |> TranscodeJob.changeset(%{
         media_file_id: media_file_id,
         user_id: user_id,
-        type: "direct",
+        type: to_string(kind),
         status: "playing",
         resolution: "original",
         progress: 0.0,
@@ -107,7 +111,9 @@ defmodule Mydia.Streaming.DirectPlaySession do
       session_id: session_id,
       media_file_id: media_file_id,
       user_id: user_id,
-      mode: :direct,
+      mode: kind,
+      kind: kind,
+      plan: plan,
       db_job_id: job.id,
       last_activity: DateTime.utc_now()
     }
@@ -127,6 +133,8 @@ defmodule Mydia.Streaming.DirectPlaySession do
       session_id: state.session_id,
       media_file_id: state.media_file_id,
       mode: state.mode,
+      kind: state.kind,
+      plan: state.plan,
       last_activity: state.last_activity,
       # Flags for compatibility with HLS interface
       ready: true,

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -34,10 +34,9 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   use GenServer
   require Logger
 
-  alias Mydia.Library.Structs.StreamInfo
   alias Mydia.Streaming.AudioTrackSelector
-  alias Mydia.Streaming.HardwareAccel
   alias Mydia.Streaming.HardwareAccel.Args, as: AccelArgs
+  alias Mydia.Streaming.StreamPlan
 
   @type transcode_opts :: [
           input_path: String.t(),
@@ -214,21 +213,15 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     on_segments = Keyword.get(opts, :on_segments)
     on_hwaccel_failed = Keyword.get(opts, :on_hwaccel_failed)
 
-    # Build FFmpeg command
-    args = build_ffmpeg_args(input_path, output_dir, opts)
+    # Built once and handed down to build_ffmpeg_args/3 via :plan, so the
+    # audio selector and AccelArgs.build/2 are not paid for twice.
+    plan = StreamPlan.for_hls(Keyword.get(opts, :media_file), opts)
+    args = build_ffmpeg_args(input_path, output_dir, Keyword.put(opts, :plan, plan))
 
-    # Derived from the argument list rather than by calling AccelArgs.build/2
-    # again: re-deriving from inputs risks drift, and build_ffmpeg_args/3's
-    # return shape can't change without breaking the six regression test
-    # files that assert its exact output. The gate below only needs to know
-    # whether this was a hardware attempt at all, but deriving the precise
-    # tier costs nothing and keeps the log line below accurate.
-    accel_tier =
-      cond do
-        "-hwaccel" in args -> :full_hardware
-        "-init_hw_device" in args -> :hybrid
-        true -> :software
-      end
+    # Read from the plan rather than recovered from the argument list. The old
+    # `"-hwaccel" in args` sniff was a symptom of the decision being made
+    # inside build_ffmpeg_args/3 and discarded; it cannot drift now.
+    accel_tier = plan.video.tier || :software
 
     Logger.info("Starting FFmpeg HLS transcoding: #{input_path}")
     Logger.debug("FFmpeg args: #{inspect(args)}")
@@ -513,50 +506,20 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     _ -> false
   end
 
-  # Determines if a video codec is compatible with browsers and can be copied instead of re-encoded
-  defp should_copy_video?(nil), do: false
-
-  defp should_copy_video?(codec) when is_binary(codec) do
-    normalized = String.downcase(codec)
-
-    # H.264 (AVC) is universally supported by browsers
-    normalized in ["h264", "avc", "avc1"]
-  end
-
-  # Determines if an audio codec is compatible with browsers and can be copied instead of re-encoded
-  defp should_copy_audio?(nil), do: false
-
-  defp should_copy_audio?(codec) when is_binary(codec) do
-    normalized = String.downcase(codec)
-
-    # AAC is universally supported by browsers
-    normalized in ["aac", "mp4a"]
-  end
-
   # Audio bitrate budget (kbps) subtracted from total when calculating video bitrate
   @audio_bitrate_kbps 128
 
   @doc """
   Whether the video stream will be re-encoded rather than copied.
 
-  This is the single place that decision gets made; `build_ffmpeg_args/3`
-  calls it too, so the two can never disagree. Only a re-encode can have its
-  keyframes forced onto the segment grid, so this is also what decides
-  whether `grid_aligned` may be set: `HlsSession` calls it before starting or
-  relocating the encoder, to decide what to pass as `grid_aligned`.
+  Delegates to `StreamPlan.encodes_video?/3` so this and `build_ffmpeg_args/3`
+  cannot answer differently. `HlsSession` calls it to decide whether to lease a
+  hardware slot and whether `grid_aligned` may be set.
   """
-  @spec reencodes_video?(Mydia.Library.MediaFile.t() | nil, integer() | nil) :: boolean()
-  def reencodes_video?(media_file, max_bitrate) do
-    transcode_policy =
-      Application.get_env(:mydia, :streaming, [])
-      |> Keyword.get(:transcode_policy, :copy_when_compatible)
-
-    cond do
-      not is_nil(max_bitrate) -> true
-      transcode_policy != :copy_when_compatible -> true
-      is_nil(media_file) -> true
-      true -> not should_copy_video?(media_file.codec)
-    end
+  @spec reencodes_video?(Mydia.Library.MediaFile.t() | nil, integer() | nil, integer() | nil) ::
+          boolean()
+  def reencodes_video?(media_file, max_bitrate, max_height) do
+    StreamPlan.encodes_video?(media_file, max_bitrate, effective_max_height(max_height))
   end
 
   # Build FFmpeg command arguments for HLS transcoding
@@ -565,91 +528,55 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # nothing outside this module should call it.
   def build_ffmpeg_args(input_path, output_dir, opts) do
     media_file = Keyword.get(opts, :media_file)
-    max_bitrate = Keyword.get(opts, :max_bitrate)
-    max_height = effective_max_height(Keyword.get(opts, :max_height))
 
-    # Get transcode policy from config
-    transcode_policy =
-      Application.get_env(:mydia, :streaming, [])
-      |> Keyword.get(:transcode_policy, :copy_when_compatible)
+    # get_lazy, not get: a caller that already built the plan (start_transcoding/1
+    # does, to read the tier) passes it in rather than paying for the audio
+    # selector and AccelArgs twice. Direct unit tests of this function pass no
+    # :plan and get one built here.
+    plan = Keyword.get_lazy(opts, :plan, fn -> StreamPlan.for_hls(media_file, opts) end)
 
-    # When max_bitrate is set, force transcoding (no video stream copy)
-    # since we need to control the output bitrate
-    force_transcode = not is_nil(max_bitrate)
-
-    # Determine video codec - use copy if compatible and policy allows, otherwise
-    # transcode. An explicit opt always wins; short of that, reencodes_video?/2
-    # is the single decider, so this can never disagree with what HlsSession
-    # used to decide `grid_aligned`.
+    # An explicit codec opt still passes through verbatim, exactly as the
+    # `explicit -> explicit` clause did before. The plan decides only the
+    # nil case. Collapsing this to `if plan.video.action == :copy` would
+    # rewrite an explicit "libx265" into "libx264" and break the
+    # byte-identical-arguments constraint.
+    #
+    # The plan cannot supply the encoder name itself: plan.video.to_codec is
+    # a codec name for display ("h264"), while FFmpeg needs an encoder name
+    # ("libx264"). Keeping the mapping here is what stops the display value
+    # leaking into the command line.
     video_codec =
       case Keyword.get(opts, :video_codec) do
-        nil when force_transcode ->
-          Logger.info("Bitrate cap set (#{max_bitrate}kbps), forcing video transcode to H.264")
-          "libx264"
-
-        nil ->
-          if reencodes_video?(media_file, max_bitrate) do
-            Logger.info(
-              "Video codec #{(media_file && media_file.codec) || "unknown"} needs transcoding to H.264"
-            )
-
-            "libx264"
-          else
-            Logger.info(
-              "Video codec #{media_file.codec} is compatible, using stream copy (fast, no quality loss)"
-            )
-
-            "copy"
-          end
-
-        explicit ->
-          explicit
+        nil -> if plan.video.action == :copy, do: "copy", else: "libx264"
+        explicit -> explicit
       end
 
-    # Which audio stream this playback carries, resolved before the codec
-    # decision because that decision has to be about the stream actually being
-    # mapped. `media_file.audio_codec` describes the *first* audio stream
-    # (see Mydia.Library.FileAnalyzer), so on a file whose first track is
-    # stereo AAC and whose second is 5.1 DTS, deciding "aac, so copy" from the
-    # first and then mapping the second puts a DTS stream in an HLS segment no
-    # browser can decode. Silent audio, no error.
-    selected_audio = AudioTrackSelector.select_for_playback(media_file, opts)
-
-    audio_source_codec =
-      case selected_audio do
-        %StreamInfo{codec: codec} when is_binary(codec) -> codec
-        _ -> media_file && media_file.audio_codec
-      end
-
-    # Determine audio codec - use copy if compatible and policy allows, otherwise transcode
     audio_codec =
       case Keyword.get(opts, :audio_codec) do
-        nil when not is_nil(media_file) and transcode_policy == :copy_when_compatible ->
-          if should_copy_audio?(audio_source_codec) do
-            Logger.info(
-              "Audio codec #{audio_source_codec} is compatible, using stream copy (fast, no quality loss)"
-            )
-
-            "copy"
-          else
-            Logger.info("Audio codec #{audio_source_codec || "unknown"} needs transcoding to AAC")
-
-            "aac"
-          end
-
-        nil ->
-          if transcode_policy == :always do
-            Logger.debug("Transcode policy is :always, transcoding audio to AAC")
-          end
-
-          "aac"
-
-        codec ->
-          codec
+        nil -> if plan.audio.action == :copy, do: "copy", else: "aac"
+        explicit -> explicit
       end
 
-    preset = Keyword.get(opts, :preset, "medium")
-    crf = Keyword.get(opts, :crf, 23)
+    selected_audio = plan.selected_audio
+
+    if video_codec == "copy" do
+      Logger.info("Video codec #{plan.video.from_codec} is compatible, using stream copy")
+    else
+      Logger.info("Video codec #{plan.video.from_codec || "unknown"} needs transcoding to H.264")
+    end
+
+    if audio_codec == "copy" do
+      Logger.info("Audio codec #{plan.audio.from_codec} is compatible, using stream copy")
+    else
+      Logger.info("Audio codec #{plan.audio.from_codec || "unknown"} needs transcoding to AAC")
+    end
+
+    # Acceleration lives on the plan. A copied stream has no accel, and the
+    # empty argument lists below preserve the previous behaviour exactly:
+    # nothing here can turn a copy into a transcode.
+    accel = plan.accel || %AccelArgs{tier: :software, input: [], video: []}
+
+    Logger.info("Encoding tier: #{accel.tier}")
 
     # Use index.m3u8 to match HLS controller expectations
     playlist_path = Path.join(output_dir, "index.m3u8")
@@ -669,34 +596,6 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
         pos when is_integer(pos) and pos > 0 -> ["-ss", to_string(pos)]
         _ -> []
       end
-
-    # Acceleration is decided only on the encode branch. A stream copy returns
-    # empty argument lists, so nothing here can turn a copy into a transcode.
-    accel =
-      if video_codec == "copy" do
-        %AccelArgs{tier: :software, input: [], video: []}
-      else
-        capabilities =
-          Keyword.get_lazy(opts, :capabilities, fn -> HardwareAccel.capabilities() end)
-
-        video_bitrate_kbps =
-          if max_bitrate do
-            kbps = max(max_bitrate - @audio_bitrate_kbps, 100)
-            Logger.info("Using ABR mode: video=#{kbps}kbps, total_cap=#{max_bitrate}kbps")
-            kbps
-          end
-
-        AccelArgs.build(capabilities,
-          source_codec: media_file && media_file.codec,
-          max_height: max_height,
-          video_bitrate_kbps: video_bitrate_kbps,
-          crf: crf,
-          preset: preset,
-          video_codec: video_codec
-        )
-      end
-
-    Logger.info("Encoding tier: #{accel.tier}")
 
     # -hwaccel flags must precede -i. After it, ffmpeg has already selected a
     # decoder and silently ignores them.

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -690,7 +690,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
 
     # Only meaningful when the video stream is re-encoded. On a copied stream
     # the keyframes are whatever the source has, and FFmpeg rejects the flag
-    # outright. reencodes_video?/2 above is what decides whether grid_aligned
+    # outright. reencodes_video?/3 above is what decides whether grid_aligned
     # may be true; HlsSession calls it before starting or relocating the
     # encoder and passes the answer straight through as this opt.
     keyframe_args =

--- a/lib/mydia/streaming/ffmpeg_remuxer.ex
+++ b/lib/mydia/streaming/ffmpeg_remuxer.ex
@@ -44,10 +44,9 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
 
   require Logger
 
-  alias Mydia.Library.Structs.StreamInfo
   alias Mydia.Streaming.AudioTrackSelector
-  alias Mydia.Streaming.Compatibility
   alias Mydia.Streaming.DeviceProfile
+  alias Mydia.Streaming.StreamPlan
 
   # Matches FfmpegHlsTranscoder's budget, so a stream that has to be encoded
   # on either path lands at the same bitrate.
@@ -179,34 +178,32 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
 
     input_args = ["-i", input_path]
 
+    # The plan is the single record of what ffmpeg will do to a stream. Video
+    # is always copied: it is the expensive stream and the REMUX strategy was
+    # offered precisely because the client can decode it. Audio is copied
+    # only when the *mapped* stream (not media_file.audio_codec, the first
+    # stream, that chose the strategy) is one the caller's device profile
+    # accepts.
+    media_file = Keyword.get(opts, :media_file)
+    plan = StreamPlan.for_remux(media_file, opts)
+
     # Which audio stream survives the remux. `-c copy` copies the codec, not
     # every stream: without an explicit -map ffmpeg still reduces to one
     # stream per type and picks the audio track with the most channels, so a
     # dual-language file silently loses its original-language track here just
     # as it does on the transcode path.
-    selected_audio =
-      opts
-      |> Keyword.get(:media_file)
-      |> AudioTrackSelector.select_for_playback(opts)
+    map_args = AudioTrackSelector.ffmpeg_map_args(plan.selected_audio)
 
-    map_args = AudioTrackSelector.ffmpeg_map_args(selected_audio)
+    codec_args =
+      if plan.audio.action == :copy do
+        ["-c", "copy"]
+      else
+        Logger.info(
+          "Remux: mapped audio stream is #{plan.audio.from_codec}, encoding to AAC for playability"
+        )
 
-    # Video is always copied: it is the expensive stream and the REMUX
-    # strategy was offered precisely because the client can decode it.
-    #
-    # Audio is copied only when the *mapped* stream is one the client can
-    # decode. The strategy was chosen from `media_file.audio_codec`, which
-    # describes the first audio stream; when language selection maps a
-    # different one, a blanket `-c copy` would put e.g. AC3 into the fMP4
-    # while the advertised MIME still said `mp4a.40.2`. Encoding that one
-    # stream to AAC keeps the promise the candidate made, and still avoids
-    # touching the video.
-    #
-    # The decision is made against the caller's device profile, not the
-    # hardcoded browser table: a client that declared it can decode e.g. AC3
-    # should get the stream copy REMUX implies, not a silent downmix to
-    # stereo AAC.
-    codec_args = remux_codec_args(selected_audio, Keyword.get(opts, :device_profile))
+        ["-c:v", "copy", "-c:a", "aac", "-b:a", "#{@audio_bitrate_kbps}k", "-ac", "2"]
+      end
 
     # Duration args - tell FFmpeg the total duration so it writes correct metadata
     # This prevents the browser from showing progressively increasing duration
@@ -240,27 +237,6 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
     ]
 
     seek_args ++ input_args ++ map_args ++ codec_args ++ duration_args ++ output_args
-  end
-
-  # No stream was selected, so no -map was emitted and ffmpeg's implicit
-  # selection stands. That is the pre-existing behaviour for an unanalysed
-  # file, and the codec the strategy was chosen from is the one it will pick.
-  defp remux_codec_args(nil, _device_profile), do: ["-c", "copy"]
-
-  defp remux_codec_args(%StreamInfo{codec: codec}, device_profile) do
-    compatible? =
-      case device_profile do
-        nil -> Compatibility.compatible_audio_codec?(codec)
-        %DeviceProfile{} = profile -> Compatibility.compatible_audio_codec?(codec, profile)
-      end
-
-    if compatible? do
-      ["-c", "copy"]
-    else
-      Logger.info("Remux: mapped audio stream is #{codec}, encoding to AAC for playability")
-
-      ["-c:v", "copy", "-c:a", "aac", "-b:a", "#{@audio_bitrate_kbps}k", "-ac", "2"]
-    end
   end
 
   # Start FFmpeg process using Port

--- a/lib/mydia/streaming/ffmpeg_remuxer.ex
+++ b/lib/mydia/streaming/ffmpeg_remuxer.ex
@@ -52,6 +52,11 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
   # on either path lands at the same bitrate.
   @audio_bitrate_kbps 128
 
+  # How often a still-running remux reports activity to its tracking session.
+  # The session's inactivity timeout is ten minutes, so this has a wide margin
+  # while staying far below one cast per 64KB chunk.
+  @activity_interval_ms 30_000
+
   @type remux_opts :: [
           seek_seconds: number() | nil,
           duration: number() | nil,
@@ -102,6 +107,15 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
     start_ffmpeg_process(args)
   end
 
+  @doc false
+  # Public only so the throttle can be unit-tested without a live FFmpeg port.
+  @spec throttle_activity(integer() | nil, integer()) :: {boolean(), integer()}
+  def throttle_activity(nil, now), do: {true, now}
+
+  def throttle_activity(last, now) when now - last >= @activity_interval_ms, do: {true, now}
+
+  def throttle_activity(last, _now), do: {false, last}
+
   @doc """
   Streams FFmpeg output to a Plug connection using chunked transfer encoding.
 
@@ -119,6 +133,7 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
   @spec stream_to_conn(Plug.Conn.t(), port(), integer(), Keyword.t()) :: Plug.Conn.t()
   def stream_to_conn(conn, port, os_pid, opts \\ []) do
     chunk_size = Keyword.get(opts, :chunk_size, 64 * 1024)
+    on_activity = Keyword.get(opts, :on_activity)
 
     # Set up chunked transfer encoding with video/mp4 content type
     conn =
@@ -128,7 +143,7 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
       |> Plug.Conn.send_chunked(200)
 
     # Stream data from FFmpeg to the connection
-    stream_loop(conn, port, os_pid, chunk_size)
+    stream_loop(conn, port, os_pid, chunk_size, on_activity, nil)
   end
 
   @doc """
@@ -277,13 +292,18 @@ defmodule Mydia.Streaming.FfmpegRemuxer do
   end
 
   # Stream data from FFmpeg port to connection
-  defp stream_loop(conn, port, os_pid, chunk_size) do
+  defp stream_loop(conn, port, os_pid, chunk_size, on_activity, last_activity) do
     receive do
       {^port, {:data, data}} ->
+        {fire?, last_activity} =
+          throttle_activity(last_activity, System.monotonic_time(:millisecond))
+
+        if fire? and is_function(on_activity, 0), do: on_activity.()
+
         # Send chunk to client
         case Plug.Conn.chunk(conn, data) do
           {:ok, conn} ->
-            stream_loop(conn, port, os_pid, chunk_size)
+            stream_loop(conn, port, os_pid, chunk_size, on_activity, last_activity)
 
           {:error, :closed} ->
             # Client disconnected

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -423,7 +423,8 @@ defmodule Mydia.Streaming.HlsSession do
         # A :playback lease is claimed once for the whole session, not once
         # per FfmpegHlsTranscoder process -- see acquire_hwaccel_lease/0 for
         # why.
-        {capabilities, hwaccel_lease} = maybe_acquire_hwaccel_lease(media_file, max_bitrate)
+        {capabilities, hwaccel_lease} =
+          maybe_acquire_hwaccel_lease(media_file, max_bitrate, max_height)
 
         # The keyword list a relocation reuses verbatim (see relocate/2), so it
         # has to carry everything start_backend/6 needs beyond the offset and
@@ -436,7 +437,7 @@ defmodule Mydia.Streaming.HlsSession do
           max_height: max_height,
           start_position: start_position,
           start_number: first_index,
-          grid_aligned: grid_aligned?(playlist_mode, media_file, max_bitrate),
+          grid_aligned: grid_aligned?(playlist_mode, media_file, max_bitrate, max_height),
           absolute_timestamps: playlist_mode == :full,
           playlist_mode: playlist_mode,
           audio_language: playback.audio_language,
@@ -504,10 +505,13 @@ defmodule Mydia.Streaming.HlsSession do
   # plain MediaFile struct, without a live HardwareAccel process, a DB row, or
   # a real init/1; nothing outside this module should call it.
   @doc false
-  @spec maybe_acquire_hwaccel_lease(Mydia.Library.MediaFile.t() | nil, integer() | nil) ::
-          {Capabilities.t() | nil, reference() | nil}
-  def maybe_acquire_hwaccel_lease(media_file, max_bitrate) do
-    if FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate) do
+  @spec maybe_acquire_hwaccel_lease(
+          Mydia.Library.MediaFile.t() | nil,
+          integer() | nil,
+          integer() | nil
+        ) :: {Capabilities.t(), reference() | nil}
+  def maybe_acquire_hwaccel_lease(media_file, max_bitrate, max_height) do
+    if FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate, max_height) do
       acquire_hwaccel_lease()
     else
       {nil, nil}
@@ -570,10 +574,15 @@ defmodule Mydia.Streaming.HlsSession do
   # job row, a real media file), which is unrelated to whether the decision
   # itself is right. Nothing outside this module should call it.
   @doc false
-  @spec grid_aligned?(:full | :window, Mydia.Library.MediaFile.t() | nil, integer() | nil) ::
-          boolean()
-  def grid_aligned?(playlist_mode, media_file, max_bitrate) do
-    playlist_mode == :full and FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate)
+  @spec grid_aligned?(
+          :full | :window,
+          Mydia.Library.MediaFile.t() | nil,
+          integer() | nil,
+          integer() | nil
+        ) :: boolean()
+  def grid_aligned?(playlist_mode, media_file, max_bitrate, max_height) do
+    playlist_mode == :full and
+      FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate, max_height)
   end
 
   @doc """

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -36,6 +36,7 @@ defmodule Mydia.Streaming.HlsSession do
   alias Mydia.Streaming.HardwareAccel
   alias Mydia.Streaming.HardwareAccel.Capabilities
   alias Mydia.Streaming.SegmentPlan
+  alias Mydia.Streaming.StreamPlan
   alias Mydia.Streaming.TranscodeWindow
   alias Mydia.Repo
   alias Mydia.Downloads.TranscodeJob
@@ -70,6 +71,7 @@ defmodule Mydia.Streaming.HlsSession do
       :segment_plan,
       :backend_opts,
       :hwaccel_lease,
+      :plan,
       playlist_mode: :window,
       window: nil,
       segment_waiters: %{},
@@ -97,6 +99,7 @@ defmodule Mydia.Streaming.HlsSession do
             segment_plan: Mydia.Streaming.SegmentPlan.t() | nil,
             backend_opts: keyword(),
             hwaccel_lease: reference() | nil,
+            plan: StreamPlan.t() | nil,
             playlist_mode: :full | :window,
             window: Mydia.Streaming.TranscodeWindow.t() | nil,
             segment_waiters: %{non_neg_integer() => [GenServer.from()]},
@@ -445,6 +448,10 @@ defmodule Mydia.Streaming.HlsSession do
           capabilities: capabilities
         ]
 
+        # Computed from the same opts the backend receives, so the plan and the
+        # arguments describe the same encode by construction.
+        plan = StreamPlan.for_hls(media_file, backend_opts)
+
         # Start FFmpeg backend
         case start_backend(:ffmpeg, media_file, temp_dir, job.id, backend_opts, 0) do
           {:ok, backend_pid} ->
@@ -469,7 +476,8 @@ defmodule Mydia.Streaming.HlsSession do
               playlist_mode: playlist_mode,
               window: if(playlist_mode == :full, do: TranscodeWindow.new(first_index), else: nil),
               backend_opts: backend_opts,
-              hwaccel_lease: hwaccel_lease
+              hwaccel_lease: hwaccel_lease,
+              plan: plan
             }
 
             # Schedule initial timeout check
@@ -610,13 +618,25 @@ defmodule Mydia.Streaming.HlsSession do
       |> Keyword.put(:capabilities, software)
       |> Keyword.put(:start_number, target)
 
+    plan = StreamPlan.for_hls(state.media_file, backend_opts)
+
+    # The dashboard reloads Now Playing on this. Without it a card keeps
+    # advertising VAAPI after the encoder dropped to software, which is a
+    # smaller copy of the bug this whole change exists to fix.
+    Phoenix.PubSub.broadcast(
+      Mydia.PubSub,
+      "hls_sessions",
+      {:session_updated, state.session_id}
+    )
+
     {:retry,
      %{
        state
        | accel: :none,
          accel_fallbacks: state.accel_fallbacks + 1,
          backend_opts: backend_opts,
-         hwaccel_lease: nil
+         hwaccel_lease: nil,
+         plan: plan
      }}
   end
 
@@ -642,7 +662,8 @@ defmodule Mydia.Streaming.HlsSession do
       last_activity: state.last_activity,
       backend_alive?: is_pid(state.backend_pid) and Process.alive?(state.backend_pid),
       playlist_mode: state.playlist_mode,
-      duration: state.segment_plan && state.segment_plan.duration
+      duration: state.segment_plan && state.segment_plan.duration,
+      plan: state.plan
     }
 
     {:reply, {:ok, info}, state}

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -497,7 +497,7 @@ defmodule Mydia.Streaming.HlsSession do
 
   # Decides whether this session is worth leasing a hardware slot for at all.
   # Only a re-encoding session ever reaches the hardware encoder --
-  # reencodes_video?/2 is the exact same decision build_ffmpeg_args/3 makes
+  # reencodes_video?/3 is the exact same decision build_ffmpeg_args/3 makes
   # between "copy" and "libx264"/"h264_vaapi" -- so a stream-copy session
   # leasing a slot it will never use would only starve a session that does.
   #
@@ -509,7 +509,7 @@ defmodule Mydia.Streaming.HlsSession do
           Mydia.Library.MediaFile.t() | nil,
           integer() | nil,
           integer() | nil
-        ) :: {Capabilities.t(), reference() | nil}
+        ) :: {Capabilities.t() | nil, reference() | nil}
   def maybe_acquire_hwaccel_lease(media_file, max_bitrate, max_height) do
     if FfmpegHlsTranscoder.reencodes_video?(media_file, max_bitrate, max_height) do
       acquire_hwaccel_lease()

--- a/lib/mydia/streaming/hls_session.ex
+++ b/lib/mydia/streaming/hls_session.ex
@@ -1059,7 +1059,20 @@ defmodule Mydia.Streaming.HlsSession do
     # Capture self() to notify when FFmpeg is ready
     session_pid = self()
 
-    # Build transcoder opts, including max_bitrate and max_height if set
+    # Build transcoder opts, including max_bitrate and max_height if set.
+    #
+    # This whitelist is why HlsSession.State.plan (built from `opts`, i.e.
+    # backend_opts) and FfmpegHlsTranscoder's own plan (built from
+    # `transcoder_opts`, i.e. this filtered base_opts ++ the callbacks below)
+    # agree today: StreamPlan.for_hls/2 also reads :video_codec, :crf and
+    # :preset, none of which backend_opts currently sets, so both builds see
+    # the same defaults for every key actually populated. That agreement is
+    # by construction only for the keys listed here -- it is NOT "the two
+    # calls share one keyword list". Adding a plan-relevant key (:video_codec,
+    # :crf, :preset, or any future StreamPlan input) to backend_opts without
+    # also forwarding it through this filter will desynchronise the two
+    # plans silently: the dashboard (reading HlsSession.State.plan) would
+    # describe an encode the transcoder never actually runs.
     base_opts =
       [
         input_path: absolute_path,

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -264,6 +264,60 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
   end
 
   @doc """
+  Starts or reuses a remux tracking session.
+
+  Keyed separately from both HLS and direct sessions so a viewer remuxing one
+  file and direct-playing another appears as two cards rather than one
+  displacing the other.
+  """
+  def start_remux_session(media_file_id, user_id, plan) do
+    session_key = {:remux_session, media_file_id, user_id}
+    started_at = DateTime.utc_now()
+
+    metadata = %{
+      media_file_id: media_file_id,
+      user_id: user_id,
+      mode: :remux,
+      kind: :remux,
+      plan: plan,
+      started_at: started_at
+    }
+
+    name = {:via, Registry, {@registry_name, session_key, metadata}}
+
+    child_spec = %{
+      id: {DirectPlaySession, :remux, media_file_id, user_id},
+      start:
+        {DirectPlaySession, :start_link,
+         [
+           [
+             media_file_id: media_file_id,
+             user_id: user_id,
+             name: name,
+             started_at: started_at,
+             kind: :remux,
+             plan: plan
+           ]
+         ]},
+      restart: :temporary
+    }
+
+    case DynamicSupervisor.start_child(__MODULE__, child_spec) do
+      {:ok, pid} -> {:ok, pid, :started}
+      {:error, {:already_started, pid}} -> {:ok, pid, :existing}
+      error -> error
+    end
+  end
+
+  @doc "Stops a remux tracking session."
+  def stop_remux_session(media_file_id, user_id) do
+    case Registry.lookup(@registry_name, {:remux_session, media_file_id, user_id}) do
+      [{pid, _}] -> DynamicSupervisor.terminate_child(__MODULE__, pid)
+      [] -> :ok
+    end
+  end
+
+  @doc """
   Gets an existing HLS session for a media file and user combination.
 
   ## Returns

--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -303,18 +303,50 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
     }
 
     case DynamicSupervisor.start_child(__MODULE__, child_spec) do
-      {:ok, pid} -> {:ok, pid, :started}
-      {:error, {:already_started, pid}} -> {:ok, pid, :existing}
-      error -> error
+      {:ok, pid} ->
+        {:ok, pid, :started}
+
+      {:error, {:already_started, pid}} ->
+        refresh_remux_plan(pid, plan)
+        {:ok, pid, :existing}
+
+      error ->
+        error
     end
+  end
+
+  # The reused tracker still carries the plan from the request that started it.
+  # A later request can resolve a different audio track, so without this the
+  # dashboard reports an encode that is not the one FFmpeg is running — the
+  # precise failure this whole feature exists to remove.
+  defp refresh_remux_plan(pid, plan) do
+    DirectPlaySession.update_plan(pid, plan)
+  catch
+    # The session died between the start attempt and this call. It is on its
+    # way out and its plan no longer describes anything.
+    :exit, _reason -> :ok
   end
 
   @doc "Stops a remux tracking session."
   def stop_remux_session(media_file_id, user_id) do
     case Registry.lookup(@registry_name, {:remux_session, media_file_id, user_id}) do
-      [{pid, _}] -> DynamicSupervisor.terminate_child(__MODULE__, pid)
+      [{pid, _}] -> stop_tracking_session(pid)
       [] -> :ok
     end
+  end
+
+  # Deliberately NOT DynamicSupervisor.terminate_child/2, for the same reason
+  # stop_gracefully/1 above avoids it: `DirectPlaySession` does not trap exits,
+  # so a `:shutdown` kills it outright and its `terminate/2` never runs —
+  # leaving the `"playing"` `TranscodeJob` row in the queue UI forever and
+  # never broadcasting `:session_ended`, so the Now Playing card never clears.
+  # `GenServer.stop/2` is equally synchronous and does run `terminate/2`.
+  defp stop_tracking_session(pid) do
+    DirectPlaySession.stop(pid)
+  catch
+    # Died on its own between the registry lookup and this call (inactivity
+    # timeout). Its `terminate/2` has already run; nothing left to stop.
+    :exit, _reason -> :ok
   end
 
   @doc """

--- a/lib/mydia/streaming/stream_plan.ex
+++ b/lib/mydia/streaming/stream_plan.ex
@@ -16,14 +16,15 @@ defmodule Mydia.Streaming.StreamPlan do
   (`lib/mydia/settings/runtime_config.ex:172`). No database, no registry, no
   port, so a plan can be asserted directly in a unit test.
 
-  `for_hls/2` serves the HLS transcoder and may encode either stream. A
-  `for_remux/2` constructor for the fMP4 remuxer, where video is always
-  copied by definition and only audio may be converted, is planned for a
-  later task and does not exist yet.
+  `for_hls/2` serves the HLS transcoder and may encode either stream.
+  `for_remux/2` serves the fMP4 remuxer, where video is always copied by
+  definition and only audio may be converted.
   """
 
   alias Mydia.Library.Structs.StreamInfo
   alias Mydia.Streaming.AudioTrackSelector
+  alias Mydia.Streaming.Compatibility
+  alias Mydia.Streaming.DeviceProfile
   alias Mydia.Streaming.FfmpegHlsTranscoder
   alias Mydia.Streaming.HardwareAccel
   alias Mydia.Streaming.HardwareAccel.Args, as: AccelArgs
@@ -140,6 +141,67 @@ defmodule Mydia.Streaming.StreamPlan do
       accel: accel,
       selected_audio: selected_audio
     }
+  end
+
+  @doc """
+  The plan for an fMP4 remux, from the same opts `FfmpegRemuxer.build_ffmpeg_args/2` reads.
+
+  Video is always copied: that is what REMUX means, and the strategy is only
+  offered when the client already decodes the source. Audio is copied only when
+  the *mapped* stream is one the caller's device profile accepts, which is a
+  different question from `media_file.audio_codec`, the first stream, that the
+  candidate was chosen from.
+  """
+  @spec for_remux(Mydia.Library.MediaFile.t() | nil, keyword()) :: t()
+  def for_remux(media_file, opts) do
+    {from_width, from_height} = source_dimensions(media_file)
+    selected = AudioTrackSelector.select_for_playback(media_file, opts)
+
+    from_codec =
+      case selected do
+        %StreamInfo{codec: codec} when is_binary(codec) -> codec
+        _ -> media_file && media_file.audio_codec
+      end
+
+    action = if remux_audio_compatible?(selected, opts), do: :copy, else: :encode
+
+    %__MODULE__{
+      video: %Video{
+        action: :copy,
+        from_codec: media_file && media_file.codec,
+        to_codec: media_file && media_file.codec,
+        from_width: from_width,
+        from_height: from_height,
+        to_width: from_width,
+        to_height: from_height,
+        tier: nil
+      },
+      audio: %Audio{
+        action: action,
+        from_codec: from_codec,
+        to_codec: if(action == :copy, do: from_codec, else: @audio_target_codec),
+        language: selected && selected.language,
+        stream_index: selected && selected.index,
+        channels: selected && selected.channels
+      },
+      container: :fmp4,
+      max_bitrate_kbps: nil,
+      accel: nil,
+      selected_audio: selected
+    }
+  end
+
+  # No stream was selected, so no -map is emitted and ffmpeg's implicit
+  # selection stands. That is the pre-existing behaviour for an unanalysed
+  # file, and the codec the strategy was chosen from is the one it will pick,
+  # so a blanket copy is correct there.
+  defp remux_audio_compatible?(nil, _opts), do: true
+
+  defp remux_audio_compatible?(%StreamInfo{codec: codec}, opts) do
+    case Keyword.get(opts, :device_profile) do
+      nil -> Compatibility.compatible_audio_codec?(codec)
+      %DeviceProfile{} = profile -> Compatibility.compatible_audio_codec?(codec, profile)
+    end
   end
 
   @doc """

--- a/lib/mydia/streaming/stream_plan.ex
+++ b/lib/mydia/streaming/stream_plan.ex
@@ -113,7 +113,11 @@ defmodule Mydia.Streaming.StreamPlan do
             video_bitrate_kbps: video_bitrate_kbps(max_bitrate),
             crf: Keyword.get(opts, :crf, 23),
             preset: Keyword.get(opts, :preset, "medium"),
-            video_codec: "libx264"
+            # The caller's override, not a hardcoded literal: this branch is
+            # only reached when video_action is :encode, so an explicit
+            # "copy" never arrives here. Falling back to "libx264" reproduces
+            # the pre-StreamPlan default for the nil case.
+            video_codec: Keyword.get(opts, :video_codec) || "libx264"
           )
       end
 

--- a/lib/mydia/streaming/stream_plan.ex
+++ b/lib/mydia/streaming/stream_plan.ex
@@ -147,11 +147,12 @@ defmodule Mydia.Streaming.StreamPlan do
   `effective_max_height/1`, so the latter would turn every session on a
   configured server into an encode.
 
-  `max_height` here is the **already-effective** height, with the operator's
-  ceiling applied. `for_hls/2` and `FfmpegHlsTranscoder.reencodes_video?/3` each
-  apply `effective_max_height/1` before calling in. Applying it again here would
-  be harmless today (the function takes a minimum, so it is idempotent) but it
-  would hide which layer owns the ceiling.
+  `max_height` here must already be the **effective** height, with the
+  operator's `MAX_TRANSCODE_HEIGHT` ceiling folded in: this function does not
+  call `effective_max_height/1` itself and takes whatever it is given at face
+  value. `for_hls/2` applies `effective_max_height/1` before calling in; any
+  other caller must do the same, or a configured ceiling will silently stop
+  applying to this decision.
   """
   @spec encodes_video?(Mydia.Library.MediaFile.t() | nil, integer() | nil, integer() | nil) ::
           boolean()

--- a/lib/mydia/streaming/stream_plan.ex
+++ b/lib/mydia/streaming/stream_plan.ex
@@ -1,0 +1,326 @@
+defmodule Mydia.Streaming.StreamPlan do
+  @moduledoc """
+  What FFmpeg will actually do to a stream, decided once.
+
+  Before this existed, `FfmpegHlsTranscoder.build_ffmpeg_args/3` chose `copy`
+  or `libx264` from the bitrate cap while `streaming_resolver.ex` separately
+  mapped the client's strategy to `:copy` or `:transcode`, and the dashboard
+  displayed the resolver's answer. The two disagreed whenever a client asked
+  for `HLS_COPY` at a capped rung, which is exactly what the quality selector
+  does: the card showed a green "Direct Play" badge on a session re-encoding
+  HEVC to H.264 at 480p.
+
+  Everything here is a pure function of the media file and the request. The
+  only environmental read is the layered config behind `effective_max_height/1`,
+  and `Mydia.Config.get/0` resolves to `Application.get_env/3`
+  (`lib/mydia/settings/runtime_config.ex:172`). No database, no registry, no
+  port, so a plan can be asserted directly in a unit test.
+
+  `for_hls/2` serves the HLS transcoder and may encode either stream. A
+  `for_remux/2` constructor for the fMP4 remuxer, where video is always
+  copied by definition and only audio may be converted, is planned for a
+  later task and does not exist yet.
+  """
+
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Streaming.AudioTrackSelector
+  alias Mydia.Streaming.FfmpegHlsTranscoder
+  alias Mydia.Streaming.HardwareAccel
+  alias Mydia.Streaming.HardwareAccel.Args, as: AccelArgs
+
+  # Kept in step with FfmpegHlsTranscoder's own audio budget. Only used to
+  # report the audio target, never to build arguments.
+  @audio_target_codec "aac"
+
+  defmodule Video do
+    @moduledoc "The video stream's fate."
+
+    defstruct [
+      :action,
+      :from_codec,
+      :to_codec,
+      :from_width,
+      :from_height,
+      :to_width,
+      :to_height,
+      :tier
+    ]
+
+    @type t :: %__MODULE__{
+            action: :copy | :encode,
+            from_codec: String.t() | nil,
+            to_codec: String.t() | nil,
+            from_width: integer() | nil,
+            from_height: integer() | nil,
+            to_width: integer() | nil,
+            to_height: integer() | nil,
+            tier: AccelArgs.tier() | nil
+          }
+  end
+
+  defmodule Audio do
+    @moduledoc "The audio stream's fate, for the stream actually mapped."
+
+    defstruct [:action, :from_codec, :to_codec, :language, :stream_index, :channels]
+
+    @type t :: %__MODULE__{
+            action: :copy | :encode,
+            from_codec: String.t() | nil,
+            to_codec: String.t() | nil,
+            language: String.t() | nil,
+            stream_index: integer() | nil,
+            channels: integer() | nil
+          }
+  end
+
+  defstruct [:video, :audio, :container, :max_bitrate_kbps, :accel, :selected_audio]
+
+  @type t :: %__MODULE__{
+          video: Video.t() | nil,
+          audio: Audio.t() | nil,
+          container: :hls_ts | :fmp4,
+          max_bitrate_kbps: integer() | nil,
+          accel: AccelArgs.t() | nil,
+          selected_audio: StreamInfo.t() | nil
+        }
+
+  @doc """
+  The plan for an HLS session, from the same opts `build_ffmpeg_args/3` reads.
+  """
+  @spec for_hls(Mydia.Library.MediaFile.t() | nil, keyword()) :: t()
+  def for_hls(media_file, opts) do
+    max_bitrate = Keyword.get(opts, :max_bitrate)
+    max_height = FfmpegHlsTranscoder.effective_max_height(Keyword.get(opts, :max_height))
+
+    video_action = hls_video_action(media_file, opts, max_bitrate, max_height)
+    {from_width, from_height} = source_dimensions(media_file)
+
+    {to_width, to_height} =
+      output_dimensions(video_action, from_width, from_height, max_height)
+
+    accel =
+      case video_action do
+        :copy ->
+          nil
+
+        :encode ->
+          capabilities =
+            Keyword.get_lazy(opts, :capabilities, fn -> HardwareAccel.capabilities() end)
+
+          AccelArgs.build(capabilities,
+            source_codec: media_file && media_file.codec,
+            max_height: max_height,
+            video_bitrate_kbps: video_bitrate_kbps(max_bitrate),
+            crf: Keyword.get(opts, :crf, 23),
+            preset: Keyword.get(opts, :preset, "medium"),
+            video_codec: "libx264"
+          )
+      end
+
+    {audio, selected_audio} = hls_audio(media_file, opts)
+
+    %__MODULE__{
+      video: %Video{
+        action: video_action,
+        from_codec: media_file && media_file.codec,
+        to_codec: if(video_action == :copy, do: media_file && media_file.codec, else: "h264"),
+        from_width: from_width,
+        from_height: from_height,
+        to_width: to_width,
+        to_height: to_height,
+        tier: accel && accel.tier
+      },
+      audio: audio,
+      container: :hls_ts,
+      max_bitrate_kbps: max_bitrate,
+      accel: accel,
+      selected_audio: selected_audio
+    }
+  end
+
+  @doc """
+  Whether the video stream will be re-encoded rather than copied.
+
+  Height-aware, unlike the `reencodes_video?/2` it replaces. The height test is
+  "does this actually reduce the source", not "is a height set": the operator's
+  `MAX_TRANSCODE_HEIGHT` ceiling is folded into every request by
+  `effective_max_height/1`, so the latter would turn every session on a
+  configured server into an encode.
+
+  `max_height` here is the **already-effective** height, with the operator's
+  ceiling applied. `for_hls/2` and `FfmpegHlsTranscoder.reencodes_video?/3` each
+  apply `effective_max_height/1` before calling in. Applying it again here would
+  be harmless today (the function takes a minimum, so it is idempotent) but it
+  would hide which layer owns the ceiling.
+  """
+  @spec encodes_video?(Mydia.Library.MediaFile.t() | nil, integer() | nil, integer() | nil) ::
+          boolean()
+  def encodes_video?(media_file, max_bitrate, max_height) do
+    cond do
+      not is_nil(max_bitrate) -> true
+      transcode_policy() != :copy_when_compatible -> true
+      is_nil(media_file) -> true
+      downscaling?(media_file, max_height) -> true
+      true -> not copyable_video_codec?(media_file.codec)
+    end
+  end
+
+  @doc """
+  The source's pixel dimensions, `{width, height}`, either element possibly nil.
+
+  Reads `metadata.streams` first, per `lib/mydia/streaming/README.md`: the flat
+  `FileMetadata` fields are a fallback for rows written before per-stream
+  capture, and some rows have neither.
+  """
+  @spec source_dimensions(Mydia.Library.MediaFile.t() | nil) ::
+          {integer() | nil, integer() | nil}
+  def source_dimensions(nil), do: {nil, nil}
+
+  def source_dimensions(%{metadata: nil}), do: {nil, nil}
+
+  def source_dimensions(%{metadata: metadata}) do
+    case video_stream(metadata) do
+      %StreamInfo{width: w, height: h} when is_integer(w) and is_integer(h) -> {w, h}
+      _ -> {metadata.width, metadata.height}
+    end
+  end
+
+  @doc "H.264 is the only video codec every target can decode untouched."
+  @spec copyable_video_codec?(String.t() | nil) :: boolean()
+  def copyable_video_codec?(nil), do: false
+
+  def copyable_video_codec?(codec) when is_binary(codec) do
+    String.downcase(codec) in ["h264", "avc", "avc1"]
+  end
+
+  @doc "AAC is the only audio codec every browser can decode untouched."
+  @spec copyable_audio_codec?(String.t() | nil) :: boolean()
+  def copyable_audio_codec?(nil), do: false
+
+  def copyable_audio_codec?(codec) when is_binary(codec) do
+    String.downcase(codec) in ["aac", "mp4a"]
+  end
+
+  ## Internals
+
+  defp hls_video_action(media_file, opts, max_bitrate, max_height) do
+    case Keyword.get(opts, :video_codec) do
+      "copy" -> :copy
+      nil -> if encodes_video?(media_file, max_bitrate, max_height), do: :encode, else: :copy
+      _explicit -> :encode
+    end
+  end
+
+  defp hls_audio(media_file, opts) do
+    selected = AudioTrackSelector.select_for_playback(media_file, opts)
+
+    from_codec =
+      case selected do
+        %StreamInfo{codec: codec} when is_binary(codec) -> codec
+        _ -> media_file && media_file.audio_codec
+      end
+
+    action =
+      case Keyword.get(opts, :audio_codec) do
+        "copy" ->
+          :copy
+
+        nil ->
+          if not is_nil(media_file) and transcode_policy() == :copy_when_compatible and
+               copyable_audio_codec?(from_codec) do
+            :copy
+          else
+            :encode
+          end
+
+        _explicit ->
+          :encode
+      end
+
+    audio = %Audio{
+      action: action,
+      from_codec: from_codec,
+      to_codec: if(action == :copy, do: from_codec, else: @audio_target_codec),
+      language: selected && selected.language,
+      stream_index: selected && selected.index,
+      channels: selected && selected.channels
+    }
+
+    {audio, selected}
+  end
+
+  # Mirrors FfmpegHlsTranscoder.reencodes_video?/2 and build_ffmpeg_args/3,
+  # which each read this flat key independently rather than through the
+  # layered Mydia.Config; see config/config.exs's :mydia, :streaming default.
+  defp transcode_policy do
+    Application.get_env(:mydia, :streaming, [])
+    |> Keyword.get(:transcode_policy, :copy_when_compatible)
+  end
+
+  defp video_stream(%{streams: streams}) when is_list(streams) do
+    Enum.find(streams, fn
+      %StreamInfo{type: :video} -> true
+      _ -> false
+    end)
+  end
+
+  defp video_stream(_metadata), do: nil
+
+  defp downscaling?(_media_file, nil), do: false
+
+  defp downscaling?(media_file, height) do
+    case source_dimensions(media_file) do
+      {_width, source_height} when is_integer(source_height) -> height < source_height
+      _ -> false
+    end
+  end
+
+  # A copy never changes geometry. An encode is bounded by the requested
+  # ceiling, and the scale filter rounds the height down to even
+  # (2*trunc(min(h,ih)/2), mirrored by `even_floor/1`) and derives width from
+  # the aspect ratio via `-2`, so reporting the requested number verbatim
+  # would name a resolution FFmpeg never wrote.
+  defp output_dimensions(:copy, from_width, from_height, _max_height) do
+    {from_width, from_height}
+  end
+
+  defp output_dimensions(:encode, from_width, from_height, max_height) do
+    cond do
+      is_nil(from_height) ->
+        {from_width, nil}
+
+      is_nil(max_height) or max_height >= from_height ->
+        {from_width, even_floor(from_height)}
+
+      true ->
+        height = even_floor(max_height)
+        {scaled_width(from_width, from_height, height), height}
+    end
+  end
+
+  defp scaled_width(nil, _from_height, _height), do: nil
+
+  defp scaled_width(from_width, from_height, height) do
+    round_even(from_width * height / from_height)
+  end
+
+  # Floors to the nearest even integer, matching AccelArgs.height_expression/1's
+  # `2*trunc(min(h,ih)/2)`: that is the actual filter FFmpeg runs, so the
+  # reported height must match it exactly rather than merely approximate it.
+  defp even_floor(value) when is_integer(value), do: 2 * div(value, 2)
+
+  # Rounds to the nearest even integer. There is no FFmpeg expression to
+  # mirror here: the `-2` scale parameter computes the output width live from
+  # whatever height the filter lands on, so this is only ever an estimate for
+  # the dashboard. Flooring (as `even_floor/1` does for height, where FFmpeg's
+  # own truncating expression must be matched exactly) would round every
+  # fractional pixel down and habitually undershoot the true output width.
+  defp round_even(value) do
+    2 * round(value / 2)
+  end
+
+  # Mirrors FfmpegHlsTranscoder's ABR split: the audio budget comes out of the
+  # total cap before the video encoder sees it.
+  defp video_bitrate_kbps(nil), do: nil
+  defp video_bitrate_kbps(max_bitrate), do: max(max_bitrate - 128, 100)
+end

--- a/lib/mydia/streaming/stream_plan.ex
+++ b/lib/mydia/streaming/stream_plan.ex
@@ -156,13 +156,7 @@ defmodule Mydia.Streaming.StreamPlan do
   def for_remux(media_file, opts) do
     {from_width, from_height} = source_dimensions(media_file)
     selected = AudioTrackSelector.select_for_playback(media_file, opts)
-
-    from_codec =
-      case selected do
-        %StreamInfo{codec: codec} when is_binary(codec) -> codec
-        _ -> media_file && media_file.audio_codec
-      end
-
+    from_codec = mapped_audio_codec(media_file, selected)
     action = if remux_audio_compatible?(selected, opts), do: :copy, else: :encode
 
     %__MODULE__{
@@ -176,14 +170,7 @@ defmodule Mydia.Streaming.StreamPlan do
         to_height: from_height,
         tier: nil
       },
-      audio: %Audio{
-        action: action,
-        from_codec: from_codec,
-        to_codec: if(action == :copy, do: from_codec, else: @audio_target_codec),
-        language: selected && selected.language,
-        stream_index: selected && selected.index,
-        channels: selected && selected.channels
-      },
+      audio: build_audio(from_codec, selected, action),
       container: :fmp4,
       max_bitrate_kbps: nil,
       accel: nil,
@@ -280,12 +267,7 @@ defmodule Mydia.Streaming.StreamPlan do
 
   defp hls_audio(media_file, opts) do
     selected = AudioTrackSelector.select_for_playback(media_file, opts)
-
-    from_codec =
-      case selected do
-        %StreamInfo{codec: codec} when is_binary(codec) -> codec
-        _ -> media_file && media_file.audio_codec
-      end
+    from_codec = mapped_audio_codec(media_file, selected)
 
     action =
       case Keyword.get(opts, :audio_codec) do
@@ -304,7 +286,26 @@ defmodule Mydia.Streaming.StreamPlan do
           :encode
       end
 
-    audio = %Audio{
+    {build_audio(from_codec, selected, action), selected}
+  end
+
+  # The mapped stream's codec, or `media_file.audio_codec` (the *first*
+  # audio stream, the one that chose the candidate strategy) when nothing
+  # was selected: no analysed streams at all, or no match among them. Shared
+  # by for_hls/2 and for_remux/2 so the fallback rule cannot drift between
+  # the two ffmpeg paths.
+  defp mapped_audio_codec(media_file, selected) do
+    case selected do
+      %StreamInfo{codec: codec} when is_binary(codec) -> codec
+      _ -> media_file && media_file.audio_codec
+    end
+  end
+
+  # The reported Audio struct for the stream actually mapped. Shared by
+  # for_hls/2 and for_remux/2, which only disagree on how `action` itself is
+  # decided; from_codec must already be `mapped_audio_codec/2`'s answer.
+  defp build_audio(from_codec, selected, action) do
+    %Audio{
       action: action,
       from_codec: from_codec,
       to_codec: if(action == :copy, do: from_codec, else: @audio_target_codec),
@@ -312,8 +313,6 @@ defmodule Mydia.Streaming.StreamPlan do
       stream_index: selected && selected.index,
       channels: selected && selected.channels
     }
-
-    {audio, selected}
   end
 
   # Mirrors FfmpegHlsTranscoder.reencodes_video?/2 and build_ffmpeg_args/3,

--- a/lib/mydia_web/controllers/api/stream_controller.ex
+++ b/lib/mydia_web/controllers/api/stream_controller.ex
@@ -533,22 +533,22 @@ defmodule MydiaWeb.Api.StreamController do
     # immediately opens another, and tearing the session down here would churn
     # out a second card and a second job row for one viewer. The session's own
     # inactivity timeout reaps it, fed by the :on_activity heartbeat below.
-    remux_session =
+    {remux_session, remux_status} =
       case get_user_id(conn) do
         {:ok, user_id} ->
           plan = StreamPlan.for_remux(media_file, remux_opts)
 
           case HlsSessionSupervisor.start_remux_session(media_file.id, user_id, plan) do
-            {:ok, pid, _status} ->
-              pid
+            {:ok, pid, status} ->
+              {pid, status}
 
             error ->
               Logger.warning("Failed to start remux session tracker: #{inspect(error)}")
-              nil
+              {nil, nil}
           end
 
         _ ->
-          nil
+          {nil, nil}
       end
 
     case FfmpegRemuxer.start_remux(file_path, remux_opts) do
@@ -559,6 +559,7 @@ defmodule MydiaWeb.Api.StreamController do
         )
 
       {:error, :ffmpeg_not_found} ->
+        discard_unused_remux_session(remux_session, remux_status)
         Logger.error("FFmpeg not found on system, cannot remux #{file_path}")
 
         conn
@@ -566,6 +567,7 @@ defmodule MydiaWeb.Api.StreamController do
         |> json(%{error: "Streaming not available", details: "FFmpeg is not installed"})
 
       {:error, reason} ->
+        discard_unused_remux_session(remux_session, remux_status)
         Logger.error("Failed to start remux for #{file_path}: #{inspect(reason)}")
 
         conn
@@ -573,6 +575,27 @@ defmodule MydiaWeb.Api.StreamController do
         |> json(%{error: "Failed to start streaming"})
     end
   end
+
+  # FFmpeg never started, so no bytes will ever flow and no `:on_activity`
+  # heartbeat will arrive: the tracker would sit in Now Playing as a phantom
+  # viewer, holding a `"playing"` job row, until its ten-minute inactivity
+  # timeout expired.
+  #
+  # Only `:started` is torn down. An `:existing` session belongs to another
+  # in-flight request that is streaming perfectly well — stopping it would
+  # delete that viewer's job row and clear their card out from under them.
+  # This is why the status is threaded down here rather than discarded.
+  #
+  # Note this does not contradict the "never stop on the way out" rule above:
+  # that rule is about a *successful* stream whose request ends, where a seek
+  # will reopen immediately. Here there is no stream to come back to.
+  defp discard_unused_remux_session(pid, :started) when is_pid(pid) do
+    DirectPlaySession.stop(pid)
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp discard_unused_remux_session(_pid, _status), do: :ok
 
   # Get duration for remuxing - try metadata first, then probe fresh
   defp get_duration_for_remux(media_file, file_path) do

--- a/lib/mydia_web/controllers/api/stream_controller.ex
+++ b/lib/mydia_web/controllers/api/stream_controller.ex
@@ -16,7 +16,8 @@ defmodule MydiaWeb.Api.StreamController do
     FfmpegRemuxer,
     HlsSession,
     HlsSessionSupervisor,
-    DirectPlaySession
+    DirectPlaySession,
+    StreamPlan
   }
 
   alias MydiaWeb.Api.RangeHelper
@@ -527,10 +528,35 @@ defmodule MydiaWeb.Api.StreamController do
           _ -> []
         end
 
+    # Tracked so a remuxing viewer appears in Now Playing at all. Deliberately
+    # never stopped on the way out: a browser seek aborts this request and
+    # immediately opens another, and tearing the session down here would churn
+    # out a second card and a second job row for one viewer. The session's own
+    # inactivity timeout reaps it, fed by the :on_activity heartbeat below.
+    remux_session =
+      case get_user_id(conn) do
+        {:ok, user_id} ->
+          plan = StreamPlan.for_remux(media_file, remux_opts)
+
+          case HlsSessionSupervisor.start_remux_session(media_file.id, user_id, plan) do
+            {:ok, pid, _status} ->
+              pid
+
+            error ->
+              Logger.warning("Failed to start remux session tracker: #{inspect(error)}")
+              nil
+          end
+
+        _ ->
+          nil
+      end
+
     case FfmpegRemuxer.start_remux(file_path, remux_opts) do
       {:ok, port, os_pid} ->
         # Stream the remuxed content to the client
-        FfmpegRemuxer.stream_to_conn(conn, port, os_pid)
+        FfmpegRemuxer.stream_to_conn(conn, port, os_pid,
+          on_activity: fn -> if remux_session, do: DirectPlaySession.heartbeat(remux_session) end
+        )
 
       {:error, :ffmpeg_not_found} ->
         Logger.error("FFmpeg not found on system, cannot remux #{file_path}")

--- a/lib/mydia_web/live/admin_dashboard_live/components.ex
+++ b/lib/mydia_web/live/admin_dashboard_live/components.ex
@@ -225,10 +225,11 @@ defmodule MydiaWeb.AdminDashboardLive.Components do
       |> assign(:username, user_label(session.user))
       |> assign(:progress_pct, progress_pct)
       |> assign(:mbps, mbps)
-      |> assign(
-        :mode_label,
-        if(session.mode == :transcode, do: "Transcode", else: "Direct Play")
-      )
+      |> assign(:mode_label, mode_label(session.plan))
+      |> assign(:mode_class, mode_class(session.plan))
+      |> assign(:video_line, video_line(session.plan))
+      |> assign(:resolution_line, resolution_line(session.plan))
+      |> assign(:audio_line, audio_line(session.plan))
 
     ~H"""
     <div
@@ -262,10 +263,7 @@ defmodule MydiaWeb.AdminDashboardLive.Components do
             <div class="text-xs opacity-60 truncate">{@username}</div>
           </div>
           <div class="flex flex-col items-end gap-1">
-            <span class={[
-              "badge badge-xs badge-outline",
-              if(@session.mode == :transcode, do: "badge-warning", else: "badge-success")
-            ]}>
+            <span class={["badge badge-xs badge-outline", @mode_class]}>
               {@mode_label}
             </span>
             <%= if @mbps do %>
@@ -284,6 +282,20 @@ defmodule MydiaWeb.AdminDashboardLive.Components do
             <span>{format_clock(@session.duration_seconds)}</span>
           </div>
         <% end %>
+        <div
+          :if={@video_line || @resolution_line || @audio_line}
+          class="text-xs font-mono opacity-60 space-y-0.5"
+        >
+          <div :if={@video_line} id={"now-playing-video-#{@session.media_file_id}"}>
+            <span class="opacity-60">Video</span> {@video_line}
+          </div>
+          <div :if={@resolution_line} id={"now-playing-resolution-#{@session.media_file_id}"}>
+            <span class="opacity-60">Res</span> {@resolution_line}
+          </div>
+          <div :if={@audio_line} id={"now-playing-audio-#{@session.media_file_id}"}>
+            <span class="opacity-60">Audio</span> {@audio_line}
+          </div>
+        </div>
       </div>
     </div>
     """
@@ -473,6 +485,58 @@ defmodule MydiaWeb.AdminDashboardLive.Components do
         if path, do: Path.basename(path), else: "Unknown"
     end
   end
+
+  # The badge follows the VIDEO action, not "either stream encodes". A
+  # video-copy stream that converts audio is a remux, and calling that a
+  # transcode would have an operator hunting for CPU load that is not there.
+  defp mode_label(nil), do: "Direct Play"
+  defp mode_label(%{video: %{action: :copy}}), do: "Remux"
+  defp mode_label(_plan), do: "Transcode"
+
+  defp mode_class(nil), do: "badge-success"
+  defp mode_class(%{video: %{action: :copy}}), do: "badge-info"
+  defp mode_class(_plan), do: "badge-warning"
+
+  defp video_line(nil), do: nil
+
+  defp video_line(%{video: %{action: :copy, from_codec: codec}}) when is_binary(codec) do
+    "#{codec} (copy)"
+  end
+
+  defp video_line(%{video: %{action: :encode} = video}) do
+    tier = tier_label(video.tier)
+    base = "#{video.from_codec || "unknown"} -> #{video.to_codec}"
+    if tier, do: "#{base} (#{tier})", else: base
+  end
+
+  defp video_line(_plan), do: nil
+
+  defp tier_label(:full_hardware), do: "VAAPI"
+  defp tier_label(:hybrid), do: "hybrid"
+  defp tier_label(:software), do: "software"
+  defp tier_label(_other), do: nil
+
+  # Omitted rather than guessed when the source dimensions are unknown, which
+  # is roughly 2% of the production library.
+  defp resolution_line(%{video: %{from_width: fw, from_height: fh, to_width: tw, to_height: th}})
+       when is_integer(fw) and is_integer(fh) and is_integer(tw) and is_integer(th) do
+    if {fw, fh} == {tw, th} do
+      "#{fw}x#{fh}"
+    else
+      "#{fw}x#{fh} -> #{tw}x#{th}"
+    end
+  end
+
+  defp resolution_line(_plan), do: nil
+
+  defp audio_line(nil), do: nil
+
+  defp audio_line(%{audio: %{action: action, from_codec: from, to_codec: to} = audio}) do
+    codecs = if action == :copy, do: "#{from} (copy)", else: "#{from || "unknown"} -> #{to}"
+    if audio.language, do: "#{codecs} - #{audio.language}", else: codecs
+  end
+
+  defp audio_line(_plan), do: nil
 
   defp user_label(nil), do: "Unknown"
   defp user_label(%{username: username}) when is_binary(username) and username != "", do: username

--- a/lib/mydia_web/live/admin_dashboard_live/index.ex
+++ b/lib/mydia_web/live/admin_dashboard_live/index.ex
@@ -54,6 +54,9 @@ defmodule MydiaWeb.AdminDashboardLive.Index do
   def handle_info(:session_ended, socket), do: {:noreply, load_now_playing(socket)}
   def handle_info({:job_updated, _id}, socket), do: {:noreply, load_now_playing(socket)}
 
+  def handle_info({:session_updated, _session_id}, socket),
+    do: {:noreply, load_now_playing(socket)}
+
   # The transcodes and hls_sessions topics carry messages this page does not
   # act on. Ignore them rather than crashing the LiveView.
   def handle_info(_message, socket), do: {:noreply, socket}

--- a/test/mydia/streaming/ffmpeg_remuxer_activity_test.exs
+++ b/test/mydia/streaming/ffmpeg_remuxer_activity_test.exs
@@ -1,0 +1,34 @@
+defmodule Mydia.Streaming.FfmpegRemuxerActivityTest do
+  @moduledoc """
+  A remux is one long-lived request, so without a periodic signal the session's
+  ten-minute inactivity timeout reaps a viewer who is still watching. The
+  throttle matters as much as the callback: firing per 64KB chunk would cast a
+  message thousands of times a minute.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Streaming.FfmpegRemuxer
+
+  describe "throttle_activity/2" do
+    test "fires on the first call" do
+      {fired?, _last} = FfmpegRemuxer.throttle_activity(nil, 1_000)
+
+      assert fired?
+    end
+
+    test "does not fire again inside the interval" do
+      {true, last} = FfmpegRemuxer.throttle_activity(nil, 1_000)
+      {fired?, ^last} = FfmpegRemuxer.throttle_activity(last, last + 5)
+
+      refute fired?
+    end
+
+    test "fires again once the interval has elapsed" do
+      {true, last} = FfmpegRemuxer.throttle_activity(nil, 1_000)
+      now = last + 30_001
+      {fired?, ^now} = FfmpegRemuxer.throttle_activity(last, now)
+
+      assert fired?
+    end
+  end
+end

--- a/test/mydia/streaming/ffmpeg_scale_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_test.exs
@@ -101,5 +101,57 @@ defmodule Mydia.Streaming.FfmpegScaleTest do
       assert List.last(args(video_codec: "libx264", max_height: 720)) ==
                "/tmp/out/index.m3u8"
     end
+
+    test "a height-only request re-encodes instead of stream-copying" do
+      # The old reencodes_video?/2 ignored max_height, so asking a compatible
+      # H.264 source for 480p emitted "-c:v copy" and shipped the file at full
+      # resolution. The scale filter cannot run on a copied stream, so the
+      # downscale was silently dropped. No player rung reaches this today
+      # (each carries a bitrate) but the GraphQL mutation accepts it directly.
+      media_file = %Mydia.Library.MediaFile{
+        codec: "h264",
+        audio_codec: "aac",
+        relative_path: "film.mkv",
+        library_path: %Mydia.Settings.LibraryPath{path: "/tmp"},
+        metadata: %Mydia.Library.Structs.FileMetadata{width: 1920, height: 1080}
+      }
+
+      result =
+        args(
+          media_file: media_file,
+          max_height: 480,
+          capabilities: Mydia.Streaming.HardwareAccel.Capabilities.software("test")
+        )
+
+      # Not `refute "copy" in result`: this media_file's audio_codec is "aac",
+      # a browser-compatible codec, so the audio stream legitimately copies
+      # ("-c:a copy") regardless of this fix. The behaviour under test is
+      # specifically the video codec no longer being "copy".
+      assert Enum.at(result, index_of(result, "-c:v") + 1) == "libx264"
+      assert filter(result) == "scale=-2:2*trunc(min(480\\,ih)/2)"
+    end
+
+    test "a height at or above the source still stream-copies" do
+      # The MAX_TRANSCODE_HEIGHT trap: effective_max_height/1 folds the
+      # operator's ceiling into every request, so treating "a height is set"
+      # as an encode would transcode a 720p file under a 1080p ceiling.
+      media_file = %Mydia.Library.MediaFile{
+        codec: "h264",
+        audio_codec: "aac",
+        relative_path: "film.mkv",
+        library_path: %Mydia.Settings.LibraryPath{path: "/tmp"},
+        metadata: %Mydia.Library.Structs.FileMetadata{width: 1280, height: 720}
+      }
+
+      result =
+        args(
+          media_file: media_file,
+          max_height: 1080,
+          capabilities: Mydia.Streaming.HardwareAccel.Capabilities.software("test")
+        )
+
+      assert "-c:v" in result
+      assert Enum.at(result, index_of(result, "-c:v") + 1) == "copy"
+    end
   end
 end

--- a/test/mydia/streaming/ffmpeg_scale_test.exs
+++ b/test/mydia/streaming/ffmpeg_scale_test.exs
@@ -153,5 +153,17 @@ defmodule Mydia.Streaming.FfmpegScaleTest do
       assert "-c:v" in result
       assert Enum.at(result, index_of(result, "-c:v") + 1) == "copy"
     end
+
+    test "an explicit non-default codec reaches -c:v, not the plan's own libx264 default" do
+      # StreamPlan.for_hls/2 builds its accel's video args by calling
+      # AccelArgs.build/2 with a video_codec of its own -- previously a
+      # hardcoded "libx264" regardless of what the caller asked for. Since
+      # build_ffmpeg_args/3 takes video_args straight from accel.video on the
+      # encode path, an explicit override that isn't "libx264" or "copy" was
+      # silently discarded: the emitted -c:v was "libx264" no matter what.
+      result = args(video_codec: "libx265")
+
+      assert Enum.at(result, index_of(result, "-c:v") + 1) == "libx265"
+    end
   end
 end

--- a/test/mydia/streaming/hls_session_hwaccel_lease_test.exs
+++ b/test/mydia/streaming/hls_session_hwaccel_lease_test.exs
@@ -11,7 +11,7 @@ defmodule Mydia.Streaming.HlsSessionHwaccelLeaseTest do
   why: the transcoder is restarted on every seek, and a per-transcoder lease
   would churn HardwareAccel on every one of them). That means the meaningful
   units to test are: the gating decision
-  (`maybe_acquire_hwaccel_lease/2`, whether a session bothers leasing at
+  (`maybe_acquire_hwaccel_lease/3`, whether a session bothers leasing at
   all), the "not running" fallback shape (`acquire_hwaccel_lease/0`, which
   `mix test` always exercises since `HardwareAccel` is never started in this
   suite), and the two release sites (`hwaccel_fallback/2` and `terminate/2`).
@@ -53,7 +53,7 @@ defmodule Mydia.Streaming.HlsSessionHwaccelLeaseTest do
     end
 
     test "a bitrate cap forces a re-encode and therefore a lease attempt" do
-      # max_bitrate forces reencodes_video?/2 to true regardless of codec --
+      # max_bitrate forces reencodes_video?/3 to true regardless of codec --
       # even an already-compatible h264 source is transcoded to control the
       # output bitrate.
       assert {%Capabilities{backend: :none}, nil} =

--- a/test/mydia/streaming/hls_session_hwaccel_lease_test.exs
+++ b/test/mydia/streaming/hls_session_hwaccel_lease_test.exs
@@ -40,14 +40,14 @@ defmodule Mydia.Streaming.HlsSessionHwaccelLeaseTest do
     library_path: %LibraryPath{path: "/tmp"}
   }
 
-  describe "maybe_acquire_hwaccel_lease/2" do
+  describe "maybe_acquire_hwaccel_lease/3" do
     test "a session that will re-encode attempts a lease" do
       # HardwareAccel is never started under mix test (see
       # hardware_accel_test.exs), so this exercises the refusal branch: a
       # session that WOULD lease still gets software capabilities rather than
       # nil, so build_ffmpeg_args/3 never reaches for hardware it was refused.
       assert {%Capabilities{backend: :none, reason: reason}, nil} =
-               HlsSession.maybe_acquire_hwaccel_lease(@reencode_media_file, nil)
+               HlsSession.maybe_acquire_hwaccel_lease(@reencode_media_file, nil, nil)
 
       assert reason =~ "no hardware slot free"
     end
@@ -57,16 +57,16 @@ defmodule Mydia.Streaming.HlsSessionHwaccelLeaseTest do
       # even an already-compatible h264 source is transcoded to control the
       # output bitrate.
       assert {%Capabilities{backend: :none}, nil} =
-               HlsSession.maybe_acquire_hwaccel_lease(@copy_media_file, 2000)
+               HlsSession.maybe_acquire_hwaccel_lease(@copy_media_file, 2000, nil)
     end
 
     test "a stream-copy session never attempts a lease" do
-      assert {nil, nil} = HlsSession.maybe_acquire_hwaccel_lease(@copy_media_file, nil)
+      assert {nil, nil} = HlsSession.maybe_acquire_hwaccel_lease(@copy_media_file, nil, nil)
     end
 
     test "no media file (mode unknown) is treated as re-encoding, matching build_ffmpeg_args/3" do
       assert {%Capabilities{backend: :none}, nil} =
-               HlsSession.maybe_acquire_hwaccel_lease(nil, nil)
+               HlsSession.maybe_acquire_hwaccel_lease(nil, nil, nil)
     end
   end
 

--- a/test/mydia/streaming/hls_session_plan_test.exs
+++ b/test/mydia/streaming/hls_session_plan_test.exs
@@ -1,0 +1,49 @@
+defmodule Mydia.Streaming.HlsSessionPlanTest do
+  @moduledoc """
+  The session carries its plan so consumers do not re-derive it. A fallback to
+  software mid-session changes the plan, and a dashboard that never hears about
+  it keeps advertising hardware encoding that stopped happening.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Structs.FileMetadata
+  alias Mydia.Settings.LibraryPath
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+  alias Mydia.Streaming.HlsSession
+  alias Mydia.Streaming.StreamPlan
+
+  @media_file %MediaFile{
+    codec: "hevc",
+    audio_codec: "eac3",
+    relative_path: "film.mkv",
+    library_path: %LibraryPath{path: "/tmp"},
+    metadata: %FileMetadata{width: 1920, height: 1080}
+  }
+
+  describe "hwaccel_fallback/2" do
+    test "re-plans in software so the reported tier stops claiming hardware" do
+      backend_opts = [
+        max_bitrate: 1500,
+        max_height: 480,
+        media_file: @media_file,
+        capabilities: Capabilities.software("test")
+      ]
+
+      state = %HlsSession.State{
+        session_id: "session-1",
+        media_file: @media_file,
+        max_bitrate: 1500,
+        max_height: 480,
+        backend_opts: backend_opts,
+        accel_fallbacks: 0,
+        hwaccel_lease: nil,
+        plan: StreamPlan.for_hls(@media_file, backend_opts)
+      }
+
+      assert {:retry, retried} = HlsSession.hwaccel_fallback(state, 0)
+      assert retried.plan.video.tier == :software
+      assert retried.plan.video.action == :encode
+    end
+  end
+end

--- a/test/mydia/streaming/hls_session_plan_test.exs
+++ b/test/mydia/streaming/hls_session_plan_test.exs
@@ -62,7 +62,7 @@ defmodule Mydia.Streaming.HlsSessionPlanTest do
 
       assert :stop = HlsSession.hwaccel_fallback(state, 0)
 
-      refute_receive {:session_updated, _}, 50
+      refute_receive {:session_updated, "session-2"}, 50
     end
   end
 

--- a/test/mydia/streaming/hls_session_plan_test.exs
+++ b/test/mydia/streaming/hls_session_plan_test.exs
@@ -22,7 +22,7 @@ defmodule Mydia.Streaming.HlsSessionPlanTest do
   }
 
   describe "hwaccel_fallback/2" do
-    test "re-plans in software so the reported tier stops claiming hardware" do
+    test "re-plans in software so the reported tier stops claiming hardware, and announces it" do
       backend_opts = [
         max_bitrate: 1500,
         max_height: 480,
@@ -41,9 +41,56 @@ defmodule Mydia.Streaming.HlsSessionPlanTest do
         plan: StreamPlan.for_hls(@media_file, backend_opts)
       }
 
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "hls_sessions")
+
       assert {:retry, retried} = HlsSession.hwaccel_fallback(state, 0)
       assert retried.plan.video.tier == :software
       assert retried.plan.video.action == :encode
+
+      # The dashboard's Now Playing reload hangs off this exact message; a
+      # plan that changed silently is the smaller copy of the bug this whole
+      # feature exists to fix.
+      assert_receive {:session_updated, "session-1"}
+    end
+
+    test "the terminal path (fallback already used) broadcasts nothing" do
+      # Only the session_id matters to the guard clause -- it returns :stop
+      # before touching backend_opts, media_file, or the plan.
+      state = %HlsSession.State{session_id: "session-2", accel_fallbacks: 1}
+
+      Phoenix.PubSub.subscribe(Mydia.PubSub, "hls_sessions")
+
+      assert :stop = HlsSession.hwaccel_fallback(state, 0)
+
+      refute_receive {:session_updated, _}, 50
+    end
+  end
+
+  describe "get_info/1" do
+    test "reports the session's plan" do
+      backend_opts = [
+        max_bitrate: 1500,
+        max_height: 480,
+        capabilities: Capabilities.software("test")
+      ]
+
+      plan = StreamPlan.for_hls(@media_file, backend_opts)
+
+      state = %HlsSession.State{
+        session_id: "session-3",
+        media_file: @media_file,
+        backend_opts: backend_opts,
+        plan: plan
+      }
+
+      {:reply, {:ok, info}, _state} =
+        HlsSession.handle_call(:get_info, {self(), make_ref()}, state)
+
+      # Full-struct equality, not merely "the key is present": a plan that
+      # got rebuilt, truncated, or swapped for another session's would fail
+      # this the same way a missing key would.
+      assert info.plan == plan
+      assert info.plan.video.tier == :software
     end
   end
 end

--- a/test/mydia/streaming/hls_session_segments_test.exs
+++ b/test/mydia/streaming/hls_session_segments_test.exs
@@ -52,29 +52,29 @@ defmodule Mydia.Streaming.HlsSessionSegmentsTest do
     end
   end
 
-  describe "grid_aligned?/3" do
+  describe "grid_aligned?/4" do
     # Nothing previously asserted what HlsSession actually passes for
     # FFmpeg's grid_aligned opt. Covering it directly here, rather than only
     # through hand-built %HlsSession.State{} fixtures elsewhere in this file
     # that could quietly encode the same mistake this guards against.
     test "is false for a :window session even when the video would be re-encoded" do
       media_file = %MediaFile{codec: "hevc"}
-      refute HlsSession.grid_aligned?(:window, media_file, nil)
+      refute HlsSession.grid_aligned?(:window, media_file, nil, nil)
     end
 
     test "is true for a :full session whose video is re-encoded" do
       media_file = %MediaFile{codec: "hevc"}
-      assert HlsSession.grid_aligned?(:full, media_file, nil)
+      assert HlsSession.grid_aligned?(:full, media_file, nil, nil)
     end
 
     test "is false for a :full session whose video is copied" do
       media_file = %MediaFile{codec: "h264"}
-      refute HlsSession.grid_aligned?(:full, media_file, nil)
+      refute HlsSession.grid_aligned?(:full, media_file, nil, nil)
     end
 
     test "is true for a :full session forced to transcode by a bitrate cap" do
       media_file = %MediaFile{codec: "h264"}
-      assert HlsSession.grid_aligned?(:full, media_file, 4000)
+      assert HlsSession.grid_aligned?(:full, media_file, 4000, nil)
     end
   end
 

--- a/test/mydia/streaming/list_active_sessions_test.exs
+++ b/test/mydia/streaming/list_active_sessions_test.exs
@@ -77,4 +77,38 @@ defmodule Mydia.Streaming.ListActiveSessionsTest do
       assert session.duration_seconds == 3389
     end
   end
+
+  describe "list_active_sessions/0 plans" do
+    test "a direct play session carries no plan" do
+      # nil is the honest encoding of "nothing is being done to this stream".
+      # A plan claiming two copies would imply FFmpeg is involved when it is not.
+      media_file = MediaFixtures.media_file_fixture(%{})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      session = start_direct_play(media_file, user)
+
+      assert session
+      assert session.plan == nil
+    end
+
+    test "a remux session carries its plan" do
+      media_file = MediaFixtures.media_file_fixture(%{})
+      user = Mydia.AccountsFixtures.user_fixture()
+      plan = Mydia.Streaming.StreamPlan.for_remux(media_file, [])
+
+      {:ok, _pid, :started} =
+        Mydia.Streaming.HlsSessionSupervisor.start_remux_session(media_file.id, user.id, plan)
+
+      on_exit(fn ->
+        Mydia.Streaming.HlsSessionSupervisor.stop_remux_session(media_file.id, user.id)
+      end)
+
+      session =
+        Enum.find(Streaming.list_active_sessions(), &(&1.media_file_id == media_file.id))
+
+      assert session
+      assert session.plan.container == :fmp4
+      assert session.plan.video.action == :copy
+    end
+  end
 end

--- a/test/mydia/streaming/remux_session_test.exs
+++ b/test/mydia/streaming/remux_session_test.exs
@@ -1,0 +1,75 @@
+defmodule Mydia.Streaming.RemuxSessionTest do
+  @moduledoc """
+  A remuxing viewer used to be invisible: stream_file_remux/3 opened a chunked
+  response and registered nothing, so Now Playing showed an empty dashboard
+  while FFmpeg repackaged a file.
+  """
+  use Mydia.DataCase, async: false
+
+  alias Mydia.MediaFixtures
+  alias Mydia.Streaming.DirectPlaySession
+  alias Mydia.Streaming.HlsSessionSupervisor
+  alias Mydia.Streaming.StreamPlan
+
+  defp plan_for(media_file), do: StreamPlan.for_remux(media_file, [])
+
+  describe "start_remux_session/3" do
+    test "registers a session carrying its plan" do
+      media_file = MediaFixtures.media_file_fixture(%{bitrate: 4_200_000})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      {:ok, pid, :started} =
+        HlsSessionSupervisor.start_remux_session(media_file.id, user.id, plan_for(media_file))
+
+      on_exit(fn -> HlsSessionSupervisor.stop_remux_session(media_file.id, user.id) end)
+
+      {:ok, info} = DirectPlaySession.get_info(pid)
+
+      assert info.kind == :remux
+      assert info.plan.container == :fmp4
+      assert info.plan.video.action == :copy
+    end
+
+    test "a second request reuses the running session" do
+      # A browser seek aborts the request and immediately opens another.
+      # Starting a fresh session there would churn out a second card and a
+      # second job row for one viewer.
+      media_file = MediaFixtures.media_file_fixture(%{})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      {:ok, first, :started} =
+        HlsSessionSupervisor.start_remux_session(media_file.id, user.id, plan_for(media_file))
+
+      {:ok, second, :existing} =
+        HlsSessionSupervisor.start_remux_session(media_file.id, user.id, plan_for(media_file))
+
+      on_exit(fn -> HlsSessionSupervisor.stop_remux_session(media_file.id, user.id) end)
+
+      assert first == second
+    end
+
+    test "a direct session for the same file and user is a separate session" do
+      # Different registry keys, so a viewer who direct-plays one file and
+      # remuxes another is two cards, not one overwriting the other.
+      media_file = MediaFixtures.media_file_fixture(%{})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      {:ok, remux, :started} =
+        HlsSessionSupervisor.start_remux_session(media_file.id, user.id, plan_for(media_file))
+
+      {:ok, direct, :started} =
+        HlsSessionSupervisor.start_direct_session(media_file.id, user.id)
+
+      on_exit(fn ->
+        HlsSessionSupervisor.stop_remux_session(media_file.id, user.id)
+        HlsSessionSupervisor.stop_direct_session(media_file.id, user.id)
+      end)
+
+      refute remux == direct
+
+      {:ok, direct_info} = DirectPlaySession.get_info(direct)
+      assert direct_info.kind == :direct
+      assert direct_info.plan == nil
+    end
+  end
+end

--- a/test/mydia/streaming/remux_session_test.exs
+++ b/test/mydia/streaming/remux_session_test.exs
@@ -71,5 +71,65 @@ defmodule Mydia.Streaming.RemuxSessionTest do
       assert direct_info.kind == :direct
       assert direct_info.plan == nil
     end
+
+    test "reusing the session refreshes its plan" do
+      # A seek reopens the stream, and the new request can resolve a different
+      # audio track. Keeping the plan the session started with would put the
+      # dashboard back to describing an encode that is not the one running,
+      # which is the whole defect this feature removes.
+      media_file = MediaFixtures.media_file_fixture(%{})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      first = plan_for(media_file)
+      second = %{first | audio: %{first.audio | from_codec: "eac3", action: :encode}}
+
+      {:ok, pid, :started} =
+        HlsSessionSupervisor.start_remux_session(media_file.id, user.id, first)
+
+      on_exit(fn -> HlsSessionSupervisor.stop_remux_session(media_file.id, user.id) end)
+
+      {:ok, ^pid, :existing} =
+        HlsSessionSupervisor.start_remux_session(media_file.id, user.id, second)
+
+      {:ok, info} = DirectPlaySession.get_info(pid)
+      assert info.plan.audio.action == :encode
+      assert info.plan.audio.from_codec == "eac3"
+
+      # The registry copy too: list_active_sessions/0 falls back to it when the
+      # process call races a shutdown, so refreshing only the process state
+      # would leave a path that still reports the stale plan.
+      [{^pid, meta}] =
+        Registry.lookup(
+          Mydia.Streaming.HlsSessionRegistry,
+          {:remux_session, media_file.id, user.id}
+        )
+
+      assert meta.plan.audio.action == :encode
+    end
+
+    test "stopping the session removes its playing job row" do
+      # DirectPlaySession does not trap exits, so stopping it through
+      # DynamicSupervisor.terminate_child/2 would skip terminate/2 and strand
+      # the "playing" TranscodeJob in the queue UI forever.
+      media_file = MediaFixtures.media_file_fixture(%{})
+      user = Mydia.AccountsFixtures.user_fixture()
+
+      {:ok, _pid, :started} =
+        HlsSessionSupervisor.start_remux_session(media_file.id, user.id, plan_for(media_file))
+
+      assert Mydia.Repo.exists?(
+               from(j in Mydia.Downloads.TranscodeJob,
+                 where: j.media_file_id == ^media_file.id and j.type == "remux"
+               )
+             )
+
+      :ok = HlsSessionSupervisor.stop_remux_session(media_file.id, user.id)
+
+      refute Mydia.Repo.exists?(
+               from(j in Mydia.Downloads.TranscodeJob,
+                 where: j.media_file_id == ^media_file.id and j.type == "remux"
+               )
+             )
+    end
   end
 end

--- a/test/mydia/streaming/stream_plan_test.exs
+++ b/test/mydia/streaming/stream_plan_test.exs
@@ -236,4 +236,68 @@ defmodule Mydia.Streaming.StreamPlanTest do
       refute StreamPlan.encodes_video?(file, nil, nil)
     end
   end
+
+  describe "for_remux/2" do
+    test "video is never encoded" do
+      # REMUX means repackaging. The strategy is only offered because the
+      # client can already decode the video, so touching it would be pure
+      # waste and would contradict the candidate the client accepted.
+      plan = StreamPlan.for_remux(media_file(codec: "hevc"), [])
+
+      assert plan.video.action == :copy
+      assert plan.video.from_codec == "hevc"
+      assert plan.video.to_codec == "hevc"
+      assert plan.container == :fmp4
+      assert plan.video.tier == nil
+      assert plan.accel == nil
+    end
+
+    test "a compatible mapped audio track is copied" do
+      # The mapped stream, not media_file.audio_codec, decides this: without an
+      # analysed audio stream select_for_playback/2 returns nil, and a nil
+      # selection always copies regardless of codec (see the next test), which
+      # would make this pass for the wrong reason.
+      file =
+        media_file(
+          audio_codec: "aac",
+          metadata: %FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: [%StreamInfo{index: 1, type: :audio, codec: "aac"}]
+          }
+        )
+
+      plan = StreamPlan.for_remux(file, [])
+
+      assert plan.audio.action == :copy
+    end
+
+    test "an incompatible mapped audio track is encoded to aac" do
+      # A blanket -c copy would put e.g. E-AC-3 into the fMP4 while the
+      # advertised MIME still said mp4a.40.2, so the browser plays silence.
+      file =
+        media_file(
+          audio_codec: "eac3",
+          metadata: %FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: [%StreamInfo{index: 1, type: :audio, codec: "eac3"}]
+          }
+        )
+
+      plan = StreamPlan.for_remux(file, [])
+
+      assert plan.audio.action == :encode
+      assert plan.audio.to_codec == "aac"
+    end
+
+    test "geometry is the source's, unchanged" do
+      plan = StreamPlan.for_remux(media_file(codec: "h264"), [])
+
+      assert plan.video.from_height == 1080
+      assert plan.video.to_height == 1080
+      assert plan.video.from_width == 1920
+      assert plan.video.to_width == 1920
+    end
+  end
 end

--- a/test/mydia/streaming/stream_plan_test.exs
+++ b/test/mydia/streaming/stream_plan_test.exs
@@ -1,0 +1,239 @@
+defmodule Mydia.Streaming.StreamPlanTest do
+  @moduledoc """
+  The plan is the single record of what FFmpeg will do to a stream. It exists
+  because two modules used to decide that independently: the transcoder chose
+  `copy` or `libx264` from the bitrate cap, while the GraphQL resolver chose
+  `:copy` or `:transcode` from the client's strategy, and the dashboard read
+  the resolver's answer. A 480p rung on an HLS_COPY strategy therefore showed
+  a green "Direct Play" badge while FFmpeg re-encoded HEVC to H.264.
+
+  These tests pin the decision itself, with no FFmpeg process and no database.
+  """
+  use ExUnit.Case, async: true
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Library.Structs.FileMetadata
+  alias Mydia.Library.Structs.StreamInfo
+  alias Mydia.Settings.LibraryPath
+  alias Mydia.Streaming.HardwareAccel.Capabilities
+  alias Mydia.Streaming.StreamPlan
+
+  defp media_file(attrs) do
+    base = %MediaFile{
+      relative_path: "film.mkv",
+      library_path: %LibraryPath{path: "/tmp"},
+      codec: "h264",
+      audio_codec: "aac",
+      metadata: %FileMetadata{width: 1920, height: 1080}
+    }
+
+    struct!(base, attrs)
+  end
+
+  defp software_opts(extra) do
+    Keyword.merge([capabilities: Capabilities.software("test")], extra)
+  end
+
+  describe "for_hls/2 video action" do
+    test "a compatible codec with no cap is copied" do
+      plan = StreamPlan.for_hls(media_file(codec: "h264"), software_opts([]))
+
+      assert plan.video.action == :copy
+      assert plan.video.from_codec == "h264"
+      assert plan.video.to_codec == "h264"
+      assert plan.container == :hls_ts
+    end
+
+    test "an incompatible codec is encoded to h264" do
+      plan = StreamPlan.for_hls(media_file(codec: "hevc"), software_opts([]))
+
+      assert plan.video.action == :encode
+      assert plan.video.from_codec == "hevc"
+      assert plan.video.to_codec == "h264"
+    end
+
+    test "a bitrate cap forces an encode even on a compatible codec" do
+      # This is the reported bug's exact shape: strategy HLS_COPY on an H.264
+      # source, plus the 480p rung's 1500kbps cap. FFmpeg re-encodes; the
+      # plan must say so.
+      plan = StreamPlan.for_hls(media_file(codec: "h264"), software_opts(max_bitrate: 1500))
+
+      assert plan.video.action == :encode
+      assert plan.max_bitrate_kbps == 1500
+    end
+
+    test "a genuine downscale forces an encode with no bitrate cap" do
+      # reencodes_video?/2 ignored max_height entirely, so a height-only
+      # request stream-copied at full resolution and silently dropped the
+      # downscale the caller asked for.
+      plan = StreamPlan.for_hls(media_file(codec: "h264"), software_opts(max_height: 480))
+
+      assert plan.video.action == :encode
+      assert plan.video.to_height == 480
+    end
+
+    test "a height at or above the source is not a downscale and stays a copy" do
+      # The trap this guards: effective_max_height/1 folds in the operator's
+      # MAX_TRANSCODE_HEIGHT ceiling, so "a height is set" is true for every
+      # session on a configured server. Only an actual reduction may force an
+      # encode, or a 720p file under a 1080p ceiling would start transcoding.
+      plan = StreamPlan.for_hls(media_file(codec: "h264"), software_opts(max_height: 1080))
+
+      assert plan.video.action == :copy
+    end
+
+    test "an unknown source height never forces an encode" do
+      # FFmpeg's own min(h, ih) clamp in height_expression/1 already makes the
+      # scale filter a no-op when the source is smaller, so guessing here
+      # would transcode files that need nothing.
+      file = media_file(codec: "h264", metadata: %FileMetadata{width: nil, height: nil})
+
+      plan = StreamPlan.for_hls(file, software_opts(max_height: 480))
+
+      assert plan.video.action == :copy
+    end
+
+    test "an explicit video_codec opt wins over the derived decision" do
+      plan =
+        StreamPlan.for_hls(media_file(codec: "hevc"), software_opts(video_codec: "copy"))
+
+      assert plan.video.action == :copy
+    end
+  end
+
+  describe "for_hls/2 output geometry" do
+    test "reports source and output dimensions for a downscale" do
+      file = media_file(codec: "hevc", metadata: %FileMetadata{width: 1920, height: 1080})
+
+      plan = StreamPlan.for_hls(file, software_opts(max_height: 480))
+
+      assert plan.video.from_width == 1920
+      assert plan.video.from_height == 1080
+      assert plan.video.to_width == 854
+      assert plan.video.to_height == 480
+    end
+
+    test "output height is rounded down to even, matching the scale expression" do
+      # AccelArgs.height_expression/1 emits 2*trunc(min(h,ih)/2), so an odd
+      # requested height produces an even output. Reporting the requested
+      # number would put a resolution on the dashboard FFmpeg never wrote.
+      file = media_file(codec: "hevc", metadata: %FileMetadata{width: 1920, height: 1080})
+
+      plan = StreamPlan.for_hls(file, software_opts(max_height: 481))
+
+      assert plan.video.to_height == 480
+    end
+
+    test "a copied stream reports the source dimensions as the output" do
+      plan = StreamPlan.for_hls(media_file(codec: "h264"), software_opts([]))
+
+      assert plan.video.to_height == 1080
+      assert plan.video.to_width == 1920
+    end
+
+    test "reads dimensions from metadata.streams in preference to the flat fields" do
+      # lib/mydia/streaming/README.md: metadata.streams is the populated
+      # source. The flat fields are a fallback for older rows.
+      file =
+        media_file(
+          codec: "h264",
+          metadata: %FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: [%StreamInfo{index: 0, type: :video, width: 3840, height: 2160}]
+          }
+        )
+
+      assert StreamPlan.source_dimensions(file) == {3840, 2160}
+    end
+
+    test "falls back to the flat metadata fields when streams are absent" do
+      file = media_file(codec: "h264", metadata: %FileMetadata{width: 1280, height: 720})
+
+      assert StreamPlan.source_dimensions(file) == {1280, 720}
+    end
+
+    test "reports nil dimensions when neither source has them" do
+      file = media_file(codec: "h264", metadata: %FileMetadata{})
+
+      assert StreamPlan.source_dimensions(file) == {nil, nil}
+    end
+  end
+
+  describe "for_hls/2 audio action" do
+    test "aac audio is copied" do
+      plan = StreamPlan.for_hls(media_file(audio_codec: "aac"), software_opts([]))
+
+      assert plan.audio.action == :copy
+      assert plan.audio.to_codec == "aac"
+    end
+
+    test "eac3 audio is encoded to aac" do
+      plan = StreamPlan.for_hls(media_file(audio_codec: "eac3"), software_opts([]))
+
+      assert plan.audio.action == :encode
+      assert plan.audio.from_codec == "eac3"
+      assert plan.audio.to_codec == "aac"
+    end
+
+    test "the decision follows the mapped stream, not the first one" do
+      # media_file.audio_codec describes the FIRST audio stream. When language
+      # selection maps a different one, deciding from the first would report
+      # "copy" while FFmpeg encodes, or the reverse.
+      file =
+        media_file(
+          audio_codec: "aac",
+          metadata: %FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: [
+              %StreamInfo{index: 1, type: :audio, codec: "aac", language: "jpn", channels: 2},
+              %StreamInfo{index: 2, type: :audio, codec: "eac3", language: "eng", channels: 6}
+            ]
+          }
+        )
+
+      plan = StreamPlan.for_hls(file, software_opts(audio_language: ["eng"]))
+
+      assert plan.audio.stream_index == 2
+      assert plan.audio.from_codec == "eac3"
+      assert plan.audio.action == :encode
+      assert plan.audio.language == "eng"
+      assert plan.audio.channels == 6
+    end
+
+    test "carries the raw selected stream so builders need not re-select" do
+      # The argument builders pass this straight to
+      # AudioTrackSelector.ffmpeg_map_args/1. Re-running select_for_playback/2
+      # there would repeat the plan's most expensive step and would let the
+      # -map arguments disagree with the audio decision beside them.
+      file =
+        media_file(
+          metadata: %FileMetadata{
+            width: 1920,
+            height: 1080,
+            streams: [
+              %StreamInfo{index: 1, type: :audio, codec: "eac3", language: "eng", channels: 6}
+            ]
+          }
+        )
+
+      plan = StreamPlan.for_hls(file, software_opts([]))
+
+      assert %StreamInfo{index: 1} = plan.selected_audio
+    end
+  end
+
+  describe "encodes_video?/3" do
+    test "a nil media file always encodes" do
+      assert StreamPlan.encodes_video?(nil, nil, nil)
+    end
+
+    test "agrees with the plan it backs" do
+      file = media_file(codec: "h264")
+
+      assert StreamPlan.encodes_video?(file, 1500, nil)
+      refute StreamPlan.encodes_video?(file, nil, nil)
+    end
+  end
+end

--- a/test/mydia/streaming/stream_plan_test.exs
+++ b/test/mydia/streaming/stream_plan_test.exs
@@ -255,8 +255,8 @@ defmodule Mydia.Streaming.StreamPlanTest do
     test "a compatible mapped audio track is copied" do
       # The mapped stream, not media_file.audio_codec, decides this: without an
       # analysed audio stream select_for_playback/2 returns nil, and a nil
-      # selection always copies regardless of codec (see the next test), which
-      # would make this pass for the wrong reason.
+      # selection always copies regardless of codec (see "no analysed audio
+      # stream copies" below), which would make this pass for the wrong reason.
       file =
         media_file(
           audio_codec: "aac",
@@ -289,6 +289,19 @@ defmodule Mydia.Streaming.StreamPlanTest do
 
       assert plan.audio.action == :encode
       assert plan.audio.to_codec == "aac"
+    end
+
+    test "no analysed audio stream copies, matching the pre-existing blanket -c copy" do
+      # media_file(audio_codec: "eac3") here has no metadata.streams, so
+      # select_for_playback/2 returns nil: no compatibility check is
+      # possible. The old remux_codec_args(nil, _device_profile) emitted a
+      # blanket "-c copy" for exactly this shape, regardless of
+      # media_file.audio_codec, and anything else here would change the
+      # arguments this refactor must leave untouched.
+      plan = StreamPlan.for_remux(media_file(audio_codec: "eac3"), [])
+
+      assert plan.selected_audio == nil
+      assert plan.audio.action == :copy
     end
 
     test "geometry is the source's, unchanged" do

--- a/test/mydia_web/live/admin_dashboard_live/components_test.exs
+++ b/test/mydia_web/live/admin_dashboard_live/components_test.exs
@@ -242,13 +242,148 @@ defmodule MydiaWeb.AdminDashboardLive.ComponentsTest do
 
     test "labels direct play and transcode distinctly" do
       direct =
-        render_component(&Components.now_playing_card/1, session: session(%{mode: :direct}))
+        render_component(&Components.now_playing_card/1, session: session(%{plan: nil}))
+
+      transcode_plan = %Mydia.Streaming.StreamPlan{
+        video: %Mydia.Streaming.StreamPlan.Video{
+          action: :encode,
+          from_codec: "h264",
+          to_codec: "h264"
+        },
+        audio: %Mydia.Streaming.StreamPlan.Audio{
+          action: :copy,
+          from_codec: "aac",
+          to_codec: "aac"
+        },
+        container: :hls_ts
+      }
 
       transcode =
-        render_component(&Components.now_playing_card/1, session: session(%{mode: :transcode}))
+        render_component(&Components.now_playing_card/1,
+          session: session(%{plan: transcode_plan})
+        )
 
       assert direct =~ "Direct Play"
       assert transcode =~ "Transcode"
+    end
+  end
+
+  describe "now_playing_card/1 badges" do
+    alias Mydia.Streaming.ActiveSession
+    alias Mydia.Streaming.StreamPlan
+
+    defp card(plan) do
+      session = %ActiveSession{
+        session_id: "s1",
+        # A plain map, not a User struct: user_label/1 matches on %{username: _},
+        # so the card does not need the schema and this test does not couple to it.
+        user: %{username: "dana"},
+        media_title: "The Lantern Quarter",
+        media_type: :movie,
+        episode_info: nil,
+        mode: :copy,
+        started_at: ~U[2026-09-08 10:00:00Z],
+        ready: true,
+        media_file_id: "file-1",
+        bitrate_bps: 4_200_000,
+        plan: plan
+      }
+
+      render_component(&Components.now_playing_card/1, session: session)
+    end
+
+    test "a capped HLS_COPY session reads Transcode, not Direct Play" do
+      # The reported bug, exactly. The client asked for HLS_COPY and the
+      # session's mode is :copy, but the 480p rung's bitrate cap makes FFmpeg
+      # re-encode. The badge must follow FFmpeg, not the request.
+      plan = %StreamPlan{
+        video: %StreamPlan.Video{
+          action: :encode,
+          from_codec: "hevc",
+          to_codec: "h264",
+          from_width: 1920,
+          from_height: 1080,
+          to_width: 854,
+          to_height: 480,
+          tier: :full_hardware
+        },
+        audio: %StreamPlan.Audio{
+          action: :encode,
+          from_codec: "eac3",
+          to_codec: "aac",
+          language: "eng"
+        },
+        container: :hls_ts,
+        max_bitrate_kbps: 1500
+      }
+
+      html = card(plan)
+
+      assert html =~ "Transcode"
+      refute html =~ "Direct Play"
+      assert html =~ "1920x1080"
+      assert html =~ "854x480"
+      assert html =~ "hevc"
+      assert html =~ "h264"
+    end
+
+    test "a video-copy stream reads Remux even when audio is converted" do
+      # Keying the badge off "either stream encodes" would call a routine
+      # audio conversion a full transcode. Video is the expensive stream and
+      # the one an operator scans for.
+      plan = %StreamPlan{
+        video: %StreamPlan.Video{
+          action: :copy,
+          from_codec: "h264",
+          to_codec: "h264",
+          from_width: 1920,
+          from_height: 1080,
+          to_width: 1920,
+          to_height: 1080
+        },
+        audio: %StreamPlan.Audio{
+          action: :encode,
+          from_codec: "eac3",
+          to_codec: "aac",
+          language: "eng"
+        },
+        container: :fmp4
+      }
+
+      html = card(plan)
+
+      assert html =~ "Remux"
+      refute html =~ "Transcode"
+      refute html =~ "Direct Play"
+    end
+
+    test "no plan reads Direct Play" do
+      html = card(nil)
+
+      assert html =~ "Direct Play"
+      refute html =~ "Transcode"
+    end
+
+    test "an unknown source height omits the resolution row" do
+      plan = %StreamPlan{
+        video: %StreamPlan.Video{
+          action: :encode,
+          from_codec: "hevc",
+          to_codec: "h264",
+          from_width: nil,
+          from_height: nil,
+          to_width: nil,
+          to_height: nil,
+          tier: :software
+        },
+        audio: %StreamPlan.Audio{action: :copy, from_codec: "aac", to_codec: "aac"},
+        container: :hls_ts
+      }
+
+      html = card(plan)
+
+      assert html =~ "Transcode"
+      refute html =~ "now-playing-resolution"
     end
   end
 end


### PR DESCRIPTION
## The bug

The dashboard's Now Playing card showed a green **Direct Play** badge on a session that was re-encoding HEVC to H.264 and scaling 1080p down to 480p.

The badge reported what the client *asked for*. FFmpeg acted on something else:

1. The player requests strategy `HLS_COPY` whenever the candidates list holds a non-leading `HLS_COPY` (compatible codecs, wrong container).
2. Picking the 480p rung also sends `maxBitrate: 1500, maxHeight: 480`.
3. The server maps strategy to session mode: `strategy_to_mode(:hls_copy) => :copy`. That is what the registry stored and what the card read.
4. FFmpeg never looked at that mode. It looked at the cap: `force_transcode = not is_nil(max_bitrate)` selects `libx264`.

Two modules deciding the same thing, nothing reconciling them. From production logs, one session, one second apart:

```
17:47:48.672 Bitrate cap set (1500kbps), forcing video transcode to H.264
17:47:48.673 Started streaming session 673654bc... (max_bitrate: 1500kbps)
```

The same split showed up elsewhere in that file: the acceleration tier was recovered afterwards by sniffing `"-hwaccel" in args`, because it was decided inside `build_ffmpeg_args/3` and thrown away.

## The fix

`Mydia.Streaming.StreamPlan` is one pure record of what FFmpeg will actually do to a stream. Both argument builders render *from* it, so the command line and the dashboard cannot disagree. The session carries its plan and announces when it changes; the card displays it.

```
+--------------------------------------+
| [poster]  Some Invented Show         |
|           S02E04 - alex              |
|                       * Transcode    |
|  Video  hevc -> h264 (VAAPI)         |
|  Res    1920x1080 -> 854x480         |
|  Audio  eac3 -> aac - English        |
|  Est.   1.50 Mbps                    |
+--------------------------------------+
```

The badge keys off the **video** action, so a video-copy stream that converts audio reads *Remux*, not *Transcode* — the audio work shows in its own row rather than sending an operator hunting for CPU load that is not there.

| plan | badge |
| --- | --- |
| none (direct play) | Direct Play |
| video copied | Remux |
| video encoded | Transcode |

## Also fixed along the way

- **A height-only request silently ignored the downscale.** `reencodes_video?/2` never looked at `max_height`, so asking a compatible H.264 source for 480p emitted `-c:v copy` and shipped it at full resolution. The predicate is now height-aware.

  The subtlety: the test is *"is this actually downscaling"* (`to_height < from_height`), not *"is a height set"*. `effective_max_height/1` folds the operator's `MAX_TRANSCODE_HEIGHT` ceiling into every request, so the naive version would turn every session on a configured server into a transcode, including a 720p file under a 1080p ceiling.

- **A remuxing viewer was invisible in Now Playing.** `stream_file_remux/3` opened a chunked response and registered no session at all. It now registers one, keyed separately from HLS and direct sessions. It deliberately does *not* stop the session when the request ends: a browser seek aborts and reopens, so stopping would show one viewer as two. An `:on_activity` heartbeat (throttled to ~30s) keeps it alive, because a two-hour film is a single request and the ten-minute inactivity timeout would otherwise reap someone still watching.

- **A remux is not always a pure copy.** It copies video but re-encodes audio to AAC when the mapped track is incompatible with the device profile. That is now visible.

## Behaviour preserved

FFmpeg's argument output is byte-identical across the refactor, with one deliberate exception (the height-only downscale above). Ten existing argument-assertion files pass unmodified and were the gate on every step; the explicit `explicit -> explicit` codec passthrough is preserved and now has a regression test.

## Testing

`test/mydia/streaming/` and the dashboard suites: 592 tests, 0 failures. Full `mix precommit` green.

New coverage includes the regression test for the reported bug — a session started with strategy `HLS_COPY` and `max_bitrate: 1500` renders **Transcode**, not Direct Play — plus the `nil`-selected-audio blanket-copy path, the plan broadcast, and the `get_info` plan key. Several of these were added specifically because deleting the production line they cover left the suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remux streaming with session reuse and activity tracking.
  * Streaming sessions now show playback plans, including video mode, resolution, audio handling, and hardware-acceleration status.
  * Added height-based streaming preferences and improved hardware-acceleration fallback behavior.
  * Added “remux” as a supported streaming job type.
  * The admin dashboard now refreshes when active sessions change.

* **Bug Fixes**
  * Corrected downscaling when only a target height is specified.
  * Preserved explicitly selected video codecs during playback.
  * Improved cleanup when remux startup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->