### PR TITLE
fix(indexers): FlareSolverr Test probes the form and ignores Enabled

### DIFF
--- a/lib/mydia/indexers/flaresolverr.ex
+++ b/lib/mydia/indexers/flaresolverr.ex
@@ -124,39 +124,33 @@ defmodule Mydia.Indexers.FlareSolverr do
   end
 
   @doc """
-  Performs a health check on the FlareSolverr service.
+  Performs a health check on the saved FlareSolverr service.
 
-  Returns service information if healthy.
+  Returns `{:error, :disabled}` or `{:error, :not_configured}` without making a
+  request when the saved config is switched off or has no URL. To probe a URL
+  regardless of the saved config, use `health_check/1`.
   """
   @spec health_check() :: {:ok, map()} | {:error, term()}
   def health_check do
     with {:ok, config} <- get_config(),
          :ok <- validate_enabled(config) do
-      url = "#{config.url}#{@api_path}"
-
-      body = %{
-        cmd: "sessions.list"
-      }
-
-      case Req.post(url, json: body, connect_options: [timeout: 5_000], receive_timeout: 10_000) do
-        {:ok, %Req.Response{status: 200, body: body}} when is_map(body) ->
-          {:ok,
-           %{
-             status: body["status"],
-             version: body["version"],
-             sessions: body["sessions"] || []
-           }}
-
-        {:ok, %Req.Response{status: status, body: body}} ->
-          {:error, {:http_error, status, body}}
-
-        {:error, %Req.TransportError{reason: reason}} ->
-          {:error, {:connection_error, reason}}
-
-        {:error, reason} ->
-          {:error, {:request_error, reason}}
-      end
+      health_check(config.url)
     end
+  end
+
+  @doc """
+  Probes the FlareSolverr instance at `url`, whether or not FlareSolverr is
+  enabled in the saved config.
+
+  This answers "does this URL respond", which is what the admin UI's Test
+  buttons need, including for values typed into the edit modal but not saved yet.
+
+  Returns `{:error, :invalid_url}` without making a request unless `url` is an
+  absolute http(s) URL with a host.
+  """
+  @spec health_check(String.t() | nil) :: {:ok, map()} | {:error, term()}
+  def health_check(url) do
+    if valid_url?(url), do: probe(url), else: {:error, :invalid_url}
   end
 
   @doc """
@@ -213,6 +207,46 @@ defmodule Mydia.Indexers.FlareSolverr do
   end
 
   ## Private Functions
+
+  defp probe(base_url) do
+    url = "#{base_url}#{@api_path}"
+    body = %{cmd: "sessions.list"}
+
+    case Req.post(url, json: body, connect_options: [timeout: 5_000], receive_timeout: 10_000) do
+      {:ok, %Req.Response{status: 200, body: body}} when is_map(body) ->
+        {:ok,
+         %{
+           status: body["status"],
+           version: body["version"],
+           sessions: body["sessions"] || []
+         }}
+
+      {:ok, %Req.Response{status: status, body: body}} ->
+        {:error, {:http_error, status, body}}
+
+      {:error, %Req.TransportError{reason: reason}} ->
+        {:error, {:connection_error, reason}}
+
+      {:error, reason} ->
+        {:error, {:request_error, reason}}
+    end
+  end
+
+  # The admin modal feeds health_check/1 free text. Anything but an absolute
+  # http(s) URL with a host is refused up front, so a typo like
+  # "flaresolverr:8191" never reaches Req.
+  defp valid_url?(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, host: host}
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  defp valid_url?(_url), do: false
 
   # Reads the merged runtime config (env > DB/UI > YAML > defaults) so that
   # FlareSolverr settings managed in the admin UI actually take effect. The

--- a/lib/mydia/indexers/flaresolverr.ex
+++ b/lib/mydia/indexers/flaresolverr.ex
@@ -179,24 +179,7 @@ defmodule Mydia.Indexers.FlareSolverr do
     config = config()
 
     if config && config.enabled && is_binary(config.url) && config.url != "" do
-      case health_check() do
-        {:ok, info} ->
-          %{
-            configured: true,
-            status: :healthy,
-            url: config.url,
-            version: info[:version],
-            sessions: info[:sessions] || []
-          }
-
-        {:error, reason} ->
-          %{
-            configured: true,
-            status: :unhealthy,
-            url: config.url,
-            error: reason
-          }
-      end
+      status_from_probe(config.url, health_check())
     else
       %{
         configured: config != nil && is_binary(config[:url]) && config[:url] != "",
@@ -206,10 +189,42 @@ defmodule Mydia.Indexers.FlareSolverr do
     end
   end
 
+  @doc """
+  Builds the `status/0` map for a probe of `url` that has already run.
+
+  Lets a caller holding a `health_check/1` result refresh the displayed status
+  without probing a second time.
+  """
+  @spec status_from_probe(String.t(), {:ok, map()} | {:error, term()}) :: map()
+  def status_from_probe(url, {:ok, info}) do
+    %{
+      configured: true,
+      status: :healthy,
+      url: url,
+      version: info[:version],
+      sessions: info[:sessions] || []
+    }
+  end
+
+  def status_from_probe(url, {:error, reason}) do
+    %{configured: true, status: :unhealthy, url: url, error: reason}
+  end
+
   ## Private Functions
 
+  # FlareSolverr's API lives at /v1 under whatever base the operator gave,
+  # which may carry a reverse-proxy path. Joining at the URI level keeps that
+  # path, avoids "//v1" from a trailing slash, and drops a query or fragment
+  # that string concatenation would put "/v1" inside of. Test and real
+  # requests both go through here, so Test cannot pass on a URL search fails on.
+  defp endpoint(base_url) do
+    uri = URI.parse(base_url)
+    path = String.trim_trailing(uri.path || "", "/") <> @api_path
+    URI.to_string(%URI{uri | path: path, query: nil, fragment: nil})
+  end
+
   defp probe(base_url) do
-    url = "#{base_url}#{@api_path}"
+    url = endpoint(base_url)
     body = %{cmd: "sessions.list"}
 
     case Req.post(url, json: body, connect_options: [timeout: 5_000], receive_timeout: 10_000) do
@@ -280,7 +295,7 @@ defmodule Mydia.Indexers.FlareSolverr do
   end
 
   defp execute_request(cmd, url, opts, config) do
-    flaresolverr_url = "#{config.url}#{@api_path}"
+    flaresolverr_url = endpoint(config.url)
     timeout = opts[:timeout] || config.timeout
     max_timeout = opts[:max_timeout] || config.max_timeout
 

--- a/lib/mydia_web/live/admin_indexers_live/flaresolverr_components.ex
+++ b/lib/mydia_web/live/admin_indexers_live/flaresolverr_components.ex
@@ -75,6 +75,7 @@ defmodule MydiaWeb.AdminIndexersLive.FlareSolverrComponents do
 
             <div class="join ml-auto sm:ml-2">
               <button
+                id="flaresolverr-row-test"
                 class="btn btn-sm btn-ghost join-item"
                 phx-click="test_flaresolverr"
                 title="Test Connection"
@@ -236,6 +237,7 @@ defmodule MydiaWeb.AdminIndexersLive.FlareSolverrComponents do
   defp fs_format_error(:timeout), do: "Connection timed out"
   defp fs_format_error(:not_configured), do: "Not configured"
   defp fs_format_error(:disabled), do: "Service is disabled"
+  defp fs_format_error(:invalid_url), do: "Not a valid http(s) URL"
   defp fs_format_error(error) when is_binary(error), do: error
   defp fs_format_error(error), do: inspect(error)
 end

--- a/lib/mydia_web/live/admin_indexers_live/flaresolverr_components.ex
+++ b/lib/mydia_web/live/admin_indexers_live/flaresolverr_components.ex
@@ -103,6 +103,8 @@ defmodule MydiaWeb.AdminIndexersLive.FlareSolverrComponents do
   A standard `modal-box` form (`Save` / `Cancel` / `Test`) over the four
   `flaresolverr.*` fields. Each field shows its ENV/DB/Default source; env-sourced
   fields render disabled (read-only) since environment variables win at runtime.
+  `Test` probes the URL currently in the form, saved or not, regardless of the
+  Enabled checkbox.
 
   `form` is the schemaless changeset form. `sources` maps each `flaresolverr.*` key
   to `:env`/`:database`/`:default`.
@@ -163,7 +165,12 @@ defmodule MydiaWeb.AdminIndexersLive.FlareSolverrComponents do
           />
 
           <div class="modal-action">
-            <button type="button" class="btn btn-ghost btn-sm gap-1.5" phx-click="test_flaresolverr">
+            <button
+              id="flaresolverr-modal-test"
+              type="button"
+              class="btn btn-ghost btn-sm gap-1.5"
+              phx-click="test_flaresolverr_form"
+            >
               <.icon name="hero-signal" class="w-4 h-4" /> Test
             </button>
             <button type="button" class="btn btn-ghost btn-sm" phx-click="close_flaresolverr_modal">

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -640,6 +640,17 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
   end
 
   @impl true
+  def handle_event("test_flaresolverr_form", _params, socket) do
+    case form_flaresolverr_url(socket) do
+      nil ->
+        {:noreply, put_flash(socket, :error, "Enter a FlareSolverr URL to test.")}
+
+      url ->
+        {:noreply, flash_flaresolverr_test(socket, FlareSolverr.health_check(url))}
+    end
+  end
+
+  @impl true
   def handle_event("edit_flaresolverr", _params, socket) do
     {values, sources} = flaresolverr_values_and_sources()
 
@@ -1086,6 +1097,21 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
     case FlareSolverr.config() do
       %{url: url} -> blank_to_nil(url)
       nil -> nil
+    end
+  end
+
+  # The URL the modal's Test probes: whatever is typed in the form, except when
+  # the URL comes from the environment. That input renders disabled, so the
+  # browser never submits it and the changeset loses it after the first
+  # validate event; env wins at runtime anyway, so probe the effective value.
+  defp form_flaresolverr_url(socket) do
+    if Map.get(socket.assigns.flaresolverr_sources, "flaresolverr.url") == :env do
+      saved_flaresolverr_url()
+    else
+      socket.assigns.flaresolverr_form.source
+      |> Ecto.Changeset.apply_changes()
+      |> Map.get(:url)
+      |> blank_to_nil()
     end
   end
 

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -629,10 +629,13 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
       url ->
         result = FlareSolverr.health_check(url)
 
+        # Refresh the row's health badge from this probe rather than probing
+        # again through status/0. Only an enabled config shows a health badge.
         socket =
-          case result do
-            {:ok, _info} -> assign(socket, :flaresolverr_status, FlareSolverr.status())
-            {:error, _reason} -> socket
+          if FlareSolverr.enabled?() do
+            assign(socket, :flaresolverr_status, FlareSolverr.status_from_probe(url, result))
+          else
+            socket
           end
 
         {:noreply, flash_flaresolverr_test(socket, result)}

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -621,42 +621,21 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
 
   @impl true
   def handle_event("test_flaresolverr", _params, socket) do
-    case FlareSolverr.health_check() do
-      {:ok, info} ->
-        version = info[:version] || "unknown"
-        sessions = length(info[:sessions] || [])
-
+    case saved_flaresolverr_url() do
+      nil ->
         {:noreply,
-         socket
-         |> put_flash(
-           :info,
-           "FlareSolverr connection successful! Version: #{version}, Active sessions: #{sessions}"
-         )
-         |> assign(:flaresolverr_status, FlareSolverr.status())}
+         put_flash(socket, :error, "No FlareSolverr URL configured. Click Edit to set one.")}
 
-      {:error, :disabled} ->
-        {:noreply,
-         put_flash(socket, :error, "FlareSolverr is disabled. Enable it in configuration.")}
+      url ->
+        result = FlareSolverr.health_check(url)
 
-      {:error, :not_configured} ->
-        {:noreply,
-         put_flash(
-           socket,
-           :error,
-           "FlareSolverr is not configured. Set FLARESOLVERR_URL in environment."
-         )}
+        socket =
+          case result do
+            {:ok, _info} -> assign(socket, :flaresolverr_status, FlareSolverr.status())
+            {:error, _reason} -> socket
+          end
 
-      {:error, {:connection_error, reason}} ->
-        {:noreply, put_flash(socket, :error, "FlareSolverr connection failed: #{reason}")}
-
-      {:error, reason} ->
-        MydiaLogger.log_error(:liveview, "FlareSolverr health check failed",
-          error: reason,
-          operation: :test_flaresolverr,
-          user_id: socket.assigns.current_user.id
-        )
-
-        {:noreply, put_flash(socket, :error, "FlareSolverr test failed: #{inspect(reason)}")}
+        {:noreply, flash_flaresolverr_test(socket, result)}
     end
   end
 
@@ -1099,6 +1078,72 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
         "is valid. Check the logs for the validation error."
     )
   end
+
+  # The saved effective URL (the merged runtime config), or nil when unset.
+  # Deliberately ignores `enabled`: Test answers "does this URL respond", and
+  # the row's Enabled/Disabled badge already reports the on/off state.
+  defp saved_flaresolverr_url do
+    case FlareSolverr.config() do
+      %{url: url} -> blank_to_nil(url)
+      nil -> nil
+    end
+  end
+
+  defp blank_to_nil(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
+  end
+
+  defp blank_to_nil(_value), do: nil
+
+  # One reading of a FlareSolverr.health_check/1 result, shared by the row's
+  # and the modal's Test buttons.
+  defp flash_flaresolverr_test(socket, {:ok, info}) do
+    version = info[:version] || "unknown"
+    sessions = length(info[:sessions] || [])
+
+    put_flash(
+      socket,
+      :info,
+      "FlareSolverr connection successful! Version: #{version}, Active sessions: #{sessions}"
+    )
+  end
+
+  defp flash_flaresolverr_test(socket, {:error, :invalid_url}),
+    do:
+      put_flash(
+        socket,
+        :error,
+        "Not a valid FlareSolverr URL. Use the form http://flaresolverr:8191."
+      )
+
+  defp flash_flaresolverr_test(socket, {:error, {:connection_error, reason}}) do
+    put_flash(
+      socket,
+      :error,
+      "FlareSolverr connection failed: #{format_transport_reason(reason)}"
+    )
+  end
+
+  defp flash_flaresolverr_test(socket, {:error, {:http_error, status, _body}}),
+    do: put_flash(socket, :error, "FlareSolverr returned HTTP #{status}")
+
+  defp flash_flaresolverr_test(socket, {:error, reason}) do
+    MydiaLogger.log_error(:liveview, "FlareSolverr health check failed",
+      error: reason,
+      operation: :test_flaresolverr,
+      user_id: socket.assigns.current_user.id
+    )
+
+    put_flash(socket, :error, "FlareSolverr test failed: #{inspect(reason)}")
+  end
+
+  # Transport reasons are usually atoms (:econnrefused, :timeout) but can be
+  # tuples, such as a TLS alert, which string interpolation cannot render.
+  defp format_transport_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_transport_reason(reason), do: inspect(reason)
 
   defp init_library_assigns(socket) do
     socket

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -1137,13 +1137,13 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
     )
   end
 
-  defp flash_flaresolverr_test(socket, {:error, :invalid_url}),
-    do:
-      put_flash(
-        socket,
-        :error,
-        "Not a valid FlareSolverr URL. Use the form http://flaresolverr:8191."
-      )
+  defp flash_flaresolverr_test(socket, {:error, :invalid_url}) do
+    put_flash(
+      socket,
+      :error,
+      "Not a valid FlareSolverr URL. Use the form http://flaresolverr:8191."
+    )
+  end
 
   defp flash_flaresolverr_test(socket, {:error, {:connection_error, reason}}) do
     put_flash(

--- a/test/mydia/indexers/flaresolverr_test.exs
+++ b/test/mydia/indexers/flaresolverr_test.exs
@@ -340,6 +340,56 @@ defmodule Mydia.Indexers.FlareSolverrTest do
                "expected #{inspect(url)} to be rejected"
       end
     end
+
+    test "a trailing slash on the URL still reaches /v1, not //v1" do
+      bypass = Bypass.open()
+      expect_sessions_ok(bypass, "/v1")
+
+      assert {:ok, _} = FlareSolverr.health_check("http://localhost:#{bypass.port}/")
+    end
+
+    test "keeps a reverse-proxy base path in front of /v1" do
+      bypass = Bypass.open()
+      expect_sessions_ok(bypass, "/flaresolverr/v1")
+
+      assert {:ok, _} = FlareSolverr.health_check("http://localhost:#{bypass.port}/flaresolverr/")
+    end
+
+    test "drops a query string instead of appending /v1 to it" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "POST", "/v1", fn conn ->
+        assert conn.request_path == "/v1"
+        assert conn.query_string == ""
+        sessions_ok(conn)
+      end)
+
+      assert {:ok, _} = FlareSolverr.health_check("http://localhost:#{bypass.port}/?token=x")
+    end
+  end
+
+  describe "status_from_probe/2" do
+    test "a successful probe is healthy and carries version and sessions" do
+      assert %{
+               configured: true,
+               status: :healthy,
+               url: "http://fs.test:8191",
+               version: "3.3.21",
+               sessions: ["s1"]
+             } =
+               FlareSolverr.status_from_probe(
+                 "http://fs.test:8191",
+                 {:ok, %{status: "ok", version: "3.3.21", sessions: ["s1"]}}
+               )
+    end
+
+    test "a failed probe is unhealthy and carries the error" do
+      assert %{configured: true, status: :unhealthy, error: {:http_error, 500, _}} =
+               FlareSolverr.status_from_probe(
+                 "http://fs.test:8191",
+                 {:error, {:http_error, 500, %{}}}
+               )
+    end
   end
 
   describe "get/2 via HTTP" do
@@ -426,6 +476,23 @@ defmodule Mydia.Indexers.FlareSolverrTest do
       assert {:error, {:connection_error, _}} =
                FlareSolverr.get("https://protected.example.com")
     end
+
+    # The Test buttons and real requests must build the endpoint the same way,
+    # or Test could pass on a URL that search then fails on.
+    test "a saved URL with a trailing slash still reaches /v1", %{bypass: bypass} do
+      put_flaresolverr_config(enabled: true, url: "http://localhost:#{bypass.port}/")
+
+      Bypass.expect_once(bypass, "POST", "/v1", fn conn ->
+        assert conn.request_path == "/v1"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(200, Jason.encode!(%{"status" => "error", "message" => "boom"}))
+      end)
+
+      assert {:error, {:unknown_error, "boom"}} =
+               FlareSolverr.get("https://protected.example.com")
+    end
   end
 
   describe "available?/0 via HTTP" do
@@ -457,6 +524,24 @@ defmodule Mydia.Indexers.FlareSolverrTest do
 
       refute FlareSolverr.available?()
     end
+  end
+
+  # Bypass routes on path_info, which drops empty segments, so "//v1" would
+  # match a "/v1" expectation. Assert the raw request_path too.
+  defp expect_sessions_ok(bypass, path) do
+    Bypass.expect_once(bypass, "POST", path, fn conn ->
+      assert conn.request_path == path
+      sessions_ok(conn)
+    end)
+  end
+
+  defp sessions_ok(conn) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.resp(
+      200,
+      Jason.encode!(%{"status" => "ok", "version" => "3.3.21", "sessions" => []})
+    )
   end
 
   ## Helpers — inject FlareSolverr settings into the layered runtime config.

--- a/test/mydia/indexers/flaresolverr_test.exs
+++ b/test/mydia/indexers/flaresolverr_test.exs
@@ -290,6 +290,58 @@ defmodule Mydia.Indexers.FlareSolverrTest do
     end
   end
 
+  describe "health_check/0 gating" do
+    # health_check/0 is the saved-config check that status/0 and available?/0
+    # build on. Only the admin Test buttons skip the enabled gate, through
+    # health_check/1; this pins that the gate itself did not move.
+    test "still returns :disabled when the saved config is switched off" do
+      put_flaresolverr_config(enabled: false, url: "http://localhost:8191")
+      assert {:error, :disabled} = FlareSolverr.health_check()
+    end
+
+    test "returns :not_configured when there is no FlareSolverr config" do
+      clear_flaresolverr_config()
+      assert {:error, :not_configured} = FlareSolverr.health_check()
+    end
+  end
+
+  describe "health_check/1" do
+    test "probes the given URL even while FlareSolverr is disabled" do
+      bypass = Bypass.open()
+      put_flaresolverr_config(enabled: false, url: nil)
+
+      Bypass.expect_once(bypass, "POST", "/v1", fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        assert %{"cmd" => "sessions.list"} = Jason.decode!(body)
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(
+          200,
+          Jason.encode!(%{"status" => "ok", "version" => "3.3.21", "sessions" => []})
+        )
+      end)
+
+      assert {:ok, %{version: "3.3.21", sessions: []}} =
+               FlareSolverr.health_check("http://localhost:#{bypass.port}")
+    end
+
+    test "returns connection_error when nothing answers at the given URL" do
+      bypass = Bypass.open()
+      Bypass.down(bypass)
+
+      assert {:error, {:connection_error, _reason}} =
+               FlareSolverr.health_check("http://localhost:#{bypass.port}")
+    end
+
+    test "rejects anything but an absolute http(s) URL without making a request" do
+      for url <- [nil, "", "   ", "flaresolverr:8191", "ftp://flaresolverr.test", "http://"] do
+        assert {:error, :invalid_url} = FlareSolverr.health_check(url),
+               "expected #{inspect(url)} to be rejected"
+      end
+    end
+  end
+
   describe "get/2 via HTTP" do
     setup do
       bypass = Bypass.open()

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -330,6 +330,26 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       assert has_element?(view, "#flaresolverr-panel")
     end
 
+    test "row Test probes the saved URL even while FlareSolverr is disabled", %{conn: conn} do
+      bypass = Bypass.open()
+      put_saved_flaresolverr(enabled: false, url: "http://localhost:#{bypass.port}")
+      expect_flaresolverr_ok(bypass)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element("#flaresolverr-row-test") |> render_click()
+
+      assert has_element?(view, "#flash-info", "FlareSolverr connection successful")
+    end
+
+    test "row Test with no saved URL points the operator at Edit", %{conn: conn} do
+      put_saved_flaresolverr(enabled: false, url: nil)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element("#flaresolverr-row-test") |> render_click()
+
+      assert has_element?(view, "#flash-error", "No FlareSolverr URL configured")
+    end
+
     test "enabling with a blank URL shows a required-error and keeps the modal open", %{
       conn: conn
     } do
@@ -514,5 +534,31 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       assert Mydia.Indexers.FlareSolverr.enabled?()
       assert has_element?(view, "#flaresolverr-panel .badge-success", "Enabled")
     end
+  end
+
+  # Seeds the merged runtime config the way a completed save leaves it. The
+  # "FlareSolverr panel" setup restores :runtime_config on exit. Keep
+  # `enabled: false` in tests that count requests: with it on, mount's async
+  # status probe would hit the same URL a second time.
+  defp put_saved_flaresolverr(attrs) do
+    config =
+      case Application.get_env(:mydia, :runtime_config) do
+        %Mydia.Config.Schema{} = config -> config
+        _ -> Mydia.Config.Schema.defaults()
+      end
+
+    fs = struct(Mydia.Config.Schema.FlareSolverr, attrs)
+    Application.put_env(:mydia, :runtime_config, %{config | flaresolverr: fs})
+  end
+
+  defp expect_flaresolverr_ok(bypass) do
+    Bypass.expect_once(bypass, "POST", "/v1", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(
+        200,
+        Jason.encode!(%{"status" => "ok", "version" => "3.3.21", "sessions" => []})
+      )
+    end)
   end
 end

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -350,6 +350,139 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       assert has_element?(view, "#flash-error", "No FlareSolverr URL configured")
     end
 
+    test "modal Test probes the typed URL before the first save (#764)", %{conn: conn} do
+      bypass = Bypass.open()
+      put_saved_flaresolverr(enabled: false, url: nil)
+      expect_flaresolverr_ok(bypass)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
+
+      view
+      |> form("#flaresolverr-form",
+        flaresolverr: %{
+          enabled: "true",
+          url: "http://localhost:#{bypass.port}",
+          timeout: "60000",
+          max_timeout: "120000"
+        }
+      )
+      |> render_change()
+
+      view |> element("#flaresolverr-modal-test") |> render_click()
+
+      assert has_element?(view, "#flash-info", "FlareSolverr connection successful")
+      assert has_element?(view, "#flaresolverr-form")
+      assert is_nil(Settings.get_config_setting_by_key("flaresolverr.url"))
+      assert is_nil(Settings.get_config_setting_by_key("flaresolverr.enabled"))
+    end
+
+    test "modal Test ignores the Enabled checkbox", %{conn: conn} do
+      bypass = Bypass.open()
+      put_saved_flaresolverr(enabled: false, url: nil)
+      expect_flaresolverr_ok(bypass)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
+
+      view
+      |> form("#flaresolverr-form",
+        flaresolverr: %{enabled: "false", url: "http://localhost:#{bypass.port}"}
+      )
+      |> render_change()
+
+      view |> element("#flaresolverr-modal-test") |> render_click()
+
+      assert has_element?(view, "#flash-info", "FlareSolverr connection successful")
+    end
+
+    test "modal Test probes the edited URL, not the saved one", %{conn: conn} do
+      saved = Bypass.open()
+      edited = Bypass.open()
+      # No expectation on `saved`: Bypass fails the test on exit if it is hit.
+      put_saved_flaresolverr(enabled: false, url: "http://localhost:#{saved.port}")
+      expect_flaresolverr_ok(edited)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
+
+      view
+      |> form("#flaresolverr-form", flaresolverr: %{url: "http://localhost:#{edited.port}"})
+      |> render_change()
+
+      view |> element("#flaresolverr-modal-test") |> render_click()
+
+      assert has_element?(view, "#flash-info", "FlareSolverr connection successful")
+    end
+
+    test "modal Test with a blank URL asks for one", %{conn: conn} do
+      put_saved_flaresolverr(enabled: false, url: nil)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
+      view |> element("#flaresolverr-modal-test") |> render_click()
+
+      assert has_element?(view, "#flash-error", "Enter a FlareSolverr URL to test")
+      assert has_element?(view, "#flaresolverr-form")
+    end
+
+    test "modal Test rejects a URL without an http(s) scheme", %{conn: conn} do
+      put_saved_flaresolverr(enabled: false, url: nil)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
+
+      view
+      |> form("#flaresolverr-form", flaresolverr: %{url: "flaresolverr:8191"})
+      |> render_change()
+
+      view |> element("#flaresolverr-modal-test") |> render_click()
+
+      assert has_element?(view, "#flash-error", "Not a valid FlareSolverr URL")
+      assert has_element?(view, "#flaresolverr-form")
+    end
+
+    test "modal Test reports a connection failure", %{conn: conn} do
+      bypass = Bypass.open()
+      Bypass.down(bypass)
+      put_saved_flaresolverr(enabled: false, url: nil)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
+
+      view
+      |> form("#flaresolverr-form", flaresolverr: %{url: "http://localhost:#{bypass.port}"})
+      |> render_change()
+
+      view |> element("#flaresolverr-modal-test") |> render_click()
+
+      assert has_element?(view, "#flash-error", "FlareSolverr connection failed")
+    end
+
+    test "modal Test probes the env URL when the URL field is env-locked", %{conn: conn} do
+      bypass = Bypass.open()
+      # The describe setup deletes FLARESOLVERR_* and restores :runtime_config on
+      # exit, and this module is async: false, so the env write cannot leak.
+      System.put_env("FLARESOLVERR_URL", "http://localhost:#{bypass.port}")
+      {:ok, _config} = Mydia.Config.Loader.reload()
+      expect_flaresolverr_ok(bypass)
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      view |> element(~s{button[phx-click="edit_flaresolverr"]}) |> render_click()
+
+      # The URL input is disabled, so a browser never submits it and the
+      # changeset drops it on the first validate event.
+      view
+      |> form("#flaresolverr-form",
+        flaresolverr: %{enabled: "false", timeout: "60000", max_timeout: "120000"}
+      )
+      |> render_change()
+
+      view |> element("#flaresolverr-modal-test") |> render_click()
+
+      assert has_element?(view, "#flash-info", "FlareSolverr connection successful")
+    end
+
     test "enabling with a blank URL shows a required-error and keeps the modal open", %{
       conn: conn
     } do

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -341,6 +341,40 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       assert has_element?(view, "#flash-info", "FlareSolverr connection successful")
     end
 
+    test "row Test on an enabled config probes once and marks the row healthy", %{conn: conn} do
+      bypass = Bypass.open()
+      # Mount disabled so its async status probe stays quiet, then enable before
+      # the click. expect_once then fails the test if the click probes twice.
+      put_saved_flaresolverr(enabled: false, url: "http://localhost:#{bypass.port}")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      await_mount_status(view)
+
+      put_saved_flaresolverr(enabled: true, url: "http://localhost:#{bypass.port}")
+      expect_flaresolverr_ok(bypass)
+      view |> element("#flaresolverr-row-test") |> render_click()
+
+      assert has_element?(view, "#flash-info", "FlareSolverr connection successful")
+      assert has_element?(view, "#flaresolverr-panel .badge", "Healthy")
+    end
+
+    test "a failed row Test on an enabled config marks the row unhealthy", %{conn: conn} do
+      bypass = Bypass.open()
+      put_saved_flaresolverr(enabled: false, url: "http://localhost:#{bypass.port}")
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+      await_mount_status(view)
+
+      put_saved_flaresolverr(enabled: true, url: "http://localhost:#{bypass.port}")
+
+      Bypass.expect_once(bypass, "POST", "/v1", fn conn ->
+        Plug.Conn.resp(conn, 500, "")
+      end)
+
+      view |> element("#flaresolverr-row-test") |> render_click()
+
+      assert has_element?(view, "#flash-error", "FlareSolverr returned HTTP 500")
+      assert has_element?(view, "#flaresolverr-panel .badge", "Unhealthy")
+    end
+
     test "row Test with no saved URL points the operator at Edit", %{conn: conn} do
       put_saved_flaresolverr(enabled: false, url: nil)
 
@@ -682,6 +716,22 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
 
     fs = struct(Mydia.Config.Schema.FlareSolverr, attrs)
     Application.put_env(:mydia, :runtime_config, %{config | flaresolverr: fs})
+  end
+
+  # mount/3 reads the FlareSolverr status in a Task, and the Task reads the
+  # config whenever it runs. Wait for its answer so a config change made after
+  # mount cannot race it.
+  defp await_mount_status(view) do
+    MydiaWeb.FeatureCase.eventually(
+      fn ->
+        if has_element?(view, "#flaresolverr-panel .badge", "Checking"),
+          do: :error,
+          else: {:ok, :done}
+      end,
+      timeout: 2_000,
+      interval: 10,
+      description: "the FlareSolverr row to leave its Checking state"
+    )
   end
 
   defp expect_flaresolverr_ok(bypass) do


### PR DESCRIPTION
Fixes #764.

## Problem

The FlareSolverr edit modal's **Test** fired the same event as the row's Test and only checked the saved config, which is gated on the saved Enabled flag. On first-time setup that meant "FlareSolverr is disabled. Enable it in configuration." even with Enabled checked and a valid URL typed in. Editing an existing config tested the old URL.

## Change

- `FlareSolverr.health_check/1` probes the URL it is given, ignores the enabled flag, and returns `{:error, :invalid_url}` without a request unless the URL is an absolute http(s) URL with a host. `health_check/0` keeps its gate and delegates, so `status/0`, `available?/0`, search and downloads are unchanged.
- The modal's Test sends a new `test_flaresolverr_form` event that probes the unsaved form values, like the indexer and download-client modals. An env-locked URL falls back to its effective value, since its disabled input is never submitted.
- The row's Test probes the saved URL whether or not FlareSolverr is enabled. The Enabled badge already shows on/off. With no URL it points at Edit instead of an environment variable.
- One flash helper renders results for both buttons, with clearer messages for invalid URLs and HTTP errors, and no longer crashes on a tuple transport reason.
- A row Test on an enabled config refreshes the health badge from its own probe via `FlareSolverr.status_from_probe/2`, so it no longer probes twice, and the badge now turns Unhealthy on failure too.
- The `/v1` endpoint is built at the URI level for Test, `get/2` and `post/2`: a reverse-proxy base path is kept, a trailing slash no longer yields `//v1`, and a query or fragment is dropped. Plain URLs build the same endpoint as before.

## Tests

- Client: `health_check/1` works while disabled, reports connection errors, and rejects malformed URLs. `health_check/0` still refuses while disabled.
- LiveView: modal Test before the first save (the #764 regression), with Enabled unchecked, against an edited URL (the saved one must not be hit), with a blank or malformed URL, on connection failure, and with an env-locked URL. Row Test while disabled, and with no saved URL.
- Wired to the old event, 6 of the 7 modal tests fail on their behavioral assertions, including the #764 regression and the edited-URL case.
- Endpoint: trailing slash, reverse-proxy base path, and query string, for both `health_check/1` and `get/2`. These assert `conn.request_path`, because Bypass routes on `path_info` and would otherwise match `//v1` against `/v1`.
- Row Test on an enabled config probes exactly once (`Bypass.expect_once`) and updates the badge to Healthy or Unhealthy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FlareSolverr connection testing for saved settings and URLs entered in the configuration form.
  * Tests use the entered URL without saving changes first and work regardless of the Enabled setting.
  * Added clearer connection feedback for missing, invalid, unreachable, and HTTP-error responses.

* **Bug Fixes**
  * Added validation for absolute HTTP(S) URLs.
  * Improved handling of environment-sourced FlareSolverr URLs.
  * Fixed endpoint handling for trailing slashes, reverse-proxy paths, and query strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->