### PR TITLE
fix(player): stop the quality menu claiming a transcode is lossless

### DIFF
--- a/player/lib/domain/models/quality_delivery_subtitle.dart
+++ b/player/lib/domain/models/quality_delivery_subtitle.dart
@@ -1,6 +1,9 @@
 /// User-facing subtitles for how a quality rung will be delivered.
 ///
 /// See `docs/superpowers/specs/2026-08-09-player-quality-delivery-labels-design.md`.
+library;
+
+import '../../core/player/hls_strategy_selection.dart';
 
 const kOriginalDirectPlaySubtitle = 'Direct Play';
 const kOriginalLosslessSubtitle = 'Original · no re-encoding';
@@ -13,7 +16,8 @@ const kOriginalPreferenceSubtitle = 'Source quality';
 ///
 /// [canDirectPlay] means native and the same candidate gate as
 /// `PlayerScreen._canDirectPlay` (ignore the currently selected rung).
-/// [hasLosslessDelivery] means any candidate is HLS_COPY or REMUX.
+/// [hasLosslessDelivery] means the HLS session will copy the video rather
+/// than re-encode it, per [hlsDeliveryIsLossless].
 /// Ordering: Direct Play, then lossless, then re-encoding required.
 String originalDeliverySubtitle({
   required bool canDirectPlay,
@@ -57,13 +61,26 @@ bool firstStrategyAllowsDirectPlay(Iterable<String> strategyValues) {
   return first == 'DIRECT_PLAY' || first == 'REMUX';
 }
 
-/// Whether any candidate is a no-re-encode delivery (HLS_COPY or REMUX).
+/// Whether the HLS session this list produces will copy the video rather
+/// than re-encode it.
 ///
-/// A bare DIRECT_PLAY without HLS_COPY/REMUX is intentionally false: on web
-/// that list still plays via TRANSCODE HLS today.
-bool strategiesAllowLosslessDelivery(Iterable<String> strategyValues) {
-  for (final value in strategyValues) {
-    if (value == 'HLS_COPY' || value == 'REMUX') return true;
-  }
-  return false;
+/// Delegates to [pickHlsStrategy], the function that actually chooses what
+/// `PlayerScreen._pickHlsStrategy` asks the streaming-session mutation for,
+/// so the label can only ever describe the delivery the player requested.
+///
+/// This used to scan the whole list for any HLS_COPY or REMUX, which read
+/// the server's *offer* instead of the player's *choice*. The two part
+/// company on a leading HLS_COPY: that is the `:needs_transcoding` verdict,
+/// [pickHlsStrategy] refuses it and falls back to TRANSCODE, and the scan
+/// still called the result lossless. A 1080p HEVC episode on web therefore
+/// showed "Original · no re-encoding" against a server dashboard reporting
+/// `hevc -> h264 (VAAPI)` at 3.0 Mbps.
+///
+/// Callers who can also direct-play must check that first: this only
+/// answers for the HLS path, and [originalDeliverySubtitle] already orders
+/// Direct Play ahead of lossless. A bare DIRECT_PLAY + TRANSCODE list is
+/// false here for the same reason it always was, since on web that list
+/// still plays via TRANSCODE HLS.
+bool hlsDeliveryIsLossless(Iterable<String> strategyValues) {
+  return pickHlsStrategy(strategyValues.toList()) == 'HLS_COPY';
 }

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1928,6 +1928,11 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   /// Cache the Original-rung delivery subtitle from resolved candidates.
   ///
   /// Labels only — does not change the [_canDirectPlay] playback gate.
+  ///
+  /// Both flags are read off the same two functions the playback path uses,
+  /// [firstStrategyAllowsDirectPlay] for the direct fork and
+  /// [hlsDeliveryIsLossless] (via [pickHlsStrategy]) for the HLS one, so the
+  /// label cannot describe a delivery this player never asked for.
   void _rememberOriginalDeliverySubtitle(
     List<Query$StreamingCandidates$streamingCandidates$candidates>? candidates,
   ) {
@@ -1935,7 +1940,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
         const <String>[];
 
     final canDirect = !kIsWeb && firstStrategyAllowsDirectPlay(values);
-    final lossless = strategiesAllowLosslessDelivery(values);
+    final lossless = hlsDeliveryIsLossless(values);
     _originalDeliverySubtitle = originalDeliverySubtitle(
       canDirectPlay: canDirect,
       hasLosslessDelivery: lossless,

--- a/player/test/domain/models/quality_delivery_subtitle_test.dart
+++ b/player/test/domain/models/quality_delivery_subtitle_test.dart
@@ -84,22 +84,62 @@ void main() {
     });
   });
 
-  group('strategiesAllowLosslessDelivery', () {
-    test('true when any HLS_COPY or REMUX is present', () {
+  group('hlsDeliveryIsLossless', () {
+    test('false when HLS_COPY leads, because that copy is never requested', () {
+      // The :needs_transcoding shape. pickHlsStrategy refuses a leading
+      // HLS_COPY and asks for TRANSCODE instead, so the delivery re-encodes
+      // however many HLS_COPY entries the server listed. Reporting these as
+      // lossless is what put "Original · no re-encoding" on a web session
+      // the dashboard showed re-encoding HEVC to H.264.
+      expect(hlsDeliveryIsLossless(['HLS_COPY', 'TRANSCODE']), isFalse);
       expect(
-        strategiesAllowLosslessDelivery(['REMUX', 'TRANSCODE']),
-        isTrue,
+        hlsDeliveryIsLossless(['HLS_COPY', 'HLS_COPY', 'TRANSCODE']),
+        isFalse,
       );
+    });
+
+    test('true when HLS_COPY sits behind REMUX', () {
+      // The :needs_remux shape, where the codecs are already compatible and
+      // only the container is not. pickHlsStrategy requests that HLS_COPY.
       expect(
-        strategiesAllowLosslessDelivery(['HLS_COPY', 'TRANSCODE']),
+        hlsDeliveryIsLossless(['REMUX', 'HLS_COPY', 'TRANSCODE']),
         isTrue,
       );
     });
 
-    test('false for DIRECT_PLAY + TRANSCODE only (web direct-play shape)', () {
+    test('false without any HLS_COPY to request', () {
+      // Both of these fall through to TRANSCODE.
+      expect(hlsDeliveryIsLossless(['DIRECT_PLAY', 'TRANSCODE']), isFalse);
+      expect(hlsDeliveryIsLossless(['REMUX', 'TRANSCODE']), isFalse);
+    });
+
+    test('false when empty', () {
+      expect(hlsDeliveryIsLossless([]), isFalse);
+    });
+  });
+
+  group('originalDeliverySubtitle over real candidate lists', () {
+    // Guards the pairing the bug broke: the same list must not be read as
+    // direct-playable by one helper and lossless by the other.
+    test('web HEVC session reports re-encoding, not lossless', () {
+      const hevc = ['HLS_COPY', 'HLS_COPY', 'TRANSCODE'];
       expect(
-        strategiesAllowLosslessDelivery(['DIRECT_PLAY', 'TRANSCODE']),
-        isFalse,
+        originalDeliverySubtitle(
+          canDirectPlay: false, // kIsWeb forces this false
+          hasLosslessDelivery: hlsDeliveryIsLossless(hevc),
+        ),
+        kOriginalTranscodeSubtitle,
+      );
+    });
+
+    test('web remux session still reports lossless', () {
+      const remux = ['REMUX', 'HLS_COPY', 'TRANSCODE'];
+      expect(
+        originalDeliverySubtitle(
+          canDirectPlay: false,
+          hasLosslessDelivery: hlsDeliveryIsLossless(remux),
+        ),
+        kOriginalLosslessSubtitle,
       );
     });
   });


### PR DESCRIPTION
Playing S03E01 of a 1080p HEVC show in the web player showed **`Original · no re-encoding`** in the quality menu while the server dashboard, for the same session, reported:

```
Transcode 3.0 Mbps
Video hevc -> h264 (VAAPI)
Audio aac (copy) - eng
```

The dashboard was right.

## Root cause

Two functions read the same candidate list and disagree about a **leading** `HLS_COPY`.

`pickHlsStrategy` (`player/lib/core/player/hls_strategy_selection.dart`) treats a leading `HLS_COPY` as the server's `:needs_transcoding` verdict and refuses it, falling back to `TRANSCODE`. That guard is deliberate and correct: `HLS_COPY` repackages without re-encoding, so it still carries the codec the server just said the client cannot decode (this is the Fire HD 10 / HEVC Main 10 case it was written for).

`strategiesAllowLosslessDelivery` (`player/lib/domain/models/quality_delivery_subtitle.dart`) scanned the whole list for *any* `HLS_COPY` or `REMUX` and returned true. It hit the very entry `pickHlsStrategy` had just rejected, so `_rememberOriginalDeliverySubtitle` printed the lossless label over a session that re-encodes.

The label described the server's **offer**; playback followed the player's **choice**.

Confirmed against the live instance. For that file the server returns:

```
compat=:needs_transcoding   conditions_reject=false
HLS_COPY  hvc1.1.4.L120.B0   (six codec-string variants)
TRANSCODE avc1.640028        <- what the player actually requested
```

## Fix

`strategiesAllowLosslessDelivery` becomes `hlsDeliveryIsLossless`, which delegates to `pickHlsStrategy`. The label is now a function of the strategy the player requested, so the two cannot drift again.

Behaviour per server branch:

| Server verdict | Candidates | Requested | Label |
| --- | --- | --- | --- |
| `:needs_transcoding` | `[HLS_COPY…, TRANSCODE]` | TRANSCODE | `Original · re-encoding required` (was wrong) |
| `:needs_remux` | `[REMUX, HLS_COPY, TRANSCODE]` | HLS_COPY | `Original · no re-encoding` (unchanged) |
| `:direct_play` | `[DIRECT_PLAY, TRANSCODE]` | TRANSCODE on web | `Original · re-encoding required` (unchanged) |

Native direct play is untouched: `originalDeliverySubtitle` still orders `Direct Play` ahead of lossless, and the `_canDirectPlay` playback gate is not modified.

## Tests

The old suite asserted the bug (`strategiesAllowLosslessDelivery(['HLS_COPY', 'TRANSCODE'])` expected `isTrue`). Replaced with coverage of all three server shapes, plus two cases that run a real candidate list through `originalDeliverySubtitle` to pin the pairing that broke.

`./dev flutter analyze` clean on the touched files; full player suite green (3342 passed, 7 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected subtitle delivery labels to reflect the HLS strategy actually selected for playback.
  * Subtitles are now identified as lossless only when delivered through HLS copying, not when transcoding or remuxing is required.
  * Improved delivery status reporting for web HEVC and remux-compatible playback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->