### PR TITLE
fix(ci): trigger workflows when draft pull requests become ready

### DIFF
--- a/.github/workflows/ci-appcast.yml
+++ b/.github/workflows/ci-appcast.yml
@@ -9,6 +9,7 @@ name: CI / Appcast
 # pointing at it would sit Pending forever. The job costs a few seconds.
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - master

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -2,6 +2,7 @@ name: CI / Documentation
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/ci-fastlane.yml
+++ b/.github/workflows/ci-fastlane.yml
@@ -6,6 +6,7 @@ name: CI / Fastlane
 # Master ruleset, so both have to report on every pull request.
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: "ci-fastlane-${{ github.ref }}"

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [master, main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-player-e2e.yml
+++ b/.github/workflows/ci-player-e2e.yml
@@ -24,6 +24,7 @@ on:
   # target/, which no BuildKit cache backend can carry because it lives in a
   # RUN --mount=type=cache. That needs a Dockerfile change.
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [master, main]
   workflow_dispatch:

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -14,6 +14,7 @@ on:
       - master
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-relay-worker.yml
+++ b/.github/workflows/ci-relay-worker.yml
@@ -40,6 +40,7 @@ on:
       - "relay-worker/**"
       - ".github/workflows/ci-relay-worker.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "**"
     paths:

--- a/.github/workflows/ci-relay.yml
+++ b/.github/workflows/ci-relay.yml
@@ -9,6 +9,7 @@ on:
       - "metadata-relay/**"
       - ".github/workflows/ci-relay.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "**"
     paths:

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -2,6 +2,7 @@ name: CI / Security
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Monday 12:30 UTC, ahead of the weekly Dependabot run.
     - cron: "30 12 * * 1"

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -13,6 +13,7 @@ on:
       - "priv/graphql/schema.graphql"
       - ".github/workflows/ci-server.yml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "server/**"
       # See the push.paths comment above: this entry is inert for the same

--- a/.github/workflows/ci-site.yml
+++ b/.github/workflows/ci-site.yml
@@ -9,6 +9,7 @@ name: CI / Site
 # few seconds when site/ is untouched.
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: "ci-site-${{ github.ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - master
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - "**"
   workflow_dispatch:

--- a/test/ci/workflow_triggers_test.exs
+++ b/test/ci/workflow_triggers_test.exs
@@ -1,0 +1,71 @@
+defmodule Mydia.CI.WorkflowTriggersTest do
+  use ExUnit.Case, async: true
+
+  @required_pull_request_types ~w(opened synchronize reopened ready_for_review)
+  @workflow_patterns [".github/workflows/*.yml", ".github/workflows/*.yaml"]
+
+  test "pull request workflows run for every required activity type" do
+    workflow_paths =
+      @workflow_patterns
+      |> Enum.flat_map(&Path.wildcard(repo_path(&1)))
+      |> Enum.filter(&pull_request_workflow?/1)
+
+    assert workflow_paths != [], "expected to find at least one pull request workflow"
+
+    Enum.each(workflow_paths, fn workflow_path ->
+      workflow = read_workflow!(workflow_path)
+      configured_types = pull_request_types(workflow)
+      missing_types = @required_pull_request_types -- configured_types
+      relative_path = Path.relative_to(workflow_path, repo_path("."))
+
+      assert missing_types == [],
+             "#{relative_path} is missing pull_request types: #{Enum.join(missing_types, ", ")}"
+    end)
+  end
+
+  defp pull_request_workflow?(workflow_path) do
+    workflow = read_workflow!(workflow_path)
+    triggers = triggers(workflow)
+
+    cond do
+      is_map(triggers) ->
+        Map.has_key?(triggers, "pull_request")
+
+      is_list(triggers) ->
+        "pull_request" in triggers
+
+      is_binary(triggers) ->
+        triggers == "pull_request"
+
+      true ->
+        false
+    end
+  end
+
+  defp pull_request_types(workflow) do
+    triggers = triggers(workflow)
+
+    if is_map(triggers) do
+      case Map.get(triggers, "pull_request") do
+        %{} = pr_config -> Map.get(pr_config, "types", [])
+        _ -> []
+      end
+    else
+      []
+    end
+  end
+
+  # YAML 1.1 parsers resolve the unquoted GitHub Actions `on` key as a boolean.
+  defp triggers(workflow) do
+    Map.get(workflow, "on") || Map.get(workflow, true) || %{}
+  end
+
+  defp read_workflow!(workflow_path) do
+    case YamlElixir.read_from_file(workflow_path) do
+      {:ok, workflow} -> workflow
+      {:error, reason} -> raise "failed to parse #{workflow_path}: #{inspect(reason)}"
+    end
+  end
+
+  defp repo_path(path), do: Path.expand(Path.join([__DIR__, "../..", path]))
+end


### PR DESCRIPTION
GitHub Actions' default activity types for `pull_request` are `[opened, synchronize, reopened]`. When a PR starts as a draft and is subsequently marked ready for review, GitHub emits the `ready_for_review` activity type. Because none of the workflows specified `ready_for_review`, marking a draft PR ready never triggered CI workflows.

This adds `types: [opened, synchronize, reopened, ready_for_review]` to all 12 workflows declaring a `pull_request` trigger:
- `.github/workflows/ci.yml`
- `.github/workflows/ci-appcast.yml`
- `.github/workflows/ci-docs.yml`
- `.github/workflows/ci-fastlane.yml`
- `.github/workflows/ci-nix.yml`
- `.github/workflows/ci-player.yml`
- `.github/workflows/ci-player-e2e.yml`
- `.github/workflows/ci-relay.yml`
- `.github/workflows/ci-relay-worker.yml`
- `.github/workflows/ci-security.yml`
- `.github/workflows/ci-server.yml`
- `.github/workflows/ci-site.yml`

Also adds `test/ci/workflow_triggers_test.exs` to verify that all workflows defining a `pull_request` trigger explicitly configure all required activity types.

Closes #322