### PR TITLE
fix(downloads): stop archive-wrapped malware and the blacklist re-grab loop

### DIFF
--- a/lib/mydia/downloads/blacklists.ex
+++ b/lib/mydia/downloads/blacklists.ex
@@ -17,10 +17,10 @@ defmodule Mydia.Downloads.Blacklists do
   ## Guid plumbing
 
   The blacklist key is `(indexer, guid)`. Some indexers return a stable
-  `guid` per release; others don't. The producer (`DownloadMonitor`) is
-  responsible for materializing a fallback guid — typically a SHA-256 of
-  `(indexer, title, size)` — when one is missing. This module performs no
-  fallback synthesis of its own.
+  `guid` per release; others don't. `release_guid/1` supplies a SHA-256 of
+  `(indexer, title, size)` for the ones that don't, and both sides of the
+  blacklist go through it: the grab path records it on the download, and
+  `reject_blacklisted/2` checks search results against it.
   """
 
   import Ecto.Query
@@ -37,6 +37,36 @@ defmodule Mydia.Downloads.Blacklists do
           expires_at: DateTime.t() | nil,
           ttl_days: non_neg_integer() | nil
         ]
+
+  @doc """
+  Returns the guid a search result is blacklisted under: the indexer's own
+  guid, or `"sha256:"` plus a SHA-256 of `(indexer, title, size)` when the
+  indexer supplies none.
+
+  The grab path and `reject_blacklisted/2` must agree on this. When only the
+  grab path synthesized it, a release from a guid-less indexer was blacklisted
+  under the fallback but checked under nothing, so every search re-grabbed
+  the release it had just rejected.
+
+  The fallback format is stored in existing blacklist rows, so changing it
+  orphans them.
+  """
+  @spec release_guid(map()) :: String.t()
+  def release_guid(%{guid: guid}) when is_binary(guid) and guid != "", do: guid
+
+  def release_guid(result) do
+    payload =
+      Enum.join(
+        [
+          Map.get(result, :indexer) || "",
+          Map.get(result, :title) || "",
+          to_string(Map.get(result, :size) || 0)
+        ],
+        "|"
+      )
+
+    "sha256:" <> (:crypto.hash(:sha256, payload) |> Base.encode16(case: :lower))
+  end
 
   @doc """
   Pulls the `(indexer, guid)` blacklist key off a download.
@@ -136,8 +166,9 @@ defmodule Mydia.Downloads.Blacklists do
   Filters out results whose `(indexer, guid)` is currently blacklisted, in
   one DB roundtrip regardless of result-list size.
 
-  Each search result is expected to expose `:indexer` and `:guid` keys.
-  Results missing either are kept (no blacklist key to compare). Rejected
+  Each search result is expected to expose `:indexer`, and `:guid` or the
+  `:title` and `:size` that `release_guid/1` falls back to. Results with no
+  indexer are kept (no blacklist key to compare). Rejected
   rows are logged at `:info` along with the supplied `log_context` keyword
   list so callers can attach episode/movie ids for traceability.
 
@@ -156,7 +187,7 @@ defmodule Mydia.Downloads.Blacklists do
       if pair && MapSet.member?(blacklisted, pair) do
         Logger.info(
           "Rejected blacklisted release",
-          [indexer: result.indexer, guid: result.guid, title: Map.get(result, :title)] ++
+          [indexer: result.indexer, guid: elem(pair, 1), title: Map.get(result, :title)] ++
             log_context
         )
 
@@ -207,9 +238,8 @@ defmodule Mydia.Downloads.Blacklists do
     end
   end
 
-  defp blacklist_key(%{indexer: indexer, guid: guid})
-       when is_binary(indexer) and is_binary(guid) and guid != "" do
-    {ReleaseBlacklist.normalize_indexer(indexer), guid}
+  defp blacklist_key(%{indexer: indexer} = result) when is_binary(indexer) and indexer != "" do
+    {ReleaseBlacklist.normalize_indexer(indexer), release_guid(result)}
   end
 
   defp blacklist_key(_), do: nil

--- a/lib/mydia/downloads/queue.ex
+++ b/lib/mydia/downloads/queue.ex
@@ -1244,7 +1244,7 @@ defmodule Mydia.Downloads.Queue do
     |> DownloadMetadata.new()
     |> DownloadMetadata.to_map()
     |> Map.put(:indexer, search_result.indexer)
-    |> Map.put(:guid, search_result.guid || fallback_release_guid(search_result))
+    |> Map.put(:guid, Blacklists.release_guid(search_result))
   end
 
   defp create_download_record(search_result, client_config, client_id, opts) do
@@ -1263,18 +1263,6 @@ defmodule Mydia.Downloads.Queue do
     }
 
     History.create_download(attrs)
-  end
-
-  # Synthesizes a stable fallback identifier when the indexer didn't provide
-  # a `guid`. SHA-256 of `(indexer, title, size)` is deterministic across
-  # processes so the same release hashes to the same key — good enough for
-  # blacklist dedup.
-  defp fallback_release_guid(%SearchResult{} = sr) do
-    parts = [sr.indexer || "", sr.title || "", to_string(sr.size || 0)]
-    payload = Enum.join(parts, "|")
-
-    "sha256:" <>
-      (:crypto.hash(:sha256, payload) |> Base.encode16(case: :lower))
   end
 
   defp create_download_record_with_retry(search_result, client_config, client_id, opts) do

--- a/lib/mydia/downloads/release_validator.ex
+++ b/lib/mydia/downloads/release_validator.ex
@@ -28,11 +28,13 @@ defmodule Mydia.Downloads.ReleaseValidator do
      - Example: `yenc movie title`
      - These are raw usenet posts, not proper releases
 
-  6. **Suspicious executable extensions** - Release name ends in an executable
-     extension (.exe, .scr, .bat, .cmd, .com, .msi, .vbs, .js, .jar, .pif)
+  6. **Suspicious executable or archive extensions** - Release name ends in an
+     executable extension (.exe, .scr, .bat, .cmd, .com, .msi, .vbs, .js, .jar,
+     .pif) or an archive extension (.zip, .zipx, .rar, .7z)
      - Example: `From.S04E05.1080p.WEB.h264-ETHEL.exe`
      - These are malware torrents disguised as 1080p video releases. A
-       legitimate video release never carries an executable extension.
+       legitimate video release never carries an executable extension, and
+       archives are how the same payload returns once the .exe is filtered.
 
   ## Usage
 
@@ -62,7 +64,7 @@ defmodule Mydia.Downloads.ReleaseValidator do
   - `:reversed_pattern` - Strange reversed naming
   - `:yenc_pattern` - Raw usenet binary encoding
   - `:no_meaningful_content` - No extractable title content
-  - `:suspicious_extension` - Release name ends in an executable extension
+  - `:suspicious_extension` - Release name ends in an executable or archive extension
   - `:no_title` - Release has a nil title (malformed result)
   """
   @spec validate_release(String.t() | nil) :: {:ok, String.t()} | {:error, atom()}
@@ -71,7 +73,10 @@ defmodule Mydia.Downloads.ReleaseValidator do
   def validate_release(name) when is_binary(name) do
     cond do
       suspicious_extension?(name) ->
-        Logger.warning("Rejecting release with suspicious executable extension: #{name}")
+        Logger.warning(
+          "Rejecting release with suspicious executable or archive extension: #{name}"
+        )
+
         {:error, :suspicious_extension}
 
       is_hashed_release?(name) ->
@@ -109,7 +114,15 @@ defmodule Mydia.Downloads.ReleaseValidator do
   # — a legitimate 1080p video release never has a .exe extension. These show
   # up periodically from public indexers using real-looking release-group
   # names (e.g. "ETHEL") to slip past automatic-grab filters.
-  @suspicious_extensions ~w(.exe .scr .bat .cmd .com .msi .vbs .js .jar .pif)
+  #
+  # The same payload also comes back wrapped in an archive once the .exe name
+  # is filtered: production grabbed a ".zipx" whose only entry was a 1.1 GB
+  # ".exe", from a search whose fourteen bare-.exe siblings this check had
+  # already dropped. Nothing in the import pipeline unpacks archives, so an
+  # archive release can never import, and rejecting one by name costs nothing.
+  @executable_extensions ~w(.exe .scr .bat .cmd .com .msi .vbs .js .jar .pif)
+  @archive_extensions ~w(.zip .zipx .rar .7z)
+  @suspicious_extensions @executable_extensions ++ @archive_extensions
 
   defp suspicious_extension?(name) do
     trimmed = String.trim(name)

--- a/test/mydia/downloads/blacklists_test.exs
+++ b/test/mydia/downloads/blacklists_test.exs
@@ -2,7 +2,9 @@ defmodule Mydia.Downloads.BlacklistsTest do
   use Mydia.DataCase, async: true
 
   alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.Queue
   alias Mydia.Downloads.ReleaseBlacklist
+  alias Mydia.Indexers.SearchResult
   alias Mydia.Repo
 
   import Mydia.DownloadsFixtures
@@ -212,6 +214,89 @@ defmodule Mydia.Downloads.BlacklistsTest do
       future = DateTime.add(DateTime.utc_now(), 3600, :second)
       {:ok, _} = Blacklists.add("a", "1", "T", "x", expires_at: future)
       assert 0 == Blacklists.cleanup_expired()
+    end
+  end
+
+  describe "reject_blacklisted/2" do
+    defp search_result(attrs) do
+      struct!(
+        SearchResult,
+        Map.merge(
+          %{
+            title: "Stillwater Bay S03E04 1080p WEB H264-NTb",
+            size: 1_073_741_824,
+            seeders: 0,
+            leechers: 0,
+            download_url: "https://example.test/info/1",
+            indexer: "MagnetDownload"
+          },
+          attrs
+        )
+      )
+    end
+
+    # Blacklists what the grab path records, so the test pins the parity
+    # between the two sides rather than either side's hashing.
+    defp blacklist_as_grabbed(result) do
+      guid = Queue.build_download_metadata(result).guid
+      {:ok, _} = Blacklists.add(result.indexer, guid, result.title, "no_importable_files")
+    end
+
+    test "drops a result whose indexer-supplied guid is blacklisted" do
+      result = search_result(%{guid: "abc123"})
+      blacklist_as_grabbed(result)
+
+      assert [] = Blacklists.reject_blacklisted([result])
+    end
+
+    # Production loop: an indexer without guids re-served a rejected malware
+    # release, and every re-grab was rejected again until the auto-reject cap
+    # stopped rejecting and the payload downloaded.
+    test "drops a guid-less result blacklisted under the grab-time fallback guid" do
+      result = search_result(%{guid: nil})
+      blacklist_as_grabbed(result)
+
+      assert [] = Blacklists.reject_blacklisted([result])
+    end
+
+    test "drops a result with an empty-string guid blacklisted when grabbed" do
+      result = search_result(%{guid: ""})
+      blacklist_as_grabbed(result)
+
+      assert [] = Blacklists.reject_blacklisted([result])
+    end
+
+    test "keeps a guid-less result from a different release" do
+      blacklist_as_grabbed(search_result(%{guid: nil}))
+      other = search_result(%{guid: nil, title: "Stillwater Bay S03E05 1080p WEB H264-NTb"})
+
+      assert [^other] = Blacklists.reject_blacklisted([other])
+    end
+
+    test "keeps a result with no indexer" do
+      result = %{indexer: nil, guid: nil, title: "Stillwater Bay S03E04", size: 1}
+
+      assert [^result] = Blacklists.reject_blacklisted([result])
+    end
+  end
+
+  describe "release_guid/1" do
+    test "returns the indexer-supplied guid" do
+      assert "abc123" = Blacklists.release_guid(%{indexer: "nyaa", guid: "abc123"})
+    end
+
+    # Existing blacklist rows carry fallback guids written at grab time, so
+    # the format is a stored contract: changing it orphans every such row.
+    test "falls back to SHA-256 of indexer, title and size" do
+      result = %{
+        indexer: "MagnetDownload",
+        guid: nil,
+        title: "Stillwater Bay S03E04 1080p WEB H264-NTb",
+        size: 1_073_741_824
+      }
+
+      assert "sha256:c9283b621de8b5f024da89b600a87a5093c206a295d6bab9b107f8911068bf4e" =
+               Blacklists.release_guid(result)
     end
   end
 

--- a/test/mydia/downloads/release_validator_test.exs
+++ b/test/mydia/downloads/release_validator_test.exs
@@ -195,6 +195,28 @@ defmodule Mydia.Downloads.ReleaseValidatorTest do
       end
     end
 
+    # Malware that the .exe filter already stops comes back wrapped in an
+    # archive: this name held a single .exe inside a .zipx. Mydia imports
+    # video files only, so an archive release cannot import either way.
+    test "rejects archive-wrapped release disguised as TV episode" do
+      name = "Stillwater Bay S03E04 1080p ATVP WEB-DL DDP5 1 Atmos.zipx"
+
+      assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+    end
+
+    test "rejects other archive extensions" do
+      for ext <- ~w(.zip .zipx .rar .7z .ZIPX) do
+        name = "Movie.Title.2020.1080p.BluRay.x264#{ext}"
+        assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+      end
+    end
+
+    test "rejects archive extension hidden behind a trailing site tag" do
+      name = "Stillwater Bay S03E04 1080p WEB H264-NTb.zipx[EZTVx.to]"
+
+      assert {:error, :suspicious_extension} = ReleaseValidator.validate_release(name)
+    end
+
     test "accepts release without an extension" do
       name = "From.S04E05.1080p.WEB.h264-ETHEL"
 


### PR DESCRIPTION
## What happened

On 2026-09-08 galactica downloaded `... S04E06 1080p ATVP WEB-DL DDP5 1 Atmos.zipx` for an airing show. The file is a ZIP whose only entry is a 1.1 GB `.exe`. Two independent defects let it through.

**The name filter didn't know archives.** The same search returned fourteen bare-`.exe` copies of the release, and `ReleaseValidator` dropped every one. The `.zipx` copy ranked first and was grabbed.

**The blacklist never matched guid-less indexers.** The early content check did its job: it rejected the grab ten seconds in and blacklisted it. MagnetDownload returns no guid, so the grab path had stored a synthesized `sha256:(indexer|title|size)` guid, and that's what got blacklisted. `reject_blacklisted/2` only built a key from the result's own guid, so for this indexer it compared against nothing. Search re-grabbed the same torrent, and the content check rejected it again. On the fourth grab the per-item auto-reject cap (3) stopped rejecting and the full payload downloaded.

| EDT | Grab | Outcome |
| --- | --- | --- |
| 20:30:18 | bitmagnet (real guid) | rejected, blacklisted |
| 20:30:36 | MagnetDownload (no guid) | rejected, blacklisted under fallback |
| 22:30:20 | same MagnetDownload release | blacklist miss, rejected |
| 22:30:38 | same again | cap reached, left alone, downloaded |

The stored guid is exactly `sha256("MagnetDownload|<title>|1073741824")`, so the search result had every field needed to match.

## Changes

- `ReleaseValidator` rejects `.zip`, `.zipx`, `.rar` and `.7z` release names alongside the executable extensions, including behind a trailing site tag. Nothing in the import pipeline unpacks archives, so an archive release could never import anyway.
- `Blacklists.release_guid/1` owns the fallback guid, and both the grab path (`Queue.build_download_metadata/1`) and `reject_blacklisted/2` use it. The hash format is unchanged and pinned by a test, so rows already blacklisted under a fallback guid start matching. An empty-string guid now counts as missing on the grab side as well.

## Not changed

The auto-reject cap still treats repeated rejections as a sign the detector is wrong. With the loop closed it would not have tripped here, but it is keyed per media item, which for TV means the whole show, so a flood of *distinct* malware releases for one show can still exhaust it. That is a policy call and is left for a follow-up.

## Testing

- New tests for archive names (bare, uppercase, behind a site tag) and for `reject_blacklisted/2` with real, nil and empty guids, plus a pinned fallback hash.
- `release_validator`, `release_intake`, `release_ranker`, `blacklists`, `queue`, `grabber`, `download_monitor`, `movie_search`, `tv_show_search` and `upgrades` suites pass.
- `mix precommit` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved blacklist matching for releases without a supplied identifier by generating a consistent fallback identifier.
  - Ensured blacklist checks remain consistent between download and grab workflows.
  - Expanded suspicious-release detection to include archive extensions such as `.zip`, `.zipx`, `.rar`, and `.7z`, including uppercase and tagged filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->