### PR TITLE
fix(player): notify TestFlight testers so builds reach external groups

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -122,7 +122,8 @@ jobs:
 
       # ci-fastlane.yml proves the Fastfile parses and that release_metadata.rb
       # is reachable through require_relative. This proves what the helpers in
-      # it actually return, which a lane listing cannot see.
+      # it actually return, which a lane listing cannot see. It also pins
+      # notify_external_testers to true in the Fastfile.
       - name: Assert the iOS fastlane metadata helpers behave
         run: ./scripts/check-ios-fastlane-metadata.sh
 

--- a/player/ios/fastlane/Fastfile
+++ b/player/ios/fastlane/Fastfile
@@ -29,11 +29,17 @@ platform :ios do
     # we can't skip waiting here. The first build of each new version goes
     # through Apple's Beta App Review; that is per version, not per group, so
     # routing a stable release to a second group does not trigger another one.
+    #
+    # notify_external_testers is what releases an approved build to external
+    # testers, and the email comes with it. Set to false, every build waits at
+    # "Approved" for a manual "Notify Testers" click in App Store Connect, and
+    # once the last released build expires the public links refuse new testers
+    # (#746). scripts/check-ios-fastlane-metadata.sh fails if this changes.
     upload_to_testflight(
       distribute_external: true,
       groups: testflight_groups,
       changelog: testflight_changelog,
-      notify_external_testers: false
+      notify_external_testers: true
     )
   end
 

--- a/scripts/check-ios-fastlane-metadata.sh
+++ b/scripts/check-ios-fastlane-metadata.sh
@@ -6,6 +6,10 @@
 # plain-Ruby file to be testable here. ci-fastlane.yml separately proves the
 # Fastfile still parses and that the file is reachable via require_relative;
 # this proves the logic inside it.
+#
+# It also reads the Fastfile as text to pin one setting whose failure is
+# silent: notify_external_testers must stay true. The comment on it there says
+# why.
 set -euo pipefail
 export LC_ALL=C.UTF-8
 
@@ -62,6 +66,15 @@ real.write("\nWhat changed.\n\n")
 real.flush
 ENV["TESTFLIGHT_CHANGELOG_PATH"] = real.path
 check.call("real notes are read and stripped", testflight_changelog, "What changed.")
+
+# The Fastfile only loads under fastlane, so this reads it as text, skipping
+# comments. notify_external_testers is what releases an approved build to
+# external testers. While it was false every build waited at "Approved", and the
+# public links closed once the last released build expired (#746).
+fastfile = File.read(File.join(File.dirname(File.expand_path(ARGV[0])), "Fastfile"))
+code = fastfile.lines.reject { |l| l.lstrip.start_with?("#") }.join
+check.call("the Fastfile notifies external testers",
+           code.scan(/notify_external_testers:\s*(\w+)/).flatten, ["true"])
 
 if failures.empty?
   puts "ios fastlane metadata: all cases pass"


### PR DESCRIPTION
## Summary

Every TestFlight build since 2026-06-02 stopped at "Approved" in App Store Connect, with a yellow "Notify Testers" link, and never reached testers. Once the last hand-distributed build hit TestFlight's 90-day expiry, both public links (Beta and Pre-release) refused new testers, and direct invites failed the same way.

The `testflight` lane passed `notify_external_testers: false`. fastlane 2.238.0 turns that into `buildBetaDetails.autoNotifyEnabled = false`, and for external groups that flag is also what releases an approved build. Setting it to `true` lets Apple release the build and notify testers as soon as Beta App Review approves it, with no polling on our side.

- `player/ios/fastlane/Fastfile`: `notify_external_testers: true`, with a comment on what `false` does.
- `scripts/check-ios-fastlane-metadata.sh`: reads the Fastfile as text and fails unless the option is set exactly once, to `true`. `ci-nix.yml` already runs it.

`release.yml` and `player-ios-refresh.yml` both build through `player-ios.yml`, so the same line fixes the refresh uploads that are meant to keep both groups alive.

Trade-off: testers get an email and push for every build, including each prerelease and each refresh. App Store Connect has no way to release a build to external testers without notifying them.

## Test plan

- [x] `./scripts/check-ios-fastlane-metadata.sh` fails against master's Fastfile (`got ["false"], wanted ["true"]`) and passes with this change
- [x] `ruby -c player/ios/fastlane/Fastfile`
- [ ] `ci-fastlane.yml` loads the Fastfile under fastlane
- [ ] Next release: the new build reaches "Testing" after review without a click

Fixes #746


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approved iOS TestFlight builds are now automatically released to external testers, with notification emails sent without requiring a manual action.

- **Chores**
  - Added automated validation to ensure external tester notifications remain enabled.
  - Updated CI documentation to reflect the additional validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->