### PR TITLE
fix: keep seven LiveViews alive on unexpected messages

### DIFF
--- a/lib/mydia_web/live/activity_live/index.ex
+++ b/lib/mydia_web/live/activity_live/index.ex
@@ -5,6 +5,8 @@ defmodule MydiaWeb.ActivityLive.Index do
   alias Mydia.Events.Visibility
   alias Phoenix.PubSub
 
+  require Logger
+
   @page_size 50
 
   # The chip catalog lives here rather than in Mydia.Events.Visibility so that
@@ -168,6 +170,11 @@ defmodule MydiaWeb.ActivityLive.Index do
         socket
       end
 
+    {:noreply, socket}
+  end
+
+  def handle_info(msg, socket) do
+    Logger.warning("Unhandled message in ActivityLive.Index: #{inspect(msg)}")
     {:noreply, socket}
   end
 

--- a/lib/mydia_web/live/admin_import_lists_live/index.ex
+++ b/lib/mydia_web/live/admin_import_lists_live/index.ex
@@ -79,6 +79,11 @@ defmodule MydiaWeb.AdminImportListsLive.Index do
     {:noreply, socket}
   end
 
+  def handle_info(msg, socket) do
+    Logger.warning("Unhandled message in AdminImportListsLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
+  end
+
   ## Data Loading
 
   defp load_data(socket) do

--- a/lib/mydia_web/live/admin_library_paths_live/index.ex
+++ b/lib/mydia_web/live/admin_library_paths_live/index.ex
@@ -94,6 +94,11 @@ defmodule MydiaWeb.AdminLibraryPathsLive.Index do
     {:noreply, socket}
   end
 
+  def handle_info(msg, socket) do
+    Logger.warning("Unhandled message in AdminLibraryPathsLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
+  end
+
   ## Library Path Events
 
   @impl true

--- a/lib/mydia_web/live/admin_plugins_live/index.ex
+++ b/lib/mydia_web/live/admin_plugins_live/index.ex
@@ -277,6 +277,11 @@ defmodule MydiaWeb.AdminPluginsLive.Index do
     end
   end
 
+  def handle_info(msg, socket) do
+    Logger.warning("Unhandled message in AdminPluginsLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
+  end
+
   ## Helpers
 
   defp approval_flash(%{ungranted: ungranted, name: name}) when ungranted != %{},

--- a/lib/mydia_web/live/admin_remote_access_live/index.ex
+++ b/lib/mydia_web/live/admin_remote_access_live/index.ex
@@ -39,6 +39,11 @@ defmodule MydiaWeb.AdminRemoteAccessLive.Index do
     {:noreply, refresh_status(socket)}
   end
 
+  def handle_info(msg, socket) do
+    Logger.warning("Unhandled message in AdminRemoteAccessLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
+  end
+
   ## Event Handlers
 
   @impl true

--- a/lib/mydia_web/live/admin_system_live/index.ex
+++ b/lib/mydia_web/live/admin_system_live/index.ex
@@ -7,6 +7,8 @@ defmodule MydiaWeb.AdminSystemLive.Index do
   alias Mydia.Settings
   alias Mydia.System
 
+  require Logger
+
   # Capture Mix.env at compile time since Mix is not available in releases
   @env Mix.env()
 
@@ -43,6 +45,11 @@ defmodule MydiaWeb.AdminSystemLive.Index do
   @impl true
   def handle_info(:refresh_system_data, socket) do
     {:noreply, load_system_data(socket)}
+  end
+
+  def handle_info(msg, socket) do
+    Logger.warning("Unhandled message in AdminSystemLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
   end
 
   ## Private Helpers

--- a/lib/mydia_web/live/transcodes_live/index.ex
+++ b/lib/mydia_web/live/transcodes_live/index.ex
@@ -4,6 +4,8 @@ defmodule MydiaWeb.TranscodesLive.Index do
   alias Phoenix.PubSub
   alias MydiaWeb.Live.Authorization
 
+  require Logger
+
   @impl true
   def mount(_params, _session, socket) do
     if connected?(socket) do
@@ -40,6 +42,11 @@ defmodule MydiaWeb.TranscodesLive.Index do
   @impl true
   def handle_info({:job_updated, _id}, socket) do
     {:noreply, load_jobs(socket)}
+  end
+
+  def handle_info(msg, socket) do
+    Logger.warning("Unhandled message in TranscodesLive.Index: #{inspect(msg)}")
+    {:noreply, socket}
   end
 
   defp load_jobs(socket) do

--- a/test/mydia_web/live/unhandled_message_test.exs
+++ b/test/mydia_web/live/unhandled_message_test.exs
@@ -13,7 +13,14 @@ defmodule MydiaWeb.UnhandledMessageTest do
     MydiaWeb.CalendarLive.Index,
     MydiaWeb.SearchLive.Index,
     MydiaWeb.DownloadsLive.Index,
-    MydiaWeb.MediaLive.Index
+    MydiaWeb.MediaLive.Index,
+    MydiaWeb.ActivityLive.Index,
+    MydiaWeb.AdminImportListsLive.Index,
+    MydiaWeb.AdminLibraryPathsLive.Index,
+    MydiaWeb.AdminPluginsLive.Index,
+    MydiaWeb.AdminRemoteAccessLive.Index,
+    MydiaWeb.AdminSystemLive.Index,
+    MydiaWeb.TranscodesLive.Index
   ]
 
   # The existing MediaLive.Index precedent logs the module name *without* the
@@ -27,14 +34,48 @@ defmodule MydiaWeb.UnhandledMessageTest do
       socket = %Socket{}
       module = unquote(module)
 
+      for message <- [{:totally_unexpected, :message}, :totally_unexpected] do
+        log =
+          capture_log(fn ->
+            assert {:noreply, ^socket} = module.handle_info(message, socket)
+          end)
+
+        assert log =~ "Unhandled message in #{short_name(module)}"
+      end
+    end
+  end
+
+  @scan_events [
+    :library_scan_started,
+    :library_scan_progress,
+    :library_scan_completed,
+    :library_scan_failed
+  ]
+
+  for event <- @scan_events do
+    test "AdminLibraryPathsLive.Index ignores #{event} silently" do
+      socket = %Socket{}
+
       log =
         capture_log(fn ->
           assert {:noreply, ^socket} =
-                   module.handle_info({:totally_unexpected, :message}, socket)
+                   MydiaWeb.AdminLibraryPathsLive.Index.handle_info({unquote(event), %{}}, socket)
         end)
 
-      assert log =~ "Unhandled message in #{short_name(module)}"
+      refute log =~ "Unhandled message in AdminLibraryPathsLive.Index"
     end
+  end
+
+  test "AdminLibraryPathsLive.Index tracks a started library reorganization" do
+    socket = Phoenix.Component.assign(%Socket{}, :reorganizing_library_ids, MapSet.new())
+
+    assert {:noreply, updated_socket} =
+             MydiaWeb.AdminLibraryPathsLive.Index.handle_info(
+               {:library_reorganize_started, %{library_path_id: "test-library"}},
+               socket
+             )
+
+    assert updated_socket.assigns.reorganizing_library_ids == MapSet.new(["test-library"])
   end
 
   # `Mydia.Downloads.Grabber` broadcasts these three shapes on the "downloads"


### PR DESCRIPTION
Seven LiveViews implement only specific `handle_info/2` clauses, so an unmatched message raises `FunctionClauseError` and terminates the view process. The library-path view's guarded two-tuple clause accepts only four scanner events and does not provide a general fallback. Collaborator `arsfeld` explicitly narrowed the issue on September 4 to these seven views, dropping the fixture, component typing, and failure-category UI items from the original body. The Music LiveView has been removed and is outside the current scope; this plan covers the entire revised issue.

## Summary

Append an unguarded `handle_info(msg, socket)` after all existing message clauses in each of the seven listed LiveView modules, returning `{:noreply, socket}` and logging `Logger.warning("Unhandled message in <ShortModuleName>: #{inspect(msg)}")` to match `MediaLive.Index` at lines 807–812. Add `require Logger` to ActivityLive.Index, AdminSystemLive.Index, and TranscodesLive.Index; the other four already require it. Keep the library scanner's explicit silent allowlist before the fallback, and preserve the other existing event and timer handlers in their current order.

## Verification

- For all twelve modules in the expanded table, send `{:totally_unexpected, :message}` and an unknown atom such as `:totally_unexpected` directly to `handle_info/2`; assert the exact input `%Phoenix.LiveView.Socket{}` is returned in `{:noreply, socket}` and capture the existing module-specific warning prefix. An atom case prevents a tuple-only pseudo-fallback from satisfying the regression.
- For AdminLibraryPathsLive.Index, exercise each existing silent event (`:library_scan_started`, `:library_scan_progress`, `:library_scan_completed`, `:library_scan_failed`) as a two-tuple with an empty payload; assert an unchanged socket and no warning containing this module's unhandled-message prefix. Do not assert an entirely empty captured log, because async tests share Logger.
- In the same regression file, construct a socket assigned an empty `:reorganizing_library_ids` MapSet and deliver `{:library_reorganize_started, %{library_path_id: "test-library"}}`; assert the ID is added. This proves the new fallback does not shadow an existing state-changing handler without needing database fixtures or a mounted view.
- Preserve the existing twelve silent manual-grab cases. With two unknown-message assertions inside each module's generated test, four new silent scanner tests, and one reorganization test, the regression file should contain 29 tests.
- During implementation, first extend the unknown-message cases and run `./dev mix test test/mydia_web/live/unhandled_message_test.exs` to observe the seven missing-clause failures, then add the callbacks and rerun for green. Finally run `./dev mix precommit` and resolve change-related failures. Run these sequentially in the implementation worktree; no tests or dependency installation were run during this read-only planning pass.

Closes #259


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LiveView stability by safely handling unexpected background messages instead of allowing them to cause crashes.
  * Added warning logs for unrecognized messages to support troubleshooting.
  * Updated handling for library scan and reorganization events.

* **Tests**
  * Expanded coverage across additional LiveView screens and message formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->