### PR TITLE
test: catch every form that puts a regex in an attribute

### DIFF
--- a/test/mydia/no_nested_regex_attributes_test.exs
+++ b/test/mydia/no_nested_regex_attributes_test.exs
@@ -94,13 +94,23 @@ defmodule Mydia.NoNestedRegexAttributesTest do
     assert nested_regex_attributes(~S"""
              @pattern ~R/^(disc|disk)\d+$/i
            """) == []
+
+    # The name alone is not the tell. A false positive here would block an
+    # attribute holding no regex at all.
+    assert nested_regex_attributes(~S"""
+             @labels ["Regex.compile_options"]
+           """) == []
   end
 
   # `~r` and `~R` build the same struct -- the uppercase sigil only turns off
   # interpolation and escape processing -- and an attribute's value is
   # evaluated at compile time, so a `Regex.compile` call in one lands a
   # reference there just as a sigil does. All three forms count.
-  @regex_forms ~r/~[rR][\/|"'({\[<]|Regex\.compile/
+  # The call syntax is required, not just the name: a bare `Regex.compile`
+  # substring also matches longer identifiers and ordinary text, so
+  # `@labels ["Regex.compile_options"]` would be flagged for containing no
+  # regex at all.
+  @regex_forms ~r/~[rR][\/|"'({\[<]|Regex\.compile!?\s*\(/
 
   # Matches `@name` followed by an opening `[`, `{` or `%{` on the same line,
   # then scans forward to the line that closes it at the same indentation. A

--- a/test/mydia/no_nested_regex_attributes_test.exs
+++ b/test/mydia/no_nested_regex_attributes_test.exs
@@ -66,15 +66,45 @@ defmodule Mydia.NoNestedRegexAttributesTest do
            """) == ["lookup"]
   end
 
+  test "the scan covers the other ways a regex reaches an attribute" do
+    # ~R builds the same struct with interpolation and escapes turned off, and
+    # it is the natural sigil for a pattern full of backslashes, so it is what
+    # a future author of one of these lists is most likely to reach for.
+    assert nested_regex_attributes(~S"""
+             @patterns [~R/a\d/, ~R/b/]
+           """) == ["patterns"]
+
+    # Any sigil delimiter, not only //.
+    assert nested_regex_attributes(~S"""
+             @patterns [~r{a}, ~r|b|]
+           """) == ["patterns"]
+
+    # An attribute's value is evaluated at compile time, so a built regex lands
+    # in it carrying a reference exactly as a sigil does.
+    assert nested_regex_attributes(~S"""
+             @patterns [Regex.compile!("a")]
+           """) == ["patterns"]
+  end
+
   test "the scan leaves a bare regex attribute alone" do
     assert nested_regex_attributes(~S"""
              @pattern ~r/^(disc|disk)\d+$/i
            """) == []
+
+    assert nested_regex_attributes(~S"""
+             @pattern ~R/^(disc|disk)\d+$/i
+           """) == []
   end
+
+  # `~r` and `~R` build the same struct -- the uppercase sigil only turns off
+  # interpolation and escape processing -- and an attribute's value is
+  # evaluated at compile time, so a `Regex.compile` call in one lands a
+  # reference there just as a sigil does. All three forms count.
+  @regex_forms ~r/~[rR][\/|"'({\[<]|Regex\.compile/
 
   # Matches `@name` followed by an opening `[`, `{` or `%{` on the same line,
   # then scans forward to the line that closes it at the same indentation. A
-  # regex sigil anywhere in that span is the failure. Deliberately textual:
+  # regex anywhere in that span is the failure. Deliberately textual:
   # `Code.string_to_quoted/1` would expand the sigils and hit the very escape
   # error this guard exists to keep out of the tree.
   defp nested_regex_attributes(source) do
@@ -86,7 +116,7 @@ defmodule Mydia.NoNestedRegexAttributesTest do
       case Regex.run(~r/^(\s*)@([a-z_][a-zA-Z0-9_]*)\s+(%?[\[{].*)$/, line) do
         [_, indent, name, rest] ->
           span = collect_span(lines, index, rest, indent)
-          if String.contains?(span, "~r"), do: [name], else: []
+          if Regex.match?(@regex_forms, span), do: [name], else: []
 
         nil ->
           []


### PR DESCRIPTION
Follow-up to #753, which merged while this commit was still in flight, so the guard landed on master with a hole in it.

CodeRabbit caught it on #753: the scan only looked for `~r`. `~R` builds the same struct, differing only in that interpolation and escape processing are off, which makes it the sigil someone writing a list of backslash-heavy patterns is most likely to reach for. Confirmed on 1.18.5 that it fails identically rather than assuming it:

```
defmodule C do
  @list [~R/a/, ~R/b/]
  def l(x), do: Enum.any?(@list, &Regex.match?(&1, x))
end

** (ArgumentError) cannot inject attribute @list into function/macro because
   cannot escape #Reference<0.3386861741.1824915457.58217>
```

Two neighbours of the same hole go with it:

- sigil delimiters other than `//`, so `~r{a}` and `~r|b|` count
- a `Regex.compile` call, which lands a reference in the attribute the same way, because an attribute's value is evaluated at compile time

Regression cases for all three, plus a negative case keeping a bare `~R` attribute allowed, since a single regex at the top level of an attribute escapes fine on both versions and is the idiom used all over `lib/`.

Test-only. `lib/` is unchanged and still clean under the widened scan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of regular expressions assigned to module attributes.
  * Recognition now covers uppercase regex sigils, alternate delimiters, and compiled expressions.
  * Reduced false positives for similarly named text that is not an actual regular expression.

* **Tests**
  * Expanded coverage to verify supported expression formats and confirm unrelated attributes remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->