### PR TITLE
fix(dashboard): stop Now Playing showing every transcode twice

### DIFF
--- a/lib/mydia/streaming/hls_session_supervisor.ex
+++ b/lib/mydia/streaming/hls_session_supervisor.ex
@@ -391,16 +391,34 @@ defmodule Mydia.Streaming.HlsSessionSupervisor do
     end
   end
 
+  # The key tags that identify a viewer. The registry holds more than these:
+  # `HlsSession` also registers itself under `{:session, session_id}` so a
+  # segment request can find it in O(1) (see `start_registered_session/7`
+  # there), which means one transcoding viewer owns two entries. Selecting the
+  # registry without discriminating on the tag counted that viewer twice and
+  # rendered two identical Now Playing cards, sharing one DOM id, for a single
+  # stream. Whitelist the session tags rather than blacklisting the alias: a
+  # future lookup key added for the same reason is then excluded by default
+  # instead of silently reappearing on the dashboard.
+  @session_key_tags [:hls_session, :direct_session, :remux_session]
+
   @doc """
-  Lists all active HLS sessions.
+  Lists all active playback sessions: HLS, direct play and remux.
 
   ## Returns
 
   List of tuples: `{session_key, pid, metadata}`
   """
   def list_sessions do
-    Registry.select(@registry_name, [{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+    @registry_name
+    |> Registry.select([{{:"$1", :"$2", :"$3"}, [], [{{:"$1", :"$2", :"$3"}}]}])
+    |> Enum.filter(&session_entry?/1)
   end
+
+  defp session_entry?({{tag, _media_file_id, _user_id}, _pid, _meta}),
+    do: tag in @session_key_tags
+
+  defp session_entry?(_entry), do: false
 
   @doc """
   Counts the number of active sessions.

--- a/test/mydia/streaming/session_registry_listing_test.exs
+++ b/test/mydia/streaming/session_registry_listing_test.exs
@@ -1,0 +1,109 @@
+defmodule Mydia.Streaming.SessionRegistryListingTest do
+  @moduledoc """
+  Pins that a session is listed once, however many registry keys it holds.
+
+  `HlsSession` registers itself twice in `Mydia.Streaming.HlsSessionRegistry`:
+  under the `{:hls_session, media_file_id, user_id}` key the supervisor names it
+  with, and again under `{:session, session_id}` so a segment request can find
+  it in O(1) (`hls_session.ex`, `start_registered_session/7`). Selecting the
+  registry without discriminating on the key therefore reported every
+  transcoding viewer twice, and the dashboard rendered two identical Now
+  Playing cards, sharing one DOM id, for a single stream.
+
+  Driven through a stub holding the same pair of keys rather than a live
+  session: `HlsSession.init/1` loads a real media file and spawns a real
+  FFmpeg, neither of which this assertion needs. Same convention as
+  `hls_session_info_test.exs` in this directory.
+  """
+
+  # Registers into the real session registry, and the stub process touches the
+  # sandbox, so this cannot run async.
+  use Mydia.DataCase, async: false
+
+  alias Mydia.MediaFixtures
+  alias Mydia.Streaming
+  alias Mydia.Streaming.HlsSessionSupervisor
+
+  @registry Mydia.Streaming.HlsSessionRegistry
+
+  defmodule DoubleRegisteredSession do
+    @moduledoc false
+    # Stands in for a running `HlsSession`: one process, both of the registry
+    # keys a real one holds, answering `:get_info` on either.
+    use GenServer
+
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+    @impl true
+    def init(opts) do
+      media_file_id = Keyword.fetch!(opts, :media_file_id)
+      user_id = Keyword.fetch!(opts, :user_id)
+      session_id = Keyword.fetch!(opts, :session_id)
+      registry = Keyword.fetch!(opts, :registry)
+
+      meta = %{
+        media_file_id: media_file_id,
+        user_id: user_id,
+        mode: :transcode,
+        started_at: DateTime.utc_now()
+      }
+
+      {:ok, _} = Registry.register(registry, {:hls_session, media_file_id, user_id}, meta)
+      {:ok, _} = Registry.register(registry, {:session, session_id}, meta)
+
+      {:ok, %{media_file_id: media_file_id, session_id: session_id}}
+    end
+
+    @impl true
+    def handle_call(:get_info, _from, state) do
+      info = %{
+        session_id: state.session_id,
+        media_file_id: state.media_file_id,
+        mode: :transcode,
+        plan: nil
+      }
+
+      {:reply, {:ok, info}, state}
+    end
+  end
+
+  defp start_double_registered_session(media_file, user) do
+    {:ok, pid} =
+      start_supervised(
+        {DoubleRegisteredSession,
+         media_file_id: media_file.id,
+         user_id: user.id,
+         session_id: Ecto.UUID.generate(),
+         registry: @registry}
+      )
+
+    pid
+  end
+
+  test "list_sessions/0 skips the by-session-id lookup key" do
+    media_file = MediaFixtures.media_file_fixture(%{})
+    user = Mydia.AccountsFixtures.user_fixture()
+
+    start_double_registered_session(media_file, user)
+
+    entries =
+      HlsSessionSupervisor.list_sessions()
+      |> Enum.filter(fn {_key, _pid, meta} -> meta[:media_file_id] == media_file.id end)
+
+    assert [{{:hls_session, _, _}, _pid, _meta}] = entries
+  end
+
+  test "a transcoding viewer produces one now-playing card, not two" do
+    movie = MediaFixtures.media_item_fixture(%{type: "movie", title: "The Sundial Coast"})
+    media_file = MediaFixtures.media_file_fixture(%{media_item_id: movie.id})
+    user = Mydia.AccountsFixtures.user_fixture()
+
+    start_double_registered_session(media_file, user)
+
+    sessions =
+      Streaming.list_active_sessions()
+      |> Enum.filter(&(&1.media_file_id == media_file.id))
+
+    assert length(sessions) == 1
+  end
+end


### PR DESCRIPTION
Every transcoding viewer rendered two identical Now Playing cards on the admin dashboard, and the active-streams KPI counted them twice to match.

## Root cause

A running `HlsSession` owns **two** keys in `Mydia.Streaming.HlsSessionRegistry`:

- `{:hls_session, media_file_id, user_id}`, the `:via` name `HlsSessionSupervisor` starts it under, and
- `{:session, session_id}`, which the session registers on itself in `start_registered_session/7` so a segment request can find it in O(1).

`HlsSessionSupervisor.list_sessions/0` selected the registry with an unconstrained match spec, so it handed back both entries. `Streaming.list_active_sessions/0` then resolved each through `get_info` on the same pid and built two byte-identical `ActiveSession` structs. The dashboard rendered both, sharing the DOM id `now-playing-<media_file_id>`.

Direct play and remux trackers hold one key each, which is why only transcoding streams duplicated. `SessionSampler` was already immune by accident: its `normalize/1` matches a three-element key and the alias is a pair, so the bandwidth chart never counted it.

## Fix

`list_sessions/0` whitelists the three session key tags rather than excluding the alias, so another lookup key added later for the same reason stays off the dashboard instead of silently reappearing on it.

## Testing

New `test/mydia/streaming/session_registry_listing_test.exs` drives a stub holding the same pair of keys a real session holds, following the `hls_session_info_test.exs` convention of not spawning FFmpeg for an assertion that does not need it. It fails on the pre-fix code with `left: 2, right: 1` and passes after.

`mix precommit` green: 11034 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented playback sessions from appearing more than once in session listings.
  - Improved active playback results so each transcoding viewer produces a single now-playing entry.
  - Session listings now consistently cover HLS, direct play, and remux playback sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->