### PR TITLE
fix(streaming): keep the hwaccel regex lists off module attributes

### DIFF
--- a/.github/ci-flakes.md
+++ b/.github/ci-flakes.md
@@ -689,6 +689,13 @@ nowhere near the config-add dialog. Master's most recent run (`fc4003317`,
 cleared it on the first try. Two occurrences on unrelated diffs; treat this
 signature as flake-first now.
 
+Seen a third time 2026-09-08, this time on master itself (run 34277779380, the
+merge of #751, a transcoding diff). Useful mainly as a warning about reading a
+red master: that same run was red twice, and the other job was a genuine break
+(`Test / NixOS Module`, a compile error on Elixir 1.18). Read every failing job
+in a run before deciding the push broke something, and before deciding it did
+not.
+
 **`MydiaWeb.Features.MediaBackdropTest`**, "below the lg breakpoint the backdrop
 spans the full width", failing alone (1 of 34) with `(MatchError) no match of
 right hand side value: "no backdrop rendered"`. Fixed, not flaky any more, but

--- a/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
+++ b/lib/mydia/streaming/ffmpeg_hls_transcoder.ex
@@ -858,14 +858,22 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   # exists to avoid. The real VAAPI case is still caught: it always appears
   # as the parenthetical on the connection line, which
   # `Failed to initialise VAAPI connection` already matches.
-  @hwaccel_failure_patterns [
-    ~r/Failed to initialise VAAPI connection/i,
-    ~r/No VA display found/i,
-    ~r/Device creation failed/i,
-    ~r/Failed to open .*\/dev\/dri\/.*Permission denied/i,
-    ~r/for option 'init_hw_device'/i,
-    ~r/for option 'hwaccel_device'/i
-  ]
+  #
+  # A private function rather than a module attribute: under OTP 28 a compiled
+  # regex holds a reference, and Elixir 1.18 can only escape one at the top
+  # level of an attribute, not nested inside a list. The Nix release builds on
+  # 1.18 while devenv and the Docker image are on 1.19, so a list of regexes in
+  # an attribute compiles here and breaks the NixOS module job.
+  defp hwaccel_failure_patterns do
+    [
+      ~r/Failed to initialise VAAPI connection/i,
+      ~r/No VA display found/i,
+      ~r/Device creation failed/i,
+      ~r/Failed to open .*\/dev\/dri\/.*Permission denied/i,
+      ~r/for option 'init_hw_device'/i,
+      ~r/for option 'hwaccel_device'/i
+    ]
+  end
 
   @doc """
   Whether ffmpeg's output describes a hardware initialisation failure.
@@ -875,7 +883,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
   """
   @spec hwaccel_failure?(String.t()) :: boolean()
   def hwaccel_failure?(output) when is_binary(output) do
-    Enum.any?(@hwaccel_failure_patterns, &Regex.match?(&1, output))
+    Enum.any?(hwaccel_failure_patterns(), &Regex.match?(&1, output))
   end
 
   def hwaccel_failure?(_), do: false
@@ -899,7 +907,7 @@ defmodule Mydia.Streaming.FfmpegHlsTranscoder do
     if size > @output_buffer_bytes do
       # A byte-based cut can land inside a multi-byte character, leaving
       # invalid UTF-8 at the start of the buffer. That's fine here: the
-      # buffer is only ever regex-matched, and @hwaccel_failure_patterns are
+      # buffer is only ever regex-matched, and hwaccel_failure_patterns/0 are
       # plain ASCII without the `u` modifier, so the regex engine matches
       # against raw bytes and never raises on the malformed prefix.
       # Scrubbing it back to valid UTF-8 would cost more than it buys.

--- a/lib/mydia/streaming/hardware_accel/probe.ex
+++ b/lib/mydia/streaming/hardware_accel/probe.ex
@@ -32,15 +32,23 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
   # VAProfile names map onto codec atoms. Profile variants (Main, Main10,
   # High, Profile0) collapse onto the codec, because the tier decision only
   # asks "can this device decode av1 at all".
-  @profile_patterns [
-    {~r/VAProfileH264/, :h264},
-    {~r/VAProfileHEVC/, :hevc},
-    {~r/VAProfileAV1/, :av1},
-    {~r/VAProfileVP9/, :vp9},
-    {~r/VAProfileVP8/, :vp8},
-    {~r/VAProfileMPEG2/, :mpeg2video},
-    {~r/VAProfileVC1/, :vc1}
-  ]
+  #
+  # A private function rather than a module attribute: under OTP 28 a compiled
+  # regex holds a reference, and Elixir 1.18 can only escape one at the top
+  # level of an attribute, not nested inside a list or tuple. The Nix release
+  # builds on 1.18 while devenv and the Docker image are on 1.19, so nesting
+  # these in an attribute compiles here and breaks the NixOS module job.
+  defp profile_patterns do
+    [
+      {~r/VAProfileH264/, :h264},
+      {~r/VAProfileHEVC/, :hevc},
+      {~r/VAProfileAV1/, :av1},
+      {~r/VAProfileVP9/, :vp9},
+      {~r/VAProfileVP8/, :vp8},
+      {~r/VAProfileMPEG2/, :mpeg2video},
+      {~r/VAProfileVC1/, :vc1}
+    ]
+  end
 
   @spec run(keyword()) :: Capabilities.t()
   def run(opts \\ []) do
@@ -167,7 +175,7 @@ defmodule Mydia.Streaming.HardwareAccel.Probe do
     lines
     |> Enum.filter(&Regex.match?(entrypoint, &1))
     |> Enum.flat_map(fn line ->
-      Enum.filter(@profile_patterns, fn {pattern, _codec} -> Regex.match?(pattern, line) end)
+      Enum.filter(profile_patterns(), fn {pattern, _codec} -> Regex.match?(pattern, line) end)
     end)
     |> Enum.map(fn {_pattern, codec} -> codec end)
     |> Enum.uniq()

--- a/test/mydia/no_nested_regex_attributes_test.exs
+++ b/test/mydia/no_nested_regex_attributes_test.exs
@@ -1,0 +1,126 @@
+defmodule Mydia.NoNestedRegexAttributesTest do
+  @moduledoc """
+  A module attribute in `lib/` may hold a regex, but never a collection of them.
+
+  Under OTP 28 a compiled regex carries a `reference` in its `re_pattern` field.
+  When `@attr` is injected into a function body the compiler has to escape that
+  value into the AST, and Elixir 1.18 special-cases a `%Regex{}` sitting at the
+  top level of the attribute while the generic path underneath it does not:
+
+      @patterns [~r/a/, ~r/b/]
+      def match?(s), do: Enum.any?(@patterns, &Regex.match?(&1, s))
+      # ** (ArgumentError) cannot inject attribute @patterns into function/macro
+      #    because cannot escape #Reference<0.3459598555.3953000449.246799>
+
+  Elixir 1.19 escapes the nested case too, which is why this never fails where
+  most people run the suite. The Nix release (`nix/packages/flake-module.nix`
+  takes whatever Elixir `beam.packages.erlang_28` defaults to, currently 1.18)
+  is the one build that still compiles on 1.18, so the whole class lands as a
+  red `Test / NixOS Module` on master with every other job green. It did, on
+  `e67579d35`, through `@hwaccel_failure_patterns` and `@profile_patterns`.
+
+  Aligning the Nix build onto 1.19 would remove the constraint, but it means
+  rebuilding every dep in `deps.nix` under a different compiler. Until someone
+  does that, keep the collection in a private function: the regexes are then
+  ordinary literals in a function body, which both versions handle.
+  """
+  use ExUnit.Case, async: true
+
+  @sources Path.wildcard("lib/**/*.ex")
+
+  test "no module attribute in lib/ holds a collection of regexes" do
+    offenders =
+      Enum.flat_map(@sources, fn path ->
+        path
+        |> File.read!()
+        |> nested_regex_attributes()
+        |> Enum.map(&"#{path}: @#{&1}")
+      end)
+
+    assert offenders == [],
+           """
+           These module attributes hold a collection containing a regex, which
+           fails to compile on Elixir 1.18 the moment the attribute is used in a
+           function body:
+
+           #{Enum.map_join(offenders, "\n", &"  #{&1}")}
+
+           Move the collection into a private function returning the same list.
+           """
+  end
+
+  test "the scan recognises the shapes that actually broke the build" do
+    assert nested_regex_attributes("""
+             @patterns [
+               ~r/a/i,
+               ~r/b/i
+             ]
+           """) == ["patterns"]
+
+    assert nested_regex_attributes(~S"""
+             @profiles [{~r/A/, :a}, {~r/B/, :b}]
+           """) == ["profiles"]
+
+    assert nested_regex_attributes(~S"""
+             @lookup %{a: ~r/A/}
+           """) == ["lookup"]
+  end
+
+  test "the scan leaves a bare regex attribute alone" do
+    assert nested_regex_attributes(~S"""
+             @pattern ~r/^(disc|disk)\d+$/i
+           """) == []
+  end
+
+  # Matches `@name` followed by an opening `[`, `{` or `%{` on the same line,
+  # then scans forward to the line that closes it at the same indentation. A
+  # regex sigil anywhere in that span is the failure. Deliberately textual:
+  # `Code.string_to_quoted/1` would expand the sigils and hit the very escape
+  # error this guard exists to keep out of the tree.
+  defp nested_regex_attributes(source) do
+    lines = String.split(source, "\n")
+
+    lines
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {line, index} ->
+      case Regex.run(~r/^(\s*)@([a-z_][a-zA-Z0-9_]*)\s+(%?[\[{].*)$/, line) do
+        [_, indent, name, rest] ->
+          span = collect_span(lines, index, rest, indent)
+          if String.contains?(span, "~r"), do: [name], else: []
+
+        nil ->
+          []
+      end
+    end)
+  end
+
+  # The attribute's value, from its opening bracket to the line that closes it.
+  # A single-line attribute closes on its own line; a multi-line one closes on
+  # the first later line whose only content is the closing bracket at the
+  # attribute's own indentation.
+  defp collect_span(lines, index, rest, indent) do
+    if balanced?(rest) do
+      rest
+    else
+      lines
+      |> Enum.drop(index + 1)
+      |> Enum.take_while(&(not closing_line?(&1, indent)))
+      |> Enum.join("\n")
+      |> then(&(rest <> "\n" <> &1))
+    end
+  end
+
+  defp balanced?(text) do
+    opens = count_chars(text, ["[", "{"])
+    closes = count_chars(text, ["]", "}"])
+    opens <= closes
+  end
+
+  defp count_chars(text, chars) do
+    text |> String.graphemes() |> Enum.count(&(&1 in chars))
+  end
+
+  defp closing_line?(line, indent) do
+    Regex.match?(~r/^#{indent}[\]}]\s*$/, line)
+  end
+end


### PR DESCRIPTION
Master went red on the merge of #751, in two jobs for two unrelated reasons. This fixes the one that is a real break.

## The break: `Test / NixOS Module` (SQLite and PostgreSQL)

```
== Compilation error in file lib/mydia/streaming/ffmpeg_hls_transcoder.ex ==
** (ArgumentError) cannot inject attribute @hwaccel_failure_patterns into
   function/macro because cannot escape #Reference<0.3541649582.2568880131.159853>
```

Under OTP 28 a compiled regex holds a reference in its `re_pattern` field. Elixir 1.18 special-cases a bare `%Regex{}` sitting at the top level of a module attribute, but the generic escape path underneath it does not, so a *collection* of regexes explodes the moment the attribute is injected into a function body. Elixir 1.19 escapes the nested case too.

That asymmetry is why only one job saw it. devenv and the Docker image are on 1.19; `nix/packages/flake-module.nix` takes whatever Elixir `beam.packages.erlang_28` defaults to, currently 1.18, and is the only build still compiling there. #751 added two of these (`@hwaccel_failure_patterns`, `@profile_patterns`) and CI on the PR was green everywhere it looked.

Reproduced directly on 1.18.5, both the failure and the fix:

```elixir
@list [~r/a/i, ~r/b/i]
def l(x), do: Enum.any?(@list, &Regex.match?(&1, x))
# ** (ArgumentError) cannot escape #Reference<0.3459598555.3953000449.246799>

defp pats, do: [~r/a/i, ~r/b/i]
def f(x), do: Enum.any?(pats(), &Regex.match?(&1, x))
# fine
```

## What changed

Both lists move into private functions, where the regexes are ordinary literals in a function body and both Elixir versions are happy. No behaviour change; the streaming suite (534 tests) passes unchanged.

`test/mydia/no_nested_regex_attributes_test.exs` scans `lib/` for the shape, so the next one fails on the machine that wrote it rather than on master a merge later. Verified by putting `@profile_patterns` back and watching it name the file.

Aligning the Nix build onto 1.19 would remove the constraint outright, but it means rebuilding every dep in `deps.nix` under a different compiler. Worth doing on its own, not as part of unbreaking master.

## The other red job is not a break

`Test / E2E Browser` failed on `AddConfigFlowTest` "…closes the dialog", already in `.github/ci-flakes.md` with two prior occurrences on unrelated diffs. This is the third, and the entry now says so, along with the lesson from this particular run: it was red twice and only one of them meant anything, so read every failing job before deciding a push broke something, and before deciding it did not.

## Verification

- `mix precommit`: format, credo, compile clean. One test failure, `Mydia.Repo.SQLiteWriteContentionTest`'s IMMEDIATE arm with "database is locked", which is catalogued at `.github/ci-flakes.md:544` and passes in isolation. Nothing in this diff is near SQLite.
- The NixOS module jobs on this PR are the actual proof; they are what was failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CI failure guidance by documenting a recurring intermittent test failure and emphasizing that all failed jobs should be reviewed before identifying the cause.

- **Refactor**
  - Updated internal streaming and hardware-acceleration configuration handling without changing user-visible behavior.

- **Tests**
  - Added automated checks to prevent a class of compatibility issues with newer Elixir and OTP versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->