### PR TITLE
Send misattached files to Review from the duplicates page

### DIFF
--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -96,6 +96,118 @@ defmodule Mydia.ImportCandidates do
   end
 
   @doc """
+  Detaches a media file the matcher filed against the wrong item and returns it
+  to the review inbox.
+
+  The row goes and the bytes stay. A candidate is written at the file's current
+  `(library_path_id, relative_path)` so `/review` can match it against the right
+  item, with three fields set so the correction sticks:
+
+    * `returned_at`, which holds it out of unattended promotion
+      (`Mydia.Library.FileIngest`) and, here, out of the ready band and
+      `queue_accept_all_matched/1`, so only a person can put it back;
+    * `queued_op: "rematch"`, so `Mydia.Jobs.RematchImportCandidates` gives it
+      a fresh suggestion under the `:review` policy, which never promotes;
+    * `dismissed_at: nil`, because a dismissed candidate already at that path
+      would otherwise hide the file from the inbox it was just sent to.
+
+  The owning item comes from the file itself (the movie for a movie file, the
+  show for an episode file) and supplies the candidate's `media_type`. Without
+  it `ImportCandidate.parsed_info/1` defaults a nil type to movie, so a
+  returned episode would be matched as a film.
+
+  A legacy row carrying only `path` has no `(library_path_id, relative_path)`
+  pair to key a candidate by, and returns `{:error, :no_library_path}`.
+  """
+  @spec return_to_review(MediaFile.t(), String.t()) ::
+          {:ok, MediaFile.t()} | {:error, :no_library_path} | {:error, term()}
+  def return_to_review(%MediaFile{} = file, actor_id) when is_binary(actor_id) do
+    file = Repo.preload(file, [:library_path, :media_item, episode: :media_item])
+
+    case {file.library_path, file.relative_path, owning_item(file)} do
+      {%LibraryPath{} = library_path, relative_path, %Media.MediaItem{} = media_item}
+      when is_binary(relative_path) ->
+        detach_to_review(file, library_path, media_item, actor_id)
+
+      _ ->
+        {:error, :no_library_path}
+    end
+  end
+
+  defp owning_item(%MediaFile{episode: %Episode{media_item: %Media.MediaItem{} = item}}),
+    do: item
+
+  defp owning_item(%MediaFile{media_item: %Media.MediaItem{} = item}), do: item
+  defp owning_item(%MediaFile{}), do: nil
+
+  defp detach_to_review(file, library_path, media_item, actor_id) do
+    now = now()
+
+    anchor =
+      PathAnchor.anchor_for(Path.join(library_path.path, file.relative_path), library_path.path)
+
+    attrs = %{
+      library_path_id: library_path.id,
+      relative_path: file.relative_path,
+      anchor_key: anchor.cluster_key,
+      size: file.size,
+      media_type: media_item.type,
+      discovered_at: now,
+      returned_at: now,
+      dismissed_at: nil,
+      queued_op: "rematch",
+      queued_at: now,
+      queue_error: nil
+    }
+
+    # Both writes (the candidate appearing, the media_files row disappearing)
+    # must succeed or fail together. Two independent Repo calls would let a
+    # hard interruption between them leave the file both still attached to the
+    # wrong item and duplicated into import_candidates.
+    #
+    # The activity event is recorded inside the same transaction on purpose:
+    # Mydia.Repo.transaction/2 defers its PubSub broadcast until the outermost
+    # transaction commits and discards it on rollback, so the feed never
+    # reports something that did not happen.
+    result =
+      Repo.transaction(fn ->
+        with {:ok, _candidate} <- upsert(attrs),
+             {:ok, deleted} <- Mydia.Library.delete_media_file(file, delete_files: false) do
+          Mydia.Events.file_returned_to_review(deleted, media_item, actor_id)
+          deleted
+        else
+          {:error, reason} -> Repo.rollback(reason)
+        end
+      end)
+
+    case result do
+      {:ok, _deleted} ->
+        enqueue_rematch(library_path.id)
+        broadcast(library_path.id)
+        result
+
+      {:error, _reason} ->
+        result
+    end
+  end
+
+  # The candidate already carries `queued_op: "rematch"`, so a failed enqueue
+  # only delays its suggestion: the next enqueue for this library path, from
+  # any caller, drains it too.
+  defp enqueue_rematch(library_path_id) do
+    case enqueue(Mydia.Jobs.RematchImportCandidates, library_path_id) do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Could not enqueue a re-match for a returned file",
+          library_path_id: library_path_id,
+          reason: inspect(reason)
+        )
+    end
+  end
+
+  @doc """
   Reaps candidates for `library_path_id` whose `relative_path` is absent from
   `relative_paths` (the paths a scan just found on disk).
 

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -348,10 +348,18 @@ defmodule Mydia.ImportCandidates do
   this function has always called it `:needs_attention` via its explicit
   `provider_type: "local"` clause below. `import_candidates_test.exs` proves
   the two paths agree, including for that exact shape.
+
+  A group holding a returned candidate (`returned_count > 0`) is never ready
+  either. An operator sent that file back from an item it was wrongly filed
+  under, and a confident suggestion can name that same item, so a person has
+  to look at it. `ready_condition/0` carries the same rule in SQL.
   """
   @spec band(ImportCandidateGroup.t()) :: :ready | :needs_attention | :no_match
   def band(%ImportCandidateGroup{provider_id: nil}), do: :no_match
   def band(%ImportCandidateGroup{provider_type: "local"}), do: :needs_attention
+
+  def band(%ImportCandidateGroup{returned_count: count}) when is_integer(count) and count > 0,
+    do: :needs_attention
 
   def band(%ImportCandidateGroup{} = group) do
     cond do
@@ -411,7 +419,8 @@ defmodule Mydia.ImportCandidates do
       suggested_year: max(c.year),
       media_type: max(c.media_type),
       queued_op: max(c.queued_op),
-      queue_error: max(c.queue_error)
+      queue_error: max(c.queue_error),
+      returned_count: count(c.returned_at)
     })
   end
 
@@ -473,7 +482,8 @@ defmodule Mydia.ImportCandidates do
       [c],
       count(c.provider_id, :distinct) == 1 and
         fragment("COALESCE(?, 0.0)", min(c.confidence)) >= ^threshold and
-        (is_nil(max(c.provider_type)) or max(c.provider_type) != "local")
+        (is_nil(max(c.provider_type)) or max(c.provider_type) != "local") and
+        count(c.returned_at) == 0
     )
   end
 
@@ -626,7 +636,8 @@ defmodule Mydia.ImportCandidates do
       provider_count: row.provider_count,
       dismissed?: status == "ignored",
       queued?: status == "queued",
-      queue_error: row.queue_error
+      queue_error: row.queue_error,
+      returned_count: row.returned_count
     }
   end
 
@@ -1009,12 +1020,17 @@ defmodule Mydia.ImportCandidates do
   synthetic `"local"` provider can never be promoted, so letting it move into
   Queued and bounce straight back with an error would be churn on the most
   common bulk path.
+
+  `exclude_returned: true` also skips groups holding a candidate an operator
+  returned to review. Only `queue_accept_all_matched/1` passes it: an explicit
+  selection is a person looking at the group, which is what a returned file
+  is waiting for.
   """
-  @spec queue_accept(SelectionScope.t()) ::
+  @spec queue_accept(SelectionScope.t(), keyword()) ::
           {:ok, %{queued: non_neg_integer(), skipped: non_neg_integer()}}
-  def queue_accept(%SelectionScope{} = scope) do
+  def queue_accept(%SelectionScope{} = scope, opts \\ []) do
     now = now()
-    eligible = eligible_accept_keys(scope)
+    eligible = eligible_accept_keys(scope, opts)
 
     # Both counts have to be read before the UPDATE. Marking a row sets
     # `queued_op`, which `filter_status/2` excludes from "pending", so the same
@@ -1051,7 +1067,9 @@ defmodule Mydia.ImportCandidates do
   Queues every pending provider-matched group for one library path.
 
   Confidence is deliberately not filtered: this is the explicit human override
-  behind the review page's "Import all" control.
+  behind the review page's "Import all" control. Groups holding a returned
+  candidate are skipped, because a returned file's suggestion can name the very
+  item it was sent back from, and this control accepts without showing it.
   """
   @spec queue_accept_all_matched(binary()) ::
           {:ok, %{queued: non_neg_integer(), skipped: non_neg_integer()}}
@@ -1059,21 +1077,25 @@ defmodule Mydia.ImportCandidates do
     library_path_id
     |> SelectionScope.new()
     |> SelectionScope.select_all_matching(%{})
-    |> queue_accept()
+    |> queue_accept(exclude_returned: true)
   end
 
   # The selected anchors that `accept_group/2` would actually accept, as a
   # grouped subquery of anchor keys. `count(provider_id, :distinct) == 1`
   # subsumes the no-match case as well: SQL counts of a nullable column ignore
   # NULLs, so a group with no provider match counts zero.
-  defp eligible_accept_keys(%SelectionScope{} = scope) do
+  defp eligible_accept_keys(%SelectionScope{} = scope, opts) do
     scope
     |> SelectionScope.to_query()
     |> exclude(:select)
     |> having([c], count(c.provider_id, :distinct) == 1)
     |> having([c], is_nil(max(c.provider_type)) or max(c.provider_type) != "local")
+    |> maybe_exclude_returned(Keyword.get(opts, :exclude_returned, false))
     |> select([c], c.anchor_key)
   end
+
+  defp maybe_exclude_returned(query, true), do: having(query, [c], count(c.returned_at) == 0)
+  defp maybe_exclude_returned(query, false), do: query
 
   # Oban's engine is disabled in test (config/test.exs sets `engine: false`), so
   # Oban.insert/1 raises there. See test/README.md and

--- a/lib/mydia/import_candidates.ex
+++ b/lib/mydia/import_candidates.ex
@@ -107,7 +107,10 @@ defmodule Mydia.ImportCandidates do
       (`Mydia.Library.FileIngest`) and, here, out of the ready band and
       `queue_accept_all_matched/1`, so only a person can put it back;
     * `queued_op: "rematch"`, so `Mydia.Jobs.RematchImportCandidates` gives it
-      a fresh suggestion under the `:review` policy, which never promotes;
+      a fresh suggestion under the `:review` policy, which never promotes.
+      The job is enqueued inside the same transaction as the detach, so a
+      failed enqueue rolls the whole detach back rather than leaving the
+      candidate queued with nothing to drain it;
     * `dismissed_at: nil`, because a dismissed candidate already at that path
       would otherwise hide the file from the inbox it was just sent to.
 
@@ -160,10 +163,12 @@ defmodule Mydia.ImportCandidates do
       queue_error: nil
     }
 
-    # Both writes (the candidate appearing, the media_files row disappearing)
-    # must succeed or fail together. Two independent Repo calls would let a
-    # hard interruption between them leave the file both still attached to the
-    # wrong item and duplicated into import_candidates.
+    # All three -- the candidate appearing, the media_files row disappearing,
+    # and the rematch job -- must succeed or fail together. Two independent
+    # Repo calls would let a hard interruption between them leave the file
+    # both still attached to the wrong item and duplicated into
+    # import_candidates; enqueueing outside the transaction would let a job
+    # insert failure leave the candidate queued with nothing left to drain it.
     #
     # The activity event is recorded inside the same transaction on purpose:
     # Mydia.Repo.transaction/2 defers its PubSub broadcast until the outermost
@@ -172,7 +177,8 @@ defmodule Mydia.ImportCandidates do
     result =
       Repo.transaction(fn ->
         with {:ok, _candidate} <- upsert(attrs),
-             {:ok, deleted} <- Mydia.Library.delete_media_file(file, delete_files: false) do
+             {:ok, deleted} <- Mydia.Library.delete_media_file(file, delete_files: false),
+             {:ok, _job} <- enqueue(Mydia.Jobs.RematchImportCandidates, library_path.id) do
           Mydia.Events.file_returned_to_review(deleted, media_item, actor_id)
           deleted
         else
@@ -182,28 +188,11 @@ defmodule Mydia.ImportCandidates do
 
     case result do
       {:ok, _deleted} ->
-        enqueue_rematch(library_path.id)
         broadcast(library_path.id)
         result
 
       {:error, _reason} ->
         result
-    end
-  end
-
-  # The candidate already carries `queued_op: "rematch"`, so a failed enqueue
-  # only delays its suggestion: the next enqueue for this library path, from
-  # any caller, drains it too.
-  defp enqueue_rematch(library_path_id) do
-    case enqueue(Mydia.Jobs.RematchImportCandidates, library_path_id) do
-      {:ok, _job} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning("Could not enqueue a re-match for a returned file",
-          library_path_id: library_path_id,
-          reason: inspect(reason)
-        )
     end
   end
 

--- a/lib/mydia/library/file_ingest.ex
+++ b/lib/mydia/library/file_ingest.ex
@@ -71,6 +71,13 @@ defmodule Mydia.Library.FileIngest do
   defp decide(_candidate, nil, _policy, _threshold), do: :candidate
   defp decide(_candidate, _match, :review, _threshold), do: :candidate
 
+  # An operator sent this file back from an item it had been filed under by
+  # mistake (Mydia.ImportCandidates.return_to_review/2). A confident match can
+  # name that same item again, so it waits for a person whatever the
+  # confidence. Matching still ran, so /review shows the suggestion.
+  defp decide(%ImportCandidate{returned_at: %DateTime{}}, _match, :unattended, _threshold),
+    do: :candidate
+
   defp decide(candidate, match, :unattended, threshold) do
     cond do
       extra?(candidate, match) -> :candidate

--- a/lib/mydia/library/import_candidate.ex
+++ b/lib/mydia/library/import_candidate.ex
@@ -29,6 +29,7 @@ defmodule Mydia.Library.ImportCandidate do
     field :queued_at, :utc_datetime
     field :queue_error, :string
     field :discovered_at, :utc_datetime
+    field :returned_at, :utc_datetime
 
     belongs_to :library_path, Mydia.Settings.LibraryPath
 
@@ -38,7 +39,7 @@ defmodule Mydia.Library.ImportCandidate do
   @castable ~w(
     library_path_id relative_path anchor_key size mtime parsed_info provider_type provider_id
     title year media_type confidence attempts last_error next_retry_at dismissed_at discovered_at
-    queued_op queued_at queue_error
+    queued_op queued_at queue_error returned_at
   )a
 
   @spec changeset(t(), map()) :: Ecto.Changeset.t()

--- a/lib/mydia/library/import_candidate_group.ex
+++ b/lib/mydia/library/import_candidate_group.ex
@@ -19,6 +19,11 @@ defmodule Mydia.Library.ImportCandidateGroup do
   is true when the group was read at `status: "queued"`, and `queue_error`
   carries the message a terminal refusal left behind when a queued accept or
   re-match was cleared without promoting -- see `Mydia.ImportCandidates.drain_accepted/2`.
+
+  `returned_count` counts the group's candidates an operator sent back from
+  the duplicates page (`Mydia.ImportCandidates.return_to_review/2`). Any
+  returned candidate keeps the group out of the ready band and out of "Import
+  all"; see `Mydia.ImportCandidates.band/1`.
   """
 
   @enforce_keys [:id, :anchor_key, :library_path_id, :file_count]
@@ -37,7 +42,8 @@ defmodule Mydia.Library.ImportCandidateGroup do
     :provider_count,
     :dismissed?,
     :queued?,
-    :queue_error
+    :queue_error,
+    returned_count: 0
   ]
 
   @type t :: %__MODULE__{
@@ -55,7 +61,8 @@ defmodule Mydia.Library.ImportCandidateGroup do
           provider_count: non_neg_integer() | nil,
           dismissed?: boolean() | nil,
           queued?: boolean() | nil,
-          queue_error: String.t() | nil
+          queue_error: String.t() | nil,
+          returned_count: non_neg_integer()
         }
 
   @doc """

--- a/lib/mydia/library/prune.ex
+++ b/lib/mydia/library/prune.ex
@@ -170,18 +170,18 @@ defmodule Mydia.Library.Prune do
       for {group, reason, _detail} <- refusals, reason != :duplicate_registration, do: group
 
     {sendable, whole_group} =
-      Enum.reduce(groups, {[], []}, fn group, {send, abort} ->
+      Enum.reduce(groups, {[], []}, fn group, {to_send, to_abort} ->
         picked = Enum.filter(group.files, &MapSet.member?(requested, &1.id))
 
         cond do
           picked == [] ->
-            {send, abort}
+            {to_send, to_abort}
 
           length(picked) == length(group.files) ->
-            {send, abort ++ Enum.map(picked, &{&1.id, :would_leave_no_file})}
+            {to_send, to_abort ++ Enum.map(picked, &{&1.id, :would_leave_no_file})}
 
           true ->
-            {send ++ picked, abort}
+            {to_send ++ picked, to_abort}
         end
       end)
 

--- a/lib/mydia/library/prune.ex
+++ b/lib/mydia/library/prune.ex
@@ -7,9 +7,11 @@ defmodule Mydia.Library.Prune do
   bonus content. `Mydia.Library.Prune.Eligibility` refuses all of those, and
   this module only ever acts on what survives that gate.
 
-  Nothing here runs on a schedule. An operator reviews a plan and confirms it.
+  Nothing here runs on a schedule. An operator reviews a plan and confirms it,
+  either trashing redundant copies (`execute/3`) or sending misfiled files from
+  refused groups back to Review (`send_to_review/2`).
 
-  ## Why execute/3 re-verifies
+  ## Why execute/3 and send_to_review/2 re-verify
 
   `execute/3` does not trust the ids it is handed. It rebuilds the plan
   (honoring the same `keepers` overrides the operator's plan was built from)
@@ -22,6 +24,7 @@ defmodule Mydia.Library.Prune do
   import Ecto.Query, only: [where: 3]
 
   alias Mydia.Events
+  alias Mydia.ImportCandidates
   alias Mydia.Library
   alias Mydia.Library.MediaFile
   alias Mydia.Library.Prune.{Decision, Eligibility, Group, Grouping, Ranker}
@@ -31,13 +34,22 @@ defmodule Mydia.Library.Prune do
   require Logger
 
   @type refusal :: {Group.t(), atom(), map()}
-  @type plan :: %{decisions: [Decision.t()], refusals: [refusal()]}
+  @type plan :: %{
+          decisions: [Decision.t()],
+          refusals: [refusal()],
+          suspects: %{optional(String.t()) => MapSet.t(String.t())}
+        }
 
   @doc """
-  Builds the current plan: what can be pruned, and what was refused and why.
+  Builds the current plan: what can be pruned, what was refused and why, and
+  which files of each refused group look misfiled.
 
   `keepers` optionally maps a group's `subject_id` to a file id the operator
   chose instead of the ranked keeper.
+
+  `suspects` maps a refused group's `subject_id` to the ids
+  `Mydia.Library.Prune.Eligibility.suspect_files/1` names. It leaves out
+  `:duplicate_registration` groups, which `send_to_review/2` never acts on.
   """
   @spec plan(%{optional(String.t()) => String.t()}) :: plan()
   def plan(keepers \\ %{}) do
@@ -51,7 +63,13 @@ defmodule Mydia.Library.Prune do
       for {group, {:refused, reason, detail}} <- checked,
           do: {group, reason, detail}
 
-    %{decisions: decisions, refusals: refusals}
+    suspects =
+      for {group, reason, _detail} <- refusals,
+          reason != :duplicate_registration,
+          into: %{},
+          do: {group.subject_id, group |> Eligibility.suspect_files() |> MapSet.new(& &1.id)}
+
+    %{decisions: decisions, refusals: refusals, suspects: suspects}
   end
 
   @doc """
@@ -123,6 +141,72 @@ defmodule Mydia.Library.Prune do
       end)
 
     %{trashed: trashed, failed: failed, aborted: refused_ids ++ aborted_keepers ++ unknown}
+  end
+
+  @doc """
+  Sends files from refused groups to Review, after re-verifying each one.
+
+  Like `execute/3`, this does not trust the ids it is handed. It rebuilds the
+  plan and drops any id that is not a file of a currently refused group, and it
+  refuses to send every file of a group, since an item must keep at least one
+  file (the same invariant `execute/3` holds for a trash run).
+  `:duplicate_registration` groups are excluded: both of their rows point at
+  one path, so sending either leaves a candidate on a path the other still owns.
+
+  Each file is its own transaction through
+  `Mydia.ImportCandidates.return_to_review/2`. A failure is reported rather
+  than rolled back, because earlier files have already committed.
+  """
+  @spec send_to_review([String.t()], String.t()) :: %{
+          returned: [MediaFile.t()],
+          failed: [{String.t(), term()}],
+          aborted: [{String.t(), atom()}]
+        }
+  def send_to_review(file_ids, actor_id) when is_list(file_ids) and is_binary(actor_id) do
+    requested = MapSet.new(file_ids)
+    %{refusals: refusals} = plan()
+
+    groups =
+      for {group, reason, _detail} <- refusals, reason != :duplicate_registration, do: group
+
+    {sendable, whole_group} =
+      Enum.reduce(groups, {[], []}, fn group, {send, abort} ->
+        picked = Enum.filter(group.files, &MapSet.member?(requested, &1.id))
+
+        cond do
+          picked == [] ->
+            {send, abort}
+
+          length(picked) == length(group.files) ->
+            {send, abort ++ Enum.map(picked, &{&1.id, :would_leave_no_file})}
+
+          true ->
+            {send ++ picked, abort}
+        end
+      end)
+
+    known = groups |> Enum.flat_map(& &1.files) |> MapSet.new(& &1.id)
+
+    unknown =
+      for id <- Enum.uniq(file_ids), not MapSet.member?(known, id), do: {id, :not_in_any_group}
+
+    {returned, failed} =
+      Enum.reduce(sendable, {[], []}, fn file, {ok, bad} ->
+        case ImportCandidates.return_to_review(file, actor_id) do
+          {:ok, deleted} ->
+            {ok ++ [deleted], bad}
+
+          {:error, reason} ->
+            Logger.error("Prune could not send a media file to Review",
+              media_file_id: file.id,
+              reason: inspect(reason)
+            )
+
+            {ok, bad ++ [{file.id, reason}]}
+        end
+      end)
+
+    %{returned: returned, failed: failed, aborted: whole_group ++ unknown}
   end
 
   @doc """

--- a/lib/mydia/library/prune/eligibility.ex
+++ b/lib/mydia/library/prune/eligibility.ex
@@ -21,13 +21,19 @@ defmodule Mydia.Library.Prune.Eligibility do
     4. `:name_mismatch` - a filename does not bind to the subject
     5. `:episode_mismatch` - parsed season/episode disagrees with the row
     6. `:nothing_to_prune` - fewer than two files survive
+
+  `suspect_files/1` reuses the per-file halves of the name and episode checks
+  to say which files in a refused group look misfiled. It is a display and
+  default-selection signal for the duplicates page, never a gate.
   """
 
   alias Mydia.Library.MediaFile
+  alias Mydia.Library.PathAnchor
   alias Mydia.Library.Prune.Group
   alias Mydia.Library.ReleaseParser
   alias Mydia.Library.ReleaseParser.TargetContext
   alias Mydia.Media.Episode
+  alias Mydia.Settings.LibraryPath
 
   # Measured against production: 1% admits 164 of 228 candidates, 2% admits
   # 177, 5% admits 199. The step from 2% to 5% is where extended cuts and
@@ -56,6 +62,43 @@ defmodule Mydia.Library.Prune.Eligibility do
          :ok <- check_enough_files(group) do
       {:ok, group}
     end
+  end
+
+  @doc """
+  The files in a group that look filed against the wrong subject.
+
+  A file is a suspect when its name says it is a different episode than the
+  row it is attached to, or when its name does not bind to the item and it sits
+  under a different anchor folder (`Mydia.Library.PathAnchor`) from every file
+  whose name does bind. The folder condition separates a misattached file from
+  bonus content: a stray from another title lives in that title's folder,
+  while a loose featurette sits in the feature's folder and fails to bind just
+  the same. A file the extras classifier has labelled (`extra_kind` set) is
+  never a suspect, and neither is a legacy row with no relative path.
+
+  When no file binds, every unbound file is a suspect, which lets a caller tell
+  "nothing here matches" apart from "one stray".
+  """
+  @spec suspect_files(Group.t()) :: [MediaFile.t()]
+  def suspect_files(%Group{media_item: media_item, files: files} = group) do
+    target = TargetContext.from_media_item(media_item)
+
+    considered =
+      Enum.reject(files, &(is_nil(&1.relative_path) or not is_nil(&1.extra_kind)))
+
+    unbound_ids = for file <- considered, unbound?(file, target), into: MapSet.new(), do: file.id
+
+    bound_anchors =
+      for file <- considered,
+          not MapSet.member?(unbound_ids, file.id),
+          into: MapSet.new(),
+          do: anchor_key(file)
+
+    Enum.filter(considered, fn file ->
+      wrong_episode_in?(group, file, target) or
+        (MapSet.member?(unbound_ids, file.id) and
+           not MapSet.member?(bound_anchors, anchor_key(file)))
+    end)
   end
 
   defp check_duplicate_registration(%Group{files: files}) do
@@ -103,33 +146,16 @@ defmodule Mydia.Library.Prune.Eligibility do
     end
   end
 
-  # Binds every filename to the item the files are attached to. The parser
-  # already knows how to say "this release name does not belong to this show":
-  # `:binding_suspect` and `:parsed_title_unbound` are exactly that signal, and
-  # `Mydia.Downloads.TorrentMatcher` uses the same two flags as a wrong-show
-  # guard.
-  #
-  # `:season_out_of_range` is deliberately not consulted here. It fires when a
-  # season is absent from the item's known seasons, which check_episode_numbers/1
-  # below already covers more precisely against the actual episode row.
+  # Binds every filename to the item the files are attached to. See
+  # `unbound?/2` for the signal. `:season_out_of_range` is deliberately not
+  # consulted: `check_episode_numbers/1` covers it more precisely against the
+  # actual episode row.
   defp check_names(%Group{media_item: media_item, files: files}) do
     target = TargetContext.from_media_item(media_item)
 
-    unbound =
-      Enum.filter(files, fn file ->
-        flags =
-          file.relative_path
-          |> ReleaseParser.parse_with_path(target: target)
-          |> Map.get(:engine_flags)
-          |> Kernel.||(%{})
-
-        Map.get(flags, :binding_suspect) || Map.get(flags, :parsed_title_unbound)
-      end)
-
-    if unbound == [] do
-      :ok
-    else
-      {:refused, :name_mismatch, %{paths: Enum.map(unbound, & &1.relative_path)}}
+    case Enum.filter(files, &unbound?(&1, target)) do
+      [] -> :ok
+      unbound -> {:refused, :name_mismatch, %{paths: Enum.map(unbound, & &1.relative_path)}}
     end
   end
 
@@ -142,24 +168,57 @@ defmodule Mydia.Library.Prune.Eligibility do
        ) do
     target = TargetContext.from_media_item(group.media_item)
 
-    mismatched =
-      Enum.filter(group.files, fn file ->
-        parsed = ReleaseParser.parse_with_path(file.relative_path, target: target)
+    case Enum.filter(group.files, &wrong_episode?(&1, episode, target)) do
+      [] ->
+        :ok
 
-        season_disagrees?(parsed.season, episode.season_number) or
-          episode_disagrees?(parsed.episodes, episode.episode_number)
-      end)
-
-    if mismatched == [] do
-      :ok
-    else
-      {:refused, :episode_mismatch,
-       %{
-         expected: {episode.season_number, episode.episode_number},
-         paths: Enum.map(mismatched, & &1.relative_path)
-       }}
+      mismatched ->
+        {:refused, :episode_mismatch,
+         %{
+           expected: {episode.season_number, episode.episode_number},
+           paths: Enum.map(mismatched, & &1.relative_path)
+         }}
     end
   end
+
+  # True when the file's name does not bind to the target item. The parser
+  # already knows how to say "this release name does not belong to this show":
+  # `:binding_suspect` and `:parsed_title_unbound` are exactly that signal, and
+  # `Mydia.Downloads.TorrentMatcher` uses the same two flags as a wrong-show
+  # guard.
+  defp unbound?(%MediaFile{relative_path: path}, target) do
+    flags =
+      path
+      |> ReleaseParser.parse_with_path(target: target)
+      |> Map.get(:engine_flags)
+      |> Kernel.||(%{})
+
+    Map.get(flags, :binding_suspect) == true or not is_nil(Map.get(flags, :parsed_title_unbound))
+  end
+
+  defp wrong_episode?(%MediaFile{relative_path: path}, %Episode{} = episode, target) do
+    parsed = ReleaseParser.parse_with_path(path, target: target)
+
+    season_disagrees?(parsed.season, episode.season_number) or
+      episode_disagrees?(parsed.episodes, episode.episode_number)
+  end
+
+  defp wrong_episode_in?(
+         %Group{subject_type: :episode, subject: %Episode{} = episode},
+         file,
+         target
+       ),
+       do: wrong_episode?(file, episode, target)
+
+  defp wrong_episode_in?(_group, _file, _target), do: false
+
+  # The folder that names the media a file sits under. `Prune.Grouping`
+  # preloads `:library_path` on every file for exactly this kind of use.
+  defp anchor_key(%MediaFile{library_path: %LibraryPath{path: root}, relative_path: rel})
+       when is_binary(root) and is_binary(rel),
+       do: PathAnchor.anchor_for(Path.join(root, rel), root).cluster_key
+
+  defp anchor_key(%MediaFile{}), do: nil
 
   # A parse that produced no season or no episode number is not evidence of a
   # mismatch, so it does not refuse here. `check_names/1` has already rejected

--- a/lib/mydia/media/README.md
+++ b/lib/mydia/media/README.md
@@ -234,6 +234,17 @@ the selection math wrong trashes real files. And hyphen-slug filenames
 (`Muppets-Most-Wanted-2014-1080p.mkv`) fail `ReleaseParser` title extraction, so
 those movies are refused rather than pruned, which fails safe.
 
+Needs Attention is where misidentification surfaces, so each file there carries
+a Leave/Review choice, and a send goes through `Prune.send_to_review/2`, which
+re-plans and never empties a subject, the same way `execute/3` never trashes a
+keeper. A file starts on Review when `Eligibility.suspect_files/1` names it: its
+name does not bind to the item and it sits under a different anchor folder from
+every file that does, or it names a different episode. The folder test is what
+keeps loose bonus content (the Monsters University shape above) from being sent
+away. The returned candidate carries `returned_at`, which keeps it out of
+unattended promotion (`FileIngest`), out of the ready band, and out of
+`queue_accept_all_matched/1`. Only an explicit Accept in `/review` puts it back.
+
 ## An empty scan trashes the whole library
 
 A library scan returning zero files classifies every existing `media_file` under

--- a/lib/mydia_web/live/admin_duplicates_live/components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/components.ex
@@ -20,7 +20,12 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
   alias Mydia.Library.MediaFile
 
   @doc """
-  Renders the Duplicates tab content.
+  Renders the Duplicates section of the page.
+
+  The Needs Attention section below it is
+  `MydiaWeb.AdminDuplicatesLive.ReviewComponents.needs_attention/1`. The page
+  template stacks the two inside one padded column, so this returns sibling
+  elements rather than a wrapper of its own.
   """
   attr :decisions, :list, required: true
   attr :refusals, :list, required: true
@@ -35,84 +40,59 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
     assigns = assign(assigns, :all_selected?, MapSet.size(assigns.selected) == total_losers)
 
     ~H"""
-    <div class="p-4 sm:p-6 space-y-4">
-      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <h2 class="text-lg font-semibold flex items-center gap-2">
-          <.icon name="hero-document-duplicate" class="w-5 h-5 opacity-60" /> Duplicates
-          <span class="badge badge-ghost">{length(@decisions)}</span>
-        </h2>
-        <div class="join">
-          <button
-            :if={not @all_selected?}
-            id="duplicates-trash-all"
-            type="button"
-            class="btn btn-sm btn-ghost join-item"
-            phx-click="trash_all_duplicates"
-          >
-            <.icon name="hero-check-circle" class="w-4 h-4" /> Mark all for trash
-          </button>
-          <button
-            id="duplicates-trash-selected"
-            type="button"
-            class="btn btn-sm btn-error join-item"
-            disabled={MapSet.size(@selected) == 0}
-            phx-click="open_trash_modal"
-          >
-            <.icon name="hero-trash" class="w-4 h-4" />
-            Trash {file_count(MapSet.size(@selected))} ({humanize_bytes(@reclaimable)})
-          </button>
-        </div>
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+      <h2 class="text-lg font-semibold flex items-center gap-2">
+        <.icon name="hero-document-duplicate" class="w-5 h-5 opacity-60" /> Duplicates
+        <span class="badge badge-ghost">{length(@decisions)}</span>
+      </h2>
+      <div class="join">
+        <button
+          :if={not @all_selected?}
+          id="duplicates-trash-all"
+          type="button"
+          class="btn btn-sm btn-ghost join-item"
+          phx-click="trash_all_duplicates"
+        >
+          <.icon name="hero-check-circle" class="w-4 h-4" /> Mark all for trash
+        </button>
+        <button
+          id="duplicates-trash-selected"
+          type="button"
+          class="btn btn-sm btn-error join-item"
+          disabled={MapSet.size(@selected) == 0}
+          phx-click="open_trash_modal"
+        >
+          <.icon name="hero-trash" class="w-4 h-4" />
+          Trash {file_count(MapSet.size(@selected))} ({humanize_bytes(@reclaimable)})
+        </button>
       </div>
-
-      <p class="text-sm text-base-content/60">
-        Items holding more than one file, where every copy is proven to be the same content.
-        Each file is set to either <span class="font-medium text-base-content">Keep</span>
-        or <span class="font-medium text-error">Trash</span>; the best copy is listed first and
-        kept, the rest are already marked for trash. Trash one item with its own button, or
-        every item with the button above. Every item always keeps at least one file. Trashed
-        files are held for {@retention_days} days before permanent deletion, and a run can be
-        undone until you leave this page.
-      </p>
-
-      <%= if @decisions == [] do %>
-        <div class="alert alert-info">
-          <.icon name="hero-information-circle" class="w-5 h-5" />
-          <span :if={@refusals == []}>
-            No item holds more than one file. There are no duplicates to review.
-          </span>
-          <span :if={@refusals != []}>
-            Nothing can be trashed safely right now. Every item below needs attention first.
-          </span>
-        </div>
-      <% else %>
-        <div class="bg-base-200 rounded-box divide-y divide-base-300">
-          <.decision_row :for={decision <- @decisions} decision={decision} selected={@selected} />
-        </div>
-      <% end %>
-
-      <%= if @refusals != [] do %>
-        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 pt-2">
-          <h2 class="text-lg font-semibold flex items-center gap-2">
-            <.icon name="hero-exclamation-triangle" class="w-5 h-5 opacity-60" /> Needs Attention
-            <span class="badge badge-ghost">{length(@refusals)}</span>
-          </h2>
-        </div>
-
-        <p class="text-sm text-base-content/60">
-          These were left alone. Each one is a matching or scanning problem rather than a
-          duplicate, and acting on them would remove real media.
-        </p>
-
-        <div class="bg-base-200 rounded-box divide-y divide-base-300">
-          <.refusal_row
-            :for={{group, reason, detail} <- @refusals}
-            group={group}
-            reason={reason}
-            detail={detail}
-          />
-        </div>
-      <% end %>
     </div>
+
+    <p class="text-sm text-base-content/60">
+      Items holding more than one file, where every copy is proven to be the same content.
+      Each file is set to either <span class="font-medium text-base-content">Keep</span>
+      or <span class="font-medium text-error">Trash</span>; the best copy is listed first and
+      kept, the rest are already marked for trash. Trash one item with its own button, or
+      every item with the button above. Every item always keeps at least one file. Trashed
+      files are held for {@retention_days} days before permanent deletion, and a run can be
+      undone until you leave this page.
+    </p>
+
+    <%= if @decisions == [] do %>
+      <div class="alert alert-info">
+        <.icon name="hero-information-circle" class="w-5 h-5" />
+        <span :if={@refusals == []}>
+          No item holds more than one file. There are no duplicates to review.
+        </span>
+        <span :if={@refusals != []}>
+          Nothing can be trashed safely right now. Every item below needs attention first.
+        </span>
+      </div>
+    <% else %>
+      <div class="bg-base-200 rounded-box divide-y divide-base-300">
+        <.decision_row :for={decision <- @decisions} decision={decision} selected={@selected} />
+      </div>
+    <% end %>
     """
   end
 
@@ -266,38 +246,18 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
     """
   end
 
-  # Library-relative folder for a file, or nil when the file sits at the root
-  # of its library path and there is nothing useful to show.
-  defp folder_of(relative_path) do
+  @doc """
+  The library-relative folder for a file, or nil when the file sits at the root
+  of its library path and there is nothing useful to show. Public because the
+  Needs Attention rows in `MydiaWeb.AdminDuplicatesLive.ReviewComponents` show
+  files the same way.
+  """
+  def folder_of(relative_path) do
     case Path.dirname(relative_path) do
       "." -> nil
       "/" -> nil
       folder -> folder
     end
-  end
-
-  attr :group, :map, required: true
-  attr :reason, :atom, required: true
-  attr :detail, :map, required: true
-
-  defp refusal_row(assigns) do
-    ~H"""
-    <div class="p-3 sm:p-4" id={"duplicates-refusal-#{@group.subject_id}"}>
-      <div class="flex items-center gap-3">
-        <div class="flex-1 min-w-0">
-          <div class="font-medium truncate">{subject_label(@group)}</div>
-          <div class="text-xs opacity-60 truncate">{file_count(length(@group.files))}</div>
-        </div>
-        <span class="badge badge-sm badge-outline badge-warning">{refusal_label(@reason)}</span>
-      </div>
-
-      <p class="text-sm text-base-content/60 mt-2">{refusal_explanation(@reason, @detail)}</p>
-
-      <ul class="text-xs opacity-60 list-disc pl-5 mt-1">
-        <li :for={file <- @group.files}>{file.relative_path}</li>
-      </ul>
-    </div>
-    """
   end
 
   @doc """
@@ -360,22 +320,30 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
   end
 
   @doc """
-  The undo affordance for a completed trash run.
+  The toast for a completed run on this page.
+
+  A trash run (`kind: :trash`) offers Undo, which `Mydia.Library.Prune.undo/2`
+  honors until the page is left. A send to Review (`kind: :review`) has no undo
+  of its own, since `/review` can reattach any file it sent, so it links there
+  instead.
 
   This cannot be a flash. `core_components.ex` puts
   `phx-click="lv:clear-flash"` on the whole flash container, which would
-  swallow a nested Undo button, and flash values are strings, so the file ids
-  would need an assign regardless.
+  swallow a nested button or link, and flash values are strings, so the file
+  ids would need an assign regardless.
 
   It sits bottom-end because the flash group sits top-end, and a partial run
   shows both: an error flash for what could not move, and this for what did.
 
   There is no auto-dismiss timer. Any interval is a guess, and an operator
   reading filenames to check they trashed the right copy will lose that race.
+
+  The DOM ids keep their `duplicates-undo` prefix from when this was only the
+  undo toast; tests select on them.
   """
   attr :run, :map, required: true
 
-  def undo_toast(assigns) do
+  def run_toast(assigns) do
     ~H"""
     <div id="duplicates-undo-toast" class="toast toast-bottom toast-end z-50" role="status">
       <div class="alert alert-success w-80 sm:w-96 max-w-80 sm:max-w-96 text-wrap">
@@ -383,6 +351,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
         <span class="text-sm">{@run.label}</span>
         <div class="flex-1" />
         <button
+          :if={@run.kind == :trash}
           id="duplicates-undo"
           type="button"
           class="btn btn-sm btn-ghost"
@@ -391,6 +360,14 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
         >
           <.icon name="hero-arrow-uturn-left" class="w-4 h-4" /> Undo
         </button>
+        <.link
+          :if={@run.kind == :review}
+          id="duplicates-open-review"
+          navigate={~p"/review"}
+          class="btn btn-sm btn-ghost"
+        >
+          <.icon name="hero-inbox-arrow-down" class="w-4 h-4" /> Open Review
+        </.link>
         <button
           id="duplicates-undo-dismiss"
           type="button"
@@ -434,39 +411,6 @@ defmodule MydiaWeb.AdminDuplicatesLive.Components do
 
   def item_count(1), do: "1 item"
   def item_count(n), do: "#{n} items"
-
-  defp refusal_label(:duplicate_registration), do: "Registered twice"
-  defp refusal_label(:unanalyzed), do: "Not analyzed"
-  defp refusal_label(:duration_mismatch), do: "Different lengths"
-  defp refusal_label(:name_mismatch), do: "Names disagree"
-  defp refusal_label(:episode_mismatch), do: "Wrong episode"
-  defp refusal_label(:nothing_to_prune), do: "Nothing to trash"
-
-  defp refusal_explanation(:duplicate_registration, detail) do
-    "One file on disk is registered twice (#{detail.path}). Trashing a copy would move the only real file. Rescan this library path instead."
-  end
-
-  defp refusal_explanation(:unanalyzed, detail) do
-    "#{detail.unanalyzed_count} file(s) have no duration, so they cannot be compared. Run analysis first."
-  end
-
-  defp refusal_explanation(:duration_mismatch, detail) do
-    "These files are #{percent(detail.spread)} apart in length, more than the #{percent(detail.tolerance)} allowed, so they are not the same content. This is usually bonus features or a file matched to the wrong item."
-  end
-
-  defp refusal_explanation(:name_mismatch, _detail) do
-    "At least one filename does not belong to this item. Fix the match before trashing anything."
-  end
-
-  defp refusal_explanation(:episode_mismatch, _detail) do
-    "At least one filename names a different episode than the one it is attached to."
-  end
-
-  defp refusal_explanation(:nothing_to_prune, _detail), do: "Only one file remains."
-
-  # Formats a fraction (0.093) as a percentage string ("9.3%") for the
-  # duration mismatch explanation.
-  defp percent(fraction), do: "#{Float.round(fraction * 100, 1)}%"
 
   @doc """
   Formats a byte count for display. Public because the page template uses it

--- a/lib/mydia_web/live/admin_duplicates_live/index.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.ex
@@ -64,6 +64,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
      |> assign(:active_tab, :duplicates)
      |> assign(:kept, MapSet.new())
      |> assign(:keepers, %{})
+     |> assign(:review_overrides, %{})
      |> assign(:show_trash_modal, false)
      |> assign(:last_run, nil)
      |> assign(:retention_days, retention_days)
@@ -114,6 +115,32 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     end
   end
 
+  def handle_event("leave_file", %{"subject" => subject_id, "file" => file_id}, socket) do
+    {:noreply, put_review_override(socket, subject_id, file_id, :leave)}
+  end
+
+  def handle_event("review_file", %{"subject" => subject_id, "file" => file_id}, socket) do
+    {:noreply, put_review_override(socket, subject_id, file_id, :review)}
+  end
+
+  # Sends one refused group's marked files at once, with no modal, for the same
+  # reason trash_group_now has none: one item's files are a small, visible
+  # blast radius. Nothing is destroyed either; /review can reattach them.
+  def handle_event("send_group_to_review", %{"subject" => subject_id}, socket) do
+    with group when not is_nil(group) <- find_refused_group(socket, subject_id),
+         ids =
+           for(
+             file <- group.files,
+             MapSet.member?(socket.assigns.returning, file.id),
+             do: file.id
+           ),
+         false <- ids == [] do
+      {:noreply, run_send(socket, ids, "from #{Components.subject_label(group)}")}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
   # Runs the trash for one group instead of the whole library. The ids are
   # narrowed to that group's marked losers, and `keepers` still goes through:
   # `execute/3` rebuilds the plan, and without the overrides it would re-rank
@@ -137,6 +164,12 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
   end
 
   def handle_event("undo_trash", _params, %{assigns: %{last_run: nil}} = socket) do
+    {:noreply, socket}
+  end
+
+  # A send to Review has nothing to undo here; its toast links to /review
+  # instead, so only a forged event arrives with this shape.
+  def handle_event("undo_trash", _params, %{assigns: %{last_run: %{kind: :review}}} = socket) do
     {:noreply, socket}
   end
 
@@ -279,8 +312,10 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     plan = Prune.plan(socket.assigns.keepers)
 
     socket
-    |> assign(decisions: plan.decisions, refusals: plan.refusals)
+    |> assign(decisions: plan.decisions, refusals: plan.refusals, suspects: plan.suspects)
     |> assign_selection()
+    |> prune_review_overrides()
+    |> assign_review_selection()
   end
 
   # `:selected` is derived, never stored: every loser of an eligible group is
@@ -316,6 +351,116 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     |> assign(:affected_items, affected)
   end
 
+  # `:returning` is derived, never stored, the same way `:selected` is for the
+  # trash. A file follows the operator's override if there is one. Otherwise it
+  # goes to Review only when it is a suspect in a group that also holds a real
+  # version that is not: a group whose only other files are extras, or that has
+  # none, is left alone, because nothing in it says which file is right.
+  defp assign_review_selection(socket) do
+    %{refusals: refusals, suspects: suspects, review_overrides: overrides} = socket.assigns
+
+    per_group =
+      for {group, reason, _detail} <- refusals, reason != :duplicate_registration do
+        group_suspects = Map.get(suspects, group.subject_id, MapSet.new())
+
+        anchored? =
+          Enum.any?(
+            group.files,
+            &(is_nil(&1.extra_kind) and not MapSet.member?(group_suspects, &1.id))
+          )
+
+        Enum.filter(group.files, &review?(&1, group_suspects, anchored?, overrides))
+      end
+
+    socket
+    |> assign(:returning, per_group |> List.flatten() |> MapSet.new(& &1.id))
+    |> assign(:returning_items, Enum.count(per_group, &(&1 != [])))
+  end
+
+  defp review?(file, group_suspects, anchored?, overrides) do
+    case Map.fetch(overrides, file.id) do
+      {:ok, disposition} -> disposition == :review
+      :error -> anchored? and MapSet.member?(group_suspects, file.id)
+    end
+  end
+
+  # A Leave/Review click moves one file's override, but only for a file of the
+  # refused group the event names, and never onto Review for that group's last
+  # file still on Leave: an item always keeps a file. That radio is disabled,
+  # so reaching the refusal here means a forged event.
+  defp put_review_override(socket, subject_id, file_id, disposition) do
+    group = find_refused_group(socket, subject_id)
+
+    cond do
+      is_nil(group) ->
+        socket
+
+      not Enum.any?(group.files, &(&1.id == file_id)) ->
+        socket
+
+      disposition == :review and last_left?(socket, group, file_id) ->
+        socket
+
+      true ->
+        socket
+        |> assign(
+          :review_overrides,
+          Map.put(socket.assigns.review_overrides, file_id, disposition)
+        )
+        |> assign_review_selection()
+    end
+  end
+
+  defp last_left?(socket, group, file_id) do
+    case Enum.reject(group.files, &MapSet.member?(socket.assigns.returning, &1.id)) do
+      [%{id: ^file_id}] -> true
+      _ -> false
+    end
+  end
+
+  defp find_refused_group(socket, subject_id) do
+    Enum.find_value(socket.assigns.refusals, fn {group, reason, _detail} ->
+      if reason != :duplicate_registration and group.subject_id == subject_id, do: group
+    end)
+  end
+
+  # An override lives only as long as its file is on the page. Files that were
+  # sent, trashed or rescanned away drop out, so no later group can inherit a
+  # choice made about a file it does not hold.
+  defp prune_review_overrides(socket) do
+    present =
+      for {group, _reason, _detail} <- socket.assigns.refusals,
+          file <- group.files,
+          into: MapSet.new(),
+          do: file.id
+
+    overrides =
+      Map.filter(socket.assigns.review_overrides, fn {id, _disposition} ->
+        MapSet.member?(present, id)
+      end)
+
+    assign(socket, :review_overrides, overrides)
+  end
+
+  defp run_send(socket, ids, scope_label) do
+    actor_id = to_string(socket.assigns.current_scope.user.id)
+    result = Prune.send_to_review(ids, actor_id)
+
+    socket
+    |> maybe_flash_problems(result)
+    |> maybe_set_review_run(result, scope_label)
+    |> load_plan()
+  end
+
+  defp maybe_set_review_run(socket, %{returned: []}, _scope_label), do: socket
+
+  defp maybe_set_review_run(socket, %{returned: returned}, scope_label) do
+    assign(socket, :last_run, %{
+      kind: :review,
+      label: "Sent #{Components.file_count(length(returned))} #{scope_label} to Review"
+    })
+  end
+
   # A clean run says everything it needs to in the undo toast, so no info flash
   # is raised: two success messages saying the same thing is noise. Failures
   # and aborts still go through the flash, so a partial run shows the error at
@@ -346,6 +491,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     bytes = trashed |> Enum.map(&(&1.size || 0)) |> Enum.sum()
 
     assign(socket, :last_run, %{
+      kind: :trash,
       file_ids: Enum.map(trashed, & &1.id),
       label:
         "Trashed #{Components.file_count(length(trashed))} #{scope_label} " <>

--- a/lib/mydia_web/live/admin_duplicates_live/index.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.ex
@@ -128,12 +128,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
   # blast radius. Nothing is destroyed either; /review can reattach them.
   def handle_event("send_group_to_review", %{"subject" => subject_id}, socket) do
     with group when not is_nil(group) <- find_refused_group(socket, subject_id),
-         ids =
-           for(
-             file <- group.files,
-             MapSet.member?(socket.assigns.returning, file.id),
-             do: file.id
-           ),
+         ids = group_returning(socket, group),
          false <- ids == [] do
       {:noreply, run_send(socket, ids, "from #{Components.subject_label(group)}")}
     else
@@ -306,6 +301,11 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     for file <- decision.losers,
         MapSet.member?(socket.assigns.selected, file.id),
         do: file.id
+  end
+
+  # The marked files of one refused group, for its Send button.
+  defp group_returning(socket, group) do
+    for file <- group.files, MapSet.member?(socket.assigns.returning, file.id), do: file.id
   end
 
   defp load_plan(socket) do

--- a/lib/mydia_web/live/admin_duplicates_live/index.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.ex
@@ -47,6 +47,23 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
   has already refused every group that is not proven to be the same content.
   A group that reaches `:decisions` holds redundant copies of one file; the
   refused ones are listed separately and have nothing selectable on them.
+
+  ## Needs Attention
+
+  Refused groups are mostly files filed against the wrong item, and the fix is
+  to send the stray to Review. The operator's choices there are stored as
+  overrides (`:review_overrides`, a file id mapped to `:leave` or `:review`)
+  rather than as a selection, for the same reason `:kept` is an exclusion set:
+  the defaults come from the plan (`Mydia.Library.Prune.Eligibility.suspect_files/1`),
+  and a re-plan must be free to move them without losing what the operator
+  changed by hand. `:returning` is derived from the two.
+
+  One group's send runs at once, like `trash_group_now`, and the page-level
+  send gets a confirmation modal, like the page-level trash. Neither destroys
+  anything: the bytes stay put and `/review` can reattach any file, which is
+  also why a send has no Undo of its own. `Mydia.Library.Prune.send_to_review/2`
+  re-verifies every id and refuses to empty an item, so the page is not the
+  security boundary here either.
   """
 
   use MydiaWeb, :live_view
@@ -66,6 +83,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
      |> assign(:keepers, %{})
      |> assign(:review_overrides, %{})
      |> assign(:show_trash_modal, false)
+     |> assign(:show_review_modal, false)
      |> assign(:last_run, nil)
      |> assign(:retention_days, retention_days)
      |> load_plan()}
@@ -134,6 +152,29 @@ defmodule MydiaWeb.AdminDuplicatesLive.Index do
     else
       _ -> {:noreply, socket}
     end
+  end
+
+  def handle_event("open_review_modal", _params, socket) do
+    {:noreply, assign(socket, :show_review_modal, MapSet.size(socket.assigns.returning) > 0)}
+  end
+
+  def handle_event("close_review_modal", _params, socket) do
+    {:noreply, assign(socket, :show_review_modal, false)}
+  end
+
+  def handle_event("confirm_review", _params, socket) do
+    # Built before run_send/3 reloads the plan, which recomputes the count
+    # against what is left.
+    label = "across #{Components.item_count(socket.assigns.returning_items)}"
+
+    {:noreply,
+     socket
+     |> assign(:show_review_modal, false)
+     |> run_send(MapSet.to_list(socket.assigns.returning), label)}
+  end
+
+  def handle_event("reset_review_marks", _params, socket) do
+    {:noreply, socket |> assign(:review_overrides, %{}) |> assign_review_selection()}
   end
 
   # Runs the trash for one group instead of the whole library. The ids are

--- a/lib/mydia_web/live/admin_duplicates_live/index.html.heex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.html.heex
@@ -1,12 +1,21 @@
 <Layouts.app {assigns}>
   <.admin_page active_tab={@active_tab}>
-    <MydiaWeb.AdminDuplicatesLive.Components.duplicates_tab
-      decisions={@decisions}
-      refusals={@refusals}
-      selected={@selected}
-      reclaimable={@reclaimable}
-      retention_days={@retention_days}
-    />
+    <div class="p-4 sm:p-6 space-y-4">
+      <MydiaWeb.AdminDuplicatesLive.Components.duplicates_tab
+        decisions={@decisions}
+        refusals={@refusals}
+        selected={@selected}
+        reclaimable={@reclaimable}
+        retention_days={@retention_days}
+      />
+
+      <MydiaWeb.AdminDuplicatesLive.ReviewComponents.needs_attention
+        :if={@refusals != []}
+        refusals={@refusals}
+        suspects={@suspects}
+        returning={@returning}
+      />
+    </div>
 
     <%!-- Trash Confirmation Modal --%>
     <%= if @show_trash_modal do %>
@@ -18,6 +27,6 @@
       />
     <% end %>
 
-    <MydiaWeb.AdminDuplicatesLive.Components.undo_toast :if={@last_run} run={@last_run} />
+    <MydiaWeb.AdminDuplicatesLive.Components.run_toast :if={@last_run} run={@last_run} />
   </.admin_page>
 </Layouts.app>

--- a/lib/mydia_web/live/admin_duplicates_live/index.html.heex
+++ b/lib/mydia_web/live/admin_duplicates_live/index.html.heex
@@ -14,6 +14,7 @@
         refusals={@refusals}
         suspects={@suspects}
         returning={@returning}
+        overridden?={@review_overrides != %{}}
       />
     </div>
 
@@ -24,6 +25,14 @@
         items={@affected_items}
         bytes={@reclaimable}
         retention_days={@retention_days}
+      />
+    <% end %>
+
+    <%!-- Send to Review Confirmation Modal --%>
+    <%= if @show_review_modal do %>
+      <MydiaWeb.AdminDuplicatesLive.ReviewComponents.review_confirm_modal
+        count={MapSet.size(@returning)}
+        items={@returning_items}
       />
     <% end %>
 

--- a/lib/mydia_web/live/admin_duplicates_live/review_components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/review_components.ex
@@ -29,6 +29,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
   attr :refusals, :list, required: true
   attr :suspects, :map, required: true
   attr :returning, :any, required: true
+  attr :overridden?, :boolean, required: true
 
   def needs_attention(assigns) do
     ~H"""
@@ -37,6 +38,27 @@ defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
         <.icon name="hero-exclamation-triangle" class="w-5 h-5 opacity-60" /> Needs Attention
         <span class="badge badge-ghost">{length(@refusals)}</span>
       </h2>
+      <div class="join">
+        <button
+          :if={@overridden?}
+          id="duplicates-review-reset"
+          type="button"
+          class="btn btn-sm btn-ghost join-item"
+          phx-click="reset_review_marks"
+        >
+          <.icon name="hero-arrow-path" class="w-4 h-4" /> Mark flagged
+        </button>
+        <button
+          id="duplicates-review-selected"
+          type="button"
+          class="btn btn-sm btn-primary join-item"
+          disabled={MapSet.size(@returning) == 0}
+          phx-click="open_review_modal"
+        >
+          <.icon name="hero-arrow-uturn-left" class="w-4 h-4" />
+          Send {Components.file_count(MapSet.size(@returning))} to Review
+        </button>
+      </div>
     </div>
 
     <p class="text-sm text-base-content/60">
@@ -55,6 +77,60 @@ defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
         suspects={Map.get(@suspects, group.subject_id, MapSet.new())}
         returning={@returning}
       />
+    </div>
+    """
+  end
+
+  @doc """
+  Confirms a page-level send to Review.
+
+  The per-group button needs no confirmation, but this one detaches every
+  marked file across the whole section in one go, so the scope is worth a
+  click. Nothing is destroyed, which is why the copy talks about where the
+  files go rather than warning.
+  """
+  attr :count, :integer, required: true
+  attr :items, :integer, required: true
+
+  def review_confirm_modal(assigns) do
+    ~H"""
+    <div id="duplicates-review-modal" class="modal modal-open">
+      <div class="modal-box">
+        <div class="flex items-center gap-3 mb-5">
+          <div class="w-10 h-10 rounded-xl bg-primary/20 flex items-center justify-center">
+            <.icon name="hero-arrow-uturn-left" class="w-5 h-5 text-primary" />
+          </div>
+          <h3 class="font-bold text-lg">
+            Send {Components.file_count(@count)} from {Components.item_count(@items)} to Review?
+          </h3>
+        </div>
+
+        <p class="py-2">
+          They stay on disk and wait in Review until someone matches them. Nothing is
+          re-attached automatically.
+        </p>
+
+        <div class="modal-action mt-6 pt-4 border-t border-base-300">
+          <button
+            id="duplicates-review-cancel"
+            type="button"
+            class="btn btn-ghost"
+            phx-click="close_review_modal"
+          >
+            Cancel
+          </button>
+          <button
+            id="duplicates-review-confirm"
+            type="button"
+            class="btn btn-primary"
+            phx-click="confirm_review"
+            phx-disable-with="Sending..."
+          >
+            <.icon name="hero-arrow-uturn-left" class="w-4 h-4" /> Send to Review
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop bg-black/50" phx-click="close_review_modal"></div>
     </div>
     """
   end

--- a/lib/mydia_web/live/admin_duplicates_live/review_components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/review_components.ex
@@ -1,0 +1,234 @@
+defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
+  @moduledoc """
+  The Needs Attention section of the duplicates page. Used only by the sibling
+  LiveView.
+
+  Every group here was refused by `Mydia.Library.Prune.Eligibility`, which in
+  practice mostly means a file filed against the wrong item. The fix for that
+  is to send the stray file to Review, so each file row carries a Leave/Review
+  pair of radios, styled like the Keep/Trash pair in
+  `MydiaWeb.AdminDuplicatesLive.Components`. The LiveView decides which files
+  are bound for Review and hands the set down as `returning`; files
+  `Eligibility.suspect_files/1` names carry a "Doesn't match" badge.
+
+  `:duplicate_registration` groups get no controls. Both of their rows point at
+  one path, and the fix there is a rescan.
+
+  This module calls `Components` for the shared display helpers and never the
+  other way round, so the two do not depend on each other at compile time.
+  """
+
+  use MydiaWeb, :html
+
+  alias MydiaWeb.AdminDuplicatesLive.Components
+
+  @doc """
+  Renders the Needs Attention section: a header, an explanation, and one row
+  per refused group.
+  """
+  attr :refusals, :list, required: true
+  attr :suspects, :map, required: true
+  attr :returning, :any, required: true
+
+  def needs_attention(assigns) do
+    ~H"""
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 pt-2">
+      <h2 class="text-lg font-semibold flex items-center gap-2">
+        <.icon name="hero-exclamation-triangle" class="w-5 h-5 opacity-60" /> Needs Attention
+        <span class="badge badge-ghost">{length(@refusals)}</span>
+      </h2>
+    </div>
+
+    <p class="text-sm text-base-content/60">
+      These are matching or scanning problems rather than duplicates. Files whose names don't
+      match their item start on <span class="font-medium text-base-content">Review</span>.
+      Sending a file to Review detaches it from the item, leaves it on disk, and holds it
+      there until someone matches it. Every item always keeps at least one file.
+    </p>
+
+    <div class="bg-base-200 rounded-box divide-y divide-base-300">
+      <.refusal_row
+        :for={{group, reason, detail} <- @refusals}
+        group={group}
+        reason={reason}
+        detail={detail}
+        suspects={Map.get(@suspects, group.subject_id, MapSet.new())}
+        returning={@returning}
+      />
+    </div>
+    """
+  end
+
+  attr :group, :map, required: true
+  attr :reason, :atom, required: true
+  attr :detail, :map, required: true
+  attr :suspects, :any, required: true
+  attr :returning, :any, required: true
+
+  defp refusal_row(assigns) do
+    files = assigns.group.files
+    returning_count = Enum.count(files, &MapSet.member?(assigns.returning, &1.id))
+
+    assigns =
+      assigns
+      |> assign(:controls?, assigns.reason != :duplicate_registration)
+      |> assign(:returning_count, returning_count)
+      |> assign(:left_count, length(files) - returning_count)
+
+    ~H"""
+    <div class="p-3 sm:p-4" id={"duplicates-refusal-#{@group.subject_id}"}>
+      <div class="flex items-center gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="font-medium truncate">{Components.subject_label(@group)}</div>
+          <div class="text-xs opacity-60 truncate">
+            {Components.file_count(length(@group.files))}
+          </div>
+        </div>
+        <span class="badge badge-sm badge-outline badge-warning">{refusal_label(@reason)}</span>
+        <span
+          :if={@controls? and @returning_count > 0}
+          class="badge badge-sm badge-outline hidden sm:inline-flex"
+        >
+          {@returning_count} to Review
+        </span>
+        <button
+          :if={@controls?}
+          id={"duplicates-review-group-#{@group.subject_id}"}
+          type="button"
+          class="btn btn-sm"
+          disabled={@returning_count == 0}
+          aria-label={"Send the marked files in #{Components.subject_label(@group)} to Review"}
+          phx-click="send_group_to_review"
+          phx-value-subject={@group.subject_id}
+          phx-disable-with="Sending..."
+        >
+          <.icon name="hero-arrow-uturn-left" class="w-4 h-4" />
+          Send {Components.file_count(@returning_count)} to Review
+        </button>
+      </div>
+
+      <p class="text-sm text-base-content/60 mt-2">{refusal_explanation(@reason, @detail)}</p>
+
+      <%= if @controls? do %>
+        <div class="bg-base-100 rounded-box divide-y divide-base-300 mt-3">
+          <.review_file_row
+            :for={file <- @group.files}
+            file={file}
+            subject_id={@group.subject_id}
+            suspect?={MapSet.member?(@suspects, file.id)}
+            returning?={MapSet.member?(@returning, file.id)}
+            last_left?={@left_count == 1 and not MapSet.member?(@returning, file.id)}
+          />
+        </div>
+      <% else %>
+        <ul class="text-xs opacity-60 list-disc pl-5 mt-1">
+          <li :for={file <- @group.files}>{file.relative_path}</li>
+        </ul>
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :file, :map, required: true
+  attr :subject_id, :string, required: true
+  attr :suspect?, :boolean, required: true
+  attr :returning?, :boolean, required: true
+  attr :last_left?, :boolean, required: true
+
+  defp review_file_row(assigns) do
+    relative_path = assigns.file.relative_path || ""
+
+    assigns =
+      assigns
+      |> assign(:name, Path.basename(relative_path))
+      |> assign(:folder, Components.folder_of(relative_path))
+
+    ~H"""
+    <div class="flex items-center gap-3 px-3 py-2">
+      <div class="flex-1 min-w-0">
+        <div class={["truncate text-sm", @returning? && "opacity-60"]}>{@name}</div>
+        <div :if={@folder} class="truncate text-xs opacity-50">{@folder}</div>
+      </div>
+
+      <span
+        :if={@suspect?}
+        id={"duplicates-suspect-#{@file.id}"}
+        class="badge badge-sm badge-warning badge-outline shrink-0"
+      >
+        Doesn't match
+      </span>
+
+      <%!-- Same shape as the Keep/Trash radiogroup in Components.file_row/1,
+            and the same variable override recolours the checked Review option,
+            for the reason given there. --%>
+      <div
+        class="join shrink-0"
+        role="radiogroup"
+        aria-label={"What to do with #{@file.relative_path}"}
+      >
+        <input
+          type="radio"
+          class="join-item btn btn-xs"
+          id={"duplicates-leave-#{@file.id}"}
+          name={"review-#{@file.id}"}
+          aria-label="Leave"
+          checked={not @returning?}
+          phx-click="leave_file"
+          phx-value-subject={@subject_id}
+          phx-value-file={@file.id}
+        />
+        <input
+          type="radio"
+          class={[
+            "join-item btn btn-xs",
+            @returning? &&
+              "[--btn-color:var(--color-warning)] [--btn-fg:var(--color-warning-content)]"
+          ]}
+          id={"duplicates-review-#{@file.id}"}
+          name={"review-#{@file.id}"}
+          aria-label="Review"
+          checked={@returning?}
+          disabled={@last_left?}
+          phx-click="review_file"
+          phx-value-subject={@subject_id}
+          phx-value-file={@file.id}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  # Moved verbatim from Components, which no longer renders refusals.
+  defp refusal_label(:duplicate_registration), do: "Registered twice"
+  defp refusal_label(:unanalyzed), do: "Not analyzed"
+  defp refusal_label(:duration_mismatch), do: "Different lengths"
+  defp refusal_label(:name_mismatch), do: "Names disagree"
+  defp refusal_label(:episode_mismatch), do: "Wrong episode"
+  defp refusal_label(:nothing_to_prune), do: "Nothing to trash"
+
+  defp refusal_explanation(:duplicate_registration, detail) do
+    "One file on disk is registered twice (#{detail.path}). Trashing a copy would move the only real file. Rescan this library path instead."
+  end
+
+  defp refusal_explanation(:unanalyzed, detail) do
+    "#{detail.unanalyzed_count} file(s) have no duration, so they cannot be compared. Run analysis first."
+  end
+
+  defp refusal_explanation(:duration_mismatch, detail) do
+    "These files are #{percent(detail.spread)} apart in length, more than the #{percent(detail.tolerance)} allowed, so they are not the same content. This is usually bonus features or a file matched to the wrong item."
+  end
+
+  defp refusal_explanation(:name_mismatch, _detail) do
+    "At least one filename does not belong to this item. Fix the match before trashing anything."
+  end
+
+  defp refusal_explanation(:episode_mismatch, _detail) do
+    "At least one filename names a different episode than the one it is attached to."
+  end
+
+  defp refusal_explanation(:nothing_to_prune, _detail), do: "Only one file remains."
+
+  # Formats a fraction (0.093) as a percentage string ("9.3%") for the
+  # duration mismatch explanation.
+  defp percent(fraction), do: "#{Float.round(fraction * 100, 1)}%"
+end

--- a/lib/mydia_web/live/admin_duplicates_live/review_components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/review_components.ex
@@ -214,10 +214,14 @@ defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
   defp review_file_row(assigns) do
     relative_path = assigns.file.relative_path || ""
 
+    path_label =
+      if relative_path != "", do: relative_path, else: "file #{assigns.file.id}"
+
     assigns =
       assigns
       |> assign(:name, Path.basename(relative_path))
       |> assign(:folder, Components.folder_of(relative_path))
+      |> assign(:path_label, path_label)
 
     ~H"""
     <div class="flex items-center gap-3 px-3 py-2">
@@ -240,7 +244,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
       <div
         class="join shrink-0"
         role="radiogroup"
-        aria-label={"What to do with #{@file.relative_path}"}
+        aria-label={"What to do with #{@path_label}"}
       >
         <input
           type="radio"

--- a/lib/mydia_web/live/admin_duplicates_live/review_components.ex
+++ b/lib/mydia_web/live/admin_duplicates_live/review_components.ex
@@ -38,12 +38,12 @@ defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
         <.icon name="hero-exclamation-triangle" class="w-5 h-5 opacity-60" /> Needs Attention
         <span class="badge badge-ghost">{length(@refusals)}</span>
       </h2>
-      <div class="join">
+      <div class="flex items-center gap-2">
         <button
           :if={@overridden?}
           id="duplicates-review-reset"
           type="button"
-          class="btn btn-sm btn-ghost join-item"
+          class="btn btn-sm btn-ghost"
           phx-click="reset_review_marks"
         >
           <.icon name="hero-arrow-path" class="w-4 h-4" /> Mark flagged
@@ -51,7 +51,7 @@ defmodule MydiaWeb.AdminDuplicatesLive.ReviewComponents do
         <button
           id="duplicates-review-selected"
           type="button"
-          class="btn btn-sm btn-primary join-item"
+          class="btn btn-sm btn-primary"
           disabled={MapSet.size(@returning) == 0}
           phx-click="open_review_modal"
         >

--- a/lib/mydia_web/live/import_media_live/components.ex
+++ b/lib/mydia_web/live/import_media_live/components.ex
@@ -333,6 +333,14 @@ defmodule MydiaWeb.ImportMediaLive.Components do
         <span class={["badge badge-sm shrink-0 font-medium", band_class(@band)]}>
           {band_label(@band)}
         </span>
+        <span
+          :if={Map.get(@group, :returned_count, 0) > 0}
+          id={"group-returned-#{@dom_key}"}
+          class="badge badge-sm badge-info badge-outline shrink-0"
+          title="Sent back from the duplicates page. Never imported automatically."
+        >
+          Returned
+        </span>
         <span :if={@group.queued?} class="badge badge-sm badge-info gap-1 shrink-0">
           <.icon name="hero-arrow-path" class="w-3 h-3 animate-spin" /> Queued
         </span>

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -543,7 +543,11 @@ defmodule MydiaWeb.MediaLive.Show.Components do
           The strip below is `flex-shrink-0` at 136px. Against a 245px row on a
           375px phone that left the filename 69px, which rendered 8 characters
           of a 92-character name and wrapped the badge line underneath onto
-          four lines. --%>
+          four lines.
+
+          With every action present the strip is six 40px squares, 260px, which is
+          wider than that same 245px row, so it wraps rather than overflowing to the
+          left; justify-end keeps the wrapped button on the right. --%>
     <div
       id={"episode-file-row-#{@file.id}"}
       class="flex flex-col gap-3 py-1 @md/eprow:flex-row @md/eprow:items-start @md/eprow:justify-between @md/eprow:gap-4"
@@ -585,7 +589,7 @@ defmodule MydiaWeb.MediaLive.Show.Components do
         />
       </div>
       <%!-- File actions --%>
-      <div class="flex items-center justify-end gap-1 flex-shrink-0">
+      <div class="flex flex-wrap items-center justify-end gap-1 flex-shrink-0">
         <button
           id={"subtitle-open-#{@file.id}"}
           type="button"

--- a/lib/mydia_web/live/media_live/show/components.ex
+++ b/lib/mydia_web/live/media_live/show/components.ex
@@ -649,6 +649,20 @@ defmodule MydiaWeb.MediaLive.Show.Components do
         >
           <.icon name="hero-star" class="w-4 h-4" />
         </button>
+        <%!-- Recovery for a file the matcher attached to the wrong episode,
+              whether it belongs to another show or to another episode of this
+              one. Same handler as the movie row's "Not this movie". --%>
+        <button
+          id={"not-this-item-#{@file.id}"}
+          type="button"
+          phx-click="not_this_item"
+          phx-value-file-id={@file.id}
+          class="btn btn-ghost btn-square @md/eprow:btn-xs"
+          aria-label="This file is not this episode"
+          title="Not this episode"
+        >
+          <.icon name="hero-arrow-uturn-left" class="w-4 h-4" />
+        </button>
         <button
           id={"file-delete-#{@file.id}"}
           type="button"

--- a/lib/mydia_web/live/media_live/show/file_events.ex
+++ b/lib/mydia_web/live/media_live/show/file_events.ex
@@ -397,24 +397,24 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
   Detaches a file the matcher filed against the wrong item and sends it back to
   the review inbox.
 
-  The row goes, the bytes stay. An import candidate is created at the file's
-  current path so `/review` can match it against the right item with the search
-  and rematch controls it already has, rather than duplicating an item picker
-  here.
+  The row goes, the bytes stay. `Mydia.ImportCandidates.return_to_review/2`
+  writes an import candidate at the file's current path and holds it for a
+  person, so `/review` can match it against the right item with the search and
+  rematch controls it already has, rather than duplicating an item picker here.
+  Movie rows and episode rows both use this handler.
   """
   def not_this_item(%{"file-id" => file_id}, socket) do
     # The id arrives on the event payload, so ownership is checked against the
     # files already on screen before anything is fetched or written. Without
     # this, any authenticated user allowed to delete media could detach a file
-    # belonging to a different item, and `detach_to_review/3` would then stamp
-    # this item's type onto that file's review candidate and event metadata.
+    # belonging to an item they are not looking at.
     with :ok <- Authorization.authorize_delete_media(socket),
          true <- owns_media_file?(socket.assigns.media_item, file_id) do
-      file = Library.get_media_file!(file_id) |> Mydia.Repo.preload(:library_path)
+      file = Library.get_media_file!(file_id)
       media_item = socket.assigns.media_item
       actor_id = to_string(socket.assigns.current_user.id)
 
-      case detach_to_review(file, media_item, actor_id) do
+      case Mydia.ImportCandidates.return_to_review(file, actor_id) do
         {:ok, _deleted} ->
           {:noreply,
            socket
@@ -444,59 +444,6 @@ defmodule MydiaWeb.MediaLive.Show.FileEvents do
         {:noreply, put_flash(socket, :error, "Could not send this file to Review")}
     end
   end
-
-  # A legacy row carrying only `path` has no `(library_path_id, relative_path)`
-  # pair, and import candidates are keyed by exactly that, so there is nowhere
-  # for it to go.
-  defp detach_to_review(
-         %{library_path: %{} = library_path, relative_path: relative_path} = file,
-         media_item,
-         actor_id
-       )
-       when is_binary(relative_path) do
-    absolute_path = Path.join(library_path.path, relative_path)
-    anchor = Mydia.Library.PathAnchor.anchor_for(absolute_path, library_path.path)
-
-    attrs = %{
-      library_path_id: library_path.id,
-      relative_path: relative_path,
-      anchor_key: anchor.cluster_key,
-      size: file.size,
-      # Mirrors LibraryScanner.discovered_candidate_attrs/4: without a type
-      # hint, ImportCandidate.parsed_info/1 defaults a nil media_type to
-      # :movie, so a returned TV episode would land in a mixed-type library's
-      # match search flagged as a movie. media_item.type is already the
-      # "movie" / "tv_show" string this column expects.
-      media_type: media_item.type,
-      discovered_at: DateTime.utc_now() |> DateTime.truncate(:second)
-    }
-
-    # Both writes -- the candidate appearing, the media_files row disappearing
-    # -- must succeed or fail together. Two independent Repo calls here would
-    # let a hard interruption (a killed process, a dropped connection) between
-    # them leave the file both still attached to the wrong item and
-    # duplicated into import_candidates.
-    #
-    # The activity event is recorded inside this same transaction on purpose,
-    # matching Media.update_media_items_monitored/2 and
-    # Media.apply_episode_monitoring/2: Mydia.Repo.transaction/2 defers the
-    # event's PubSub broadcast until the outermost transaction call actually
-    # commits, and discards it on rollback (see that module's moduledoc), so
-    # the feed never reports something that did not happen, and there is no
-    # need to thread the file/media_item back out to broadcast after the
-    # fact.
-    Mydia.Repo.transaction(fn ->
-      with {:ok, _candidate} <- Mydia.ImportCandidates.upsert(attrs),
-           {:ok, deleted} <- Library.delete_media_file(file, delete_files: false) do
-        Mydia.Events.file_returned_to_review(deleted, media_item, actor_id)
-        deleted
-      else
-        {:error, reason} -> Mydia.Repo.rollback(reason)
-      end
-    end)
-  end
-
-  defp detach_to_review(_file, _media_item, _actor_id), do: {:error, :no_library_path}
 
   def show_file_details(%{"file-id" => file_id}, socket) do
     # Without the preload, MediaFile.absolute_path/1 hits its

--- a/priv/repo/migrations/20260910183841_add_returned_at_to_import_candidates.exs
+++ b/priv/repo/migrations/20260910183841_add_returned_at_to_import_candidates.exs
@@ -1,0 +1,12 @@
+defmodule Mydia.Repo.Migrations.AddReturnedAtToImportCandidates do
+  use Ecto.Migration
+
+  # Set by Mydia.ImportCandidates.return_to_review/2 when an operator detaches
+  # a misattached file. Nullable with no default, so adding it needs no table
+  # rebuild on SQLite.
+  def change do
+    alter table(:import_candidates) do
+      add :returned_at, :utc_datetime
+    end
+  end
+end

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -125,6 +125,11 @@ defmodule Mydia.ImportCandidatesTest do
       g = group(provider_id: "local-abc", provider_type: "local", min_confidence: 1.0)
       assert ImportCandidates.band(g) == :needs_attention
     end
+
+    test "a group holding a returned candidate is never ready" do
+      g = group(provider_id: "1", min_confidence: 1.0, returned_count: 1)
+      assert ImportCandidates.band(g) == :needs_attention
+    end
   end
 
   describe "group disagreement" do
@@ -1035,6 +1040,52 @@ defmodule Mydia.ImportCandidatesTest do
 
       assert Repo.get(MediaFile, file.id)
       assert Repo.aggregate(ImportCandidate, :count) == 0
+    end
+  end
+
+  describe "a group holding a returned candidate" do
+    setup do
+      lp = library_path_fixture(%{type: "series"})
+
+      returned =
+        import_candidate_fixture(%{
+          library_path_id: lp.id,
+          relative_path: "Quillmoor/s01e01.mkv",
+          provider_type: "tvdb",
+          provider_id: "9002",
+          title: "Quillmoor",
+          media_type: "tv_show",
+          confidence: 0.99,
+          returned_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+
+      %{lp: lp, returned: returned}
+    end
+
+    test "is never ready, in band/1 and in the SQL bands alike", %{lp: lp, returned: returned} do
+      assert {[group], nil} = ImportCandidates.page(lp.id)
+      assert group.returned_count == 1
+      assert ImportCandidates.band(group) == :needs_attention
+
+      assert %{ready: 0, needs_attention: 1, no_match: 0, total: 1} =
+               ImportCandidates.band_counts(lp.id)
+
+      assert {[], nil} = ImportCandidates.page(lp.id, band: :ready)
+
+      {attention, _cursor} = ImportCandidates.page(lp.id, band: :needs_attention)
+      assert Enum.map(attention, & &1.anchor_key) == [returned.anchor_key]
+    end
+
+    test "is skipped by Import all results", %{lp: lp, returned: returned} do
+      assert {:ok, %{queued: 0, skipped: 1}} = ImportCandidates.queue_accept_all_matched(lp.id)
+      assert is_nil(Repo.get!(ImportCandidate, returned.id).queued_op)
+    end
+
+    test "is still accepted from an explicit selection", %{lp: lp, returned: returned} do
+      scope = lp.id |> SelectionScope.new() |> SelectionScope.select_page([returned.anchor_key])
+
+      assert {:ok, %{queued: 1}} = ImportCandidates.queue_accept(scope)
+      assert Repo.get!(ImportCandidate, returned.id).queued_op == "accept"
     end
   end
 end

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -1040,6 +1040,7 @@ defmodule Mydia.ImportCandidatesTest do
 
       assert Repo.get(MediaFile, file.id)
       assert Repo.aggregate(ImportCandidate, :count) == 0
+      refute_enqueued(worker: Mydia.Jobs.RematchImportCandidates)
     end
   end
 

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -1,5 +1,6 @@
 defmodule Mydia.ImportCandidatesTest do
   use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
 
   import Ecto.Query
   import Mydia.MediaFixtures
@@ -928,6 +929,112 @@ defmodule Mydia.ImportCandidatesTest do
 
       assert is_nil(Mydia.Repo.get!(Mydia.Library.ImportCandidate, queued.id).dismissed_at)
       refute is_nil(Mydia.Repo.get!(Mydia.Library.ImportCandidate, newcomer.id).dismissed_at)
+    end
+  end
+
+  describe "return_to_review/2" do
+    test "detaches a movie file into a held, rematch-queued movie candidate" do
+      lp = library_path_fixture(%{type: "movies"})
+      movie = media_item_fixture(%{type: "movie", title: "Zephyr Station", year: 2030})
+
+      file =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: "Starveil (2031)/Starveil.2031.1080p.mkv"
+        })
+
+      assert {:ok, %MediaFile{id: id}} = ImportCandidates.return_to_review(file, "42")
+      assert id == file.id
+      refute Repo.get(MediaFile, file.id)
+
+      candidate = ImportCandidates.get_by_path(lp.id, "Starveil (2031)/Starveil.2031.1080p.mkv")
+      assert candidate.media_type == "movie"
+      assert %DateTime{} = candidate.returned_at
+      assert candidate.queued_op == "rematch"
+      assert is_nil(candidate.dismissed_at)
+
+      assert_enqueued(
+        worker: Mydia.Jobs.RematchImportCandidates,
+        args: %{"library_path_id" => lp.id}
+      )
+    end
+
+    test "detaches an episode file into a tv_show candidate and leaves the episode's other file" do
+      lp = library_path_fixture(%{type: "series"})
+      show = media_item_fixture(%{type: "tv_show", title: "Harbor Lights", year: 2013})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+      kept =
+        media_file_fixture(%{
+          episode_id: episode.id,
+          library_path_id: lp.id,
+          relative_path: "Harbor Lights/Season 01/Harbor.Lights.S01E01.mkv"
+        })
+
+      stray =
+        media_file_fixture(%{
+          episode_id: episode.id,
+          library_path_id: lp.id,
+          relative_path: "Quillmoor/Season 01/Quillmoor.S01E01.mkv"
+        })
+
+      assert {:ok, _deleted} = ImportCandidates.return_to_review(stray, "42")
+
+      assert Repo.get(MediaFile, kept.id)
+      refute Repo.get(MediaFile, stray.id)
+
+      assert %{media_type: "tv_show"} =
+               ImportCandidates.get_by_path(lp.id, "Quillmoor/Season 01/Quillmoor.S01E01.mkv")
+    end
+
+    test "un-dismisses a candidate already sitting at the file's path" do
+      lp = library_path_fixture(%{type: "movies"})
+      movie = media_item_fixture(%{type: "movie", title: "Zephyr Station", year: 2030})
+      path = "Starveil (2031)/Starveil.2031.1080p.mkv"
+
+      import_candidate_fixture(%{
+        library_path_id: lp.id,
+        relative_path: path,
+        dismissed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+      file =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: path
+        })
+
+      assert {:ok, _deleted} = ImportCandidates.return_to_review(file, "42")
+
+      candidate = ImportCandidates.get_by_path(lp.id, path)
+      assert is_nil(candidate.dismissed_at)
+      assert %DateTime{} = candidate.returned_at
+    end
+
+    test "refuses a legacy row with no library path and writes nothing" do
+      lp = library_path_fixture(%{type: "movies"})
+      movie = media_item_fixture(%{type: "movie", title: "Zephyr Station", year: 2030})
+
+      file =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: "Zephyr Station (2030)/Zephyr.Station.2030.mkv"
+        })
+
+      # MediaFile.changeset/2 requires both fields, so the legacy shape is only
+      # reachable by bypassing it, as eligibility_test.exs does.
+      Repo.update_all(from(f in MediaFile, where: f.id == ^file.id),
+        set: [library_path_id: nil, relative_path: nil]
+      )
+
+      assert {:error, :no_library_path} =
+               ImportCandidates.return_to_review(Repo.reload!(file), "42")
+
+      assert Repo.get(MediaFile, file.id)
+      assert Repo.aggregate(ImportCandidate, :count) == 0
     end
   end
 end

--- a/test/mydia/import_candidates_test.exs
+++ b/test/mydia/import_candidates_test.exs
@@ -73,6 +73,21 @@ defmodule Mydia.ImportCandidatesTest do
     assert {[], nil} = ImportCandidates.page(candidate.library_path_id)
   end
 
+  test "returned_at survives a fresh import upsert" do
+    returned_at = DateTime.utc_now() |> DateTime.truncate(:second)
+    candidate = import_candidate_fixture(%{returned_at: returned_at})
+
+    # Discovery never carries returned_at, so a rescan's upsert must leave it
+    # alone, the same way it leaves dismissed_at alone.
+    assert {:ok, _} =
+             ImportCandidates.upsert(
+               Map.from_struct(candidate)
+               |> Map.take([:library_path_id, :relative_path, :anchor_key, :size, :discovered_at])
+             )
+
+    assert Repo.reload!(candidate).returned_at == returned_at
+  end
+
   describe "band/1" do
     defp group(attrs) do
       Map.merge(

--- a/test/mydia/jobs/import_run_unattended_test.exs
+++ b/test/mydia/jobs/import_run_unattended_test.exs
@@ -159,4 +159,21 @@ defmodule Mydia.Jobs.ImportRunUnattendedTest do
       assert ImportCandidates.count_outstanding(lp.id) == 0
     end
   end
+
+  describe "a candidate an operator returned to review" do
+    test "is matched but never promoted by an unattended run" do
+      {lp, run} = library_with("movies", ["#{MetadataStubProvider.movie_title()} (1999).mkv"])
+
+      [candidate] = Repo.all(from c in ImportCandidate, where: c.library_path_id == ^lp.id)
+
+      candidate
+      |> Ecto.Changeset.change(returned_at: DateTime.utc_now() |> DateTime.truncate(:second))
+      |> Repo.update!()
+
+      assert :ok = match_within(run)
+
+      assert Library.list_media_files(library_path_id: lp.id) == []
+      assert Repo.reload!(candidate).provider_id
+    end
+  end
 end

--- a/test/mydia/library/file_ingest_test.exs
+++ b/test/mydia/library/file_ingest_test.exs
@@ -63,6 +63,25 @@ defmodule Mydia.Library.FileIngestTest do
     refute Repo.exists?(MediaFile)
   end
 
+  test "unattended mode keeps a returned candidate in review at full confidence" do
+    # An operator sent this file back from an item it was filed under by
+    # mistake. A confident match can name that same item again, so it waits
+    # for a person.
+    candidate =
+      candidate()
+      |> Ecto.Changeset.change(returned_at: DateTime.utc_now() |> DateTime.truncate(:second))
+      |> Repo.update!()
+
+    movie = media_item_fixture(%{type: "movie", tmdb_id: 60_311})
+
+    assert {:candidate, %ImportCandidate{id: id, provider_id: provider_id}} =
+             FileIngest.ingest(candidate, match(movie, 1.0), policy: :unattended)
+
+    assert id == candidate.id
+    assert provider_id == Integer.to_string(movie.tmdb_id)
+    refute Repo.exists?(MediaFile)
+  end
+
   test "a nil match records retry backoff on the same candidate" do
     candidate = candidate()
 

--- a/test/mydia/library/prune/eligibility_test.exs
+++ b/test/mydia/library/prune/eligibility_test.exs
@@ -31,6 +31,55 @@ defmodule Mydia.Library.Prune.EligibilityTest do
 
   defp duration(seconds), do: %{"container" => "mkv", "duration" => seconds}
 
+  # A movie group attached to an invented title, so a test controls which
+  # filenames bind to it.
+  defp zephyr_group(file_specs) do
+    movie = media_item_fixture(%{type: "movie", title: "Zephyr Station", year: 2030})
+    lp = library_path_fixture(%{type: "movies"})
+
+    files =
+      Enum.map(file_specs, fn attrs ->
+        attrs
+        |> Map.merge(%{media_item_id: movie.id, library_path_id: lp.id})
+        |> media_file_fixture()
+      end)
+
+    %Group{
+      subject_type: :movie,
+      subject_id: movie.id,
+      subject: movie,
+      media_item: Mydia.Repo.preload(movie, :episodes),
+      files: Mydia.Repo.preload(files, :library_path)
+    }
+  end
+
+  defp harbor_episode_group(paths) do
+    show = media_item_fixture(%{type: "tv_show", title: "Harbor Lights", year: 2013})
+    episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+    lp = library_path_fixture(%{type: "series"})
+
+    files =
+      for path <- paths do
+        media_file_fixture(%{
+          episode_id: episode.id,
+          library_path_id: lp.id,
+          relative_path: path,
+          metadata: %{"container" => "mkv", "duration" => 3000.0}
+        })
+      end
+
+    %Group{
+      subject_type: :episode,
+      subject_id: episode.id,
+      subject: episode,
+      media_item: Mydia.Repo.preload(show, :episodes),
+      files: Mydia.Repo.preload(files, :library_path)
+    }
+  end
+
+  defp suspect_paths(group),
+    do: group |> Eligibility.suspect_files() |> Enum.map(& &1.relative_path) |> Enum.sort()
+
   # Builds a group with two rows sharing the same (library_path_id,
   # relative_path) key. Two ACTIVE rows genuinely at the same library path
   # and relative path are no longer reachable: migration
@@ -280,6 +329,94 @@ defmodule Mydia.Library.Prune.EligibilityTest do
       }
 
       assert {:ok, ^group} = Eligibility.check(group)
+    end
+  end
+
+  describe "suspect_files/1" do
+    test "flags the file from another title's folder in a duration-mismatch group" do
+      group =
+        zephyr_group([
+          %{
+            relative_path: "Zephyr Station (2030)/Zephyr.Station.2030.1080p.mkv",
+            metadata: duration(6000.0)
+          },
+          %{relative_path: "Starveil (2031)/Starveil.2031.1080p.mkv", metadata: duration(7000.0)}
+        ])
+
+      # The gate stops at duration and never reaches the name check, which is
+      # why the page needs this separate signal.
+      assert {:refused, :duration_mismatch, _} = Eligibility.check(group)
+      assert suspect_paths(group) == ["Starveil (2031)/Starveil.2031.1080p.mkv"]
+    end
+
+    test "does not flag bonus content in the feature's own folder" do
+      group =
+        zephyr_group([
+          %{
+            relative_path: "Zephyr Station (2030)/Zephyr.Station.2030.1080p.mkv",
+            metadata: duration(6000.0)
+          },
+          %{
+            relative_path: "Zephyr Station (2030)/Orientation Week.mkv",
+            metadata: duration(280.0)
+          }
+        ])
+
+      assert suspect_paths(group) == []
+    end
+
+    test "never flags a classified extra, whatever folder it sits in" do
+      group =
+        zephyr_group([
+          %{
+            relative_path: "Zephyr Station (2030)/Zephyr.Station.2030.1080p.mkv",
+            metadata: duration(6000.0)
+          },
+          %{
+            relative_path: "Zephyr Station (2030)/Featurettes/Behind the Scenes.mkv",
+            metadata: duration(600.0),
+            extra_kind: :other,
+            extra_source: :operator
+          }
+        ])
+
+      assert suspect_paths(group) == []
+    end
+
+    test "flags every unbound file when none binds" do
+      group =
+        zephyr_group([
+          %{relative_path: "Starveil (2031)/Starveil.2031.1080p.mkv", metadata: duration(7000.0)},
+          %{
+            relative_path: "Emberline (2029)/Emberline.2029.1080p.mkv",
+            metadata: duration(5000.0)
+          }
+        ])
+
+      assert suspect_paths(group) == [
+               "Emberline (2029)/Emberline.2029.1080p.mkv",
+               "Starveil (2031)/Starveil.2031.1080p.mkv"
+             ]
+    end
+
+    test "flags another show's file in an episode group" do
+      group =
+        harbor_episode_group([
+          "Harbor Lights/Season 01/Harbor.Lights.S01E01.mkv",
+          "Quillmoor/Season 01/Quillmoor.S01E01.mkv"
+        ])
+
+      assert suspect_paths(group) == ["Quillmoor/Season 01/Quillmoor.S01E01.mkv"]
+    end
+
+    test "flags the wrong-episode file even in the show's own folder" do
+      group =
+        harbor_episode_group([
+          "Harbor Lights/Season 01/Harbor.Lights.S01E01.mkv",
+          "Harbor Lights/Season 01/Harbor.Lights.S01E02.mkv"
+        ])
+
+      assert suspect_paths(group) == ["Harbor Lights/Season 01/Harbor.Lights.S01E02.mkv"]
     end
   end
 end

--- a/test/mydia/library/prune/eligibility_test.exs
+++ b/test/mydia/library/prune/eligibility_test.exs
@@ -5,6 +5,8 @@ defmodule Mydia.Library.Prune.EligibilityTest do
   import Mydia.SettingsFixtures
 
   alias Mydia.Library.Prune.{Eligibility, Group}
+  alias Mydia.Library.ReleaseParser
+  alias Mydia.Library.ReleaseParser.TargetContext
 
   # Builds a movie group whose files differ only in the attrs given.
   defp movie_group(file_attrs) do
@@ -79,6 +81,18 @@ defmodule Mydia.Library.Prune.EligibilityTest do
 
   defp suspect_paths(group),
     do: group |> Eligibility.suspect_files() |> Enum.map(& &1.relative_path) |> Enum.sort()
+
+  # A precondition for the "does not flag..." tests below: if the given
+  # relative_path actually binds to the group's item, the test proves nothing
+  # because the folder rule (or the extras exclusion) is never reached.
+  defp assert_name_unbound!(group, relative_path) do
+    target = TargetContext.from_media_item(group.media_item)
+    flags = ReleaseParser.parse_with_path(relative_path, target: target).engine_flags || %{}
+
+    assert flags[:binding_suspect],
+           "precondition: #{relative_path} must not bind to #{group.media_item.title}, " <>
+             "or this test proves nothing"
+  end
 
   # Builds a group with two rows sharing the same (library_path_id,
   # relative_path) key. Two ACTIVE rows genuinely at the same library path
@@ -350,22 +364,24 @@ defmodule Mydia.Library.Prune.EligibilityTest do
     end
 
     test "does not flag bonus content in the feature's own folder" do
+      bonus_path = "Zephyr Station (2030)/Gag Reel.mkv"
+
       group =
         zephyr_group([
           %{
             relative_path: "Zephyr Station (2030)/Zephyr.Station.2030.1080p.mkv",
             metadata: duration(6000.0)
           },
-          %{
-            relative_path: "Zephyr Station (2030)/Orientation Week.mkv",
-            metadata: duration(280.0)
-          }
+          %{relative_path: bonus_path, metadata: duration(280.0)}
         ])
 
+      assert_name_unbound!(group, bonus_path)
       assert suspect_paths(group) == []
     end
 
     test "never flags a classified extra, whatever folder it sits in" do
+      extra_path = "Zephyr Station (2030)/Featurettes/Outtakes.mkv"
+
       group =
         zephyr_group([
           %{
@@ -373,13 +389,14 @@ defmodule Mydia.Library.Prune.EligibilityTest do
             metadata: duration(6000.0)
           },
           %{
-            relative_path: "Zephyr Station (2030)/Featurettes/Behind the Scenes.mkv",
+            relative_path: extra_path,
             metadata: duration(600.0),
             extra_kind: :other,
             extra_source: :operator
           }
         ])
 
+      assert_name_unbound!(group, extra_path)
       assert suspect_paths(group) == []
     end
 
@@ -388,13 +405,13 @@ defmodule Mydia.Library.Prune.EligibilityTest do
         zephyr_group([
           %{relative_path: "Starveil (2031)/Starveil.2031.1080p.mkv", metadata: duration(7000.0)},
           %{
-            relative_path: "Emberline (2029)/Emberline.2029.1080p.mkv",
+            relative_path: "Quillmoor (2029)/Quillmoor.2029.1080p.mkv",
             metadata: duration(5000.0)
           }
         ])
 
       assert suspect_paths(group) == [
-               "Emberline (2029)/Emberline.2029.1080p.mkv",
+               "Quillmoor (2029)/Quillmoor.2029.1080p.mkv",
                "Starveil (2031)/Starveil.2031.1080p.mkv"
              ]
     end

--- a/test/mydia/library/prune_test.exs
+++ b/test/mydia/library/prune_test.exs
@@ -1,5 +1,6 @@
 defmodule Mydia.Library.PruneTest do
   use Mydia.DataCase, async: true
+  use Oban.Testing, repo: Mydia.Repo
 
   import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
@@ -40,6 +41,35 @@ defmodule Mydia.Library.PruneTest do
 
     {episode, files}
   end
+
+  # A movie holding its own file plus one from another title's folder, with
+  # lengths far enough apart that Eligibility refuses the group.
+  defp misfiled_movie do
+    movie = media_item_fixture(%{type: "movie", title: "Zephyr Station", year: 2030})
+    lp = library_path_fixture(%{type: "movies"})
+
+    [own, stray] =
+      for {path, seconds} <- [
+            {"Zephyr Station (2030)/Zephyr.Station.2030.1080p.mkv", 6000.0},
+            {"Starveil (2031)/Starveil.2031.1080p.mkv", 7000.0}
+          ] do
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: path,
+          metadata: %{"container" => "mkv", "duration" => seconds}
+        })
+      end
+
+    {movie, own, stray}
+  end
+
+  @same_episode_twice [
+    {"Harbor Lights/Season 02/Harbor.Lights.S02E03.1080p.BluRay.x265.mp4",
+     %{resolution: "1080p", codec: "hevc", bitrate: 2_002_656}},
+    {"Harbor Lights/Season 02/Harbor.Lights.S02E03.360p.WEBRip.x264.mp4",
+     %{resolution: "360p", codec: "h264", bitrate: 1_000_000}}
+  ]
 
   describe "plan/0" do
     test "separates prunable decisions from refusals" do
@@ -347,6 +377,84 @@ defmodule Mydia.Library.PruneTest do
 
       assert event_a.metadata["restored"] == [loser_a.relative_path]
       assert event_b.metadata["restored"] == [loser_b.relative_path]
+    end
+  end
+
+  describe "plan/1 suspects" do
+    test "names the stray file of a refused group" do
+      {movie, _own, stray} = misfiled_movie()
+
+      assert %{suspects: suspects} = Prune.plan()
+      assert suspects[movie.id] == MapSet.new([stray.id])
+    end
+
+    test "leaves eligible groups out" do
+      {episode, _files} = episode_with(@same_episode_twice, 1320.0)
+
+      assert %{suspects: suspects} = Prune.plan()
+      refute Map.has_key?(suspects, episode.id)
+    end
+  end
+
+  describe "send_to_review/2" do
+    test "sends the requested file to Review and leaves the rest attached" do
+      {_movie, own, stray} = misfiled_movie()
+
+      assert %{returned: [%MediaFile{id: id}], failed: [], aborted: []} =
+               Prune.send_to_review([stray.id], "42")
+
+      assert id == stray.id
+      refute Mydia.Repo.get(MediaFile, stray.id)
+      assert Mydia.Repo.get(MediaFile, own.id)
+      assert_enqueued(worker: Mydia.Jobs.RematchImportCandidates)
+    end
+
+    test "refuses to send every file of a group" do
+      {_movie, own, stray} = misfiled_movie()
+
+      assert %{returned: [], failed: [], aborted: aborted} =
+               Prune.send_to_review([own.id, stray.id], "42")
+
+      assert Enum.sort(aborted) ==
+               Enum.sort([{own.id, :would_leave_no_file}, {stray.id, :would_leave_no_file}])
+
+      assert Mydia.Repo.get(MediaFile, own.id)
+      assert Mydia.Repo.get(MediaFile, stray.id)
+    end
+
+    test "refuses a file that is not in a refused group" do
+      {_episode, [file | _]} = episode_with(@same_episode_twice, 1320.0)
+
+      assert %{returned: [], aborted: [{id, :not_in_any_group}]} =
+               Prune.send_to_review([file.id], "42")
+
+      assert id == file.id
+      assert Mydia.Repo.get(MediaFile, file.id)
+    end
+
+    test "reports a file it could not send and still sends the others" do
+      {movie, _own, stray} = misfiled_movie()
+      lp = library_path_fixture(%{type: "movies"})
+
+      legacy =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: "Legacy/legacy.mkv",
+          metadata: %{"container" => "mkv", "duration" => 9000.0}
+        })
+
+      # The legacy shape (no library path, no relative path) is only reachable
+      # by bypassing MediaFile.changeset/2.
+      Mydia.Repo.update_all(from(f in MediaFile, where: f.id == ^legacy.id),
+        set: [library_path_id: nil, relative_path: nil]
+      )
+
+      assert %{returned: [%MediaFile{id: returned_id}], failed: [{failed_id, :no_library_path}]} =
+               Prune.send_to_review([stray.id, legacy.id], "42")
+
+      assert returned_id == stray.id
+      assert failed_id == legacy.id
     end
   end
 end

--- a/test/mydia_web/live/admin_duplicates_live_test.exs
+++ b/test/mydia_web/live/admin_duplicates_live_test.exs
@@ -707,5 +707,60 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
       assert has_element?(view, "#duplicates-undo-toast")
       assert render(view) =~ "2 items"
     end
+
+    test "the page-level send confirms first, then detaches every marked file", %{conn: conn} do
+      {_movie_a, own_a, stray_a} = misfiled_movie("Zephyr Station", "Starveil")
+      {_movie_b, own_b, stray_b} = misfiled_movie("Emberline", "Quillmoor")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-review-selected") |> render_click()
+      assert has_element?(view, "#duplicates-review-modal")
+
+      view |> element("#duplicates-review-confirm") |> render_click()
+
+      refute has_element?(view, "#duplicates-review-modal")
+      refute Mydia.Repo.get(Mydia.Library.MediaFile, stray_a.id)
+      refute Mydia.Repo.get(Mydia.Library.MediaFile, stray_b.id)
+      assert Mydia.Repo.get(Mydia.Library.MediaFile, own_a.id)
+      assert Mydia.Repo.get(Mydia.Library.MediaFile, own_b.id)
+      assert has_element?(view, "#duplicates-open-review")
+    end
+
+    test "Cancel closes the confirm modal and sends nothing", %{conn: conn} do
+      {_movie, _own, stray} = misfiled_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-review-selected") |> render_click()
+      view |> element("#duplicates-review-cancel") |> render_click()
+
+      refute has_element?(view, "#duplicates-review-modal")
+      assert Mydia.Repo.get(Mydia.Library.MediaFile, stray.id)
+    end
+
+    test "the page-level send is disabled when nothing is marked", %{conn: conn} do
+      _movie = refused_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      assert has_element?(view, "#duplicates-review-selected[disabled]")
+    end
+
+    test "Mark flagged puts the operator's changes back to the defaults", %{conn: conn} do
+      {_movie, _own, stray} = misfiled_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      refute has_element?(view, "#duplicates-review-reset")
+
+      view |> element("#duplicates-leave-#{stray.id}") |> render_click()
+      assert has_element?(view, "#duplicates-review-reset")
+
+      view |> element("#duplicates-review-reset") |> render_click()
+
+      assert has_element?(view, "#duplicates-review-#{stray.id}[checked]")
+      refute has_element?(view, "#duplicates-review-reset")
+    end
   end
 end

--- a/test/mydia_web/live/admin_duplicates_live_test.exs
+++ b/test/mydia_web/live/admin_duplicates_live_test.exs
@@ -249,6 +249,31 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
       refute has_element?(view, "#duplicates-undo")
     end
 
+    test "a legacy row with no relative_path gets a Leave/Review group named by file id",
+         %{conn: conn} do
+      {movie, _own, _stray} = misfiled_movie()
+      other_lp = library_path_fixture(%{type: "movies"})
+
+      legacy =
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: other_lp.id,
+          relative_path: "Orphaned/orphan.mkv",
+          metadata: %{"container" => "mkv", "duration" => 100.0}
+        })
+
+      Mydia.Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id == ^legacy.id),
+        set: [library_path_id: nil, relative_path: nil]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      assert has_element?(
+               view,
+               "#duplicates-refusal-#{movie.id} [role='radiogroup'][aria-label='What to do with file #{legacy.id}']"
+             )
+    end
+
     test "a group registered twice gets no Leave/Review controls", %{conn: conn} do
       movie = media_item_fixture(%{type: "movie", title: "Zephyr Station", year: 2030})
       lp = library_path_fixture(%{type: "movies"})

--- a/test/mydia_web/live/admin_duplicates_live_test.exs
+++ b/test/mydia_web/live/admin_duplicates_live_test.exs
@@ -2,6 +2,7 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
   use MydiaWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+  import Ecto.Query, only: [from: 2]
   import Mydia.MediaFixtures
   import Mydia.SettingsFixtures
 
@@ -80,6 +81,30 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
     movie
   end
 
+  # A movie holding its own file plus one from another title's folder. The
+  # lengths differ by far more than 2%, so the group is refused, and only the
+  # stray fails to bind to the title.
+  defp misfiled_movie(title \\ "Zephyr Station", stray_title \\ "Starveil") do
+    movie = media_item_fixture(%{type: "movie", title: title, year: 2030})
+    lp = library_path_fixture(%{type: "movies"})
+    dotted = &String.replace(&1, " ", ".")
+
+    [own, stray] =
+      for {path, seconds} <- [
+            {"#{title} (2030)/#{dotted.(title)}.2030.1080p.mkv", 6000.0},
+            {"#{stray_title} (2031)/#{dotted.(stray_title)}.2031.1080p.mkv", 7000.0}
+          ] do
+        media_file_fixture(%{
+          media_item_id: movie.id,
+          library_path_id: lp.id,
+          relative_path: path,
+          metadata: %{"container" => "mkv", "duration" => seconds}
+        })
+      end
+
+    {movie, own, stray}
+  end
+
   defp trashed?(file),
     do: not is_nil(Mydia.Repo.get!(Mydia.Library.MediaFile, file.id).trashed_at)
 
@@ -147,7 +172,110 @@ defmodule MydiaWeb.AdminDuplicatesLiveTest do
       {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
 
       assert has_element?(view, "#duplicates-refusal-#{movie.id}")
+      refute has_element?(view, "#duplicates-refusal-#{movie.id} input[aria-label='Keep']")
+      refute has_element?(view, "#duplicates-refusal-#{movie.id} input[aria-label='Trash']")
+    end
+
+    test "a stray file starts on Review with a Doesn't match badge, its sibling on Leave",
+         %{conn: conn} do
+      {movie, own, stray} = misfiled_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      assert has_element?(view, "#duplicates-suspect-#{stray.id}")
+      refute has_element?(view, "#duplicates-suspect-#{own.id}")
+      assert has_element?(view, "#duplicates-review-#{stray.id}[checked]")
+      assert has_element?(view, "#duplicates-leave-#{own.id}[checked]")
+      refute has_element?(view, "#duplicates-review-group-#{movie.id}[disabled]")
+    end
+
+    test "a group with nothing flagged starts all on Leave", %{conn: conn} do
+      # refused_movie/0 is a feature plus bonus content in the feature's own
+      # folder, which suspect_files/1 deliberately does not flag.
+      movie = refused_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      refute has_element?(view, "#duplicates-refusal-#{movie.id} [id^='duplicates-suspect-']")
+      assert has_element?(view, "#duplicates-review-group-#{movie.id}[disabled]")
+    end
+
+    test "a group's last Leave file cannot be put on Review", %{conn: conn} do
+      {movie, own, _stray} = misfiled_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      assert has_element?(view, "#duplicates-review-#{own.id}[disabled]")
+
+      # The radio is disabled, so only a forged event reaches the handler.
+      render_click(view, "review_file", %{"subject" => movie.id, "file" => own.id})
+
+      assert has_element?(view, "#duplicates-leave-#{own.id}[checked]")
+    end
+
+    test "Leave takes a stray back off Review", %{conn: conn} do
+      {movie, _own, stray} = misfiled_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-leave-#{stray.id}") |> render_click()
+
+      assert has_element?(view, "#duplicates-leave-#{stray.id}[checked]")
+      assert has_element?(view, "#duplicates-review-group-#{movie.id}[disabled]")
+    end
+
+    test "a subject paired with another group's file moves nothing", %{conn: conn} do
+      {_movie, _own, stray} = misfiled_movie()
+      other = refused_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      render_click(view, "leave_file", %{"subject" => other.id, "file" => stray.id})
+
+      assert has_element?(view, "#duplicates-review-#{stray.id}[checked]")
+    end
+
+    test "sending a group detaches its marked file and links to Review", %{conn: conn} do
+      {movie, own, stray} = misfiled_movie()
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      view |> element("#duplicates-review-group-#{movie.id}") |> render_click()
+
+      refute has_element?(view, "#duplicates-refusal-#{movie.id}")
+      refute Mydia.Repo.get(Mydia.Library.MediaFile, stray.id)
+      assert Mydia.Repo.get(Mydia.Library.MediaFile, own.id)
+      assert has_element?(view, "#duplicates-open-review")
+      refute has_element?(view, "#duplicates-undo")
+    end
+
+    test "a group registered twice gets no Leave/Review controls", %{conn: conn} do
+      movie = media_item_fixture(%{type: "movie", title: "Zephyr Station", year: 2030})
+      lp = library_path_fixture(%{type: "movies"})
+
+      files =
+        for path <- ["ZS/a.mkv", "ZS/b.mkv"] do
+          media_file_fixture(%{
+            media_item_id: movie.id,
+            library_path_id: lp.id,
+            relative_path: path,
+            metadata: %{"container" => "mkv", "duration" => 6000.0}
+          })
+        end
+
+      ids = Enum.map(files, & &1.id)
+
+      # Two orphaned rows share the {nil, nil} key, the only shape
+      # :duplicate_registration still guards (see eligibility_test.exs).
+      Mydia.Repo.update_all(from(f in Mydia.Library.MediaFile, where: f.id in ^ids),
+        set: [library_path_id: nil, relative_path: nil]
+      )
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/duplicates")
+
+      assert has_element?(view, "#duplicates-refusal-#{movie.id}")
       refute has_element?(view, "#duplicates-refusal-#{movie.id} input")
+      refute has_element?(view, "#duplicates-review-group-#{movie.id}")
     end
 
     test "explains a duration mismatch refusal with the actual spread and tolerance",

--- a/test/mydia_web/live/import_media_returned_badge_test.exs
+++ b/test/mydia_web/live/import_media_returned_badge_test.exs
@@ -1,0 +1,45 @@
+defmodule MydiaWeb.ImportMediaLive.ReturnedBadgeTest do
+  use MydiaWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.ImportCandidates
+  alias Mydia.Library.ImportCandidateGroup
+  alias MydiaWeb.ImportMediaLive.Components
+
+  defp only_group(attrs) do
+    lp = library_path_fixture(%{type: "series"})
+
+    import_candidate_fixture(
+      Map.merge(%{library_path_id: lp.id, relative_path: "Quillmoor/s01e01.mkv"}, attrs)
+    )
+
+    {[group], nil} = ImportCandidates.page(lp.id)
+    group
+  end
+
+  defp badge?(group) do
+    render_component(&Components.group_row/1,
+      id: "row",
+      group: group,
+      band: ImportCandidates.band(group),
+      selected: false,
+      expanded: false,
+      members: []
+    )
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.query("#group-returned-#{ImportCandidateGroup.dom_id(group)}")
+    |> Enum.any?()
+  end
+
+  test "a group holding a returned file carries a Returned badge" do
+    group = only_group(%{returned_at: DateTime.utc_now() |> DateTime.truncate(:second)})
+    assert badge?(group)
+  end
+
+  test "an ordinary group does not" do
+    refute badge?(only_group(%{}))
+  end
+end

--- a/test/mydia_web/live/media_live/not_this_item_test.exs
+++ b/test/mydia_web/live/media_live/not_this_item_test.exs
@@ -5,6 +5,8 @@ defmodule MydiaWeb.MediaLive.NotThisItemTest do
 
   import Phoenix.LiveViewTest
   import Mydia.Factory
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
 
   alias Mydia.Events
   alias Mydia.ImportCandidates
@@ -228,5 +230,52 @@ defmodule MydiaWeb.MediaLive.NotThisItemTest do
 
     # The row is untouched: neither deleted nor sent anywhere.
     assert Mydia.Repo.get(Mydia.Library.MediaFile, file.id)
+  end
+
+  describe "an episode file" do
+    test "its row offers Not this episode" do
+      file = %Mydia.Library.MediaFile{
+        id: "mf-1",
+        relative_path: "Quillmoor/Season 01/Quillmoor.S01E01.mkv",
+        library_path: %Mydia.Settings.LibraryPath{path: "/media/series"}
+      }
+
+      html =
+        render_component(&MydiaWeb.MediaLive.Show.Components.episode_file_row/1,
+          file: file,
+          episode: %Mydia.Media.Episode{id: "ep-1", monitored: true, media_files: [file]},
+          playback_enabled: false,
+          transcode_jobs: []
+        )
+
+      refute html
+             |> LazyHTML.from_fragment()
+             |> LazyHTML.query("#not-this-item-mf-1[title='Not this episode']")
+             |> Enum.empty?()
+    end
+
+    test "is sent to Review as a held tv_show candidate", %{conn: conn} do
+      lp = library_path_fixture(%{type: "series"})
+      show = media_item_fixture(%{type: "tv_show", title: "Undertow", year: 2030})
+      episode = episode_fixture(%{media_item_id: show.id, season_number: 1, episode_number: 1})
+
+      file =
+        media_file_fixture(%{
+          episode_id: episode.id,
+          library_path_id: lp.id,
+          relative_path: "Quillmoor/Season 01/Quillmoor.S01E01.mkv"
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/tv/#{show.id}")
+
+      # The row only renders once its episode is expanded, so this sends the
+      # event the button carries instead of clicking through the season UI.
+      render_click(view, "not_this_item", %{"file-id" => file.id})
+
+      refute Mydia.Repo.get(Mydia.Library.MediaFile, file.id)
+
+      assert %{media_type: "tv_show", returned_at: %DateTime{}} =
+               ImportCandidates.get_by_path(lp.id, "Quillmoor/Season 01/Quillmoor.S01E01.mkv")
+    end
   end
 end

--- a/test/mydia_web/live/media_live/not_this_item_test.exs
+++ b/test/mydia_web/live/media_live/not_this_item_test.exs
@@ -68,7 +68,7 @@ defmodule MydiaWeb.MediaLive.NotThisItemTest do
     # And the file is now waiting in the review inbox at its current path,
     # carrying the item's type as a hint so a mixed-type library's match
     # search does not default it to "movie" (review finding 3).
-    assert %{media_type: "movie"} =
+    assert %{media_type: "movie", queued_op: "rematch", returned_at: %DateTime{}} =
              ImportCandidates.get_by_path(
                library_path.id,
                "Starveil (2031)/Starveil.2031.1080p.mkv"


### PR DESCRIPTION
Closes #768.

A user with a large library reported that the duplicates page lists 150 groups that are not duplicates, and that clearing each one meant opening the item and clicking "Not this movie". A group on that page is one movie or one episode holding more than one file, so each of these is a file attached to the wrong item. Sending the stray to Review removes the group by itself.

- **Needs Attention rows get a Leave/Review choice per file**, a per-group "Send to Review" button, and a section-level one behind a confirm modal. A file starts on Review when its name does not bind to the item and it sits in a different folder from the files that do, or when it names a different episode. The folder test keeps loose bonus content in the feature's own folder from being sent away. An item always keeps at least one file.
- **Episode files get "Not this episode"** on the show page. Until now only movie files could be sent back.
- **A returned file stays returned.** Its candidate carries `returned_at`: unattended imports never promote it, `/review` never counts its group as ready and shows a "Returned" badge, and "Import all results" skips it. A review-only rematch gives it a fresh suggestion, and a person accepts it.
- `Prune.send_to_review/2` re-verifies every id against a fresh plan and refuses to empty an item, as `execute/3` does for trash. `return_to_review/2` moves the show page's detach logic into `Mydia.ImportCandidates`.
- The Needs Attention UI moves to `admin_duplicates_live/review_components.ex`; `components.ex` would have passed 500 lines.

Known limitation: title binding uses the parser's lenient similarity (threshold 0.5), so a stray whose title resembles the item's can still bind and will not start on Review. The operator marks it by hand.

The episode row's action strip now wraps. Measured in Chromium with the built stylesheet: six 40px buttons need 260px, and the row is 245px on a 375px phone, so without `flex-wrap` the first button sat 15px outside the row.

Migration: adds nullable `import_candidates.returned_at` (no rebuild on SQLite).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Needs Attention workflow for identifying and sending suspected misfiled files back to Review.
  * Added confirmation, per-file Leave/Review choices, and bulk send-to-Review actions on the duplicates page.
  * Added a “Not this episode” recovery control for incorrectly matched episode files.
  * Returned files now display a Returned badge and remain in Review until explicitly accepted.

* **Bug Fixes**
  * Prevented returned candidates from automatic import or bulk acceptance.
  * Failed review returns now leave the original operation unchanged.
  * Improved action layout on narrow episode file rows.

* **Documentation**
  * Documented the review workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->