### PR TITLE
fix(player): stop the web fullscreen button lying about what it can do

### DIFF
--- a/player/lib/core/player/fullscreen/fullscreen_backend.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 
+import 'fullscreen_failure.dart';
 import 'fullscreen_mode.dart';
+import 'fullscreen_report.dart';
 
 /// The platform half of fullscreen.
 ///
@@ -11,12 +14,34 @@ import 'fullscreen_mode.dart';
 ///
 /// [enter] and [exit] are synchronous by contract. `webkitEnterFullscreen`
 /// requires live user activation and any `await` before the call spends it.
+/// This is also why failures arrive through the `onFailure` handed to
+/// [createFullscreenBackend] rather than as a return value: the document route
+/// answers through a `Promise`, so a synchronous `bool` would have to guess,
+/// and guessing whether the platform complied is the original defect this
+/// module exists to prevent.
 abstract class FullscreenBackend {
-  /// Resolved once at construction. Stable for the life of the process.
+  /// The route in use. Stable for the life of the process on native. On web it
+  /// can demote once, when the route resolved at construction is refused at
+  /// request time; [ready] and [report] are how that becomes visible.
   FullscreenMode get mode;
+
+  /// Whether a request made right now would be carried out.
+  ///
+  /// Distinct from `mode != unsupported`, which only says the platform has an
+  /// API. Readiness additionally covers "the route needs a media element and
+  /// none is bound yet" and "this route has already been refused", which is
+  /// what stops the control being drawn over a request that cannot succeed.
+  ValueListenable<bool> get ready;
+
+  /// A snapshot for the diagnostics readout. Cheap; built on demand.
+  FullscreenReport get report;
 
   /// Hands over the media_kit player once it exists, so a web backend can
   /// reach the underlying `HTMLVideoElement`. A no-op on native.
+  ///
+  /// Safe and expected to call again with a different [Player]: `PlayerScreen`
+  /// constructs a fresh one on every source load, and a backend still holding
+  /// the previous one would be fullscreening a disposed element.
   void attach(Player player);
 
   void enter();
@@ -25,3 +50,6 @@ abstract class FullscreenBackend {
 
   void dispose();
 }
+
+/// Signature of the failure sink handed to [createFullscreenBackend].
+typedef FullscreenFailureSink = void Function(FullscreenFailure failure);

--- a/player/lib/core/player/fullscreen/fullscreen_backend_native.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend_native.dart
@@ -6,9 +6,11 @@ import '../../window/window_fullscreen.dart';
 import '../platform_features.dart';
 import 'fullscreen_backend.dart';
 import 'fullscreen_mode.dart';
+import 'fullscreen_report.dart';
 
 FullscreenBackend createFullscreenBackend({
   required ValueChanged<bool> onChange,
+  required FullscreenFailureSink onFailure,
 }) =>
     NativeFullscreenBackend(onChange: onChange);
 
@@ -22,15 +24,31 @@ FullscreenBackend createFullscreenBackend({
 /// button, the View menu and Cmd+Ctrl+F are all reflected — the exact reason
 /// `WindowFullscreenController` was written. That controller stays the only
 /// writer of the signal; this only listens.
+///
+/// It takes no `onFailure`: neither `defaultEnterNativeFullscreen` nor
+/// `defaultExitNativeFullscreen` reports one, so inventing failures here would
+/// be the same guessing the web backend was fixed to stop doing.
 class NativeFullscreenBackend implements FullscreenBackend {
   NativeFullscreenBackend({required this.onChange});
 
   final ValueChanged<bool> onChange;
 
+  /// Both native routes exist unconditionally, so this never moves. It is a
+  /// notifier rather than a constant only because the interface is shaped for
+  /// web, where readiness genuinely changes.
+  final ValueNotifier<bool> _ready = ValueNotifier<bool>(true);
+
+  @override
+  ValueListenable<bool> get ready => _ready;
+
   @override
   FullscreenMode get mode => PlatformFeatures.isDesktop
       ? FullscreenMode.osWindow
       : FullscreenMode.systemUi;
+
+  @override
+  FullscreenReport get report =>
+      FullscreenReport(mode: mode, ready: _ready.value);
 
   bool _listening = false;
 
@@ -65,5 +83,6 @@ class NativeFullscreenBackend implements FullscreenBackend {
       windowFullscreen.removeListener(_republish);
       _listening = false;
     }
+    _ready.dispose();
   }
 }

--- a/player/lib/core/player/fullscreen/fullscreen_backend_web.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_backend_web.dart
@@ -10,12 +10,17 @@ import 'package:media_kit/media_kit.dart';
 import 'package:web/web.dart' as web;
 
 import 'fullscreen_backend.dart';
+import 'fullscreen_failure.dart';
 import 'fullscreen_mode.dart';
+import 'fullscreen_report.dart';
+import 'fullscreen_web_core.dart';
+import 'fullscreen_web_platform.dart';
 
 FullscreenBackend createFullscreenBackend({
   required ValueChanged<bool> onChange,
+  required FullscreenFailureSink onFailure,
 }) =>
-    WebFullscreenBackend(onChange: onChange);
+    WebFullscreenBackend(onChange: onChange, onFailure: onFailure);
 
 /// Browser fullscreen, over whichever route the browser actually offers.
 ///
@@ -23,37 +28,69 @@ FullscreenBackend createFullscreenBackend({
 /// `defaultEnterNativeFullscreen` catches every failure to `debugPrint` and
 /// returns, leaving the caller believing it worked, which is exactly how the
 /// icon came to lie on iPhone Safari.
-class WebFullscreenBackend implements FullscreenBackend {
-  WebFullscreenBackend({required this.onChange}) {
-    _mode = resolveWebMode(
-      documentFullscreenEnabled: _documentFullscreenEnabled,
-      videoElementFullscreenSupported: _videoElementFullscreenSupported,
+///
+/// Every decision lives in [WebFullscreenCore]; this class is the
+/// [WebFullscreenPlatform] half, and holds nothing but the `package:web` calls
+/// and the element handles they need. The split is what makes any of it
+/// testable: this file compiles only under `dart.library.js_interop`, so
+/// `flutter test`, which always runs non-web, can never reach it.
+class WebFullscreenBackend implements FullscreenBackend, WebFullscreenPlatform {
+  WebFullscreenBackend({
+    required ValueChanged<bool> onChange,
+    required FullscreenFailureSink onFailure,
+  }) {
+    _core = WebFullscreenCore(
+      platform: this,
+      onChange: onChange,
+      onFailure: onFailure,
     );
-    if (_mode == FullscreenMode.documentElement) {
-      _documentListener = _onDocumentFullscreenChange.toJS;
-      web.document.addEventListener('fullscreenchange', _documentListener);
-    }
   }
 
-  final ValueChanged<bool> onChange;
+  late final WebFullscreenCore _core;
 
-  late final FullscreenMode _mode;
   JSFunction? _documentListener;
   web.HTMLVideoElement? _video;
   JSFunction? _beginListener;
   JSFunction? _endListener;
+  final List<FullscreenFailure> _probeFailures = <FullscreenFailure>[];
+
+  // --- FullscreenBackend ---------------------------------------------------
 
   @override
-  FullscreenMode get mode => _mode;
+  FullscreenMode get mode => _core.mode;
+
+  @override
+  ValueListenable<bool> get ready => _core.ready;
+
+  @override
+  FullscreenReport get report => _core.report;
+
+  @override
+  void attach(Player player) => _core.attach(player);
+
+  @override
+  void enter() => _core.enter();
+
+  @override
+  void exit() => _core.exit();
+
+  @override
+  void dispose() => _core.dispose();
+
+  // --- WebFullscreenPlatform: capability probes ----------------------------
 
   /// `document.fullscreenEnabled`, not a probe for `requestFullscreen`. It is
   /// also false inside an iframe lacking `allow="fullscreen"`, so one read
   /// covers both cases that must fall back.
-  static bool get _documentFullscreenEnabled {
+  @override
+  bool get documentFullscreenEnabled {
     try {
       return web.document.fullscreenEnabled;
     } catch (e) {
-      debugPrint('[Fullscreen] fullscreenEnabled read failed: $e');
+      _probeFailures.add(FullscreenFailure(
+        FullscreenFailureCause.documentEnabledProbeFailed,
+        detail: '$e',
+      ));
       return false;
     }
   }
@@ -61,7 +98,8 @@ class WebFullscreenBackend implements FullscreenBackend {
   /// Probed on the prototype, never on a live element:
   /// `video.webkitSupportsFullscreen` stays false until metadata loads, and
   /// the button has to decide whether to exist before then.
-  static bool get _videoElementFullscreenSupported {
+  @override
+  bool get videoElementFullscreenSupported {
     try {
       final ctor = globalContext['HTMLVideoElement'];
       if (ctor.isUndefinedOrNull) return false;
@@ -69,13 +107,146 @@ class WebFullscreenBackend implements FullscreenBackend {
       if (proto.isUndefinedOrNull) return false;
       return (proto as JSObject).has('webkitEnterFullscreen');
     } catch (e) {
-      debugPrint('[Fullscreen] video prototype probe failed: $e');
+      _probeFailures.add(FullscreenFailure(
+        FullscreenFailureCause.videoSupportProbeFailed,
+        detail: '$e',
+      ));
       return false;
     }
   }
 
-  void _onDocumentFullscreenChange(web.Event _) {
-    onChange(web.document.fullscreenElement != null);
+  @override
+  List<FullscreenFailure> get probeFailures => _probeFailures;
+
+  // --- WebFullscreenPlatform: the document route ---------------------------
+
+  @override
+  void listenDocumentFullscreen(void Function(bool fullscreen) onChange) {
+    if (_documentListener != null) return;
+    _documentListener = ((web.Event _) {
+      onChange(web.document.fullscreenElement != null);
+    }).toJS;
+    web.document.addEventListener('fullscreenchange', _documentListener!);
+  }
+
+  @override
+  void stopListeningDocumentFullscreen() {
+    final listener = _documentListener;
+    if (listener == null) return;
+    web.document.removeEventListener('fullscreenchange', listener);
+    _documentListener = null;
+  }
+
+  @override
+  void requestDocumentFullscreen(void Function(Object error) onRejected) {
+    final element = web.document.documentElement;
+    if (element == null) {
+      onRejected('document.documentElement is null');
+      return;
+    }
+    element.requestFullscreen().toDart.catchError((Object e) {
+      debugPrint('[Fullscreen] requestFullscreen rejected: $e');
+      onRejected(e);
+      return null;
+    });
+  }
+
+  @override
+  void exitDocumentFullscreen(void Function(Object error) onRejected) {
+    if (web.document.fullscreenElement == null) return;
+    web.document.exitFullscreen().toDart.catchError((Object e) {
+      debugPrint('[Fullscreen] exitFullscreen rejected: $e');
+      onRejected(e);
+      return null;
+    });
+  }
+
+  // --- WebFullscreenPlatform: the media element route ----------------------
+
+  @override
+  FullscreenFailureCause? bindVideo(
+    Object player, {
+    required void Function(bool fullscreen) onChange,
+  }) {
+    unbindVideo();
+
+    if (player is! Player) return FullscreenFailureCause.playerNotWebPlayer;
+
+    // media_kit exports its web player publicly:
+    // `package:media_kit/media_kit.dart` re-exports
+    // `src/player/web/player/player.dart`, itself
+    // `export 'stub.dart' if (dart.library.js_interop) 'real.dart';`. On a web
+    // build that resolves to `WebPlayer`, whose `element` field is public. This
+    // file only compiles on web, so the cast is safe and needs no `src/`
+    // import, no `$com.alexmercerind.media_kit.instances` global, and no
+    // `querySelector` guessing.
+    final platform = player.platform;
+    if (platform is! WebPlayer) {
+      debugPrint('[Fullscreen] player.platform is not a WebPlayer');
+      return FullscreenFailureCause.playerNotWebPlayer;
+    }
+    // `WebPlayer.element` exists on media_kit's web `real.dart`, which
+    // `flutter build web` resolves. `dart analyze` / `flutter analyze` resolve
+    // the same conditional export to `stub.dart`, which has no `element`, so
+    // a static read fails analysis even though the web compiler accepts it.
+    // Same runtime API the plan specifies; dynamic only bridges the stub gap.
+    final video = (platform as dynamic).element as web.HTMLVideoElement?;
+    if (video == null) return FullscreenFailureCause.noVideoElement;
+    _video = video;
+
+    _beginListener = ((web.Event _) {
+      // Apple renders only the video element, so hand the browser the cues
+      // media_kit normally keeps hidden and paints through Flutter.
+      _setTextTrackMode('showing');
+      onChange(true);
+    }).toJS;
+    _endListener = ((web.Event _) {
+      _setTextTrackMode('hidden');
+      onChange(false);
+    }).toJS;
+
+    video.addEventListener('webkitbeginfullscreen', _beginListener!);
+    video.addEventListener('webkitendfullscreen', _endListener!);
+    return null;
+  }
+
+  /// Releases the bound element.
+  ///
+  /// The player screen mounts repeatedly across SPA navigations and builds a
+  /// fresh `Player` on every source load, so leaked listeners would accumulate
+  /// on elements nobody is playing any more.
+  @override
+  void unbindVideo() {
+    final video = _video;
+    if (video != null) {
+      final begin = _beginListener;
+      final end = _endListener;
+      if (begin != null) {
+        video.removeEventListener('webkitbeginfullscreen', begin);
+      }
+      if (end != null) {
+        video.removeEventListener('webkitendfullscreen', end);
+      }
+    }
+    _beginListener = null;
+    _endListener = null;
+    _video = null;
+  }
+
+  @override
+  void enterVideoFullscreen() {
+    final video = _video;
+    if (video == null) throw StateError('no video element attached');
+    // Called synchronously on the tap frame. `webkitEnterFullscreen` requires
+    // live user activation and any await above would spend it.
+    (video as JSObject).callMethod('webkitEnterFullscreen'.toJS);
+  }
+
+  @override
+  void exitVideoFullscreen() {
+    final video = _video;
+    if (video == null) return;
+    (video as JSObject).callMethod('webkitExitFullscreen'.toJS);
   }
 
   /// Flips media_kit's subtitle `<track>` between browser-rendered and
@@ -105,125 +276,5 @@ class WebFullscreenBackend implements FullscreenBackend {
     } catch (e) {
       debugPrint('[Fullscreen] text track mode $mode failed: $e');
     }
-  }
-
-  @override
-  void attach(Player player) {
-    if (_mode != FullscreenMode.nativeVideoElement || _video != null) return;
-
-    // media_kit exports its web player publicly:
-    // `package:media_kit/media_kit.dart` re-exports
-    // `src/player/web/player/player.dart`, itself
-    // `export 'stub.dart' if (dart.library.js_interop) 'real.dart';`. On a web
-    // build that resolves to `WebPlayer`, whose `element` field is public. This
-    // file only compiles on web, so the cast is safe and needs no `src/`
-    // import, no `$com.alexmercerind.media_kit.instances` global, and no
-    // `querySelector` guessing.
-    final platform = player.platform;
-    if (platform is! WebPlayer) {
-      debugPrint('[Fullscreen] player.platform is not a WebPlayer');
-      return;
-    }
-    // `WebPlayer.element` exists on media_kit's web `real.dart`, which
-    // `flutter build web` resolves. `dart analyze` / `flutter analyze` resolve
-    // the same conditional export to `stub.dart`, which has no `element`, so
-    // a static read fails analysis even though the web compiler accepts it.
-    // Same runtime API the plan specifies; dynamic only bridges the stub gap.
-    final video = (platform as dynamic).element as web.HTMLVideoElement;
-    _video = video;
-
-    _beginListener = ((web.Event _) {
-      // Apple renders only the video element, so hand the browser the cues
-      // media_kit normally keeps hidden and paints through Flutter.
-      _setTextTrackMode('showing');
-      onChange(true);
-    }).toJS;
-    _endListener = ((web.Event _) {
-      _setTextTrackMode('hidden');
-      onChange(false);
-    }).toJS;
-
-    video.addEventListener('webkitbeginfullscreen', _beginListener!);
-    video.addEventListener('webkitendfullscreen', _endListener!);
-  }
-
-  @override
-  void enter() {
-    switch (_mode) {
-      case FullscreenMode.documentElement:
-        final element = web.document.documentElement;
-        if (element == null) return;
-        element.requestFullscreen().toDart.catchError((Object e) {
-          debugPrint('[Fullscreen] requestFullscreen rejected: $e');
-          return null;
-        });
-      case FullscreenMode.nativeVideoElement:
-        final video = _video;
-        if (video == null) {
-          debugPrint('[Fullscreen] no video element attached');
-          return;
-        }
-        try {
-          // Called synchronously on the tap frame. `webkitEnterFullscreen`
-          // requires live user activation and any await above would spend it.
-          (video as JSObject).callMethod('webkitEnterFullscreen'.toJS);
-        } catch (e) {
-          debugPrint('[Fullscreen] webkitEnterFullscreen failed: $e');
-        }
-      case FullscreenMode.osWindow:
-      case FullscreenMode.systemUi:
-      case FullscreenMode.unsupported:
-        return;
-    }
-  }
-
-  @override
-  void exit() {
-    switch (_mode) {
-      case FullscreenMode.documentElement:
-        if (web.document.fullscreenElement == null) return;
-        web.document.exitFullscreen().toDart.catchError((Object e) {
-          debugPrint('[Fullscreen] exitFullscreen rejected: $e');
-          return null;
-        });
-      case FullscreenMode.nativeVideoElement:
-        final video = _video;
-        if (video == null) return;
-        try {
-          (video as JSObject).callMethod('webkitExitFullscreen'.toJS);
-        } catch (e) {
-          debugPrint('[Fullscreen] webkitExitFullscreen failed: $e');
-        }
-      case FullscreenMode.osWindow:
-      case FullscreenMode.systemUi:
-      case FullscreenMode.unsupported:
-        return;
-    }
-  }
-
-  @override
-  void dispose() {
-    final documentListener = _documentListener;
-    if (documentListener != null) {
-      web.document.removeEventListener('fullscreenchange', documentListener);
-      _documentListener = null;
-    }
-
-    // The player screen mounts repeatedly across SPA navigations, so leaked
-    // listeners on a long-lived video element would accumulate.
-    final video = _video;
-    if (video != null) {
-      final begin = _beginListener;
-      final end = _endListener;
-      if (begin != null) {
-        video.removeEventListener('webkitbeginfullscreen', begin);
-      }
-      if (end != null) {
-        video.removeEventListener('webkitendfullscreen', end);
-      }
-    }
-    _beginListener = null;
-    _endListener = null;
-    _video = null;
   }
 }

--- a/player/lib/core/player/fullscreen/fullscreen_controller.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_controller.dart
@@ -1,9 +1,20 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 
 import 'fullscreen_backend.dart';
 import 'fullscreen_backend_factory.dart';
+import 'fullscreen_failure.dart';
 import 'fullscreen_mode.dart';
+import 'fullscreen_report.dart';
+
+/// Builds the platform backend. Takes both sinks so a test can drive state and
+/// failures independently of any platform.
+typedef FullscreenBackendFactory = FullscreenBackend Function(
+  ValueChanged<bool> onChange,
+  FullscreenFailureSink onFailure,
+);
 
 /// Fullscreen state that reports what happened rather than what was asked.
 ///
@@ -14,32 +25,54 @@ import 'fullscreen_mode.dart';
 /// `WindowFullscreenController`'s class comment.
 class FullscreenController {
   FullscreenController({
-    FullscreenBackend Function(ValueChanged<bool>)? backendFactory,
+    FullscreenBackendFactory? backendFactory,
     ValueNotifier<bool>? state,
   })  : _state = state ?? ValueNotifier<bool>(false),
         _ownsState = state == null {
-    _backend = (backendFactory ?? _defaultBackend)(_set);
+    _backend = (backendFactory ?? _defaultBackend)(_set, _fail);
   }
 
-  static FullscreenBackend _defaultBackend(ValueChanged<bool> onChange) =>
-      createFullscreenBackend(onChange: onChange);
+  static FullscreenBackend _defaultBackend(
+    ValueChanged<bool> onChange,
+    FullscreenFailureSink onFailure,
+  ) =>
+      createFullscreenBackend(onChange: onChange, onFailure: onFailure);
 
   final ValueNotifier<bool> _state;
   final bool _ownsState;
   late final FullscreenBackend _backend;
+  final StreamController<FullscreenFailure> _failures =
+      StreamController<FullscreenFailure>.broadcast();
 
   /// Observed fullscreen state. Never written by this class directly.
   ValueListenable<bool> get isFullscreen => _state;
 
   FullscreenMode get mode => _backend.mode;
 
-  /// False only where no fullscreen route exists, which is the signal to hide
-  /// the button rather than render a dead one.
-  bool get available => _backend.mode != FullscreenMode.unsupported;
+  /// Whether a request made right now would be carried out, which is what the
+  /// control's presence must follow.
+  ///
+  /// This used to be `mode != unsupported`, a capability probe resolved once at
+  /// construction. It stayed true when the web backend had bailed out of
+  /// binding a media element and when every `requestFullscreen()` was being
+  /// rejected, so the button was drawn over a route that could not work. The
+  /// backend owns this the same way it owns [isFullscreen].
+  ValueListenable<bool> get available => _backend.ready;
+
+  /// Refusals, for whoever wants to tell the viewer. Broadcast, so a screen can
+  /// subscribe and unsubscribe without consuming them for anyone else.
+  Stream<FullscreenFailure> get failures => _failures.stream;
+
+  /// A snapshot for the diagnostics readout.
+  FullscreenReport get report => _backend.report;
 
   void attach(Player player) => _backend.attach(player);
 
   void _set(bool value) => _state.value = value;
+
+  void _fail(FullscreenFailure failure) {
+    if (!_failures.isClosed) _failures.add(failure);
+  }
 
   /// Synchronous by contract, and must stay that way: `webkitEnterFullscreen`
   /// needs live user activation, and an `await` between the tap and the call
@@ -53,6 +86,7 @@ class FullscreenController {
 
   void dispose() {
     _backend.dispose();
+    _failures.close();
     if (_ownsState) _state.dispose();
   }
 }

--- a/player/lib/core/player/fullscreen/fullscreen_failure.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_failure.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+
+/// Why a fullscreen request could not be carried out.
+///
+/// Every value here used to be a bare `debugPrint` inside
+/// `WebFullscreenBackend`. On a phone that output is unreachable without a Mac
+/// and Safari Web Inspector attached, which is exactly why "the fullscreen
+/// button does nothing on iOS Safari" could not be diagnosed from the device it
+/// happened on. Naming the causes is what makes them reportable: to the viewer
+/// as a message, and to `DiagnosticsScreen` as a line a bug report can carry.
+enum FullscreenFailureCause {
+  /// `document.fullscreenEnabled` could not be read at all.
+  documentEnabledProbeFailed,
+
+  /// The `HTMLVideoElement.prototype` capability probe threw.
+  videoSupportProbeFailed,
+
+  /// `requestFullscreen()` was rejected by the browser.
+  documentRequestRejected,
+
+  /// `exitFullscreen()` was rejected by the browser.
+  documentExitRejected,
+
+  /// The media player was not the web implementation, so no media element
+  /// could be reached to fullscreen.
+  playerNotWebPlayer,
+
+  /// The media element route is in use but nothing is bound to fullscreen.
+  noVideoElement,
+
+  /// `webkitEnterFullscreen()` threw.
+  videoEnterFailed,
+
+  /// `webkitExitFullscreen()` threw.
+  videoExitFailed,
+}
+
+/// A single refusal, with enough detail to put in a bug report and not so much
+/// that it belongs in front of a viewer.
+///
+/// [detail] carries the platform's own words where there were any. It is for
+/// the diagnostics readout; the message shown during playback stays plain,
+/// because a WebKit rejection reason is not something a viewer can act on.
+@immutable
+class FullscreenFailure {
+  const FullscreenFailure(
+    this.cause, {
+    this.detail,
+    this.requestInitiated = false,
+  });
+
+  final FullscreenFailureCause cause;
+  final String? detail;
+
+  /// Whether this followed an explicit request from the viewer.
+  ///
+  /// Only these are worth a message. A capability probe that threw while the
+  /// screen was opening, or a media element that could not be bound during
+  /// source setup, are real and belong in the readout, but telling someone who
+  /// has not asked for fullscreen that fullscreen failed is noise.
+  final bool requestInitiated;
+
+  /// One line, safe to copy out of `DiagnosticsScreen`.
+  String get label => switch (cause) {
+        FullscreenFailureCause.documentEnabledProbeFailed =>
+          'document.fullscreenEnabled could not be read',
+        FullscreenFailureCause.videoSupportProbeFailed =>
+          'video element capability probe failed',
+        FullscreenFailureCause.documentRequestRejected =>
+          'requestFullscreen was rejected',
+        FullscreenFailureCause.documentExitRejected =>
+          'exitFullscreen was rejected',
+        FullscreenFailureCause.playerNotWebPlayer =>
+          'player is not the web implementation',
+        FullscreenFailureCause.noVideoElement => 'no media element bound',
+        FullscreenFailureCause.videoEnterFailed =>
+          'webkitEnterFullscreen failed',
+        FullscreenFailureCause.videoExitFailed => 'webkitExitFullscreen failed',
+      };
+
+  @override
+  String toString() => detail == null ? label : '$label: $detail';
+
+  @override
+  bool operator ==(Object other) =>
+      other is FullscreenFailure &&
+      other.cause == cause &&
+      other.detail == detail &&
+      other.requestInitiated == requestInitiated;
+
+  @override
+  int get hashCode => Object.hash(cause, detail, requestInitiated);
+}

--- a/player/lib/core/player/fullscreen/fullscreen_mode.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_mode.dart
@@ -18,9 +18,15 @@ enum FullscreenMode {
   /// is why this is preferred wherever it works.
   documentElement,
 
-  /// iPhone Safari below iOS 26, which implements fullscreen only for
-  /// `HTMLVideoElement`. Apple draws the chrome and everything Flutter draws
-  /// is unreachable until the viewer exits.
+  /// WebKit builds that implement fullscreen only for `HTMLVideoElement`.
+  /// Apple draws the chrome and everything Flutter draws is unreachable until
+  /// the viewer exits.
+  ///
+  /// This is no longer reachable from the probes alone on a current iPhone.
+  /// Safari 16.4 unprefixed the Fullscreen API on iPadOS and 17.2 brought it to
+  /// iPhone, so `document.fullscreenEnabled` now answers true there and
+  /// [documentElement] wins at construction. [demoteWebMode] is what brings
+  /// this route back, after the document route has actually been refused.
   nativeVideoElement,
 
   /// No fullscreen route at all. The button is hidden rather than left dead.
@@ -55,4 +61,41 @@ FullscreenMode resolveWebMode({
     return FullscreenMode.nativeVideoElement;
   }
   return FullscreenMode.unsupported;
+}
+
+/// The route to use after [current] has been refused at request time.
+///
+/// [resolveWebMode] answers from capability probes, which is all that is
+/// available before anything has been asked. This answers from what actually
+/// happened, which is the only thing that settles WebKit: on a current iPhone
+/// `document.fullscreenEnabled` is true, so [FullscreenMode.documentElement]
+/// wins at construction, and if that request is then refused the video element
+/// route is still there and still works.
+///
+/// Demotion is one-way for the session on purpose. Re-promoting after a single
+/// success would let the mode oscillate and make the diagnostics readout
+/// useless for the thing it exists to answer.
+///
+/// Refusing the video element route returns [FullscreenMode.unsupported], which
+/// withdraws the control. That is a deliberate trade: a `webkitEnterFullscreen`
+/// throw can be transient (WebKit refuses before the video has metadata), so
+/// this can retire a route that would have worked on a later tap. A control that
+/// is present and inert is the defect being fixed, and a control that is honest
+/// about having failed is the lesser harm.
+FullscreenMode demoteWebMode({
+  required FullscreenMode current,
+  required bool videoElementFullscreenSupported,
+}) {
+  switch (current) {
+    case FullscreenMode.documentElement:
+      return videoElementFullscreenSupported
+          ? FullscreenMode.nativeVideoElement
+          : FullscreenMode.unsupported;
+    case FullscreenMode.nativeVideoElement:
+      return FullscreenMode.unsupported;
+    case FullscreenMode.osWindow:
+    case FullscreenMode.systemUi:
+    case FullscreenMode.unsupported:
+      return current;
+  }
 }

--- a/player/lib/core/player/fullscreen/fullscreen_report.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_report.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/foundation.dart';
+
+import 'fullscreen_failure.dart';
+import 'fullscreen_mode.dart';
+
+/// What the fullscreen module currently believes, in a form a bug report can
+/// carry.
+///
+/// This exists because the failure it describes is only reachable on devices
+/// this repo cannot test: `flutter test` always runs non-web, and the reporter
+/// is on an iPhone with no console. `DiagnosticsScreen` already exists so a bug
+/// report can carry the whole picture without a screenshot, and this is the
+/// playback half of that picture.
+///
+/// [documentFullscreenEnabled] and [videoElementFullscreenSupported] are the
+/// two probes `resolveWebMode` ran, and are null on native builds where neither
+/// applies. They are reported separately from [mode] on purpose: "this browser
+/// has no fullscreen at all" and "we picked a route and it refused" are the two
+/// answers being told apart, and [mode] alone cannot distinguish them once
+/// [demoted] is involved.
+@immutable
+class FullscreenReport {
+  const FullscreenReport({
+    required this.mode,
+    required this.ready,
+    this.mediaElementBound = false,
+    this.demoted = false,
+    this.lastFailure,
+    this.documentFullscreenEnabled,
+    this.videoElementFullscreenSupported,
+  });
+
+  /// The route in use right now, after any demotion.
+  final FullscreenMode mode;
+
+  /// Whether a request made at this moment would be carried out. This is what
+  /// the control's presence follows, not [mode].
+  final bool ready;
+
+  /// Whether a media element is bound for the video element route. Always
+  /// false on the document route and on native.
+  final bool mediaElementBound;
+
+  /// Whether the initially resolved route was refused at request time and the
+  /// backend fell back. One-way for the life of the session.
+  final bool demoted;
+
+  /// The most recent refusal, if any. Not cleared on a later success, because
+  /// its whole audience is someone reading back what went wrong.
+  final FullscreenFailure? lastFailure;
+
+  /// `document.fullscreenEnabled` as read at construction. Null on native.
+  final bool? documentFullscreenEnabled;
+
+  /// Whether `HTMLVideoElement.prototype` carried `webkitEnterFullscreen`.
+  /// Null on native.
+  final bool? videoElementFullscreenSupported;
+
+  FullscreenReport copyWith({
+    FullscreenMode? mode,
+    bool? ready,
+    bool? mediaElementBound,
+    bool? demoted,
+    FullscreenFailure? lastFailure,
+  }) =>
+      FullscreenReport(
+        mode: mode ?? this.mode,
+        ready: ready ?? this.ready,
+        mediaElementBound: mediaElementBound ?? this.mediaElementBound,
+        demoted: demoted ?? this.demoted,
+        lastFailure: lastFailure ?? this.lastFailure,
+        documentFullscreenEnabled: documentFullscreenEnabled,
+        videoElementFullscreenSupported: videoElementFullscreenSupported,
+      );
+
+  /// Rows for the diagnostics readout, in display order.
+  ///
+  /// Pure and shared by the section and the copy button so the two cannot drift
+  /// apart, which is the failure mode of every hand-maintained "copy
+  /// diagnostics" that lists fewer fields than the screen above it.
+  List<(String label, String value)> get rows => [
+        ('Route', mode.name),
+        ('Ready', ready ? 'yes' : 'no'),
+        if (mode == FullscreenMode.nativeVideoElement)
+          ('Media element', mediaElementBound ? 'bound' : 'not bound'),
+        if (demoted) ('Fell back', 'yes'),
+        if (documentFullscreenEnabled != null)
+          ('document.fullscreenEnabled', '$documentFullscreenEnabled'),
+        if (videoElementFullscreenSupported != null)
+          ('Video element fullscreen', '$videoElementFullscreenSupported'),
+        if (lastFailure != null) ('Last failure', '$lastFailure'),
+      ];
+
+  @override
+  String toString() => 'FullscreenReport(mode: ${mode.name}, ready: $ready, '
+      'mediaElementBound: $mediaElementBound, demoted: $demoted, '
+      'lastFailure: $lastFailure, '
+      'documentFullscreenEnabled: $documentFullscreenEnabled, '
+      'videoElementFullscreenSupported: $videoElementFullscreenSupported)';
+}
+
+/// The Playback block of a copied diagnostics report.
+///
+/// Empty when nothing has played this session, so a bug report about something
+/// else does not carry a section of "unknown" rows.
+List<String> fullscreenReportLines(FullscreenReport? report) {
+  if (report == null) return const [];
+  return [
+    'Fullscreen:',
+    for (final (label, value) in report.rows) '  $label: $value',
+  ];
+}

--- a/player/lib/core/player/fullscreen/fullscreen_report.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_report.dart
@@ -73,6 +73,12 @@ class FullscreenReport {
         videoElementFullscreenSupported: videoElementFullscreenSupported,
       );
 
+  /// The one row whose value is free-form platform text rather than a short
+  /// token. A WebKit rejection reason has no length bound, so the screen wraps
+  /// this row instead of laying it out as trailing text. Named here so the
+  /// screen does not have to match on a literal that lives in [rows].
+  static const String lastFailureLabel = 'Last failure';
+
   /// Rows for the diagnostics readout, in display order.
   ///
   /// Pure and shared by the section and the copy button so the two cannot drift
@@ -88,7 +94,7 @@ class FullscreenReport {
           ('document.fullscreenEnabled', '$documentFullscreenEnabled'),
         if (videoElementFullscreenSupported != null)
           ('Video element fullscreen', '$videoElementFullscreenSupported'),
-        if (lastFailure != null) ('Last failure', '$lastFailure'),
+        if (lastFailure != null) (lastFailureLabel, '$lastFailure'),
       ];
 
   @override

--- a/player/lib/core/player/fullscreen/fullscreen_report_signal.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_report_signal.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/foundation.dart';
+
+import 'fullscreen_report.dart';
+
+/// The last fullscreen report the player published, kept after the player
+/// screen is gone.
+///
+/// It has to outlive the screen. The sequence a bug report is made of is "play
+/// something, tap fullscreen, nothing happens, go to settings and copy the
+/// diagnostics", and by the final step the `FullscreenController` that knew
+/// what happened has been disposed.
+///
+/// Same shape and same reasoning as `windowFullscreenSignal`: a platform-free
+/// global signal, one intended writer, read-only view for consumers, and no
+/// `@visibleForTesting` annotation because that fires
+/// `invalid_use_of_visible_for_testing_member` the moment a different library
+/// file writes to it.
+///
+/// Null until a player screen has run at least once, which is the honest answer
+/// for a session that has never played anything.
+final ValueNotifier<FullscreenReport?> fullscreenReportSignal =
+    ValueNotifier<FullscreenReport?>(null);
+
+/// Read-only view of [fullscreenReportSignal] for consumers.
+ValueListenable<FullscreenReport?> get fullscreenReport =>
+    fullscreenReportSignal;

--- a/player/lib/core/player/fullscreen/fullscreen_web_core.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_web_core.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/foundation.dart';
+
+import 'fullscreen_backend.dart';
+import 'fullscreen_failure.dart';
+import 'fullscreen_mode.dart';
+import 'fullscreen_report.dart';
+import 'fullscreen_web_platform.dart';
+
+/// Everything the web backend decides, with no browser in sight.
+///
+/// `WebFullscreenBackend` is now an adapter over this: it implements
+/// [WebFullscreenPlatform] with `package:web` and forwards. The split exists so
+/// the branching can be tested at all. See `fullscreen_web_platform.dart`.
+///
+/// Three behaviours live here that the previous implementation got wrong, all
+/// of which presented identically as "the fullscreen button does nothing":
+///
+/// 1. **Rebinding.** [attach] is keyed on the player's identity, not on whether
+///    an element was ever bound. `PlayerScreen` builds a fresh `Player` on every
+///    source load, and the old `if (_video != null) return` meant that from the
+///    second episode, quality switch or Retry onward the backend was
+///    fullscreening a disposed element.
+/// 2. **Readiness.** [ready] answers "would a request now be carried out",
+///    where the old `available` answered "does this browser have an API". The
+///    control follows readiness, so it is absent rather than inert.
+/// 3. **Demotion.** A refused document request falls back to the media element
+///    route for the rest of the session. On a current iPhone
+///    `document.fullscreenEnabled` is true, so the document route always wins at
+///    construction and the video route written for that device was unreachable.
+class WebFullscreenCore {
+  WebFullscreenCore({
+    required this.platform,
+    required this.onChange,
+    required this.onFailure,
+  }) {
+    _documentEnabled = platform.documentFullscreenEnabled;
+    _videoSupported = platform.videoElementFullscreenSupported;
+    _mode = resolveWebMode(
+      documentFullscreenEnabled: _documentEnabled,
+      videoElementFullscreenSupported: _videoSupported,
+    );
+    if (_mode == FullscreenMode.documentElement) {
+      platform.listenDocumentFullscreen(onChange);
+    }
+    // Probe failures are real and belong in the readout, but nobody asked for
+    // fullscreen yet, so they are recorded rather than announced. Nothing is
+    // subscribed this early in any case; the report is where they are read.
+    for (final failure in platform.probeFailures) {
+      _record(failure, emit: false);
+    }
+    _ready = ValueNotifier<bool>(_computeReady());
+  }
+
+  final WebFullscreenPlatform platform;
+  final ValueChanged<bool> onChange;
+  final FullscreenFailureSink onFailure;
+
+  late final bool _documentEnabled;
+  late final bool _videoSupported;
+
+  /// Mutable, unlike its native counterpart: [_demoteAfterRefusal] moves it
+  /// once when a route is refused at request time.
+  late FullscreenMode _mode;
+
+  late final ValueNotifier<bool> _ready;
+
+  Object? _player;
+  bool _videoBound = false;
+  bool _demoted = false;
+  FullscreenFailure? _lastFailure;
+
+  FullscreenMode get mode => _mode;
+
+  ValueListenable<bool> get ready => _ready;
+
+  FullscreenReport get report => FullscreenReport(
+        mode: _mode,
+        ready: _ready.value,
+        mediaElementBound: _videoBound,
+        demoted: _demoted,
+        lastFailure: _lastFailure,
+        documentFullscreenEnabled: _documentEnabled,
+        videoElementFullscreenSupported: _videoSupported,
+      );
+
+  /// Binds the media element of [player], releasing any previous one.
+  ///
+  /// A repeat call with the same instance is a no-op, so the four
+  /// `_initializePlayer` call sites need no bookkeeping of their own. The
+  /// player is retained even on the document route, because [_demoteAfterRefusal]
+  /// may need it later.
+  void attach(Object player) {
+    if (identical(_player, player)) return;
+    platform.unbindVideo();
+    _videoBound = false;
+    _player = player;
+    _bindVideoIfNeeded(requestInitiated: false);
+    _updateReady();
+  }
+
+  void enter() {
+    switch (_mode) {
+      case FullscreenMode.documentElement:
+        platform.requestDocumentFullscreen(_onDocumentRequestRejected);
+      case FullscreenMode.nativeVideoElement:
+        _enterVideo();
+      case FullscreenMode.osWindow:
+      case FullscreenMode.systemUi:
+      case FullscreenMode.unsupported:
+        return;
+    }
+  }
+
+  void exit() {
+    switch (_mode) {
+      case FullscreenMode.documentElement:
+        platform.exitDocumentFullscreen((error) => _record(
+              FullscreenFailure(
+                FullscreenFailureCause.documentExitRejected,
+                detail: '$error',
+                requestInitiated: true,
+              ),
+            ));
+      case FullscreenMode.nativeVideoElement:
+        if (!_videoBound) return;
+        try {
+          platform.exitVideoFullscreen();
+        } catch (e) {
+          _record(FullscreenFailure(
+            FullscreenFailureCause.videoExitFailed,
+            detail: '$e',
+            requestInitiated: true,
+          ));
+        }
+      case FullscreenMode.osWindow:
+      case FullscreenMode.systemUi:
+      case FullscreenMode.unsupported:
+        return;
+    }
+  }
+
+  void dispose() {
+    platform.stopListeningDocumentFullscreen();
+    platform.unbindVideo();
+    _ready.dispose();
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  bool _computeReady() => switch (_mode) {
+        FullscreenMode.documentElement => true,
+        FullscreenMode.nativeVideoElement => _videoBound,
+        FullscreenMode.osWindow => true,
+        FullscreenMode.systemUi => true,
+        FullscreenMode.unsupported => false,
+      };
+
+  void _updateReady() => _ready.value = _computeReady();
+
+  /// [emit] is false on the demotion path, where the caller announces whatever
+  /// ends up being the final word. Announcing here as well would report the
+  /// same refused tap twice.
+  void _bindVideoIfNeeded({required bool requestInitiated, bool emit = true}) {
+    if (_mode != FullscreenMode.nativeVideoElement) return;
+    final player = _player;
+    if (player == null) return;
+
+    final cause = platform.bindVideo(player, onChange: onChange);
+    if (cause != null) {
+      _videoBound = false;
+      _record(
+        FullscreenFailure(cause, requestInitiated: requestInitiated),
+        emit: emit,
+      );
+      return;
+    }
+    _videoBound = true;
+  }
+
+  void _enterVideo() {
+    if (!_videoBound) {
+      _record(const FullscreenFailure(
+        FullscreenFailureCause.noVideoElement,
+        requestInitiated: true,
+      ));
+      _demoteAfterRefusal();
+      _updateReady();
+      return;
+    }
+    try {
+      platform.enterVideoFullscreen();
+    } catch (e) {
+      _record(FullscreenFailure(
+        FullscreenFailureCause.videoEnterFailed,
+        detail: '$e',
+        requestInitiated: true,
+      ));
+      _demoteAfterRefusal();
+      _updateReady();
+    }
+  }
+
+  /// The document route was refused. Fall back if there is anywhere to fall
+  /// back to, and retry the request on the new route immediately.
+  ///
+  /// The retry is worth attempting rather than deferring to the next tap: the
+  /// rejection arrives off a promise, so transient user activation is usually
+  /// still live. Not throwing is the strongest synchronous signal available;
+  /// the authoritative answer is the `webkitbeginfullscreen` event, which
+  /// [onChange] carries whenever it arrives.
+  ///
+  /// The refusal itself is only announced when there is nothing left to try.
+  /// If the fallback works the viewer got what they asked for, and the readout
+  /// still records what happened on the way.
+  void _onDocumentRequestRejected(Object error) {
+    _record(
+      FullscreenFailure(
+        FullscreenFailureCause.documentRequestRejected,
+        detail: '$error',
+        requestInitiated: true,
+      ),
+      emit: false,
+    );
+
+    final fellBack = _demoteAfterRefusal();
+    _updateReady();
+
+    if (!fellBack) {
+      onFailure(_lastFailure!);
+      return;
+    }
+    _enterVideo();
+  }
+
+  /// Moves to the route left after a refusal. Returns whether a usable one
+  /// remains. One-way: see [demoteWebMode].
+  bool _demoteAfterRefusal() {
+    final next = demoteWebMode(
+      current: _mode,
+      videoElementFullscreenSupported: _videoSupported,
+    );
+    if (next == _mode) return false;
+
+    if (_mode == FullscreenMode.documentElement) {
+      platform.stopListeningDocumentFullscreen();
+    }
+    _mode = next;
+    _demoted = true;
+
+    if (_mode == FullscreenMode.nativeVideoElement) {
+      _bindVideoIfNeeded(requestInitiated: true, emit: false);
+      return _videoBound;
+    }
+
+    platform.unbindVideo();
+    _videoBound = false;
+    return false;
+  }
+
+  void _record(FullscreenFailure failure, {bool emit = true}) {
+    _lastFailure = failure;
+    if (emit) onFailure(failure);
+  }
+}

--- a/player/lib/core/player/fullscreen/fullscreen_web_core.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_web_core.dart
@@ -69,6 +69,11 @@ class WebFullscreenCore {
   bool _demoted = false;
   FullscreenFailure? _lastFailure;
 
+  /// Both document routes answer through a `Promise`, so a rejection can land
+  /// after the player screen is gone. Writing `_ready` then would throw on a
+  /// disposed `ValueNotifier`.
+  bool _disposed = false;
+
   FullscreenMode get mode => _mode;
 
   ValueListenable<bool> get ready => _ready;
@@ -114,13 +119,14 @@ class WebFullscreenCore {
   void exit() {
     switch (_mode) {
       case FullscreenMode.documentElement:
-        platform.exitDocumentFullscreen((error) => _record(
-              FullscreenFailure(
-                FullscreenFailureCause.documentExitRejected,
-                detail: '$error',
-                requestInitiated: true,
-              ),
-            ));
+        platform.exitDocumentFullscreen((error) {
+          if (_disposed) return;
+          _record(FullscreenFailure(
+            FullscreenFailureCause.documentExitRejected,
+            detail: '$error',
+            requestInitiated: true,
+          ));
+        });
       case FullscreenMode.nativeVideoElement:
         if (!_videoBound) return;
         try {
@@ -140,6 +146,7 @@ class WebFullscreenCore {
   }
 
   void dispose() {
+    _disposed = true;
     platform.stopListeningDocumentFullscreen();
     platform.unbindVideo();
     _ready.dispose();
@@ -201,45 +208,36 @@ class WebFullscreenCore {
   }
 
   /// The document route was refused. Fall back if there is anywhere to fall
-  /// back to, and retry the request on the new route immediately.
+  /// back to, and let the viewer's next request use the new route.
   ///
-  /// The retry is worth attempting rather than deferring to the next tap: the
-  /// rejection arrives off a promise, so transient user activation is usually
-  /// still live. Not throwing is the strongest synchronous signal available;
-  /// the authoritative answer is the `webkitbeginfullscreen` event, which
-  /// [onChange] carries whenever it arrives.
+  /// Deliberately does not retry on this tap. `requestFullscreen()` consumes
+  /// transient user activation, and this rejection arrives after it, so
+  /// `webkitEnterFullscreen` would run without the activation WebKit demands.
+  /// It would fail, and [_enterVideo] reads a failure there as evidence the
+  /// video route is dead and retires it. The fallback would destroy itself the
+  /// first time it was needed, on the iPhone path it exists for.
   ///
-  /// The refusal itself is only announced when there is nothing left to try.
-  /// If the fallback works the viewer got what they asked for, and the readout
-  /// still records what happened on the way.
+  /// So this tap is honestly reported as refused and the next one enters by the
+  /// video route with fresh activation. One message, then it works.
   void _onDocumentRequestRejected(Object error) {
-    _record(
-      FullscreenFailure(
-        FullscreenFailureCause.documentRequestRejected,
-        detail: '$error',
-        requestInitiated: true,
-      ),
-      emit: false,
-    );
+    if (_disposed) return;
+    _record(FullscreenFailure(
+      FullscreenFailureCause.documentRequestRejected,
+      detail: '$error',
+      requestInitiated: true,
+    ));
 
-    final fellBack = _demoteAfterRefusal();
+    _demoteAfterRefusal();
     _updateReady();
-
-    if (!fellBack) {
-      onFailure(_lastFailure!);
-      return;
-    }
-    _enterVideo();
   }
 
-  /// Moves to the route left after a refusal. Returns whether a usable one
-  /// remains. One-way: see [demoteWebMode].
-  bool _demoteAfterRefusal() {
+  /// Moves to the route left after a refusal. One-way: see [demoteWebMode].
+  void _demoteAfterRefusal() {
     final next = demoteWebMode(
       current: _mode,
       videoElementFullscreenSupported: _videoSupported,
     );
-    if (next == _mode) return false;
+    if (next == _mode) return;
 
     if (_mode == FullscreenMode.documentElement) {
       platform.stopListeningDocumentFullscreen();
@@ -248,13 +246,14 @@ class WebFullscreenCore {
     _demoted = true;
 
     if (_mode == FullscreenMode.nativeVideoElement) {
+      // Bound now rather than on the next tap, so readiness is already correct
+      // and the control does not flicker away between the two.
       _bindVideoIfNeeded(requestInitiated: true, emit: false);
-      return _videoBound;
+      return;
     }
 
     platform.unbindVideo();
     _videoBound = false;
-    return false;
   }
 
   void _record(FullscreenFailure failure, {bool emit = true}) {

--- a/player/lib/core/player/fullscreen/fullscreen_web_platform.dart
+++ b/player/lib/core/player/fullscreen/fullscreen_web_platform.dart
@@ -1,0 +1,61 @@
+import 'fullscreen_failure.dart';
+
+/// The browser calls [WebFullscreenCore] needs, behind a seam.
+///
+/// This file deliberately imports nothing from `package:web`. That is the whole
+/// point: `fullscreen_backend_web.dart` compiles only under
+/// `dart.library.js_interop`, so nothing in it can be reached from
+/// `flutter test`, which always runs non-web. Everything worth testing (route
+/// selection, demotion, readiness, rebinding, which failures are reported) is
+/// on this side of the seam and runs on the VM against a fake. What stays on
+/// the far side is the `package:web` calls themselves, and it stays thin enough
+/// to read.
+///
+/// The same reasoning as `resolveWebMode`, `PlatformFeatures.
+/// computeSupportsKeyboardShortcuts` and `windowChromeInsetFor`, applied to
+/// state rather than to a single pure decision.
+abstract interface class WebFullscreenPlatform {
+  /// `document.fullscreenEnabled`. False when the read threw, in which case the
+  /// reason is in [probeFailures].
+  bool get documentFullscreenEnabled;
+
+  /// Whether `HTMLVideoElement.prototype` carries `webkitEnterFullscreen`.
+  /// False when the probe threw, in which case the reason is in
+  /// [probeFailures].
+  bool get videoElementFullscreenSupported;
+
+  /// Anything that went wrong while answering the two probes above. Read once,
+  /// at construction. Empty on a healthy browser.
+  List<FullscreenFailure> get probeFailures;
+
+  void listenDocumentFullscreen(void Function(bool fullscreen) onChange);
+
+  void stopListeningDocumentFullscreen();
+
+  /// Synchronous by contract: the call must happen on the tap frame, because
+  /// user activation does not survive an await. [onRejected] fires later, off
+  /// the returned promise.
+  void requestDocumentFullscreen(void Function(Object error) onRejected);
+
+  void exitDocumentFullscreen(void Function(Object error) onRejected);
+
+  /// Binds the media element behind [player] and subscribes to its own
+  /// fullscreen transitions.
+  ///
+  /// Returns null on success, or the cause when there is no element to bind.
+  /// Any element bound by a previous call is released first.
+  FullscreenFailureCause? bindVideo(
+    Object player, {
+    required void Function(bool fullscreen) onChange,
+  });
+
+  /// Releases the currently bound element, if any. Safe to call when nothing is
+  /// bound.
+  void unbindVideo();
+
+  /// Throws when the browser refuses.
+  void enterVideoFullscreen();
+
+  /// Throws when the browser refuses.
+  void exitVideoFullscreen();
+}

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -4382,10 +4382,19 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     _publishFullscreenReport();
     if (!failure.requestInitiated) return;
     if (!mounted) return;
+    // A refused exit is also viewer-initiated, so it reaches here too. Saying
+    // "could not enter" to someone trying to leave fullscreen would describe
+    // the opposite of what they did.
+    final message = switch (failure.cause) {
+      FullscreenFailureCause.documentExitRejected ||
+      FullscreenFailureCause.videoExitFailed =>
+        'Could not exit fullscreen',
+      _ => 'Could not enter fullscreen',
+    };
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('Could not enter fullscreen'),
-        duration: Duration(seconds: 2),
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(seconds: 2),
       ),
     );
   }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -24,6 +24,8 @@ import '../../../core/playback/playback_progress_store.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
 import '../../../core/utils/web_lifecycle.dart' as web_lifecycle;
 import '../../../core/player/fullscreen/fullscreen_controller.dart';
+import '../../../core/player/fullscreen/fullscreen_failure.dart';
+import '../../../core/player/fullscreen/fullscreen_report_signal.dart';
 import '../../../core/player/input_capabilities.dart';
 import '../../../core/player/platform_features.dart';
 import '../../../core/player/playback_error.dart';
@@ -201,6 +203,19 @@ class PlayerScreen extends ConsumerStatefulWidget {
         backgroundColor: Colors.black,
         body: SafeArea(top: false, child: child),
       );
+
+  /// Stands in for the platform fullscreen backend while a test is mounted.
+  ///
+  /// The real one is chosen by a conditional import, so a `flutter test` host
+  /// always gets the native backend, which is unconditionally ready. That makes
+  /// the case this change exists for — a route that exists but cannot be used
+  /// right now, so the button must not draw — unreachable without a seam. The
+  /// controller is a field initializer with no constructor to thread an
+  /// argument through, hence a static rather than a parameter.
+  ///
+  /// Null in production, and a test that sets it must clear it.
+  @visibleForTesting
+  static FullscreenBackendFactory? debugFullscreenBackendFactory;
 
   /// Whether this build should install the playback key handler.
   ///
@@ -687,7 +702,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   /// optimistically and never learned that the platform had refused, which is
   /// why the button reported "exit fullscreen" over an inline video on
   /// iPhone Safari.
-  final FullscreenController _fullscreen = FullscreenController();
+  final FullscreenController _fullscreen = FullscreenController(
+    backendFactory: PlayerScreen.debugFullscreenBackendFactory,
+  );
+
+  /// Live while the screen is mounted. Carries refused requests to the viewer;
+  /// see [_onFullscreenFailure].
+  StreamSubscription<FullscreenFailure>? _fullscreenFailures;
 
   // Always-on-top state. Not persisted — starts false for every playback
   // session and is force-disabled in dispose() if still true, so it never
@@ -777,6 +798,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
 
     _loadAutoSkipPreference();
     _fullscreen.isFullscreen.addListener(_onFullscreenChanged);
+    // Availability moves at runtime on web: the media element route is not
+    // ready until a player is attached, and a refused request can retire the
+    // route mid-session. The button follows it, so the rebuild has to as well.
+    _fullscreen.available.addListener(_onFullscreenChanged);
+    _fullscreenFailures = _fullscreen.failures.listen(_onFullscreenFailure);
     _initializePlayer();
 
     // Force landscape orientation on mobile devices. Skipped on a television,
@@ -1709,7 +1735,14 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     _videoController = VideoController(player);
     // Hands the backend the media_kit player so the web backend can reach the
     // underlying HTMLVideoElement. A no-op on native.
+    //
+    // Called again for every source this screen plays, and that repetition is
+    // load-bearing: each one is a fresh `Player` with a fresh element, and a
+    // backend still holding the previous one would fullscreen a disposed
+    // element. The backend keys on instance identity, so a repeat with the same
+    // player is free.
     _fullscreen.attach(player);
+    _publishFullscreenReport();
 
     // Bound before `open` deliberately: a source that fails to resolve at all
     // (a deleted file id, a dead HLS session) errors during the open itself,
@@ -4251,6 +4284,10 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
         return KeyEventResult.handled;
 
       case LogicalKeyboardKey.keyF:
+        // Gated on the same signal as the button, so the two cannot disagree
+        // about whether fullscreen exists. Claiming the key while doing nothing
+        // would swallow it from anything else that wants it.
+        if (!_fullscreen.available.value) return KeyEventResult.ignored;
         _fullscreen.toggle();
         return KeyEventResult.handled;
 
@@ -4319,10 +4356,38 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     }
   }
 
-  /// Rebuilds so the chrome's fullscreen icon follows observed state. Cheap:
-  /// the notifier only fires on a real transition.
+  /// Rebuilds so the chrome's fullscreen icon follows observed state, and so
+  /// the button appears and disappears with the route. Cheap: both notifiers
+  /// only fire on a real transition.
   void _onFullscreenChanged() {
+    _publishFullscreenReport();
     if (mounted) setState(() {});
+  }
+
+  /// Hands the current picture to `/settings/diagnostics`, which outlives this
+  /// screen and is where a bug report is assembled. See
+  /// `fullscreen_report_signal.dart`.
+  void _publishFullscreenReport() =>
+      fullscreenReportSignal.value = _fullscreen.report;
+
+  /// Tells the viewer that a fullscreen request was refused.
+  ///
+  /// Only requests get a message. A capability probe that threw while the
+  /// screen was opening is real and lands in `/settings/diagnostics`, but
+  /// announcing it to someone who never asked for fullscreen is noise.
+  ///
+  /// The text stays plain on purpose: a WebKit rejection reason is not
+  /// something a viewer can act on, and the detail is in the readout.
+  void _onFullscreenFailure(FullscreenFailure failure) {
+    _publishFullscreenReport();
+    if (!failure.requestInitiated) return;
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Could not enter fullscreen'),
+        duration: Duration(seconds: 2),
+      ),
+    );
   }
 
   /// Toggle always-on-top across desktop platforms.
@@ -4359,6 +4424,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     // `_element` is nulled only after dispose returns, so it still reads true.
     // Then exit before `dispose()`, which disposes the notifier underneath it.
     _fullscreen.isFullscreen.removeListener(_onFullscreenChanged);
+    _fullscreen.available.removeListener(_onFullscreenChanged);
+    unawaited(_fullscreenFailures?.cancel());
+    _fullscreenFailures = null;
     if (_fullscreen.isFullscreen.value) {
       _fullscreen.exit();
     }
@@ -4801,7 +4869,8 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
           // Null where no fullscreen route exists, which hides the button
           // rather than leaving a dead one — matching how `onQualityTap`
           // above hides itself at a single quality rung.
-          onFullscreenTap: _fullscreen.available ? _fullscreen.toggle : null,
+          onFullscreenTap:
+              _fullscreen.available.value ? _fullscreen.toggle : null,
           onAlwaysOnTopTap: _toggleAlwaysOnTop,
           onPreviousEpisode: _hasPreviousEpisode ? _playPreviousEpisode : null,
           onNextEpisode: _hasNextEpisode ? _playNextEpisode : null,

--- a/player/lib/presentation/screens/settings/diagnostics_screen.dart
+++ b/player/lib/presentation/screens/settings/diagnostics_screen.dart
@@ -5,18 +5,25 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/connection/connection_provider.dart';
 import '../../../core/connection/connection_summary.dart';
 import '../../../core/p2p/p2p_service.dart';
+import '../../../core/player/fullscreen/fullscreen_report.dart';
+import '../../../core/player/fullscreen/fullscreen_report_signal.dart';
 import '../../../core/theme/colors.dart';
 import '../../../core/update/update_provider.dart';
 import '../../widgets/connection_tone_color.dart';
 import 'widgets/settings_row.dart';
 import 'widgets/settings_section.dart';
 
-/// Read-only connection internals.
+/// Read-only internals.
 ///
 /// These used to sit inline on the settings screen, where a relay URL and a
 /// peer count read as things you could act on. Nothing here is actionable
 /// except the copy button, which exists so a bug report can carry the whole
 /// picture without a screenshot.
+///
+/// The Playback section is here for the same reason and answers a question the
+/// device itself cannot otherwise be asked: on iOS Safari the fullscreen button
+/// can be present and do nothing, and every explanation for that used to be a
+/// `debugPrint` reachable only from a Mac with Web Inspector attached.
 class DiagnosticsScreen extends ConsumerWidget {
   const DiagnosticsScreen({super.key});
 
@@ -33,7 +40,7 @@ class DiagnosticsScreen extends ConsumerWidget {
     );
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Connection details')),
+      appBar: AppBar(title: const Text('Diagnostics')),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
         children: [
@@ -89,6 +96,11 @@ class DiagnosticsScreen extends ConsumerWidget {
               ],
             ),
           ],
+          const SizedBox(height: 18),
+          ValueListenableBuilder<FullscreenReport?>(
+            valueListenable: fullscreenReport,
+            builder: (context, report, _) => _PlaybackSection(report: report),
+          ),
           const SizedBox(height: 24),
           FilledButton.icon(
             key: const Key('copy-diagnostics'),
@@ -115,6 +127,7 @@ class DiagnosticsScreen extends ConsumerWidget {
       if (status.relayUrl != null) 'Relay server: ${status.relayUrl}',
       'Peers: ${status.connectedPeersCount}',
       if (status.nodeAddr != null) 'Node address: ${status.nodeAddr}',
+      ...fullscreenReportLines(fullscreenReport.value),
     ].join('\n');
 
     await Clipboard.setData(ClipboardData(text: report));
@@ -122,6 +135,39 @@ class DiagnosticsScreen extends ConsumerWidget {
     if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('Diagnostics copied')),
+    );
+  }
+}
+
+/// The fullscreen readout, or a line saying nothing has played yet.
+///
+/// Read-only like everything else on this screen. It exists to be looked at
+/// once, on a device whose console is unreachable, and copied.
+class _PlaybackSection extends StatelessWidget {
+  const _PlaybackSection({required this.report});
+
+  final FullscreenReport? report;
+
+  @override
+  Widget build(BuildContext context) {
+    final report = this.report;
+    return SettingsSection(
+      label: 'Playback',
+      children: [
+        if (report == null)
+          const SettingsRow.action(
+            icon: Icons.fullscreen,
+            title: 'Fullscreen',
+            subtitle: 'Nothing played yet this session',
+          )
+        else
+          for (final (label, value) in report.rows)
+            SettingsRow.action(
+              icon: Icons.fullscreen,
+              title: label,
+              trailing: _Value(value),
+            ),
+      ],
     );
   }
 }

--- a/player/lib/presentation/screens/settings/diagnostics_screen.dart
+++ b/player/lib/presentation/screens/settings/diagnostics_screen.dart
@@ -162,11 +162,21 @@ class _PlaybackSection extends StatelessWidget {
           )
         else
           for (final (label, value) in report.rows)
-            SettingsRow.action(
-              icon: Icons.fullscreen,
-              title: label,
-              trailing: _Value(value),
-            ),
+            // `trailing` sits unconstrained beside the expanded title column,
+            // so a browser's rejection text laid out there overflows the row
+            // on a phone. The subtitle is inside that column and wraps.
+            if (label == FullscreenReport.lastFailureLabel)
+              SettingsRow.action(
+                icon: Icons.fullscreen,
+                title: label,
+                subtitle: value,
+              )
+            else
+              SettingsRow.action(
+                icon: Icons.fullscreen,
+                title: label,
+                trailing: _Value(value),
+              ),
       ],
     );
   }

--- a/player/test/core/player/fullscreen/fullscreen_controller_test.dart
+++ b/player/test/core/player/fullscreen/fullscreen_controller_test.dart
@@ -4,19 +4,27 @@
 // false, because that is precisely the bug this replaces — `PlayerScreen`
 // used to flip `_isFullscreen` inside `setState` before asking the platform,
 // so on iPhone Safari the icon said "exit fullscreen" over an inline video.
+//
+// `available` is held to the same standard. It used to be `mode != unsupported`,
+// a capability probe read once at construction, so it stayed true while the web
+// backend had nothing bound and while every request was being rejected. The
+// button drawn from it was present and dead, which is the same lie one layer
+// down.
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:player/core/player/fullscreen/fullscreen_backend.dart';
 import 'package:player/core/player/fullscreen/fullscreen_controller.dart';
+import 'package:player/core/player/fullscreen/fullscreen_failure.dart';
 import 'package:player/core/player/fullscreen/fullscreen_mode.dart';
+import 'package:player/core/player/fullscreen/fullscreen_report.dart';
 
 void main() {
   group('FullscreenController', () {
     test('starts windowed', () {
       final controller = FullscreenController(
-        backendFactory: (onChange) => _FakeBackend(onChange),
+        backendFactory: (onChange, onFailure) => _FakeBackend(onChange),
       );
       addTearDown(controller.dispose);
 
@@ -26,7 +34,8 @@ void main() {
     test('enter forwards to the backend', () {
       late _FakeBackend backend;
       final controller = FullscreenController(
-        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+        backendFactory: (onChange, onFailure) =>
+            backend = _FakeBackend(onChange),
       );
       addTearDown(controller.dispose);
 
@@ -39,7 +48,7 @@ void main() {
         'a backend that accepts the request but never reports leaves the '
         'notifier false — the iPhone Safari case', () {
       final controller = FullscreenController(
-        backendFactory: (onChange) => _SilentBackend(onChange),
+        backendFactory: (onChange, onFailure) => _SilentBackend(onChange),
       );
       addTearDown(controller.dispose);
 
@@ -51,14 +60,15 @@ void main() {
     test('the notifier follows backend events', () {
       late _FakeBackend backend;
       final controller = FullscreenController(
-        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+        backendFactory: (onChange, onFailure) =>
+            backend = _FakeBackend(onChange),
       );
       addTearDown(controller.dispose);
 
-      backend.report(true);
+      backend.emit(true);
       expect(controller.isFullscreen.value, isTrue);
 
-      backend.report(false);
+      backend.emit(false);
       expect(controller.isFullscreen.value, isFalse);
     });
 
@@ -67,13 +77,14 @@ void main() {
         'backend reported means the next tap enters rather than exits', () {
       late _FakeBackend backend;
       final controller = FullscreenController(
-        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+        backendFactory: (onChange, onFailure) =>
+            backend = _FakeBackend(onChange),
       );
       addTearDown(controller.dispose);
 
       controller.toggle();
-      backend.report(true);
-      backend.report(false); // viewer pressed Apple's Done button
+      backend.emit(true);
+      backend.emit(false); // viewer pressed Apple's Done button
 
       controller.toggle();
 
@@ -81,26 +92,83 @@ void main() {
       expect(backend.exitCalls, 0);
     });
 
-    test('available is false only in unsupported mode', () {
-      final unsupported = FullscreenController(
-        backendFactory: (onChange) =>
-            _FakeBackend(onChange, mode: FullscreenMode.unsupported),
+    test('available follows the backend, not the mode', () {
+      final controller = FullscreenController(
+        backendFactory: (onChange, onFailure) => _FakeBackend(
+          onChange,
+          mode: FullscreenMode.nativeVideoElement,
+          ready: false,
+        ),
       );
-      addTearDown(unsupported.dispose);
-      final supported = FullscreenController(
-        backendFactory: (onChange) =>
-            _FakeBackend(onChange, mode: FullscreenMode.nativeVideoElement),
-      );
-      addTearDown(supported.dispose);
+      addTearDown(controller.dispose);
 
-      expect(unsupported.available, isFalse);
-      expect(supported.available, isTrue);
+      // A route exists. Nothing is bound to it, so the button must not draw.
+      expect(controller.mode, FullscreenMode.nativeVideoElement);
+      expect(controller.available.value, isFalse);
+    });
+
+    test('a readiness change notifies, so the button can appear', () {
+      late _FakeBackend backend;
+      final controller = FullscreenController(
+        backendFactory: (onChange, onFailure) =>
+            backend = _FakeBackend(onChange, ready: false),
+      );
+      addTearDown(controller.dispose);
+
+      var notified = 0;
+      controller.available.addListener(() => notified++);
+
+      backend.setReady(true);
+
+      expect(notified, 1);
+      expect(controller.available.value, isTrue);
+    });
+
+    test('failures reach a listener without moving fullscreen state', () async {
+      late _FakeBackend backend;
+      final controller = FullscreenController(
+        backendFactory: (onChange, onFailure) =>
+            backend = _FakeBackend(onChange, onFailure: onFailure),
+      );
+      addTearDown(controller.dispose);
+
+      final seen = <FullscreenFailure>[];
+      final subscription = controller.failures.listen(seen.add);
+      addTearDown(subscription.cancel);
+
+      backend.fail(const FullscreenFailure(
+        FullscreenFailureCause.documentRequestRejected,
+        requestInitiated: true,
+      ));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(seen, hasLength(1));
+      expect(
+        seen.single.cause,
+        FullscreenFailureCause.documentRequestRejected,
+      );
+      expect(controller.isFullscreen.value, isFalse);
+    });
+
+    test('the report reflects the backend', () {
+      final controller = FullscreenController(
+        backendFactory: (onChange, onFailure) => _FakeBackend(
+          onChange,
+          mode: FullscreenMode.nativeVideoElement,
+          ready: false,
+        ),
+      );
+      addTearDown(controller.dispose);
+
+      expect(controller.report.mode, FullscreenMode.nativeVideoElement);
+      expect(controller.report.ready, isFalse);
     });
 
     test('dispose forwards to the backend', () {
       late _FakeBackend backend;
       final controller = FullscreenController(
-        backendFactory: (onChange) => backend = _FakeBackend(onChange),
+        backendFactory: (onChange, onFailure) =>
+            backend = _FakeBackend(onChange),
       );
 
       controller.dispose();
@@ -111,7 +179,7 @@ void main() {
     test('an injected notifier is not disposed by the controller', () {
       final state = ValueNotifier<bool>(false);
       final controller = FullscreenController(
-        backendFactory: (onChange) => _FakeBackend(onChange),
+        backendFactory: (onChange, onFailure) => _FakeBackend(onChange),
         state: state,
       );
 
@@ -125,18 +193,39 @@ void main() {
 }
 
 class _FakeBackend implements FullscreenBackend {
-  _FakeBackend(this.onChange, {this.mode = FullscreenMode.osWindow});
+  _FakeBackend(
+    this.onChange, {
+    this.mode = FullscreenMode.osWindow,
+    bool ready = true,
+    this.onFailure,
+  }) : _ready = ValueNotifier<bool>(ready);
 
   final ValueChanged<bool> onChange;
+  final FullscreenFailureSink? onFailure;
 
   @override
   final FullscreenMode mode;
+
+  final ValueNotifier<bool> _ready;
+
+  @override
+  ValueListenable<bool> get ready => _ready;
+
+  @override
+  FullscreenReport get report =>
+      FullscreenReport(mode: mode, ready: _ready.value);
 
   int enterCalls = 0;
   int exitCalls = 0;
   bool disposed = false;
 
-  void report(bool value) => onChange(value);
+  /// Reports a platform transition, the way a real backend does. Named `emit`
+  /// rather than `report` because the interface now carries a `report` getter.
+  void emit(bool value) => onChange(value);
+
+  void setReady(bool value) => _ready.value = value;
+
+  void fail(FullscreenFailure failure) => onFailure?.call(failure);
 
   @override
   void attach(Player player) {}
@@ -148,7 +237,10 @@ class _FakeBackend implements FullscreenBackend {
   void exit() => exitCalls++;
 
   @override
-  void dispose() => disposed = true;
+  void dispose() {
+    disposed = true;
+    _ready.dispose();
+  }
 }
 
 /// Accepts every request and reports nothing, like `requestFullscreen` failing

--- a/player/test/core/player/fullscreen/fullscreen_mode_test.dart
+++ b/player/test/core/player/fullscreen/fullscreen_mode_test.dart
@@ -53,4 +53,64 @@ void main() {
       );
     });
   });
+
+  // `resolveWebMode` answers from capability probes, which is everything
+  // available before anything has been asked. This answers from what actually
+  // happened, which is the only thing that settles WebKit: Safari 16.4
+  // unprefixed the Fullscreen API on iPadOS and 17.2 brought it to iPhone, so
+  // `document.fullscreenEnabled` is now true on the very device the video
+  // element route was written for, and the route was unreachable.
+  group('demoteWebMode', () {
+    test('the document route falls back to the video element', () {
+      expect(
+        demoteWebMode(
+          current: FullscreenMode.documentElement,
+          videoElementFullscreenSupported: true,
+        ),
+        FullscreenMode.nativeVideoElement,
+      );
+    });
+
+    test('with no video element there is nowhere left to go', () {
+      expect(
+        demoteWebMode(
+          current: FullscreenMode.documentElement,
+          videoElementFullscreenSupported: false,
+        ),
+        FullscreenMode.unsupported,
+      );
+    });
+
+    test('a refused video element route is the end of the line', () {
+      expect(
+        demoteWebMode(
+          current: FullscreenMode.nativeVideoElement,
+          videoElementFullscreenSupported: true,
+        ),
+        FullscreenMode.unsupported,
+      );
+    });
+
+    test('unsupported stays unsupported', () {
+      expect(
+        demoteWebMode(
+          current: FullscreenMode.unsupported,
+          videoElementFullscreenSupported: true,
+        ),
+        FullscreenMode.unsupported,
+      );
+    });
+
+    test('the native modes are not web routes and never demote', () {
+      for (final mode in [FullscreenMode.osWindow, FullscreenMode.systemUi]) {
+        expect(
+          demoteWebMode(
+            current: mode,
+            videoElementFullscreenSupported: false,
+          ),
+          mode,
+        );
+      }
+    });
+  });
 }

--- a/player/test/core/player/fullscreen/fullscreen_report_test.dart
+++ b/player/test/core/player/fullscreen/fullscreen_report_test.dart
@@ -1,0 +1,112 @@
+// The readout is the only way to ask an iPhone what its fullscreen module
+// decided: `debugPrint` needs a Mac with Web Inspector attached, and the
+// reporter has neither. `rows` is shared by the on-screen section and the copy
+// button so the two cannot drift, which is the usual failure of a
+// hand-maintained "copy diagnostics" that lists fewer fields than the screen
+// above it.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/fullscreen/fullscreen_failure.dart';
+import 'package:player/core/player/fullscreen/fullscreen_mode.dart';
+import 'package:player/core/player/fullscreen/fullscreen_report.dart';
+
+void main() {
+  group('FullscreenReport.rows', () {
+    test('always names the route and whether it is usable', () {
+      const report = FullscreenReport(
+        mode: FullscreenMode.documentElement,
+        ready: true,
+      );
+
+      expect(report.rows, contains(('Route', 'documentElement')));
+      expect(report.rows, contains(('Ready', 'yes')));
+    });
+
+    test('reports the media element only where the route needs one', () {
+      const document = FullscreenReport(
+        mode: FullscreenMode.documentElement,
+        ready: true,
+      );
+      const video = FullscreenReport(
+        mode: FullscreenMode.nativeVideoElement,
+        ready: false,
+      );
+
+      expect(
+        document.rows.map((row) => row.$1),
+        isNot(contains('Media element')),
+      );
+      expect(video.rows, contains(('Media element', 'not bound')));
+    });
+
+    test('a fallback that happened is visible', () {
+      const report = FullscreenReport(
+        mode: FullscreenMode.nativeVideoElement,
+        ready: true,
+        mediaElementBound: true,
+        demoted: true,
+      );
+
+      expect(report.rows, contains(('Fell back', 'yes')));
+    });
+
+    test('carries both probe answers on web and neither on native', () {
+      const web = FullscreenReport(
+        mode: FullscreenMode.documentElement,
+        ready: true,
+        documentFullscreenEnabled: true,
+        videoElementFullscreenSupported: false,
+      );
+      const native = FullscreenReport(
+        mode: FullscreenMode.osWindow,
+        ready: true,
+      );
+
+      expect(web.rows, contains(('document.fullscreenEnabled', 'true')));
+      expect(web.rows, contains(('Video element fullscreen', 'false')));
+      expect(
+        native.rows.map((row) => row.$1),
+        isNot(contains('document.fullscreenEnabled')),
+      );
+    });
+
+    test('the last failure carries its cause and the platform detail', () {
+      const report = FullscreenReport(
+        mode: FullscreenMode.unsupported,
+        ready: false,
+        lastFailure: FullscreenFailure(
+          FullscreenFailureCause.documentRequestRejected,
+          detail: 'NotAllowedError',
+        ),
+      );
+
+      final failure = report.rows.firstWhere((row) => row.$1 == 'Last failure');
+      expect(failure.$2, contains('requestFullscreen was rejected'));
+      expect(failure.$2, contains('NotAllowedError'));
+    });
+  });
+
+  group('fullscreenReportLines', () {
+    test('a session that never played contributes nothing', () {
+      expect(fullscreenReportLines(null), isEmpty);
+    });
+
+    test('every row on screen is in the copied text', () {
+      const report = FullscreenReport(
+        mode: FullscreenMode.nativeVideoElement,
+        ready: true,
+        mediaElementBound: true,
+        demoted: true,
+        documentFullscreenEnabled: true,
+        videoElementFullscreenSupported: true,
+      );
+
+      final lines = fullscreenReportLines(report);
+
+      expect(lines.first, 'Fullscreen:');
+      for (final (label, value) in report.rows) {
+        expect(lines, contains('  $label: $value'));
+      }
+    });
+  });
+}

--- a/player/test/core/player/fullscreen/fullscreen_web_core_test.dart
+++ b/player/test/core/player/fullscreen/fullscreen_web_core_test.dart
@@ -161,7 +161,7 @@ void main() {
   });
 
   group('the document route is refused', () {
-    test('falls back to the video element and enters by that route', () {
+    test('falls back to the video element, ready for the next request', () {
       final harness = _Harness(documentRequestError: 'NotAllowedError');
       addTearDown(harness.dispose);
       harness.core.attach(Object());
@@ -169,28 +169,39 @@ void main() {
       harness.core.enter();
 
       expect(harness.core.mode, FullscreenMode.nativeVideoElement);
-      expect(harness.platform.enterVideoCalls, 1);
       expect(harness.core.ready.value, isTrue);
       expect(harness.core.report.demoted, isTrue);
     });
 
-    test('a fallback that worked is not announced to the viewer', () {
+    test('does not retry on the refused tap, whose activation is spent', () {
       final harness = _Harness(documentRequestError: 'NotAllowedError');
       addTearDown(harness.dispose);
       harness.core.attach(Object());
 
       harness.core.enter();
 
-      expect(harness.failures, isEmpty);
-      // Still recorded, because the readout is how anyone learns the document
-      // route is dead on this browser.
-      expect(
-        harness.core.report.lastFailure?.cause,
-        FullscreenFailureCause.documentRequestRejected,
-      );
+      // `requestFullscreen()` consumed the transient activation, so calling
+      // `webkitEnterFullscreen` now would fail for want of a gesture and
+      // `_enterVideo` would read that as the video route being dead.
+      expect(harness.platform.enterVideoCalls, 0);
     });
 
-    test('later requests take the video route directly', () {
+    test('the refusal is announced, so the dead tap is not silent', () {
+      final harness = _Harness(documentRequestError: 'NotAllowedError');
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.failures, hasLength(1));
+      expect(
+        harness.failures.single.cause,
+        FullscreenFailureCause.documentRequestRejected,
+      );
+      expect(harness.failures.single.requestInitiated, isTrue);
+    });
+
+    test('the next request takes the video route and works', () {
       final harness = _Harness(documentRequestError: 'NotAllowedError');
       addTearDown(harness.dispose);
       harness.core.attach(Object());
@@ -199,7 +210,9 @@ void main() {
       harness.core.enter();
 
       expect(harness.platform.documentRequests, 1);
-      expect(harness.platform.enterVideoCalls, 2);
+      expect(harness.platform.enterVideoCalls, 1);
+      // The second tap succeeded, so it added no message of its own.
+      expect(harness.failures, hasLength(1));
     });
 
     test('the document listener is dropped on demotion', () {
@@ -233,7 +246,8 @@ void main() {
       expect(harness.failures.single.requestInitiated, isTrue);
     });
 
-    test('a fallback that also fails is announced exactly once', () {
+    test('a video route that then refuses a real tap withdraws the control',
+        () {
       final harness = _Harness(
         documentRequestError: 'NotAllowedError',
         videoEnterError: 'InvalidStateError',
@@ -242,10 +256,13 @@ void main() {
       harness.core.attach(Object());
 
       harness.core.enter();
+      // The second tap has its own activation, so this refusal is the platform
+      // speaking rather than a spent gesture, and is worth acting on.
+      harness.core.enter();
 
-      expect(harness.failures, hasLength(1));
+      expect(harness.failures, hasLength(2));
       expect(
-        harness.failures.single.cause,
+        harness.failures.last.cause,
         FullscreenFailureCause.videoEnterFailed,
       );
       expect(harness.core.mode, FullscreenMode.unsupported);
@@ -264,6 +281,19 @@ void main() {
 
       expect(harness.failures, hasLength(1));
       expect(harness.core.ready.value, isFalse);
+    });
+
+    test('a rejection landing after disposal is ignored', () {
+      final harness = _Harness(documentRequestError: 'NotAllowedError');
+      harness.platform.deferRejection = true;
+      harness.core.attach(Object());
+
+      harness.core.enter();
+      harness.core.dispose();
+
+      // A real rejection arrives off a promise and can outlive the screen.
+      // Writing readiness here would throw on the disposed notifier.
+      expect(harness.platform.releaseRejection, returnsNormally);
     });
   });
 
@@ -427,9 +457,20 @@ class _FakePlatform implements WebFullscreenPlatform {
   int enterVideoCalls = 0;
   int exitVideoCalls = 0;
 
+  /// Holds the rejection instead of delivering it, so a test can land one
+  /// after `dispose()` the way a real promise can.
+  bool deferRejection = false;
+  void Function()? _pendingRejection;
+
   Object? _currentPlayer;
   void Function(bool)? _documentListener;
   void Function(bool)? _videoListener;
+
+  void releaseRejection() {
+    final pending = _pendingRejection;
+    _pendingRejection = null;
+    pending?.call();
+  }
 
   void emitDocumentFullscreen(bool value) => _documentListener?.call(value);
 
@@ -449,10 +490,16 @@ class _FakePlatform implements WebFullscreenPlatform {
   void requestDocumentFullscreen(void Function(Object error) onRejected) {
     documentRequests++;
     final error = documentRequestError;
-    // Synchronous, unlike a real promise rejection. The state machine treats
-    // it the same either way, and a synchronous fake keeps the assertions
-    // readable.
-    if (error != null) onRejected(error);
+    if (error == null) return;
+    // Synchronous by default, unlike a real promise rejection. The state
+    // machine treats it the same either way, and a synchronous fake keeps the
+    // assertions readable. `deferRejection` restores the real timing for the
+    // one case that turns on it: a rejection outliving the screen.
+    if (deferRejection) {
+      _pendingRejection = () => onRejected(error);
+      return;
+    }
+    onRejected(error);
   }
 
   @override

--- a/player/test/core/player/fullscreen/fullscreen_web_core_test.dart
+++ b/player/test/core/player/fullscreen/fullscreen_web_core_test.dart
@@ -1,0 +1,494 @@
+// The web backend's decisions, tested without a browser.
+//
+// `fullscreen_backend_web.dart` compiles only under `dart.library.js_interop`,
+// and `flutter test` always runs non-web, so nothing in that file is reachable
+// from here. Everything worth testing was moved behind `WebFullscreenPlatform`
+// for exactly that reason -- the same trade `fullscreen_mode_test.dart` makes
+// for `resolveWebMode`, applied to state rather than a single pure decision.
+//
+// The three defects these cover all presented identically on iOS Safari, as
+// "the fullscreen button is there and does nothing":
+//   1. the media element was bound once and never rebound
+//   2. availability answered "this browser has an API", not "this will work"
+//   3. a refused document request had nowhere to go, even though iPhone Safari
+//      still has a working video element route
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/fullscreen/fullscreen_failure.dart';
+import 'package:player/core/player/fullscreen/fullscreen_mode.dart';
+import 'package:player/core/player/fullscreen/fullscreen_web_core.dart';
+import 'package:player/core/player/fullscreen/fullscreen_web_platform.dart';
+
+void main() {
+  group('route selection', () {
+    test('prefers the document route, which keeps Mydia chrome', () {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+
+      expect(harness.core.mode, FullscreenMode.documentElement);
+      expect(harness.core.ready.value, isTrue);
+    });
+
+    test('the document route is ready before anything is attached', () {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+
+      expect(harness.core.report.mediaElementBound, isFalse);
+      expect(harness.core.ready.value, isTrue);
+    });
+
+    test(
+        'the video route is not ready until a player is attached, so the '
+        'button is absent rather than inert', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      addTearDown(harness.dispose);
+
+      expect(harness.core.mode, FullscreenMode.nativeVideoElement);
+      expect(harness.core.ready.value, isFalse);
+
+      harness.core.attach(Object());
+
+      expect(harness.core.ready.value, isTrue);
+      expect(harness.core.report.mediaElementBound, isTrue);
+    });
+
+    test('no route at all is never ready', () {
+      final harness = _Harness(
+        documentFullscreenEnabled: false,
+        videoElementFullscreenSupported: false,
+      );
+      addTearDown(harness.dispose);
+
+      expect(harness.core.mode, FullscreenMode.unsupported);
+      expect(harness.core.ready.value, isFalse);
+
+      harness.core.attach(Object());
+
+      expect(harness.core.ready.value, isFalse);
+    });
+
+    test('a probe that threw is recorded but not announced', () {
+      const probe = FullscreenFailure(
+        FullscreenFailureCause.documentEnabledProbeFailed,
+        detail: 'boom',
+      );
+      final harness = _Harness(
+        documentFullscreenEnabled: false,
+        probeFailures: const [probe],
+      );
+      addTearDown(harness.dispose);
+
+      expect(harness.core.report.lastFailure, probe);
+      // Nobody asked for fullscreen yet. A message here would be noise.
+      expect(harness.failures, isEmpty);
+    });
+  });
+
+  group('rebinding across players', () {
+    test('attaching the same player twice binds once', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      addTearDown(harness.dispose);
+      final player = Object();
+
+      harness.core.attach(player);
+      harness.core.attach(player);
+
+      expect(harness.platform.boundPlayers, [player]);
+    });
+
+    test(
+        'a second player rebinds, which is the episode change, quality switch '
+        'and Retry case', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      addTearDown(harness.dispose);
+      final first = Object();
+      final second = Object();
+
+      harness.core.attach(first);
+      harness.core.attach(second);
+
+      expect(harness.platform.boundPlayers, [first, second]);
+      expect(harness.core.ready.value, isTrue);
+    });
+
+    test('rebinding releases the previous element exactly once', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      addTearDown(harness.dispose);
+
+      harness.core.attach(Object());
+      final afterFirst = harness.platform.unbindCalls;
+      harness.core.attach(Object());
+
+      // One from `attach` itself, one from `bindVideo`'s own release. What
+      // matters is that the count moves, not that it moves by one: the point
+      // is the old element's listeners are gone before the new ones land.
+      expect(harness.platform.unbindCalls, greaterThan(afterFirst));
+      expect(harness.platform.boundPlayers, hasLength(2));
+    });
+
+    test('dispose releases the element bound last, not the first', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      final first = Object();
+      final second = Object();
+
+      harness.core.attach(first);
+      harness.core.attach(second);
+      harness.core.dispose();
+
+      expect(harness.platform.lastUnboundPlayer, second);
+    });
+
+    test('a player with no media element leaves the route unready', () {
+      final harness = _Harness(
+        documentFullscreenEnabled: false,
+        bindResult: FullscreenFailureCause.playerNotWebPlayer,
+      );
+      addTearDown(harness.dispose);
+
+      harness.core.attach(Object());
+
+      expect(harness.core.ready.value, isFalse);
+      expect(harness.core.report.mediaElementBound, isFalse);
+      expect(harness.failures, hasLength(1));
+      expect(
+        harness.failures.single.cause,
+        FullscreenFailureCause.playerNotWebPlayer,
+      );
+      // The viewer never asked for fullscreen, so this one stays out of their
+      // way; it is still in the readout.
+      expect(harness.failures.single.requestInitiated, isFalse);
+    });
+  });
+
+  group('the document route is refused', () {
+    test('falls back to the video element and enters by that route', () {
+      final harness = _Harness(documentRequestError: 'NotAllowedError');
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.core.mode, FullscreenMode.nativeVideoElement);
+      expect(harness.platform.enterVideoCalls, 1);
+      expect(harness.core.ready.value, isTrue);
+      expect(harness.core.report.demoted, isTrue);
+    });
+
+    test('a fallback that worked is not announced to the viewer', () {
+      final harness = _Harness(documentRequestError: 'NotAllowedError');
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.failures, isEmpty);
+      // Still recorded, because the readout is how anyone learns the document
+      // route is dead on this browser.
+      expect(
+        harness.core.report.lastFailure?.cause,
+        FullscreenFailureCause.documentRequestRejected,
+      );
+    });
+
+    test('later requests take the video route directly', () {
+      final harness = _Harness(documentRequestError: 'NotAllowedError');
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+      harness.core.enter();
+
+      expect(harness.platform.documentRequests, 1);
+      expect(harness.platform.enterVideoCalls, 2);
+    });
+
+    test('the document listener is dropped on demotion', () {
+      final harness = _Harness(documentRequestError: 'NotAllowedError');
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.platform.stopListeningCalls, 1);
+    });
+
+    test('with no video route left, the control is withdrawn and announced',
+        () {
+      final harness = _Harness(
+        videoElementFullscreenSupported: false,
+        documentRequestError: 'NotAllowedError',
+      );
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.core.mode, FullscreenMode.unsupported);
+      expect(harness.core.ready.value, isFalse);
+      expect(harness.failures, hasLength(1));
+      expect(
+        harness.failures.single.cause,
+        FullscreenFailureCause.documentRequestRejected,
+      );
+      expect(harness.failures.single.requestInitiated, isTrue);
+    });
+
+    test('a fallback that also fails is announced exactly once', () {
+      final harness = _Harness(
+        documentRequestError: 'NotAllowedError',
+        videoEnterError: 'InvalidStateError',
+      );
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.failures, hasLength(1));
+      expect(
+        harness.failures.single.cause,
+        FullscreenFailureCause.videoEnterFailed,
+      );
+      expect(harness.core.mode, FullscreenMode.unsupported);
+      expect(harness.core.ready.value, isFalse);
+    });
+
+    test('a fallback with nothing to bind is announced exactly once', () {
+      final harness = _Harness(
+        documentRequestError: 'NotAllowedError',
+        bindResult: FullscreenFailureCause.noVideoElement,
+      );
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.failures, hasLength(1));
+      expect(harness.core.ready.value, isFalse);
+    });
+  });
+
+  group('the video route is refused', () {
+    test('entering with nothing bound withdraws the control', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      addTearDown(harness.dispose);
+
+      // Never attached, so nothing is bound.
+      harness.core.enter();
+
+      expect(harness.failures, hasLength(1));
+      expect(
+        harness.failures.single.cause,
+        FullscreenFailureCause.noVideoElement,
+      );
+      expect(harness.core.mode, FullscreenMode.unsupported);
+      expect(harness.core.ready.value, isFalse);
+    });
+
+    test('a throw from the browser withdraws the control', () {
+      final harness = _Harness(
+        documentFullscreenEnabled: false,
+        videoEnterError: 'InvalidStateError',
+      );
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+
+      expect(harness.failures, hasLength(1));
+      expect(
+        harness.failures.single.cause,
+        FullscreenFailureCause.videoEnterFailed,
+      );
+      expect(harness.core.ready.value, isFalse);
+    });
+  });
+
+  group('state comes from the platform', () {
+    test('the document route reports through its listener, not the request',
+        () {
+      final harness = _Harness();
+      addTearDown(harness.dispose);
+
+      harness.core.enter();
+      expect(harness.changes, isEmpty);
+
+      harness.platform.emitDocumentFullscreen(true);
+      expect(harness.changes, [true]);
+
+      harness.platform.emitDocumentFullscreen(false);
+      expect(harness.changes, [true, false]);
+    });
+
+    test('the video route reports through the element it bound', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      addTearDown(harness.dispose);
+      harness.core.attach(Object());
+
+      harness.core.enter();
+      expect(harness.changes, isEmpty);
+
+      harness.platform.emitVideoFullscreen(true);
+      expect(harness.changes, [true]);
+    });
+
+    test('exit is a no-op on a route with nothing bound', () {
+      final harness = _Harness(documentFullscreenEnabled: false);
+      addTearDown(harness.dispose);
+
+      harness.core.exit();
+
+      expect(harness.platform.exitVideoCalls, 0);
+      expect(harness.failures, isEmpty);
+    });
+
+    test('a refused exit is announced but does not retire the route', () {
+      final harness = _Harness(documentExitError: 'NotAllowedError');
+      addTearDown(harness.dispose);
+
+      harness.core.exit();
+
+      expect(harness.failures, hasLength(1));
+      expect(
+        harness.failures.single.cause,
+        FullscreenFailureCause.documentExitRejected,
+      );
+      expect(harness.core.mode, FullscreenMode.documentElement);
+      expect(harness.core.ready.value, isTrue);
+    });
+  });
+}
+
+/// Wires a [WebFullscreenCore] to a fake browser and collects what came out.
+class _Harness {
+  _Harness({
+    bool documentFullscreenEnabled = true,
+    bool videoElementFullscreenSupported = true,
+    List<FullscreenFailure> probeFailures = const [],
+    FullscreenFailureCause? bindResult,
+    Object? documentRequestError,
+    Object? documentExitError,
+    Object? videoEnterError,
+  }) : platform = _FakePlatform(
+          documentFullscreenEnabled: documentFullscreenEnabled,
+          videoElementFullscreenSupported: videoElementFullscreenSupported,
+          probeFailures: probeFailures,
+          bindResult: bindResult,
+          documentRequestError: documentRequestError,
+          documentExitError: documentExitError,
+          videoEnterError: videoEnterError,
+        ) {
+    core = WebFullscreenCore(
+      platform: platform,
+      onChange: changes.add,
+      onFailure: failures.add,
+    );
+  }
+
+  final _FakePlatform platform;
+  late final WebFullscreenCore core;
+  final List<bool> changes = [];
+  final List<FullscreenFailure> failures = [];
+
+  void dispose() => core.dispose();
+}
+
+class _FakePlatform implements WebFullscreenPlatform {
+  _FakePlatform({
+    required this.documentFullscreenEnabled,
+    required this.videoElementFullscreenSupported,
+    required this.probeFailures,
+    required this.bindResult,
+    required this.documentRequestError,
+    required this.documentExitError,
+    required this.videoEnterError,
+  });
+
+  @override
+  final bool documentFullscreenEnabled;
+
+  @override
+  final bool videoElementFullscreenSupported;
+
+  @override
+  final List<FullscreenFailure> probeFailures;
+
+  /// Non-null makes `bindVideo` fail with that cause.
+  final FullscreenFailureCause? bindResult;
+
+  final Object? documentRequestError;
+  final Object? documentExitError;
+  final Object? videoEnterError;
+
+  final List<Object> boundPlayers = [];
+  Object? lastUnboundPlayer;
+  int unbindCalls = 0;
+  int documentRequests = 0;
+  int stopListeningCalls = 0;
+  int enterVideoCalls = 0;
+  int exitVideoCalls = 0;
+
+  Object? _currentPlayer;
+  void Function(bool)? _documentListener;
+  void Function(bool)? _videoListener;
+
+  void emitDocumentFullscreen(bool value) => _documentListener?.call(value);
+
+  void emitVideoFullscreen(bool value) => _videoListener?.call(value);
+
+  @override
+  void listenDocumentFullscreen(void Function(bool fullscreen) onChange) =>
+      _documentListener = onChange;
+
+  @override
+  void stopListeningDocumentFullscreen() {
+    stopListeningCalls++;
+    _documentListener = null;
+  }
+
+  @override
+  void requestDocumentFullscreen(void Function(Object error) onRejected) {
+    documentRequests++;
+    final error = documentRequestError;
+    // Synchronous, unlike a real promise rejection. The state machine treats
+    // it the same either way, and a synchronous fake keeps the assertions
+    // readable.
+    if (error != null) onRejected(error);
+  }
+
+  @override
+  void exitDocumentFullscreen(void Function(Object error) onRejected) {
+    final error = documentExitError;
+    if (error != null) onRejected(error);
+  }
+
+  @override
+  FullscreenFailureCause? bindVideo(
+    Object player, {
+    required void Function(bool fullscreen) onChange,
+  }) {
+    unbindVideo();
+    if (bindResult != null) return bindResult;
+    boundPlayers.add(player);
+    _currentPlayer = player;
+    _videoListener = onChange;
+    return null;
+  }
+
+  @override
+  void unbindVideo() {
+    unbindCalls++;
+    if (_currentPlayer != null) lastUnboundPlayer = _currentPlayer;
+    _currentPlayer = null;
+    _videoListener = null;
+  }
+
+  @override
+  void enterVideoFullscreen() {
+    enterVideoCalls++;
+    final error = videoEnterError;
+    if (error != null) throw StateError('$error');
+  }
+
+  @override
+  void exitVideoFullscreen() => exitVideoCalls++;
+}

--- a/player/test/presentation/screens/player/player_screen_fullscreen_test.dart
+++ b/player/test/presentation/screens/player/player_screen_fullscreen_test.dart
@@ -114,6 +114,20 @@ void main() {
     expect(find.text('Could not enter fullscreen'), findsOneWidget);
   });
 
+  testWidgets('a refused exit says exit, not enter', (tester) async {
+    await mount(tester);
+
+    backend.fail(const FullscreenFailure(
+      FullscreenFailureCause.documentExitRejected,
+      requestInitiated: true,
+    ));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Could not exit fullscreen'), findsOneWidget);
+    expect(find.text('Could not enter fullscreen'), findsNothing);
+  });
+
   testWidgets('a failure nobody asked for stays out of the way',
       (tester) async {
     await mount(tester);

--- a/player/test/presentation/screens/player/player_screen_fullscreen_test.dart
+++ b/player/test/presentation/screens/player/player_screen_fullscreen_test.dart
@@ -1,0 +1,200 @@
+// The wiring between `FullscreenController` and the screen, which is where the
+// reported bug survives even after the backend is fixed: the route can go
+// unusable at any moment on web, and a screen that reads availability once and
+// never listens draws a button over a request that cannot succeed.
+//
+// `PlayerScreen.debugFullscreenBackendFactory` exists because a `flutter test`
+// host always resolves the native backend, which is unconditionally ready, so
+// "a route exists but cannot be used right now" is otherwise unreachable.
+//
+// These stop at the seam rather than asserting on the rendered chrome.
+// `PlayerScreen` does not reach `SecondaryCluster` under `flutter test`: it
+// polls the HLS playlist over an `HttpClient` it constructs itself, and
+// `TestWidgetsFlutterBinding` answers every request 400, so the screen stays in
+// its retry state forever. Making the chrome mount needs an injectable client,
+// which is a change to streaming, not to fullscreen. The two halves either side
+// of this seam are covered where they live: that `available` notifies, in
+// `fullscreen_controller_test.dart`, and that a null `onFullscreenTap` omits
+// the button, in `panel_controls_test.dart`.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:media_kit/media_kit.dart';
+import 'package:player/core/cast/cast_target.dart';
+import 'package:player/core/connection/connection_provider.dart' as conn;
+import 'package:player/core/player/fullscreen/fullscreen_backend.dart';
+import 'package:player/core/player/fullscreen/fullscreen_failure.dart';
+import 'package:player/core/player/fullscreen/fullscreen_mode.dart';
+import 'package:player/core/player/fullscreen/fullscreen_report.dart';
+import 'package:player/core/player/fullscreen/fullscreen_report_signal.dart';
+import 'package:player/presentation/screens/player/player_screen.dart';
+
+import '../../../test_utils/stub_graphql_client.dart';
+import 'player_screen_test_harness.dart';
+
+void main() {
+  late _TestBackend backend;
+
+  setUp(() {
+    backend = _TestBackend();
+    PlayerScreen.debugFullscreenBackendFactory = (onChange, onFailure) {
+      backend.onChange = onChange;
+      backend.onFailure = onFailure;
+      return backend;
+    };
+  });
+
+  tearDown(() {
+    PlayerScreen.debugFullscreenBackendFactory = null;
+    fullscreenReportSignal.value = null;
+  });
+
+  /// Mounts the screen with a cast target already set, so `_initializePlayer`
+  /// short-circuits before HLS negotiation.
+  ///
+  /// The same trick `player_screen_dispose_cleanup_test.dart` uses, and for a
+  /// related reason: left to run, the playlist poll retries on a timer that is
+  /// still pending when the tree is torn down, and the binding fails the test
+  /// on it. Nothing here needs playback, only `initState` and the failure
+  /// handler.
+  Future<void> mount(WidgetTester tester) async {
+    mockPathProviderDocumentsDirectory();
+    final castManager = CapturingCastSessionManager();
+    final container = buildPlayerScreenContainer(
+      link: StubLink.responses([
+        movieDetailResponse(),
+        movieSegmentsResponse(),
+        subtitleTrackSettingsResponse(),
+        streamingCandidatesResponse(duration: 5400),
+      ]),
+      connectionState:
+          const conn.ConnectionState(type: conn.ConnectionType.direct),
+      castManager: castManager,
+      proxyService: TrackingLocalProxyService(),
+    );
+    addTearDown(container.dispose);
+
+    container.read(castTargetProvider.notifier).set(testDevice);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntil(tester, () => castManager.capturedRequest != null);
+  }
+
+  testWidgets('the screen follows availability, not just fullscreen state',
+      (tester) async {
+    await mount(tester);
+
+    // The defect this guards: reading `available` once at build time leaves the
+    // button drawn after the route dies, and hidden after it comes back.
+    expect(backend.readyNotifier.listenerCount, greaterThan(0));
+  });
+
+  testWidgets('the availability listener is released on dispose',
+      (tester) async {
+    await mount(tester);
+    expect(backend.readyNotifier.listenerCount, greaterThan(0));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(backend.readyNotifier.listenerCount, 0);
+  });
+
+  testWidgets('a refused request tells the viewer', (tester) async {
+    await mount(tester);
+
+    backend.fail(const FullscreenFailure(
+      FullscreenFailureCause.documentRequestRejected,
+      requestInitiated: true,
+    ));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Could not enter fullscreen'), findsOneWidget);
+  });
+
+  testWidgets('a failure nobody asked for stays out of the way',
+      (tester) async {
+    await mount(tester);
+
+    backend.fail(const FullscreenFailure(
+      FullscreenFailureCause.documentEnabledProbeFailed,
+    ));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Could not enter fullscreen'), findsNothing);
+  });
+
+  testWidgets('the report reaches the diagnostics signal', (tester) async {
+    await mount(tester);
+
+    backend.fail(const FullscreenFailure(
+      FullscreenFailureCause.documentRequestRejected,
+      requestInitiated: true,
+    ));
+    await tester.pump();
+
+    expect(fullscreenReportSignal.value, isNotNull);
+    expect(fullscreenReportSignal.value!.mode, backend.mode);
+  });
+}
+
+/// Exposes `hasListeners`, which `ChangeNotifier` keeps `@protected`, so a test
+/// can assert that the screen actually subscribed.
+class _ObservableFlag extends ValueNotifier<bool> {
+  _ObservableFlag(super.value);
+
+  int listenerCount = 0;
+
+  @override
+  void addListener(VoidCallback listener) {
+    listenerCount++;
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    listenerCount--;
+    super.removeListener(listener);
+  }
+}
+
+/// A backend whose readiness and failures a test drives directly.
+class _TestBackend implements FullscreenBackend {
+  ValueChanged<bool>? onChange;
+  FullscreenFailureSink? onFailure;
+
+  final _ObservableFlag readyNotifier = _ObservableFlag(true);
+  bool _disposed = false;
+
+  @override
+  FullscreenMode get mode => FullscreenMode.documentElement;
+
+  @override
+  ValueListenable<bool> get ready => readyNotifier;
+
+  @override
+  FullscreenReport get report =>
+      FullscreenReport(mode: mode, ready: readyNotifier.value);
+
+  void fail(FullscreenFailure failure) => onFailure?.call(failure);
+
+  @override
+  void attach(Player player) {}
+
+  @override
+  void enter() {}
+
+  @override
+  void exit() {}
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    // Not disposed: the screen removes its listener after this runs, and the
+    // assertions read the count afterwards.
+  }
+}

--- a/player/test/presentation/screens/settings/diagnostics_screen_test.dart
+++ b/player/test/presentation/screens/settings/diagnostics_screen_test.dart
@@ -4,6 +4,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/connection/connection_provider.dart';
 import 'package:player/core/p2p/p2p_service.dart';
+import 'package:player/core/player/fullscreen/fullscreen_failure.dart';
+import 'package:player/core/player/fullscreen/fullscreen_mode.dart';
+import 'package:player/core/player/fullscreen/fullscreen_report.dart';
+import 'package:player/core/player/fullscreen/fullscreen_report_signal.dart';
 import 'package:player/presentation/screens/settings/diagnostics_screen.dart';
 
 class _FakeConnectionNotifier extends ConnectionNotifier {
@@ -145,5 +149,87 @@ void main() {
     expect(written, hasLength(1));
     expect(written.single, contains('https://relay.mydia.dev'));
     expect(written.single, contains('Connected through a relay'));
+  });
+
+  // The Playback section is the only way to ask an iPhone what its fullscreen
+  // module decided. Everything it reports used to be a `debugPrint`, which on
+  // that device needs a Mac with Safari Web Inspector attached.
+  group('playback section', () {
+    tearDown(() => fullscreenReportSignal.value = null);
+
+    testWidgets('says so when nothing has played this session', (tester) async {
+      fullscreenReportSignal.value = null;
+
+      await _pump(tester, status: const P2pStatus.initial());
+
+      expect(find.text('Playback'), findsOneWidget);
+      expect(find.text('Nothing played yet this session'), findsOneWidget);
+    });
+
+    testWidgets('shows the route, readiness and what refused', (tester) async {
+      fullscreenReportSignal.value = const FullscreenReport(
+        mode: FullscreenMode.unsupported,
+        ready: false,
+        demoted: true,
+        documentFullscreenEnabled: true,
+        videoElementFullscreenSupported: false,
+        lastFailure: FullscreenFailure(
+          FullscreenFailureCause.documentRequestRejected,
+          detail: 'NotAllowedError',
+        ),
+      );
+
+      await _pump(tester, status: const P2pStatus.initial());
+
+      expect(find.text('Route'), findsOneWidget);
+      expect(find.text('unsupported'), findsOneWidget);
+      expect(find.text('Fell back'), findsOneWidget);
+      expect(find.text('Last failure'), findsOneWidget);
+    });
+
+    testWidgets('the copy button carries every row the screen shows',
+        (tester) async {
+      final written = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            written.add((call.arguments as Map)['text'] as String);
+          }
+          return null;
+        },
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      const report = FullscreenReport(
+        mode: FullscreenMode.nativeVideoElement,
+        ready: true,
+        mediaElementBound: true,
+        demoted: true,
+        documentFullscreenEnabled: true,
+        videoElementFullscreenSupported: true,
+      );
+      fullscreenReportSignal.value = report;
+
+      // The Playback section pushes the button past the fold on the default
+      // 800x600 surface, and the `ListView` never builds what it cannot show.
+      tester.view.physicalSize = const Size(1200, 3000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await _pump(tester, status: const P2pStatus.initial());
+      await tester.tap(find.byKey(const Key('copy-diagnostics')));
+      await tester.pump();
+
+      expect(written, hasLength(1));
+      for (final (label, value) in report.rows) {
+        expect(written.single, contains('$label: $value'));
+      }
+    });
   });
 }


### PR DESCRIPTION
## Why

On iOS and iPadOS Safari the fullscreen button in the web player at `/player` renders, accepts the tap, and nothing happens. The button is drawn only when `FullscreenController.available` is true, so the backend has already decided a fullscreen route exists; the route it picked then fails at `enter()`.

Every one of those failures ended in a `debugPrint`. On a phone that output goes nowhere unless a Mac with Safari Web Inspector happens to be attached, so the one defect the module was written to prevent, a control that claims a capability it does not have, is exactly what shipped. `WebFullscreenBackend`'s own class comment names that failure and the code reproduced it one layer down.

Three defects each produce this symptom, none of them covered by a test. All three are fixed here.

## What changed

**`available` answers the question the button asks.** It was derived from `mode`, a capability probe resolved once at construction. It stayed true when `attach()` bailed because `player.platform` was not a `WebPlayer`, when no video was ever attached, and when `requestFullscreen()` was rejected on every call. It is now a `ValueListenable<bool>` sourced from the backend's readiness: whether a request made right now would be carried out. The `keyF` shortcut reads the same signal and returns `KeyEventResult.ignored` when the route is unusable, so the key is not swallowed.

**The video element is rebound across players.** `attach()` returned early on `_video != null` and `_video` was never cleared. `PlayerScreen._initializePlayer()` builds a fresh `Player()` on every source load (episode change, quality switch, Retry), so from the second source onward the backend held a disposed `<video>` and `dispose()` detached from the dead one. `attach()` now keys on instance identity and releases the previous element's listeners first.

**The route is no longer decided from probes alone.** `resolveWebMode` prefers `documentElement` whenever `document.fullscreenEnabled` is true. Safari 16.4 unprefixed the Fullscreen API on iPadOS and 17.2 brought it to iPhone, so `FullscreenMode.nativeVideoElement`, added in `c648b9add` specifically for iPhone Safari, no longer runs there. The path that executes is the document route, which is the one reported as doing nothing. `demoteWebMode` falls back to the video element route when the document route is refused at runtime, one-way for the session, and withdraws the control when no route is left.

**Failures travel instead of printing.** `enter()` and `exit()` stay synchronous and `void` on purpose: `webkitEnterFullscreen` needs live user activation and any `await` before the call spends it, so a refusal cannot be a return value. They arrive through an `onFailure` sink instead. A request the viewer initiated raises a snack bar; a probe that threw while the screen was opening does not, since telling someone who never asked for fullscreen that fullscreen failed is noise.

**A diagnostics readout.** `FullscreenReport` and a read-only Playback section on `/settings/diagnostics` make the resolved route, readiness, whether an element is bound, whether the backend demoted, and the last failure copyable from the device it happened on. That is what the original bug report had no way to carry. The screen's title broadens from "Connection details" to "Diagnostics".

## Testing

`player/test/core/player/fullscreen/` previously covered only the mode resolver and the controller against a fake backend; the web backend had no tests at all, because `fullscreen_backend_web.dart` compiles only under `dart.library.js_interop` and `flutter test` always runs non-web.

Every decision moved into `WebFullscreenCore` behind a `WebFullscreenPlatform` seam that imports nothing from `package:web`, leaving the far side to the `package:web` calls themselves. `fullscreen_web_core_test.dart` drives route selection, demotion, readiness transitions, rebinding across players, and which failures are reported, on the VM against a fake. Same reasoning as `resolveWebMode` and `PlatformFeatures.computeSupportsKeyboardShortcuts`, applied to state rather than a single pure decision.

`./dev flutter analyze` clean, `./dev flutter test` green at 3335 tests.

**One gap.** Rendering `PlayerScreen`'s chrome under `flutter test` is not reachable: the screen polls the HLS playlist over an `HttpClient` it constructs itself, `TestWidgetsFlutterBinding` answers every request 400, so it stays in its retry state and its timer trips the pending-timer check. Making it reachable needs an injectable HTTP client in the streaming path, which is a streaming change, not a fullscreen one. The wiring is covered at the seam instead: `player_screen_fullscreen_test.dart` asserts the screen subscribes to `available` and releases it on dispose, `fullscreen_controller_test.dart` that `available` notifies, and the pre-existing `panel_controls_test.dart` that a null `onFullscreenTap` omits the button.

## Not verified

Risk is concentrated on a platform CI cannot reach. The Dart-side branching is covered through injected probes; the WebKit behaviour itself is not confirmed. Still outstanding, and each needs a human at a device:

- iPhone and iPad Safari: the button enters fullscreen, a second item played in the same session still does, and a quality switch still does.
- Desktop Chrome, Firefox and Safari: the document route still enters and exits, Escape returns the icon to "Fullscreen", and no snack bar appears on success.
- One native desktop build: fullscreen still works from the control, the green button and the keyboard shortcut, confirming the native backend did not move.

The diagnostics readout is what settles which of the three defects was live on the reporter's device. All three ship regardless, since each is independently correct.

## Scope

Flutter player only. No server, GraphQL, or database change, and no migration. The Phoenix `PlaybackLive` page and its Alpine `videoPlayer` component have their own `toggleFullscreen` and are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fullscreen availability now reflects whether fullscreen can be used immediately.
  - Web fullscreen requests can automatically fall back to video fullscreen when supported.
  - Added clear, cause-specific notifications when a user-initiated fullscreen request is refused.
  - Added fullscreen status and failure details to the Diagnostics screen and copied diagnostic reports.

- **Bug Fixes**
  - Improved fullscreen behavior across browsers and devices, including WebKit-based platforms.
  - Prevented fullscreen actions when the feature is temporarily unavailable.
  - Preserved the latest fullscreen report after leaving the player screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->