### PR TITLE
fix(indexers): accept base URLs with a trailing slash

### DIFF
--- a/lib/mydia/downloads/client/nzbget.ex
+++ b/lib/mydia/downloads/client/nzbget.ex
@@ -398,7 +398,8 @@ defmodule Mydia.Downloads.Client.Nzbget do
   end
 
   defp build_rpc_path(config) do
-    base = config[:url_base] || ""
+    # "/nzbget/" would otherwise give "/nzbget//jsonrpc" (#765)
+    base = String.trim_trailing(config[:url_base] || "", "/")
     "#{base}/jsonrpc"
   end
 

--- a/lib/mydia/downloads/client/sabnzbd.ex
+++ b/lib/mydia/downloads/client/sabnzbd.ex
@@ -461,7 +461,8 @@ defmodule Mydia.Downloads.Client.Sabnzbd do
   ## Private Functions
 
   defp build_api_path(config) do
-    base = config[:url_base] || ""
+    # "/sabnzbd/" would otherwise give "/sabnzbd//api" (#765)
+    base = String.trim_trailing(config[:url_base] || "", "/")
     "#{base}/api"
   end
 

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -453,16 +453,16 @@ defmodule Mydia.Indexers do
   def list_prowlarr_indexers(%{base_url: base_url, api_key: api_key})
       when is_binary(base_url) and is_binary(api_key) do
     # Build a minimal adapter config from raw connection details
-    uri = URI.parse(base_url)
+    fields = connection_fields(base_url)
 
     adapter_config = %{
       type: :prowlarr,
-      host: uri.host || "localhost",
-      port: uri.port || default_port(uri.scheme),
+      host: fields.host,
+      port: fields.port,
       api_key: api_key,
-      use_ssl: uri.scheme == "https",
+      use_ssl: fields.use_ssl,
       options: %{
-        base_path: uri.path
+        base_path: fields.base_path
       }
     }
 
@@ -691,8 +691,7 @@ defmodule Mydia.Indexers do
     # Resolve environment variable inheritance if env_name is set
     resolved_config = Settings.resolve_env_inheritance(config)
 
-    # Parse base_url to extract host, port, and use_ssl
-    uri = URI.parse(resolved_config.base_url)
+    fields = connection_fields(resolved_config.base_url)
 
     # Get timeout from connection_settings or use default
     timeout =
@@ -704,16 +703,16 @@ defmodule Mydia.Indexers do
     %{
       type: resolved_config.type,
       name: resolved_config.name,
-      host: uri.host || "localhost",
-      port: uri.port || default_port(uri.scheme),
+      host: fields.host,
+      port: fields.port,
       api_key: resolved_config.api_key,
-      use_ssl: uri.scheme == "https",
+      use_ssl: fields.use_ssl,
       options: %{
         indexer_ids: resolved_config.indexer_ids || [],
         categories: resolved_config.categories || [],
         rate_limit: resolved_config.rate_limit,
         timeout: timeout,
-        base_path: uri.path
+        base_path: fields.base_path
       }
     }
   end
@@ -722,21 +721,35 @@ defmodule Mydia.Indexers do
   # This handles the case where test_connection is called from the UI with a raw config map
   # rather than an IndexerConfig struct.
   defp maybe_convert_base_url(%{base_url: base_url} = config) when is_binary(base_url) do
-    uri = URI.parse(base_url)
+    fields = connection_fields(base_url)
 
     config
-    |> Map.put(:host, uri.host || "localhost")
-    |> Map.put(:port, uri.port || default_port(uri.scheme))
-    |> Map.put(:use_ssl, uri.scheme == "https")
+    |> Map.put(:host, fields.host)
+    |> Map.put(:port, fields.port)
+    |> Map.put(:use_ssl, fields.use_ssl)
     |> Map.put(:name, Map.get(config, :name, "Test"))
     |> Map.put_new(:options, %{
       indexer_ids: [],
       categories: [],
-      base_path: uri.path
+      base_path: fields.base_path
     })
   end
 
   defp maybe_convert_base_url(config), do: config
+
+  # Splits a base URL into the fields adapters build request URLs from. Every
+  # source (form, env, YAML, stored rows) goes through the same normalizer, so
+  # base_path is nil or a prefix like "/prowlarr" and never "/" (#765).
+  defp connection_fields(base_url) do
+    uri = base_url |> Settings.IndexerConfig.normalize_url() |> URI.parse()
+
+    %{
+      host: uri.host || "localhost",
+      port: uri.port || default_port(uri.scheme),
+      use_ssl: uri.scheme == "https",
+      base_path: uri.path
+    }
+  end
 
   defp default_port("https"), do: 443
   defp default_port("http"), do: 80

--- a/lib/mydia/indexers/adapter/prowlarr.ex
+++ b/lib/mydia/indexers/adapter/prowlarr.ex
@@ -64,13 +64,19 @@ defmodule Mydia.Indexers.Adapter.Prowlarr do
     headers = build_headers(config)
 
     case Req.get(url, headers: headers, receive_timeout: 10_000, retry: false) do
-      {:ok, %Req.Response{status: 200, body: body}} ->
+      {:ok, %Req.Response{status: 200, body: %{} = body}} ->
         {:ok,
          %{
            name: "Prowlarr",
            version: body["version"] || "unknown",
            app_name: body["appName"]
          }}
+
+      # Any other 200 isn't the Prowlarr API: usually its web UI, which it
+      # serves for paths the API doesn't own, or a proxy's login page (#765).
+      {:ok, %Req.Response{status: 200}} ->
+        {:error,
+         Error.connection_failed("Unexpected response, check that the URL points at Prowlarr")}
 
       {:ok, %Req.Response{status: 401}} ->
         {:error, Error.connection_failed("Authentication failed - invalid API key")}

--- a/lib/mydia/settings/indexer_config.ex
+++ b/lib/mydia/settings/indexer_config.ex
@@ -100,7 +100,7 @@ defmodule Mydia.Settings.IndexerConfig do
     end
   end
 
-  # Auto-prepend http:// if no scheme is provided
+  # Stores the same normalized URL that reads use, see normalize_url/1
   defp normalize_base_url(changeset) do
     case get_change(changeset, :base_url) do
       nil ->
@@ -117,24 +117,38 @@ defmodule Mydia.Settings.IndexerConfig do
     end
   end
 
-  defp normalize_url(url) when is_binary(url) do
-    trimmed = String.trim(url)
+  @doc """
+  Normalizes an indexer base URL from any source: the admin form, env vars,
+  YAML config, or a row saved before normalization existed.
 
-    case URI.parse(trimmed) do
+  Trims whitespace, prepends `http://` when the scheme is missing, and strips
+  trailing slashes. Adapters append paths such as `/api/v1/system/status`, so a
+  trailing slash would otherwise produce `//api/...` (#765).
+  """
+  @spec normalize_url(String.t()) :: String.t()
+  def normalize_url(url) when is_binary(url) do
+    url
+    |> String.trim()
+    |> ensure_scheme()
+    |> String.trim_trailing("/")
+  end
+
+  defp ensure_scheme(url) do
+    case URI.parse(url) do
       # URL with valid http/https scheme - keep as-is
       %URI{scheme: scheme} when scheme in ["http", "https"] ->
-        trimmed
+        url
 
       # URL with another scheme (ftp://, etc.) - keep as-is, let validation reject it
       %URI{scheme: scheme, host: host} when is_binary(scheme) and is_binary(host) ->
-        trimmed
+        url
 
       # If scheme is missing, prepend http://
       # URI.parse("192.168.1.1:9696") -> %URI{scheme: nil, path: "192.168.1.1:9696"}
       # URI.parse("localhost:9696") -> %URI{scheme: "localhost", host: nil, path: "9696"}
       # In both cases, we need to prepend http://
       _ ->
-        "http://#{trimmed}"
+        "http://#{url}"
     end
   end
 

--- a/test/mydia/downloads/client/nzbget_test.exs
+++ b/test/mydia/downloads/client/nzbget_test.exs
@@ -2,7 +2,7 @@ defmodule Mydia.Downloads.Client.NzbgetTest do
   use ExUnit.Case, async: true
 
   alias Mydia.Downloads.Client.Nzbget
-  alias Mydia.Downloads.Structs.DownloadStatus
+  alias Mydia.Downloads.Structs.{ClientInfo, DownloadStatus}
 
   @config %{
     type: :nzbget,
@@ -213,6 +213,28 @@ defmodule Mydia.Downloads.Client.NzbgetTest do
       # Should fail with connection error, not path error
       {:error, error} = Nzbget.test_connection(timeout_config)
       assert error.type in [:connection_failed, :network_error, :timeout]
+    end
+
+    test "strips a trailing slash from url_base (#765)" do
+      bypass = Bypass.open()
+      config = %{@config | host: "localhost", port: bypass.port, url_base: "/nzbget/"}
+
+      Mydia.BypassHelpers.stub_exact_json(
+        bypass,
+        "POST",
+        "/nzbget/jsonrpc",
+        ~s({"result": "21.1"})
+      )
+
+      assert {:ok, %ClientInfo{version: "21.1"}} = Nzbget.test_connection(config)
+    end
+
+    test "treats a url_base of \"/\" as no base (#765)" do
+      bypass = Bypass.open()
+      config = %{@config | host: "localhost", port: bypass.port, url_base: "/"}
+      Mydia.BypassHelpers.stub_exact_json(bypass, "POST", "/jsonrpc", ~s({"result": "21.1"}))
+
+      assert {:ok, %ClientInfo{version: "21.1"}} = Nzbget.test_connection(config)
     end
   end
 

--- a/test/mydia/downloads/client/sabnzbd_test.exs
+++ b/test/mydia/downloads/client/sabnzbd_test.exs
@@ -2,7 +2,7 @@ defmodule Mydia.Downloads.Client.SabnzbdTest do
   use ExUnit.Case, async: true
 
   alias Mydia.Downloads.Client.Sabnzbd
-  alias Mydia.Downloads.Structs.DownloadStatus
+  alias Mydia.Downloads.Structs.{ClientInfo, DownloadStatus}
 
   @config %{
     type: :sabnzbd,
@@ -175,6 +175,22 @@ defmodule Mydia.Downloads.Client.SabnzbdTest do
       # Should fail with connection error, not path error
       {:error, error} = Sabnzbd.test_connection(timeout_config)
       assert error.type in [:connection_failed, :network_error, :timeout]
+    end
+
+    test "strips a trailing slash from url_base (#765)" do
+      bypass = Bypass.open()
+      config = %{@config | host: "localhost", port: bypass.port, url_base: "/sabnzbd/"}
+      Mydia.BypassHelpers.stub_exact_json(bypass, "GET", "/sabnzbd/api", ~s({"version": "4.3.2"}))
+
+      assert {:ok, %ClientInfo{version: "4.3.2"}} = Sabnzbd.test_connection(config)
+    end
+
+    test "treats a url_base of \"/\" as no base (#765)" do
+      bypass = Bypass.open()
+      config = %{@config | host: "localhost", port: bypass.port, url_base: "/"}
+      Mydia.BypassHelpers.stub_exact_json(bypass, "GET", "/api", ~s({"version": "4.3.2"}))
+
+      assert {:ok, %ClientInfo{version: "4.3.2"}} = Sabnzbd.test_connection(config)
     end
   end
 

--- a/test/mydia/indexers/adapter/prowlarr_test.exs
+++ b/test/mydia/indexers/adapter/prowlarr_test.exs
@@ -72,6 +72,24 @@ defmodule Mydia.Indexers.Adapter.ProwlarrTest do
     end
   end
 
+  describe "test_connection/1 against a page that isn't the Prowlarr API (#765)" do
+    test "returns an error for a 200 HTML page" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(
+        bypass,
+        "GET",
+        "/api/v1/system/status",
+        &Mydia.IndexerMock.prowlarr_web_ui/1
+      )
+
+      assert {:error, %Error{type: :connection_failed, message: message}} =
+               Prowlarr.test_connection(build_config(bypass))
+
+      assert message =~ "Unexpected response"
+    end
+  end
+
   describe "search/3" do
     @tag :skip
     test "successfully searches Prowlarr" do

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -741,6 +741,62 @@ defmodule Mydia.IndexersTest do
       assert {:ok, info} = Indexers.test_connection(config)
       assert info.version == "1.25.0"
     end
+
+    test "raw config map with a trailing slash reaches the API path (#765)" do
+      bypass = Bypass.open()
+      IndexerMock.mock_prowlarr_status(bypass, version: "1.25.0")
+
+      config = %{
+        type: :prowlarr,
+        base_url: "http://localhost:#{bypass.port}/",
+        api_key: "test-api-key"
+      }
+
+      assert {:ok, %{version: "1.25.0"}} = Indexers.test_connection(config)
+    end
+
+    test "stored config with a trailing slash reaches the API path (#765)" do
+      bypass = Bypass.open()
+      IndexerMock.mock_prowlarr_status(bypass, version: "1.25.0")
+
+      # Built directly, skipping the changeset, the way env and YAML configs
+      # and rows saved before normalization reach the adapter.
+      config = %Settings.IndexerConfig{
+        name: "Stored Prowlarr",
+        type: :prowlarr,
+        base_url: "http://localhost:#{bypass.port}/",
+        api_key: "test-api-key"
+      }
+
+      assert {:ok, %{version: "1.25.0"}} = Indexers.test_connection(config)
+    end
+
+    test "keeps a URL base prefix while dropping its trailing slash (#765)" do
+      bypass = Bypass.open()
+      IndexerMock.mock_prowlarr_status(bypass, version: "1.25.0", base_path: "/prowlarr")
+
+      config = %Settings.IndexerConfig{
+        name: "Prefixed Prowlarr",
+        type: :prowlarr,
+        base_url: "http://localhost:#{bypass.port}/prowlarr/",
+        api_key: "test-api-key"
+      }
+
+      assert {:ok, %{version: "1.25.0"}} = Indexers.test_connection(config)
+    end
+  end
+
+  describe "list_prowlarr_indexers/1" do
+    test "raw connection details with a trailing slash reach the API path (#765)" do
+      bypass = Bypass.open()
+      IndexerMock.mock_prowlarr_indexers(bypass)
+
+      assert {:ok, [%{id: 1, name: "Fictional Tracker", enabled: true}]} =
+               Indexers.list_prowlarr_indexers(%{
+                 base_url: "http://localhost:#{bypass.port}/",
+                 api_key: "test-api-key"
+               })
+    end
   end
 
   describe "rank_and_dedupe/3" do

--- a/test/mydia/settings/indexer_config_test.exs
+++ b/test/mydia/settings/indexer_config_test.exs
@@ -77,5 +77,41 @@ defmodule Mydia.Settings.IndexerConfigTest do
       assert changeset.valid?
       assert get_change(changeset, :base_url) == "http://localhost:9696"
     end
+
+    test "strips a trailing slash (#765)" do
+      attrs = Map.put(@valid_attrs, :base_url, "http://192.168.68.66:9696/")
+      changeset = IndexerConfig.changeset(%IndexerConfig{}, attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :base_url) == "http://192.168.68.66:9696"
+    end
+  end
+
+  describe "normalize_url/1" do
+    test "strips one or more trailing slashes" do
+      assert IndexerConfig.normalize_url("http://192.168.68.66:9696/") ==
+               "http://192.168.68.66:9696"
+
+      assert IndexerConfig.normalize_url("http://192.168.68.66:9696//") ==
+               "http://192.168.68.66:9696"
+    end
+
+    test "keeps a path prefix and drops only its trailing slash" do
+      assert IndexerConfig.normalize_url("http://localhost/prowlarr/") ==
+               "http://localhost/prowlarr"
+    end
+
+    test "prepends http:// and strips the slash in one pass" do
+      assert IndexerConfig.normalize_url("192.168.68.66:9696/") == "http://192.168.68.66:9696"
+      assert IndexerConfig.normalize_url("localhost:9696/") == "http://localhost:9696"
+    end
+
+    test "trims surrounding whitespace, including a newline from a mounted secret" do
+      assert IndexerConfig.normalize_url("  http://localhost:9696/\n") == "http://localhost:9696"
+    end
+
+    test "leaves a clean URL alone" do
+      assert IndexerConfig.normalize_url("https://secure.example.com:443") ==
+               "https://secure.example.com:443"
+    end
   end
 end

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -116,6 +116,35 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       assert has_element?(view, "#flash-info", "Connection successful")
     end
 
+    test "test connection shows an error when the URL answers with a web page (#765)",
+         %{view: view} do
+      bypass = Bypass.open()
+      Bypass.stub(bypass, "GET", "/api/v1/system/status", &Mydia.IndexerMock.prowlarr_web_ui/1)
+
+      view
+      |> element(~s{button[phx-click="new_indexer"]})
+      |> render_click()
+
+      view
+      |> form("#indexer-form",
+        indexer_config: %{
+          name: "Web Page Prowlarr",
+          type: "prowlarr",
+          base_url: "http://localhost:#{bypass.port}",
+          api_key: "test-api-key",
+          enabled: "true",
+          priority: "1"
+        }
+      )
+      |> render_change()
+
+      view
+      |> element(~s{button[phx-click="test_indexer_connection"]})
+      |> render_click()
+
+      assert has_element?(view, "#flash-error", "Unexpected response")
+    end
+
     @tag :skip
     test "test connection succeeds with valid prowlarr server", %{view: view} do
       bypass = Bypass.open()

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -88,6 +88,34 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       refute has_element?(view, ~s{div[class*="modal-open"]})
     end
 
+    test "test connection succeeds when the URL has a trailing slash (#765)", %{view: view} do
+      bypass = Bypass.open()
+      Mydia.IndexerMock.mock_prowlarr_status(bypass, version: "1.25.0")
+
+      view
+      |> element(~s{button[phx-click="new_indexer"]})
+      |> render_click()
+
+      view
+      |> form("#indexer-form",
+        indexer_config: %{
+          name: "Slash Prowlarr",
+          type: "prowlarr",
+          base_url: "http://localhost:#{bypass.port}/",
+          api_key: "test-api-key",
+          enabled: "true",
+          priority: "1"
+        }
+      )
+      |> render_change()
+
+      view
+      |> element(~s{button[phx-click="test_indexer_connection"]})
+      |> render_click()
+
+      assert has_element?(view, "#flash-info", "Connection successful")
+    end
+
     @tag :skip
     test "test connection succeeds with valid prowlarr server", %{view: view} do
       bypass = Bypass.open()

--- a/test/support/bypass_helpers.ex
+++ b/test/support/bypass_helpers.ex
@@ -1,0 +1,38 @@
+defmodule Mydia.BypassHelpers do
+  @moduledoc """
+  Bypass stubs that match on the raw request path.
+
+  Bypass routes on path segments and drops empty ones, so a stub registered
+  for `/api` also answers `//api`, and a test for a double-slash bug passes
+  with the bug still in place (#765). These helpers compare
+  `conn.request_path` and send any other path to a fallback responder.
+  """
+
+  @doc """
+  Stubs `method` on `path` to answer with `json_body` only when the raw
+  request path is exactly `path`. Anything else reaching the same route goes
+  to the fallback.
+
+  ## Options
+
+    - `:status` - HTTP status for the JSON response (default: 200)
+    - `:fallback` - `(Plug.Conn.t() -> Plug.Conn.t())` for any other path
+      (default: a 404)
+  """
+  def stub_exact_json(bypass, method, path, json_body, opts \\ []) do
+    status = Keyword.get(opts, :status, 200)
+    fallback = Keyword.get(opts, :fallback, &not_found/1)
+
+    Bypass.stub(bypass, method, path, fn conn ->
+      if conn.request_path == path do
+        conn
+        |> Plug.Conn.put_resp_content_type("application/json")
+        |> Plug.Conn.resp(status, json_body)
+      else
+        fallback.(conn)
+      end
+    end)
+  end
+
+  defp not_found(conn), do: Plug.Conn.resp(conn, 404, "Not Found")
+end

--- a/test/support/indexer_mock.ex
+++ b/test/support/indexer_mock.ex
@@ -6,6 +6,8 @@ defmodule Mydia.IndexerMock do
   responses in tests, preventing real API calls that consume quotas.
   """
 
+  alias Mydia.BypassHelpers
+
   @doc """
   Sets up a Bypass server to mock Prowlarr search endpoint.
 
@@ -41,22 +43,60 @@ defmodule Mydia.IndexerMock do
 
   @doc """
   Sets up a Bypass server to mock Prowlarr system status endpoint.
+
+  Answers the way real Prowlarr does: JSON only when the raw request path is
+  exactly `<base_path>/api/v1/system/status`, and its web UI (a 200 HTML page)
+  for anything else. See `Mydia.BypassHelpers.stub_exact_json/5` for why the
+  raw path matters (#765).
+
+  ## Options
+
+    - `:status` - HTTP status code for the JSON response (default: 200)
+    - `:version` - version string in the JSON body (default: "1.0.0")
+    - `:base_path` - URL base Prowlarr runs under, e.g. "/prowlarr" (default: "")
   """
   def mock_prowlarr_status(bypass, opts \\ []) do
     status = Keyword.get(opts, :status, 200)
     version = Keyword.get(opts, :version, "1.0.0")
+    path = Keyword.get(opts, :base_path, "") <> "/api/v1/system/status"
+    body = Jason.encode!(%{"appName" => "Prowlarr", "version" => version})
 
-    Bypass.stub(bypass, "GET", "/api/v1/system/status", fn conn ->
-      conn
-      |> Plug.Conn.put_resp_content_type("application/json")
-      |> Plug.Conn.resp(
-        status,
-        Jason.encode!(%{
-          "appName" => "Prowlarr",
-          "version" => version
-        })
-      )
-    end)
+    BypassHelpers.stub_exact_json(bypass, "GET", path, body,
+      status: status,
+      fallback: &prowlarr_web_ui/1
+    )
+  end
+
+  @doc """
+  Sets up a Bypass server to mock Prowlarr's indexer list endpoint, with the
+  same exact-path rule as `mock_prowlarr_status/2`.
+
+  ## Options
+
+    - `:indexers` - list of Prowlarr indexer maps (default: one enabled torrent indexer)
+  """
+  def mock_prowlarr_indexers(bypass, opts \\ []) do
+    indexers =
+      Keyword.get(opts, :indexers, [
+        %{"id" => 1, "name" => "Fictional Tracker", "enable" => true, "protocol" => "torrent"}
+      ])
+
+    BypassHelpers.stub_exact_json(bypass, "GET", "/api/v1/indexer", Jason.encode!(indexers),
+      fallback: &prowlarr_web_ui/1
+    )
+  end
+
+  @doc """
+  Answers like Prowlarr does for any path its API doesn't own: a 200 with the
+  web UI's HTML.
+  """
+  def prowlarr_web_ui(conn) do
+    conn
+    |> Plug.Conn.put_resp_content_type("text/html")
+    |> Plug.Conn.resp(
+      200,
+      "<!doctype html><html><head><title>Prowlarr</title></head><body></body></html>"
+    )
   end
 
   @doc """


### PR DESCRIPTION
Fixes #765.

## What happened

Entering the Prowlarr address as `http://192.168.1.100:9696/` broke the add-indexer modal. Test crashed it, and Add saved a config that never connected.

`URI.parse("http://192.168.1.100:9696/").path` is `"/"`, which became the adapter's `base_path`, so every request went to `//api/v1/...`. Prowlarr serves its web UI for paths its API doesn't own, so the answer was a 200 with an HTML body. `Prowlarr.test_connection/1` read `body["version"]` off that string, `Access.get/3` raised, and the admin LiveView went down with it.

## The fix

`IndexerConfig.normalize_url/1` is public and strips trailing slashes after the existing whitespace trim and `http://` prepend. The changeset stores its output, so new saves are clean.

That alone doesn't reach env vars, YAML config or rows saved before this change, since none of them go through the changeset. The three places in `Mydia.Indexers` that split a base URL into host, port and `base_path` share a `connection_fields/1` helper that runs the same normalizer first. Jackett and NZBHydra2 build their URLs the same way and get the fix for free.

`Prowlarr.test_connection/1` treats any 200 without a JSON object as a connection error, so a URL pointing at a proxy login page or the wrong port shows an error flash in the modal.

SABnzbd and NZBGet had the same bug in `url_base`, where `"/sabnzbd/"` requested `/sabnzbd//api`. Both trim it where they build the request path.

No migration. Stored URLs with a slash are handled on read.

## Tests

Bypass routes on path segments and drops empty ones, so a stub for `/api/v1/system/status` happily answers `//api/v1/system/status`, and the existing modal test would have passed with the bug still in. `Mydia.BypassHelpers.stub_exact_json/5` checks `conn.request_path` and hands anything else to a fallback. The Prowlarr mocks answer the way Prowlarr does: JSON on the exact API path, the web UI's HTML everywhere else. Every new test failed against the old code before its fix went in.

`mix precommit` passes locally with 11,060 tests and 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed connection URLs with trailing slashes, preventing malformed API requests for NZBGet, SABnzbd, and Prowlarr.
  - Preserved configured URL prefixes when connecting to indexer services.
  - Improved URL normalization by trimming whitespace, adding missing schemes, and removing trailing slashes.
  - Prowlarr connection checks now reject HTML pages or other unexpected responses instead of treating them as successful connections.
- **Tests**
  - Added coverage for trailing-slash URLs, prefixed paths, URL normalization, and invalid Prowlarr responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->