### PR TITLE
feat(player): report crashes to the relay like the server does

### DIFF
--- a/metadata-relay/lib/metadata_relay/router.ex
+++ b/metadata-relay/lib/metadata_relay/router.ex
@@ -755,6 +755,7 @@ defmodule MetadataRelay.Router do
 
     # Create context from additional metadata
     context = %{
+      source: crash_source(Map.get(body, "source")),
       version: Map.get(body, "version"),
       environment: Map.get(body, "environment"),
       occurred_at: Map.get(body, "occurred_at"),
@@ -771,6 +772,13 @@ defmodule MetadataRelay.Router do
         {:ok, occurrence}
     end
   end
+
+  # Which client sent the report. Mydia.CrashReporter never sends `source`, so
+  # its absence means a server; the Flutter player sends "player". A closed set
+  # because this endpoint is unauthenticated. Mirrors crashSourceOf in
+  # relay-worker/src/crashes/ingest.ts.
+  defp crash_source("player"), do: "player"
+  defp crash_source(_), do: "server"
 
   # Build a synthetic stacktrace frame from the crash report `metadata` map.
   # Returns nil when there is no usable source information.

--- a/metadata-relay/mix.exs
+++ b/metadata-relay/mix.exs
@@ -4,7 +4,7 @@ defmodule MetadataRelay.MixProject do
   def project do
     [
       app: :metadata_relay,
-      version: "0.14.0",
+      version: "0.15.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/metadata-relay/test/metadata_relay/crash_report_test.exs
+++ b/metadata-relay/test/metadata_relay/crash_report_test.exs
@@ -35,6 +35,33 @@ defmodule MetadataRelay.CrashReportTest do
     MetadataRelay.Repo.all(from(e in ErrorTracker.Error, order_by: e.id))
   end
 
+  defp stored_occurrences do
+    MetadataRelay.Repo.all(from(o in ErrorTracker.Occurrence, order_by: o.id))
+  end
+
+  # The body the Flutter player's CrashReporter sends, varying only the crash
+  # site so two reports land in two groups.
+  defp player_report(file, line) do
+    %{
+      "source" => "player",
+      "error_type" => "StateError",
+      "error_message" => "Bad state: No element",
+      "stacktrace" => [
+        %{"function" => "PlayerController.seek", "file" => file, "line" => line}
+      ],
+      "version" => "0.52.1",
+      "environment" => "prod",
+      "metadata" => %{
+        "capture" => "zone",
+        "manual" => false,
+        "platform" => "android",
+        "function" => "PlayerController.seek",
+        "file" => file,
+        "line" => line
+      }
+    }
+  end
+
   describe "POST /crashes/report" do
     test "successfully stores a crash report with valid data" do
       crash_report = %{
@@ -148,6 +175,44 @@ defmodule MetadataRelay.CrashReportTest do
       assert conn.status == 429
       assert %{"error" => "Too many requests"} = Jason.decode!(conn.resp_body)
       assert ["60"] = Plug.Conn.get_resp_header(conn, "retry-after")
+    end
+
+    test "a player report is labelled player and its Dart frames keep crash sites apart" do
+      assert report(player_report("package:player/core/player/player_controller.dart", 412)).status ==
+               201
+
+      assert report(player_report("package:player/core/cast/cast_session_manager.dart", 88)).status ==
+               201
+
+      errors = stored_errors()
+      assert length(errors) == 2
+      assert Enum.any?(errors, &(&1.source_line =~ "player_controller.dart:412"))
+      assert Enum.any?(errors, &(&1.source_line =~ "cast_session_manager.dart:88"))
+
+      assert Enum.map(stored_occurrences(), & &1.context["source"]) == ["player", "player"]
+    end
+
+    test "a report without a source is labelled server" do
+      assert report(%{
+               "error_type" => "RuntimeError",
+               "error_message" => "boom",
+               "stacktrace" => [%{"file" => "lib/mydia/a.ex", "line" => 1}]
+             }).status == 201
+
+      assert [occurrence] = stored_occurrences()
+      assert occurrence.context["source"] == "server"
+    end
+
+    test "a source outside the closed set is labelled server" do
+      assert report(%{
+               "source" => "web",
+               "error_type" => "RuntimeError",
+               "error_message" => "boom",
+               "stacktrace" => [%{"file" => "lib/mydia/a.ex", "line" => 1}]
+             }).status == 201
+
+      assert [occurrence] = stored_occurrences()
+      assert occurrence.context["source"] == "server"
     end
   end
 

--- a/player/lib/core/crash_reporting/crash_app_context.dart
+++ b/player/lib/core/crash_reporting/crash_app_context.dart
@@ -1,0 +1,64 @@
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import 'crash_report.dart';
+
+/// Reads the facts every report carries.
+///
+/// The reporter calls this once, on the first report, so startup pays
+/// nothing for it. Uses [defaultTargetPlatform] rather than `dart:io`'s
+/// `Platform` so the file compiles on web.
+Future<CrashAppContext> loadCrashAppContext() async {
+  final package = await PackageInfo.fromPlatform();
+  return CrashAppContext(
+    version: package.version,
+    buildNumber: package.buildNumber,
+    platform: crashPlatformName(defaultTargetPlatform),
+    osVersion: await _osVersion(),
+    environment: crashEnvironment(release: kReleaseMode, profile: kProfileMode),
+  );
+}
+
+/// The same names `DeviceInfoService.getPlatform` uses.
+@visibleForTesting
+String crashPlatformName(TargetPlatform platform) => switch (platform) {
+      TargetPlatform.android => 'android',
+      TargetPlatform.iOS => 'ios',
+      TargetPlatform.macOS => 'macos',
+      TargetPlatform.windows => 'windows',
+      TargetPlatform.linux => 'linux',
+      TargetPlatform.fuchsia => 'fuchsia',
+    };
+
+/// `prod` in release builds, matching what the server sends in production.
+@visibleForTesting
+String crashEnvironment({required bool release, required bool profile}) =>
+    release ? 'prod' : (profile ? 'profile' : 'dev');
+
+// Version fields only. getDeviceName() in core/auth/ returns the device's
+// personal name ("John's iPhone"), which identifies the user, and
+// Platform.operatingSystemVersion is the raw kernel string on Android and
+// Linux.
+Future<String> _osVersion() async {
+  final plugin = DeviceInfoPlugin();
+  try {
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => await plugin.androidInfo.then(
+          (i) => 'Android ${i.version.release} (SDK ${i.version.sdkInt})',
+        ),
+      TargetPlatform.iOS =>
+        await plugin.iosInfo.then((i) => 'iOS ${i.systemVersion}'),
+      TargetPlatform.macOS =>
+        await plugin.macOsInfo.then((i) => 'macOS ${i.osRelease}'),
+      TargetPlatform.windows => await plugin.windowsInfo.then(
+          (i) => 'Windows ${i.displayVersion} (${i.buildNumber})',
+        ),
+      TargetPlatform.linux => await plugin.linuxInfo.then((i) => i.prettyName),
+      TargetPlatform.fuchsia => 'unknown',
+    };
+  } catch (e) {
+    debugPrint('[CrashReporter] Could not read the OS version: $e');
+    return 'unknown';
+  }
+}

--- a/player/lib/core/crash_reporting/crash_report.dart
+++ b/player/lib/core/crash_reporting/crash_report.dart
@@ -1,0 +1,168 @@
+import 'package:stack_trace/stack_trace.dart';
+
+/// Where a report was captured. [wireName] is what the relay stores in
+/// `metadata.capture`.
+enum CrashCapture {
+  flutterError('flutter_error'),
+  zone('zone'),
+  platformDispatcher('platform_dispatcher'),
+  startup('startup');
+
+  const CrashCapture(this.wireName);
+
+  final String wireName;
+}
+
+/// Facts about this install that every report carries.
+class CrashAppContext {
+  const CrashAppContext({
+    required this.version,
+    required this.buildNumber,
+    required this.platform,
+    required this.osVersion,
+    required this.environment,
+  });
+
+  final String version;
+  final String buildNumber;
+  final String platform;
+  final String osVersion;
+
+  /// `prod`, `profile` or `dev`.
+  final String environment;
+}
+
+/// One stack frame, in the `{function, file, line}` shape both relays parse.
+class CrashFrame {
+  const CrashFrame({
+    required this.function,
+    required this.file,
+    required this.line,
+  });
+
+  final String function;
+
+  /// The library URI, `package:player/...` for the player's own code. It
+  /// holds no local filesystem path and is the same on every machine.
+  final String file;
+
+  final int line;
+
+  Map<String, Object?> toJson() =>
+      {'function': function, 'file': file, 'line': line};
+}
+
+/// Most frames sent, matching relay-worker's `MAX_STACK_FRAMES`.
+const int kMaxCrashFrames = 64;
+
+const _appPackage = 'package:player/';
+
+/// Parses [stack] into frames the relays can group on.
+///
+/// Frames without a line number (the VM's `...` fold, anything unparseable)
+/// are dropped, because both relays discard an entry missing `line`. The
+/// leading run of frames outside the player's own package is dropped too:
+/// both relays fingerprint on frame 0, and a Flutter framework frame there
+/// would merge unrelated crashes into one group. A trace with no player frame
+/// at all is kept whole.
+List<CrashFrame> parseCrashFrames(StackTrace? stack) {
+  if (stack == null) return const [];
+
+  final frames = [
+    for (final frame in Trace.from(stack).frames)
+      if (frame.line case final line?)
+        CrashFrame(
+          function: frame.member ?? '<unknown>',
+          file: frame.library,
+          line: line,
+        ),
+  ];
+
+  final firstApp = frames.indexWhere((f) => f.file.startsWith(_appPackage));
+  final fromApp = firstApp > 0 ? frames.sublist(firstApp) : frames;
+  return fromApp.length > kMaxCrashFrames
+      ? fromApp.sublist(0, kMaxCrashFrames)
+      : fromApp;
+}
+
+/// One crash, ready to serialize.
+class CrashReport {
+  const CrashReport({
+    required this.errorType,
+    required this.errorMessage,
+    required this.frames,
+    required this.capture,
+    required this.context,
+    required this.occurredAt,
+    this.manual = false,
+  });
+
+  factory CrashReport.fromError(
+    Object error,
+    StackTrace? stack, {
+    required CrashCapture capture,
+    required CrashAppContext context,
+    required DateTime occurredAt,
+    bool manual = false,
+  }) {
+    return CrashReport(
+      errorType: error.runtimeType.toString(),
+      errorMessage: error.toString(),
+      frames: parseCrashFrames(stack),
+      capture: capture,
+      context: context,
+      occurredAt: occurredAt,
+      manual: manual,
+    );
+  }
+
+  final String errorType;
+  final String errorMessage;
+  final List<CrashFrame> frames;
+  final CrashCapture capture;
+  final CrashAppContext context;
+  final DateTime occurredAt;
+
+  /// True only when the user tapped Send report on the startup-error screen.
+  final bool manual;
+
+  /// The request body, unsanitized. It must go through `sanitizeReport`
+  /// before it leaves the device.
+  Map<String, Object?> toJson() {
+    final top = frames.isEmpty ? null : frames.first;
+    return {
+      'source': 'player',
+      'error_type': errorType,
+      'error_message': errorMessage,
+      'stacktrace': [for (final frame in frames) frame.toJson()],
+      'version': context.version,
+      'environment': context.environment,
+      'occurred_at': occurredAt.toUtc().toIso8601String(),
+      'metadata': {
+        'capture': capture.wireName,
+        'manual': manual,
+        'platform': context.platform,
+        'os_version': context.osVersion,
+        'build_number': context.buildNumber,
+        // Repeats the top frame, as the server does: both relays build a
+        // frame from these when `stacktrace` is empty.
+        if (top != null) ...top.toJson(),
+      },
+    };
+  }
+}
+
+/// The key a session dedups reports on: the error type plus the top frame's
+/// file and line, or plus the first 200 characters of the message when there
+/// is no frame. Takes the sanitized body, so the key never holds a secret.
+String crashDedupKey(Map<String, Object?> body) {
+  final type = body['error_type'];
+  final frames = body['stacktrace'];
+  if (frames is List && frames.isNotEmpty) {
+    final top = frames.first;
+    if (top is Map) return '$type|${top['file']}|${top['line']}';
+  }
+  final message = body['error_message'];
+  final text = message is String ? message : '';
+  return '$type|${text.length > 200 ? text.substring(0, 200) : text}';
+}

--- a/player/lib/core/crash_reporting/crash_report_queue.dart
+++ b/player/lib/core/crash_reporting/crash_report_queue.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// What one POST to `/crashes/report` came to.
+enum SendOutcome {
+  /// 201. Both relays also answer 201 when their own throttle drops a report.
+  sent,
+
+  /// 400. The relay rejected the body, and resending it can never succeed.
+  rejected,
+
+  /// 429. Retried after [SendResult.retryAfter] when the relay gave one.
+  rateLimited,
+
+  /// Any other status, a network error, or a timeout.
+  failed,
+}
+
+class SendResult {
+  const SendResult(this.outcome, {this.retryAfter});
+
+  factory SendResult.fromStatus(int status, {String? retryAfterHeader}) {
+    switch (status) {
+      case 201:
+        return const SendResult(SendOutcome.sent);
+      case 400:
+        return const SendResult(SendOutcome.rejected);
+      case 429:
+        // Whole seconds only; the Elixir relay sends "60". An HTTP date or a
+        // non-positive value falls back to the normal backoff.
+        final seconds = int.tryParse(retryAfterHeader?.trim() ?? '');
+        return SendResult(
+          SendOutcome.rateLimited,
+          retryAfter: seconds == null || seconds < 1
+              ? null
+              : Duration(seconds: seconds),
+        );
+      default:
+        return const SendResult(SendOutcome.failed);
+    }
+  }
+
+  final SendOutcome outcome;
+  final Duration? retryAfter;
+}
+
+/// Crash reports waiting to be delivered, retried with backoff.
+///
+/// The numbers are the server's (`Mydia.CrashReporter.Queue`). The queue is
+/// never written to disk: Hive or secure storage may be the very thing that
+/// just failed, and the server's queue is in memory too. Unsent reports are
+/// lost when the app exits.
+class CrashReportQueue {
+  CrashReportQueue({
+    required http.Client client,
+    required Uri endpoint,
+    DateTime Function()? now,
+    this.maxLength = 20,
+  })  : _client = client,
+        _endpoint = endpoint,
+        _now = now ?? DateTime.now;
+
+  static const initialBackoff = Duration(seconds: 60);
+  static const maxBackoff = Duration(minutes: 8);
+  static const maxAttempts = 10;
+  static const maxAge = Duration(hours: 24);
+  static const requestTimeout = Duration(seconds: 10);
+
+  final http.Client _client;
+  final Uri _endpoint;
+  final DateTime Function() _now;
+
+  /// When full, the oldest report is dropped to make room.
+  final int maxLength;
+
+  final List<_QueuedReport> _entries = [];
+  Timer? _timer;
+  bool _draining = false;
+
+  int get length => _entries.length;
+
+  void enqueue(Map<String, Object?> body) {
+    if (_entries.length >= maxLength) _entries.removeAt(0);
+    final now = _now();
+    _entries.add(_QueuedReport(body, queuedAt: now, nextAttemptAt: now));
+    unawaited(_drain());
+  }
+
+  /// One POST, no retry. Never throws.
+  Future<SendResult> sendOnce(Map<String, Object?> body) async {
+    try {
+      final response = await _client
+          .post(
+            _endpoint,
+            headers: const {'content-type': 'application/json'},
+            body: jsonEncode(body),
+          )
+          .timeout(requestTimeout);
+      return SendResult.fromStatus(
+        response.statusCode,
+        retryAfterHeader: response.headers['retry-after'],
+      );
+    } catch (e) {
+      debugPrint('[CrashReporter] Send failed: $e');
+      return const SendResult(SendOutcome.failed);
+    }
+  }
+
+  /// The wait after [failures] consecutive failures: 60 s, doubling, held at
+  /// 8 minutes.
+  static Duration backoffAfter(int failures) {
+    final seconds = initialBackoff.inSeconds << (failures - 1);
+    return seconds >= maxBackoff.inSeconds
+        ? maxBackoff
+        : Duration(seconds: seconds);
+  }
+
+  /// Stops retrying and drops everything queued.
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+    _entries.clear();
+  }
+
+  Future<void> _drain() async {
+    if (_draining) return;
+    _draining = true;
+    _timer?.cancel();
+    _timer = null;
+    try {
+      // A copy: enqueue may add, and a full queue may drop, while a send is
+      // in flight. Anything added meanwhile is picked up by _scheduleNext.
+      for (final entry in List.of(_entries)) {
+        if (entry.nextAttemptAt.isAfter(_now())) continue;
+        final result = await sendOnce(entry.body);
+        switch (result.outcome) {
+          case SendOutcome.sent:
+          case SendOutcome.rejected:
+            _entries.remove(entry);
+          case SendOutcome.rateLimited:
+          case SendOutcome.failed:
+            entry.failures++;
+            final expired = entry.failures >= maxAttempts ||
+                _now().difference(entry.queuedAt) >= maxAge;
+            if (expired) {
+              _entries.remove(entry);
+            } else {
+              entry.nextAttemptAt =
+                  _now().add(result.retryAfter ?? backoffAfter(entry.failures));
+            }
+        }
+      }
+    } finally {
+      _draining = false;
+      _scheduleNext();
+    }
+  }
+
+  void _scheduleNext() {
+    if (_entries.isEmpty) return;
+    var next = _entries.first.nextAttemptAt;
+    for (final entry in _entries) {
+      if (entry.nextAttemptAt.isBefore(next)) next = entry.nextAttemptAt;
+    }
+    final delay = next.difference(_now());
+    _timer = Timer(
+      delay.isNegative ? Duration.zero : delay,
+      () => unawaited(_drain()),
+    );
+  }
+}
+
+class _QueuedReport {
+  _QueuedReport(
+    this.body, {
+    required this.queuedAt,
+    required this.nextAttemptAt,
+  });
+
+  final Map<String, Object?> body;
+  final DateTime queuedAt;
+  DateTime nextAttemptAt;
+  int failures = 0;
+}

--- a/player/lib/core/crash_reporting/crash_report_queue.dart
+++ b/player/lib/core/crash_reporting/crash_report_queue.dart
@@ -90,15 +90,27 @@ class CrashReportQueue {
   }
 
   /// One POST, no retry. Never throws.
+  ///
+  /// A timed-out request is aborted, not just abandoned: left running, a late
+  /// success followed by the queue's retry would store the crash twice.
   Future<SendResult> sendOnce(Map<String, Object?> body) async {
+    final abort = Completer<void>();
+    final request = http.AbortableRequest(
+      'POST',
+      _endpoint,
+      abortTrigger: abort.future,
+    )
+      ..headers['content-type'] = 'application/json'
+      ..body = jsonEncode(body);
     try {
-      final response = await _client
-          .post(
-            _endpoint,
-            headers: const {'content-type': 'application/json'},
-            body: jsonEncode(body),
-          )
-          .timeout(requestTimeout);
+      final response =
+          await _client.send(request).then(http.Response.fromStream).timeout(
+        requestTimeout,
+        onTimeout: () {
+          abort.complete();
+          throw TimeoutException('crash report send timed out', requestTimeout);
+        },
+      );
       return SendResult.fromStatus(
         response.statusCode,
         retryAfterHeader: response.headers['retry-after'],
@@ -135,6 +147,12 @@ class CrashReportQueue {
       // in flight. Anything added meanwhile is picked up by _scheduleNext.
       for (final entry in List.of(_entries)) {
         if (entry.nextAttemptAt.isAfter(_now())) continue;
+        // Too old to send. Checked before the attempt as well as after a
+        // failure, so a long retry-after cannot carry a report past 24 hours.
+        if (_now().difference(entry.queuedAt) >= maxAge) {
+          _entries.remove(entry);
+          continue;
+        }
         final result = await sendOnce(entry.body);
         switch (result.outcome) {
           case SendOutcome.sent:

--- a/player/lib/core/crash_reporting/crash_reporter.dart
+++ b/player/lib/core/crash_reporting/crash_reporter.dart
@@ -97,6 +97,9 @@ class CrashReporter {
   final CrashReportQueue _queue;
   final Set<String> _seen = {};
   bool? _consent;
+  // Bumped by every setEnabled. A consent read or an earlier write that
+  // finishes after a newer choice was made must not overwrite it.
+  int _consentRevision = 0;
   CrashAppContext? _appContext;
 
   /// Routes Flutter framework errors, and errors raised outside any zone,
@@ -201,15 +204,20 @@ class CrashReporter {
   /// Throws when the choice could not be stored, leaving the previous one in
   /// force.
   Future<void> setEnabled(bool enabled) async {
+    final revision = ++_consentRevision;
     await _saveConsent(enabled);
-    _consent = enabled;
+    if (revision == _consentRevision) _consent = enabled;
   }
 
   Future<bool> _consentGranted() async {
     final cached = _consent;
     if (cached != null) return cached;
+    final revision = _consentRevision;
     try {
       final granted = await _loadConsent().timeout(_consentTimeout);
+      // A choice made while the read was in flight wins; the read is not
+      // cached in that case.
+      if (revision != _consentRevision) return _consent ?? false;
       _consent = granted;
       return granted;
     } catch (e) {

--- a/player/lib/core/crash_reporting/crash_reporter.dart
+++ b/player/lib/core/crash_reporting/crash_reporter.dart
@@ -1,0 +1,293 @@
+import 'dart:async';
+import 'dart:ui' show PlatformDispatcher;
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+import '../relay/relay_api_client.dart' show metadataRelayBaseUrl;
+import '../settings/settings_service.dart';
+import 'crash_app_context.dart';
+import 'crash_report.dart';
+import 'crash_report_queue.dart';
+import 'crash_sanitizer.dart';
+import 'startup_report_controller.dart';
+
+/// Sends the player's crashes to the relay's `POST /crashes/report`, the
+/// endpoint the mydia server's `Mydia.CrashReporter` already uses.
+///
+/// Nothing is sent until the user opts in. The parts mirror the server's:
+/// [install] stands in for its Tower reporter, `_Throttle` for `Throttle`,
+/// `sanitizeReport` for `Sanitizer`, and [CrashReportQueue] for `Queue` and
+/// `Sender`.
+///
+/// Everything after capture runs in the reporter's own guarded zone, so an
+/// error raised while reporting is logged and never reported, and no handler
+/// installed here can throw.
+class CrashReporter {
+  CrashReporter({
+    required http.Client client,
+    required Uri endpoint,
+    required Future<bool> Function() loadConsent,
+    required Future<void> Function(bool enabled) saveConsent,
+    required Future<CrashAppContext> Function() loadAppContext,
+    this.isAvailable = true,
+    DateTime Function()? now,
+    void Function(FlutterErrorDetails details)? presentFlutterError,
+    Duration consentTimeout = const Duration(seconds: 2),
+  })  : _loadConsent = loadConsent,
+        _saveConsent = saveConsent,
+        _loadAppContext = loadAppContext,
+        _now = now ?? DateTime.now,
+        _presentFlutterError = presentFlutterError ??
+            ((details) => FlutterError.presentError(details)),
+        _consentTimeout = consentTimeout,
+        _throttle = _Throttle(now ?? DateTime.now),
+        _queue = CrashReportQueue(client: client, endpoint: endpoint, now: now);
+
+  /// The reporter `main()` installs.
+  ///
+  /// Consent lives in [SettingsService], built on first use so nothing
+  /// touches storage before the binding exists. Web builds install the
+  /// handlers but send nothing: dart2js traces are minified, and neither
+  /// relay answers CORS for `/crashes/report`.
+  factory CrashReporter.production() {
+    SettingsService? settings;
+    SettingsService settingsService() => settings ??= SettingsService();
+    return CrashReporter(
+      client: http.Client(),
+      endpoint: Uri.parse('$metadataRelayBaseUrl/crashes/report'),
+      loadConsent: () => settingsService().getCrashReportingEnabled(),
+      saveConsent: (enabled) =>
+          settingsService().setCrashReportingEnabled(enabled),
+      loadAppContext: loadCrashAppContext,
+      isAvailable: !kIsWeb,
+    );
+  }
+
+  /// Sends nothing and stores nothing. What `crashReporterProvider` hands to
+  /// code running without `main()`'s override, such as widget tests that
+  /// pump the whole app.
+  factory CrashReporter.inert() => CrashReporter(
+        client: _NoNetworkClient(),
+        endpoint: Uri(),
+        loadConsent: () async => false,
+        saveConsent: (_) async {},
+        loadAppContext: () async => const CrashAppContext(
+          version: '',
+          buildNumber: '',
+          platform: '',
+          osVersion: '',
+          environment: '',
+        ),
+        isAvailable: false,
+      );
+
+  /// False on web and for [CrashReporter.inert]. The handlers still log, but
+  /// nothing is sent, [reportStartupFailure] returns null, and the settings
+  /// row is hidden.
+  final bool isAvailable;
+
+  final Future<bool> Function() _loadConsent;
+  final Future<void> Function(bool enabled) _saveConsent;
+  final Future<CrashAppContext> Function() _loadAppContext;
+  final DateTime Function() _now;
+  final void Function(FlutterErrorDetails details) _presentFlutterError;
+  final Duration _consentTimeout;
+  final _Throttle _throttle;
+  final CrashReportQueue _queue;
+  final Set<String> _seen = {};
+  bool? _consent;
+  CrashAppContext? _appContext;
+
+  /// Routes Flutter framework errors, and errors raised outside any zone,
+  /// through this reporter.
+  void install() {
+    FlutterError.onError = handleFlutterError;
+    PlatformDispatcher.instance.onError = handlePlatformError;
+  }
+
+  /// Presents and logs the error exactly as `main()` always has, then
+  /// reports it.
+  @visibleForTesting
+  void handleFlutterError(FlutterErrorDetails details) {
+    _presentFlutterError(details);
+    debugPrint('Flutter error: ${details.exception}');
+    debugPrint('Stack trace: ${details.stack}');
+    // Flutter marks environmental failures, image loads among them, silent.
+    if (details.silent) return;
+    unawaited(
+      report(
+        details.exception,
+        details.stack,
+        capture: CrashCapture.flutterError,
+      ),
+    );
+  }
+
+  @visibleForTesting
+  bool handlePlatformError(Object error, StackTrace stack) {
+    debugPrint('Platform error: $error');
+    debugPrint('Stack trace: $stack');
+    unawaited(report(error, stack, capture: CrashCapture.platformDispatcher));
+    return true;
+  }
+
+  /// Reports an unhandled error, when the user has opted in.
+  ///
+  /// Consent first, so nothing is built when it is off; then the per-session
+  /// dedup, then the throttle, then the queue. Completes once the report is
+  /// queued or dropped, not when it is delivered. Never throws.
+  Future<void> report(
+    Object error,
+    StackTrace? stack, {
+    required CrashCapture capture,
+  }) {
+    if (!isAvailable) return Future<void>.value();
+    final occurredAt = _now();
+    return _guarded<void>(() async {
+      if (!await _consentGranted()) return;
+      final body = await _body(
+        error,
+        stack,
+        capture: capture,
+        occurredAt: occurredAt,
+        manual: false,
+      );
+      if (!_seen.add(crashDedupKey(body))) return;
+      if (!_throttle.allow()) return;
+      _queue.enqueue(body);
+    }, null);
+  }
+
+  /// Reports a fatal startup failure through the returned controller: sent at
+  /// once when the user has opted in, otherwise held until they tap Send
+  /// report. Null when unavailable.
+  ///
+  /// Never throws. It runs inside `_startApp`, which must reach `runApp` on
+  /// every path.
+  StartupReportController? reportStartupFailure(
+    Object error,
+    StackTrace stack,
+  ) {
+    if (!isAvailable) return null;
+    final occurredAt = _now();
+    final controller = StartupReportController(
+      send: ({required bool manual}) => _guarded(() async {
+        final body = await _body(
+          error,
+          stack,
+          capture: CrashCapture.startup,
+          occurredAt: occurredAt,
+          manual: manual,
+        );
+        final result = await _queue.sendOnce(body);
+        return result.outcome == SendOutcome.sent;
+      }, false),
+    );
+    unawaited(
+      _guarded<void>(() async {
+        if (await _consentGranted()) await controller.send(manual: false);
+      }, null),
+    );
+    return controller;
+  }
+
+  /// Whether the user has opted in. False when consent cannot be read.
+  Future<bool> isEnabled() =>
+      isAvailable ? _consentGranted() : Future<bool>.value(false);
+
+  /// Stores the user's choice and applies it from the next report on.
+  ///
+  /// Throws when the choice could not be stored, leaving the previous one in
+  /// force.
+  Future<void> setEnabled(bool enabled) async {
+    await _saveConsent(enabled);
+    _consent = enabled;
+  }
+
+  Future<bool> _consentGranted() async {
+    final cached = _consent;
+    if (cached != null) return cached;
+    try {
+      final granted = await _loadConsent().timeout(_consentTimeout);
+      _consent = granted;
+      return granted;
+    } catch (e) {
+      // A locked keyring or a slow read. Off for this report, and read again
+      // next time rather than caching a guess.
+      debugPrint('[CrashReporter] Could not read consent: $e');
+      return false;
+    }
+  }
+
+  Future<Map<String, Object?>> _body(
+    Object error,
+    StackTrace? stack, {
+    required CrashCapture capture,
+    required DateTime occurredAt,
+    required bool manual,
+  }) async {
+    final context = _appContext ??= await _loadAppContext();
+    final report = CrashReport.fromError(
+      error,
+      stack,
+      capture: capture,
+      context: context,
+      occurredAt: occurredAt,
+      manual: manual,
+    );
+    return sanitizeReport(report.toJson());
+  }
+
+  // Runs [work] in its own error zone. Whatever it throws, synchronously, from
+  // a stray future, or later from a queue retry timer (timers keep the zone
+  // they were created in), lands here instead of in FlutterError.onError or
+  // main()'s zone, which would report it again. A reentrancy flag would not
+  // do: it would also drop an unrelated crash arriving while this report
+  // waits on its consent read.
+  Future<T> _guarded<T>(Future<T> Function() work, T fallback) {
+    final done = Completer<T>();
+    runZonedGuarded(
+      () async {
+        final result = await work();
+        if (!done.isCompleted) done.complete(result);
+      },
+      (error, stack) {
+        debugPrint('[CrashReporter] Internal error: $error');
+        if (!done.isCompleted) done.complete(fallback);
+      },
+    );
+    return done.future;
+  }
+}
+
+// Fixed window, the numbers Mydia.CrashReporter.Throttle uses: at most 10
+// reports in any 60-second window.
+class _Throttle {
+  _Throttle(this._now);
+
+  static const _window = Duration(seconds: 60);
+  static const _max = 10;
+
+  final DateTime Function() _now;
+  DateTime? _windowStart;
+  int _count = 0;
+
+  bool allow() {
+    final now = _now();
+    final start = _windowStart;
+    if (start == null || now.difference(start) >= _window) {
+      _windowStart = now;
+      _count = 0;
+    }
+    if (_count >= _max) return false;
+    _count++;
+    return true;
+  }
+}
+
+class _NoNetworkClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) =>
+      throw StateError('CrashReporter.inert() never sends');
+}

--- a/player/lib/core/crash_reporting/crash_reporter_provider.dart
+++ b/player/lib/core/crash_reporting/crash_reporter_provider.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'crash_reporter.dart';
+
+/// The app's [CrashReporter].
+///
+/// `main()` overrides this with the reporter it installed. Anything running
+/// without that override, such as the widget and integration tests that pump
+/// `MyApp` directly, gets an inert reporter that sends nothing, the way
+/// `fetchLogProvider` falls back to an in-memory log.
+final Provider<CrashReporter> crashReporterProvider =
+    Provider<CrashReporter>((ref) => CrashReporter.inert());

--- a/player/lib/core/crash_reporting/crash_sanitizer.dart
+++ b/player/lib/core/crash_reporting/crash_sanitizer.dart
@@ -20,7 +20,12 @@ const _truncationMarker = '...[truncated]';
 
 final _homeUnix = RegExp(r'/home/[^/\s]+');
 final _homeMac = RegExp(r'/Users/[^/\s]+');
-final _homeWindows = RegExp(r'C:\\Users\\[^\\:\s]+');
+// Any drive, either separator, any case: C:\Users\x, d:\users\x, C:/Users/x.
+// Only the name is replaced; drive, separators and casing are kept.
+final _homeWindows = RegExp(
+  r'([A-Za-z]:)([\\/])(users)([\\/])[^\\/:\s]+',
+  caseSensitive: false,
+);
 
 // scheme://authority path ?query #fragment. The authority must be non-empty,
 // so file:///home/... is left to the home-directory rules.
@@ -119,7 +124,10 @@ String sanitizeString(String input) {
 String redactHomeDirectories(String input) => input
     .replaceAll(_homeUnix, '/home/[USER]')
     .replaceAll(_homeMac, '/Users/[USER]')
-    .replaceAll(_homeWindows, r'C:\Users\[USER]');
+    .replaceAllMapped(
+      _homeWindows,
+      (m) => '${m[1]}${m[2]}${m[3]}${m[4]}[USER]',
+    );
 
 Map<String, Object?> _sanitizeFrame(Map<String, Object?> frame) {
   final out = Map<String, Object?>.of(frame);

--- a/player/lib/core/crash_reporting/crash_sanitizer.dart
+++ b/player/lib/core/crash_reporting/crash_sanitizer.dart
@@ -1,0 +1,178 @@
+/// Scrubs a crash report before it leaves the device.
+///
+/// A port of the server's `Mydia.CrashReporter.Sanitizer`
+/// (`lib/mydia/crash_reporter/sanitizer.ex`), plus rules for what a player
+/// error carries that a server error does not: the address of the user's own
+/// server, and stream URLs with tokens in their query strings.
+///
+/// As on the server, free text gets every rule and frame fields get only the
+/// home-directory rule. Frame files are package URIs, and redacting a long
+/// class name out of a function would break grouping on the relay.
+library;
+
+/// Longest `error_message` sent, matching relay-worker's `MAX_MESSAGE_CHARS`.
+///
+/// Applied after redaction, so a cut can never split a secret into a fragment
+/// the patterns no longer recognise.
+const int kMaxCrashMessageChars = 4096;
+
+const _truncationMarker = '...[truncated]';
+
+final _homeUnix = RegExp(r'/home/[^/\s]+');
+final _homeMac = RegExp(r'/Users/[^/\s]+');
+final _homeWindows = RegExp(r'C:\\Users\\[^\\:\s]+');
+
+// scheme://authority path ?query #fragment. The authority must be non-empty,
+// so file:///home/... is left to the home-directory rules.
+final _url = RegExp(
+  r'''([a-zA-Z][a-zA-Z0-9+.\-]*)://([^\s/?#<>"']+)([^\s?#<>"']*)(\?[^\s#<>"']*)?(#[^\s<>"']*)?''',
+);
+final _hostAndPort = RegExp(r'^(\[[^\]]*\]|[^:]*)(:\d+)?$');
+
+// dart:io's SocketException names the host outside any URL.
+final _hostLookup = RegExp(r"Failed host lookup: '([^']*)'");
+final _socketAddress = RegExp(r'address = ([^,\s)]+)');
+
+final _bearer = RegExp(r'Bearer\s+[a-zA-Z0-9_\-.]+');
+final _jwt = RegExp(r'eyJ[\w-]+\.[\w-]+\.[\w-]+');
+final _longToken = RegExp(r'[a-zA-Z0-9_-]{32,}');
+final _digit = RegExp(r'[0-9]');
+final _password = RegExp(r'''password["\s:=]+[^\s"]+''', caseSensitive: false);
+final _secret = RegExp(r'''secret["\s:=]+[^\s"]+''', caseSensitive: false);
+final _apiKey = RegExp(r'''api_key["\s:=]+[^\s"]+''', caseSensitive: false);
+
+const _sensitiveKeyParts = [
+  'password',
+  'secret',
+  'api_key',
+  'apikey',
+  'token',
+  'auth',
+  'bearer',
+  'credentials',
+  'private_key',
+  'private',
+  'key',
+  'jwt',
+  'session',
+  'cookie',
+];
+
+/// Returns a copy of [report] that is safe to send.
+///
+/// Rewrites `error_message`, each `stacktrace` entry's `file`, and the string
+/// values of the flat `metadata` map. Every other key passes through.
+Map<String, Object?> sanitizeReport(Map<String, Object?> report) {
+  final out = Map<String, Object?>.of(report);
+
+  final message = out['error_message'];
+  if (message is String)
+    out['error_message'] = _truncate(sanitizeString(message));
+
+  final frames = out['stacktrace'];
+  if (frames is List) {
+    out['stacktrace'] = [
+      for (final frame in frames)
+        frame is Map<String, Object?> ? _sanitizeFrame(frame) : frame,
+    ];
+  }
+
+  final metadata = out['metadata'];
+  if (metadata is Map<String, Object?>) {
+    out['metadata'] = {
+      for (final entry in metadata.entries)
+        entry.key: _sanitizeMetadataValue(entry.key, entry.value),
+    };
+  }
+
+  return out;
+}
+
+/// Applies every free-text rule to [input].
+String sanitizeString(String input) {
+  var out = redactHomeDirectories(input);
+  out = out.replaceAllMapped(_url, _rewriteUrl);
+  out = out.replaceAllMapped(
+    _hostLookup,
+    (m) => "Failed host lookup: '${_redactHost(m[1]!)}'",
+  );
+  out = out.replaceAllMapped(
+    _socketAddress,
+    (m) => 'address = ${_redactHost(m[1]!)}',
+  );
+  out = out.replaceAll(_bearer, 'Bearer [REDACTED]');
+  out = out.replaceAll(_jwt, '[REDACTED]');
+  // The server redacts every 32+ run. The player also requires a digit:
+  // Dart class names run past 32 characters in most framework errors, while
+  // keys, session tokens and node ids essentially always contain one.
+  out = out.replaceAllMapped(
+    _longToken,
+    (m) => _digit.hasMatch(m[0]!) ? '[REDACTED]' : m[0]!,
+  );
+  out = out.replaceAll(_password, 'password: [REDACTED]');
+  out = out.replaceAll(_secret, 'secret: [REDACTED]');
+  out = out.replaceAll(_apiKey, 'api_key: [REDACTED]');
+  return out;
+}
+
+/// Replaces the username in Unix, macOS and Windows home directories.
+String redactHomeDirectories(String input) => input
+    .replaceAll(_homeUnix, '/home/[USER]')
+    .replaceAll(_homeMac, '/Users/[USER]')
+    .replaceAll(_homeWindows, r'C:\Users\[USER]');
+
+Map<String, Object?> _sanitizeFrame(Map<String, Object?> frame) {
+  final out = Map<String, Object?>.of(frame);
+  final file = out['file'];
+  if (file is String) out['file'] = redactHomeDirectories(file);
+  return out;
+}
+
+// `file` and `function` in metadata repeat the top frame, so they follow the
+// frame rules rather than the free-text ones.
+Object? _sanitizeMetadataValue(String key, Object? value) {
+  if (value is! String) return value;
+  if (key == 'function') return value;
+  if (key == 'file') return redactHomeDirectories(value);
+  if (_isSensitiveKey(key)) return '[REDACTED]';
+  return sanitizeString(value);
+}
+
+bool _isSensitiveKey(String key) {
+  final lower = key.toLowerCase();
+  return _sensitiveKeyParts.any(lower.contains);
+}
+
+String _rewriteUrl(Match m) {
+  final scheme = m[1]!;
+  final authority = m[2]!;
+  final path = m[3] ?? '';
+  final query = m[4];
+
+  final at = authority.lastIndexOf('@');
+  final userinfo = at >= 0 ? '[REDACTED]:[REDACTED]@' : '';
+  final hostAndPort = at >= 0 ? authority.substring(at + 1) : authority;
+
+  final parts = _hostAndPort.firstMatch(hostAndPort);
+  final host =
+      parts == null ? '[HOST]' : '${_redactHost(parts[1]!)}${parts[2] ?? ''}';
+
+  return '$scheme://$userinfo$host$path${query == null ? '' : '?[REDACTED]'}';
+}
+
+// mydia.dev is ours, and loopback is where the player's own HLS proxy
+// listens. Every other host is the user's.
+String _redactHost(String host) {
+  final lower = host.toLowerCase();
+  final kept = lower == 'mydia.dev' ||
+      lower.endsWith('.mydia.dev') ||
+      lower == 'localhost' ||
+      lower == '127.0.0.1' ||
+      lower == '::1' ||
+      lower == '[::1]';
+  return kept ? host : '[HOST]';
+}
+
+String _truncate(String value) => value.length <= kMaxCrashMessageChars
+    ? value
+    : '${value.substring(0, kMaxCrashMessageChars)}$_truncationMarker';

--- a/player/lib/core/crash_reporting/startup_report_controller.dart
+++ b/player/lib/core/crash_reporting/startup_report_controller.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+
+enum StartupReportState { idle, sending, sent, failed }
+
+/// Drives the Send report button on the startup-error screen.
+///
+/// Each [send] is one POST: no queue, no throttle, no dedup. A tap is the
+/// consent, the way an admin's manual report is on the server.
+class StartupReportController extends ValueNotifier<StartupReportState> {
+  StartupReportController({
+    required Future<bool> Function({required bool manual}) send,
+  })  : _send = send,
+        super(StartupReportState.idle);
+
+  final Future<bool> Function({required bool manual}) _send;
+
+  /// Sends the report unless one is in flight or already delivered.
+  ///
+  /// [manual] is true for a tap and false when the reporter sends on its own
+  /// because the user opted in earlier.
+  Future<void> send({bool manual = true}) async {
+    if (value == StartupReportState.sending ||
+        value == StartupReportState.sent) {
+      return;
+    }
+    value = StartupReportState.sending;
+    final delivered = await _send(manual: manual);
+    value = delivered ? StartupReportState.sent : StartupReportState.failed;
+  }
+}

--- a/player/lib/core/settings/settings_service.dart
+++ b/player/lib/core/settings/settings_service.dart
@@ -18,6 +18,7 @@ class SettingsService {
   static const _defaultQualityKey = 'default_quality';
   static const _autoSkipSegmentsKey = 'auto_skip_segments';
   static const _librarySortKeyPrefix = 'library_sort_';
+  static const _crashReportingEnabledKey = 'crash_reporting_enabled';
 
   /// Get the default quality setting.
   Future<String> getDefaultQuality() async {
@@ -42,6 +43,20 @@ class SettingsService {
   /// Set the automatic intro and credits skipping setting.
   Future<void> setAutoSkipSegments(bool enabled) async {
     await _storage.write(_autoSkipSegmentsKey, enabled.toString());
+  }
+
+  /// Whether crash reports are sent to the Mydia developers.
+  ///
+  /// Off by default, matching the server's own opt-in. A device-level choice
+  /// rather than an account preference, so [clearSettings] leaves it alone.
+  Future<bool> getCrashReportingEnabled() async {
+    final value = await _storage.read(_crashReportingEnabledKey);
+    return value == 'true';
+  }
+
+  /// Set whether crash reports are sent to the Mydia developers.
+  Future<void> setCrashReportingEnabled(bool enabled) async {
+    await _storage.write(_crashReportingEnabledKey, enabled.toString());
   }
 
   /// Get the remembered sort for a library, as its encoded string.

--- a/player/lib/core/startup/startup_error_app.dart
+++ b/player/lib/core/startup/startup_error_app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
+import '../crash_reporting/startup_report_controller.dart';
 
 /// Last-resort UI for when startup cannot proceed to [MyApp].
 ///
@@ -13,6 +14,7 @@ class StartupErrorApp extends StatelessWidget {
     required this.title,
     required this.message,
     this.details,
+    this.report,
   });
 
   /// Shown when another instance of the app is already running and holding
@@ -28,11 +30,16 @@ class StartupErrorApp extends StatelessWidget {
 
   /// Shown for any other fatal startup failure, with whatever underlying
   /// error text is available so the user (or a bug report) has something to
-  /// go on.
-  factory StartupErrorApp.generic(Object error) => StartupErrorApp(
+  /// go on. [report], when given, adds a Send report button.
+  factory StartupErrorApp.generic(
+    Object error, {
+    StartupReportController? report,
+  }) =>
+      StartupErrorApp(
         title: "Mydia Player couldn't start",
         message: 'Something went wrong while starting the app.',
         details: '$error',
+        report: report,
         key: const Key('startup-error-generic'),
       );
 
@@ -40,8 +47,13 @@ class StartupErrorApp extends StatelessWidget {
   final String message;
   final String? details;
 
+  /// Drives the Send report button. Null hides it: on web, where nothing is
+  /// sent, and on the already-running screen, which is not a crash.
+  final StartupReportController? report;
+
   @override
   Widget build(BuildContext context) {
+    final report = this.report;
     return MaterialApp(
       title: 'Mydia Player',
       debugShowCheckedModeBanner: false,
@@ -81,11 +93,62 @@ class StartupErrorApp extends StatelessWidget {
                     ),
                   ),
                 ],
+                if (report != null) ...[
+                  const SizedBox(height: 24),
+                  _SendReportButton(controller: report),
+                ],
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// One button whose label and enabled state follow the controller.
+class _SendReportButton extends StatelessWidget {
+  const _SendReportButton({required this.controller});
+
+  final StartupReportController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<StartupReportState>(
+      valueListenable: controller,
+      builder: (context, state, _) {
+        final (icon, label, onPressed) = switch (state) {
+          StartupReportState.idle => (
+              const Icon(Icons.send_outlined),
+              'Send report',
+              controller.send,
+            ),
+          StartupReportState.sending => (
+              const SizedBox.square(
+                dimension: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+              'Sending report',
+              null,
+            ),
+          StartupReportState.sent => (
+              const Icon(Icons.check),
+              'Report sent',
+              null,
+            ),
+          StartupReportState.failed => (
+              const Icon(Icons.refresh),
+              "Couldn't send. Try again",
+              controller.send,
+            ),
+        };
+        return OutlinedButton.icon(
+          key: const Key('startup-report-button'),
+          onPressed: onPressed,
+          icon: icon,
+          label: Text(label),
+        );
+      },
     );
   }
 }

--- a/player/lib/main.dart
+++ b/player/lib/main.dart
@@ -6,6 +6,9 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:media_kit/media_kit.dart';
 import 'app.dart';
 import 'core/downloads/download_service.dart';
+import 'core/crash_reporting/crash_report.dart';
+import 'core/crash_reporting/crash_reporter.dart';
+import 'core/crash_reporting/crash_reporter_provider.dart';
 import 'package:flutter/services.dart';
 
 import 'core/graphql/watch/fetch_log.dart';
@@ -52,12 +55,10 @@ const kWebP2pEnabled = bool.fromEnvironment('MYDIA_WEB_P2P');
 const _rustInitTimeout = Duration(seconds: 60);
 
 void main() async {
-  // Add error logging for debugging
-  FlutterError.onError = (details) {
-    FlutterError.presentError(details);
-    debugPrint('Flutter error: ${details.exception}');
-    debugPrint('Stack trace: ${details.stack}');
-  };
+  // Presents and logs every Flutter framework error, as this spot always has,
+  // and reports it to the relay once the user opts in. See
+  // core/crash_reporting/crash_reporter.dart.
+  final crashReporter = CrashReporter.production()..install();
 
   runZonedGuarded(
     () async {
@@ -74,17 +75,18 @@ void main() async {
         yield LicenseEntryWithLineBreaks(<String>['Inter'], license);
       });
 
-      await _startApp();
+      await _startApp(crashReporter);
     },
     (error, stack) {
       // `_startApp` guarantees `runApp` has already run by the time control
       // reaches here, falling back to a startup-error screen along the way
-      // if a step failed fatally. This handler only logs whatever slips
-      // through afterwards (e.g. an error from deep inside a running widget
-      // tree) — it must never again be the sole handler of a fatal startup
-      // failure, silently leaving the window black.
+      // if a step failed fatally. This handler only logs and reports
+      // whatever slips through afterwards (e.g. an error from deep inside a
+      // running widget tree). It must never again be the sole handler of a
+      // fatal startup failure, silently leaving the window black.
       debugPrint('Caught error: $error');
       debugPrint('Stack trace: $stack');
+      unawaited(crashReporter.report(error, stack, capture: CrashCapture.zone));
     },
   );
 }
@@ -99,7 +101,7 @@ void main() async {
 /// app pointed at the same user-data directory will otherwise leave the
 /// window completely black forever with no indication why (the bug this
 /// function exists to fix).
-Future<void> _startApp() async {
+Future<void> _startApp(CrashReporter crashReporter) async {
   // Initialize the Rust bridge. This MUST complete before any p2p code runs.
   //
   // On native there is no reasonable degraded mode without it, so a failure
@@ -124,7 +126,14 @@ Future<void> _startApp() async {
     } catch (e, st) {
       debugPrint('[RustLib] Failed to initialize Rust bridge: $e');
       debugPrint('Stack trace: $st');
-      runApp(StartupErrorApp.generic(e));
+      // Never throws, so this path still reaches runApp. Null on web, where
+      // the screen shows no Send report button.
+      runApp(
+        StartupErrorApp.generic(
+          e,
+          report: crashReporter.reportStartupFailure(e, st),
+        ),
+      );
       return;
     }
   } else {
@@ -252,6 +261,7 @@ Future<void> _startApp() async {
   runApp(
     ProviderScope(
       overrides: [
+        crashReporterProvider.overrideWithValue(crashReporter),
         fetchLogProvider.overrideWithValue(fetchLog),
         sidebarLayoutStoreProvider.overrideWithValue(sidebarLayoutStore),
       ],

--- a/player/lib/presentation/screens/settings/settings_screen.dart
+++ b/player/lib/presentation/screens/settings/settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../core/connection/connection_provider.dart';
 import '../../../core/connection/connection_summary.dart';
+import '../../../core/crash_reporting/crash_reporter_provider.dart';
 import '../../../core/graphql/graphql_provider.dart';
 import '../../../core/p2p/p2p_service.dart';
 import '../../../core/player/platform_features.dart';
@@ -24,6 +25,7 @@ import '../../widgets/connection_tone_color.dart';
 import '../../widgets/hls_quality_selector.dart';
 import 'settings_controller.dart';
 import 'widgets/beta_channel_row.dart';
+import 'widgets/crash_reporting_row.dart';
 import 'widgets/settings_identity.dart';
 import 'widgets/settings_row.dart';
 import 'widgets/settings_section.dart';
@@ -267,6 +269,10 @@ class _ManageSection extends ConsumerWidget {
         // Flatpak branch, chosen at install time rather than in-app, and
         // Windows has no channel support at all.
         if (PlatformFeatures.isMacOS) const BetaChannelRow(),
+        // Hidden where nothing would be sent: web builds, and the inert
+        // reporter whole-app tests run with. See CrashReporter.isAvailable.
+        if (ref.watch(crashReporterProvider).isAvailable)
+          const CrashReportingRow(),
         if (updateState.manualCheck != ManualCheckBehaviour.unavailable)
           SettingsRow.action(
             key: const Key('check-for-updates-row'),

--- a/player/lib/presentation/screens/settings/widgets/crash_reporting_row.dart
+++ b/player/lib/presentation/screens/settings/widgets/crash_reporting_row.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/crash_reporting/crash_reporter_provider.dart';
+import 'settings_row.dart';
+
+/// Opt-in for sending crash reports to the Mydia developers.
+///
+/// The choice belongs to the device, not the account, and lives behind the
+/// app's `CrashReporter`, so flipping it applies to the next report with no
+/// restart. Built like `BetaChannelRow`: the switch moves at once, and a
+/// generation counter keeps a slow first read from clobbering a tap.
+///
+/// The platform gate lives at the call site (`CrashReporter.isAvailable`), so
+/// a `flutter test` host can still exercise the row.
+class CrashReportingRow extends ConsumerStatefulWidget {
+  const CrashReportingRow({super.key});
+
+  @override
+  ConsumerState<CrashReportingRow> createState() => _CrashReportingRowState();
+}
+
+class _CrashReportingRowState extends ConsumerState<CrashReportingRow> {
+  bool _enabled = false;
+  int _generation = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final generation = _generation;
+    final enabled = await ref.read(crashReporterProvider).isEnabled();
+    if (mounted && generation == _generation) {
+      setState(() => _enabled = enabled);
+    }
+  }
+
+  Future<void> _set(bool value) async {
+    final generation = ++_generation;
+    setState(() => _enabled = value);
+
+    final reporter = ref.read(crashReporterProvider);
+    try {
+      await reporter.setEnabled(value);
+    } catch (e) {
+      debugPrint('[CrashReporter] Could not store the choice: $e');
+      // The write did not land, so the optimistic value is a lie. Show what
+      // the reporter actually holds.
+      final actual = await reporter.isEnabled();
+      if (mounted && generation == _generation) {
+        setState(() => _enabled = actual);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsRow.toggle(
+      key: const Key('crash-reporting-switch'),
+      icon: Icons.bug_report_outlined,
+      title: 'Share crashes with developers',
+      subtitle: 'Sends error details, app version and platform to the Mydia '
+          'developers when the app hits an error.',
+      value: _enabled,
+      onChanged: _set,
+    );
+  }
+}

--- a/player/pubspec.lock
+++ b/player/pubspec.lock
@@ -1505,7 +1505,7 @@ packages:
     source: hosted
     version: "2.4.1"
   stack_trace:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"

--- a/player/pubspec.yaml
+++ b/player/pubspec.yaml
@@ -47,6 +47,10 @@ dependencies:
   connectivity_plus: ^7.3.1
   device_info_plus: ^13.2.0
   package_info_plus: ^10.2.1
+  # Parses crash stack traces into frames for core/crash_reporting. Already
+  # resolved transitively; declared so the import is not an undeclared
+  # dependency.
+  stack_trace: ^1.12.1
   mobile_scanner: ^7.0.1
   url_launcher: ^6.3.0
   flutter_rust_bridge: ^2.13.0

--- a/player/pubspec.yaml
+++ b/player/pubspec.yaml
@@ -27,7 +27,9 @@ dependencies:
   flutter_secure_storage: ^11.0.0
   cached_network_image: ^4.0.0
   flutter_cache_manager: ^3.3.0
-  http: ^1.1.0
+  # 1.5.0 added AbortableRequest, which the crash reporter uses to cancel a
+  # send that timed out instead of leaving it running.
+  http: ^1.5.0
   shimmer: ^4.0.0
   media_kit: ^1.2.6
   media_kit_video: ^2.0.1

--- a/player/test/core/crash_reporting/crash_app_context_test.dart
+++ b/player/test/core/crash_reporting/crash_app_context_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/crash_reporting/crash_app_context.dart';
+
+void main() {
+  test('platform names match DeviceInfoService.getPlatform', () {
+    expect(crashPlatformName(TargetPlatform.android), 'android');
+    expect(crashPlatformName(TargetPlatform.iOS), 'ios');
+    expect(crashPlatformName(TargetPlatform.macOS), 'macos');
+    expect(crashPlatformName(TargetPlatform.windows), 'windows');
+    expect(crashPlatformName(TargetPlatform.linux), 'linux');
+  });
+
+  test('environment follows the build mode, as the server names it', () {
+    expect(crashEnvironment(release: true, profile: false), 'prod');
+    expect(crashEnvironment(release: false, profile: true), 'profile');
+    expect(crashEnvironment(release: false, profile: false), 'dev');
+  });
+}

--- a/player/test/core/crash_reporting/crash_report_queue_test.dart
+++ b/player/test/core/crash_reporting/crash_report_queue_test.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:player/core/crash_reporting/crash_report_queue.dart';
+
+final _endpoint = Uri.parse('https://relay.test/crashes/report');
+final _start = DateTime.utc(2026, 9, 10, 12);
+
+CrashReportQueue _queue(
+  FakeAsync async,
+  http.Client client, {
+  int maxLength = 20,
+}) =>
+    CrashReportQueue(
+      client: client,
+      endpoint: _endpoint,
+      now: () => _start.add(async.elapsed),
+      maxLength: maxLength,
+    );
+
+void main() {
+  group('SendResult.fromStatus', () {
+    test('maps the statuses the relays answer with', () {
+      expect(SendResult.fromStatus(201).outcome, SendOutcome.sent);
+      expect(SendResult.fromStatus(400).outcome, SendOutcome.rejected);
+      expect(SendResult.fromStatus(429).outcome, SendOutcome.rateLimited);
+      expect(SendResult.fromStatus(500).outcome, SendOutcome.failed);
+      expect(SendResult.fromStatus(503).outcome, SendOutcome.failed);
+    });
+
+    test('reads retry-after as whole seconds only', () {
+      expect(
+        SendResult.fromStatus(429, retryAfterHeader: '60').retryAfter,
+        const Duration(seconds: 60),
+      );
+      expect(
+        SendResult.fromStatus(429,
+                retryAfterHeader: 'Wed, 21 Oct 2026 07:28:00 GMT')
+            .retryAfter,
+        isNull,
+      );
+      expect(
+        SendResult.fromStatus(429, retryAfterHeader: '0').retryAfter,
+        isNull,
+      );
+    });
+  });
+
+  test('backoff doubles from 60 seconds and holds at 8 minutes', () {
+    expect(
+      [for (var n = 1; n <= 6; n++) CrashReportQueue.backoffAfter(n).inSeconds],
+      [60, 120, 240, 480, 480, 480],
+    );
+  });
+
+  test('posts the body as JSON and empties the queue on a 201', () {
+    fakeAsync((async) {
+      final requests = <http.Request>[];
+      final queue = _queue(
+        async,
+        MockClient((request) async {
+          requests.add(request);
+          return http.Response('{}', 201);
+        }),
+      );
+
+      queue.enqueue({'error_type': 'StateError'});
+      async.flushMicrotasks();
+
+      expect(requests, hasLength(1));
+      expect(requests.single.method, 'POST');
+      expect(requests.single.url, _endpoint);
+      expect(requests.single.headers['content-type'],
+          startsWith('application/json'));
+      expect(jsonDecode(requests.single.body), {'error_type': 'StateError'});
+      expect(queue.length, 0);
+    });
+  });
+
+  test('drops a report the relay rejects with a 400', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final queue = _queue(
+        async,
+        MockClient((_) async {
+          calls++;
+          return http.Response('{}', 400);
+        }),
+      );
+
+      queue.enqueue({'n': 1});
+      async.elapse(const Duration(hours: 1));
+
+      expect(calls, 1);
+      expect(queue.length, 0);
+    });
+  });
+
+  test('retries failures on the backoff schedule', () {
+    fakeAsync((async) {
+      final attempts = <Duration>[];
+      final queue = _queue(
+        async,
+        MockClient((_) async {
+          attempts.add(async.elapsed);
+          return http.Response('', 503);
+        }),
+      );
+
+      queue.enqueue({'n': 1});
+      async.elapse(const Duration(minutes: 30));
+
+      expect(attempts.map((d) => d.inSeconds), [0, 60, 180, 420, 900, 1380]);
+    });
+  });
+
+  test('gives up after 10 failed attempts', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final queue = _queue(
+        async,
+        MockClient((_) async {
+          calls++;
+          return http.Response('', 500);
+        }),
+      );
+
+      queue.enqueue({'n': 1});
+      async.elapse(const Duration(hours: 2));
+
+      expect(calls, 10);
+      expect(queue.length, 0);
+    });
+  });
+
+  test('honours retry-after, and gives up on a report older than 24 hours', () {
+    fakeAsync((async) {
+      final attempts = <Duration>[];
+      final queue = _queue(
+        async,
+        MockClient((_) async {
+          attempts.add(async.elapsed);
+          return http.Response('', 429, headers: {'retry-after': '36000'});
+        }),
+      );
+
+      queue.enqueue({'n': 1});
+      async.elapse(const Duration(hours: 31));
+
+      expect(attempts.map((d) => d.inHours), [0, 10, 20, 30]);
+      expect(queue.length, 0);
+    });
+  });
+
+  test('a 429 without a usable retry-after falls back to the backoff', () {
+    fakeAsync((async) {
+      final attempts = <Duration>[];
+      _queue(
+        async,
+        MockClient((_) async {
+          attempts.add(async.elapsed);
+          return http.Response('', 429);
+        }),
+      ).enqueue({'n': 1});
+
+      async.elapse(const Duration(seconds: 90));
+
+      expect(attempts.map((d) => d.inSeconds), [0, 60]);
+    });
+  });
+
+  test('a network error counts as a failure', () {
+    fakeAsync((async) {
+      final attempts = <Duration>[];
+      _queue(
+        async,
+        MockClient((_) async {
+          attempts.add(async.elapsed);
+          throw http.ClientException('connection refused');
+        }),
+      ).enqueue({'n': 1});
+
+      async.elapse(const Duration(seconds: 90));
+
+      expect(attempts.map((d) => d.inSeconds), [0, 60]);
+    });
+  });
+
+  test('a request that hangs times out after 10 seconds and is retried', () {
+    fakeAsync((async) {
+      final attempts = <Duration>[];
+      _queue(
+        async,
+        MockClient((_) {
+          attempts.add(async.elapsed);
+          return Completer<http.Response>().future;
+        }),
+      ).enqueue({'n': 1});
+
+      async.elapse(const Duration(seconds: 75));
+
+      expect(attempts.map((d) => d.inSeconds), [0, 70]);
+    });
+  });
+
+  test('holds at most maxLength reports, dropping the oldest', () {
+    fakeAsync((async) {
+      var online = false;
+      final delivered = <Object?>[];
+      final queue = _queue(
+        async,
+        MockClient((request) async {
+          if (!online) return http.Response('', 503);
+          delivered.add((jsonDecode(request.body) as Map)['n']);
+          return http.Response('{}', 201);
+        }),
+        maxLength: 3,
+      );
+
+      for (var n = 1; n <= 5; n++) {
+        queue.enqueue({'n': n});
+        async.flushMicrotasks();
+      }
+      expect(queue.length, 3);
+
+      online = true;
+      async.elapse(const Duration(minutes: 2));
+
+      expect(delivered, [3, 4, 5]);
+      expect(queue.length, 0);
+    });
+  });
+
+  test('sendOnce makes one attempt and never queues', () {
+    fakeAsync((async) {
+      var calls = 0;
+      final queue = _queue(
+        async,
+        MockClient((_) async {
+          calls++;
+          return http.Response('', 503);
+        }),
+      );
+
+      SendResult? result;
+      queue.sendOnce({'n': 1}).then((r) => result = r);
+      async.elapse(const Duration(minutes: 10));
+
+      expect(result?.outcome, SendOutcome.failed);
+      expect(calls, 1);
+      expect(queue.length, 0);
+    });
+  });
+}

--- a/player/test/core/crash_reporting/crash_report_queue_test.dart
+++ b/player/test/core/crash_reporting/crash_report_queue_test.dart
@@ -22,6 +22,19 @@ CrashReportQueue _queue(
       maxLength: maxLength,
     );
 
+/// Never answers, and records whether the queue aborted the request.
+class _HangingClient extends http.BaseClient {
+  var aborted = 0;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    if (request is http.Abortable) {
+      request.abortTrigger?.then((_) => aborted++);
+    }
+    return Completer<http.StreamedResponse>().future;
+  }
+}
+
 void main() {
   group('SendResult.fromStatus', () {
     test('maps the statuses the relays answer with', () {
@@ -151,8 +164,22 @@ void main() {
       queue.enqueue({'n': 1});
       async.elapse(const Duration(hours: 31));
 
-      expect(attempts.map((d) => d.inHours), [0, 10, 20, 30]);
+      expect(attempts.map((d) => d.inHours), [0, 10, 20]);
       expect(queue.length, 0);
+    });
+  });
+
+  test('aborts a request that times out, so a late success cannot duplicate it',
+      () {
+    fakeAsync((async) {
+      final client = _HangingClient();
+      _queue(async, client).enqueue({'n': 1});
+
+      async.elapse(const Duration(seconds: 9));
+      expect(client.aborted, 0);
+
+      async.elapse(const Duration(seconds: 2));
+      expect(client.aborted, 1);
     });
   });
 

--- a/player/test/core/crash_reporting/crash_report_test.dart
+++ b/player/test/core/crash_reporting/crash_report_test.dart
@@ -1,0 +1,215 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/crash_reporting/crash_report.dart';
+
+const _context = CrashAppContext(
+  version: '0.52.1',
+  buildNumber: '5201',
+  platform: 'android',
+  osVersion: 'Android 15 (SDK 35)',
+  environment: 'prod',
+);
+
+// What an AOT release build prints: no column, and <asynchronous suspension>
+// between frames. Captured from a real ahead-of-time compiled probe.
+const _releaseTrace = '''
+#0      PlayerController.seek (package:player/core/player/player_controller.dart:412)
+<asynchronous suspension>
+#1      _PlayerScreenState._onSeek (package:player/presentation/screens/player/player_screen.dart:2201)
+<asynchronous suspension>
+''';
+
+void main() {
+  group('parseCrashFrames', () {
+    test('reads function, file and line from a release trace', () {
+      final frames = parseCrashFrames(StackTrace.fromString(_releaseTrace));
+
+      expect(frames.map((f) => f.toJson()), [
+        {
+          'function': 'PlayerController.seek',
+          'file': 'package:player/core/player/player_controller.dart',
+          'line': 412,
+        },
+        {
+          'function': '_PlayerScreenState._onSeek',
+          'file':
+              'package:player/presentation/screens/player/player_screen.dart',
+          'line': 2201,
+        },
+      ]);
+    });
+
+    test('drops leading framework frames so frame 0 is player code', () {
+      final frames = parseCrashFrames(StackTrace.fromString('''
+#0      State.setState (package:flutter/src/widgets/framework.dart:1219:9)
+#1      _DownloadsScreenState._onProgress (package:player/presentation/screens/downloads/downloads_screen.dart:88:5)
+#2      _rootRunUnary (dart:async/zone.dart:1538:47)
+'''));
+
+      expect(frames.map((f) => f.file), [
+        'package:player/presentation/screens/downloads/downloads_screen.dart',
+        'dart:async/zone.dart',
+      ]);
+      expect(frames.first.line, 88);
+    });
+
+    test('keeps a trace with no player frame whole', () {
+      final frames = parseCrashFrames(StackTrace.fromString('''
+#0      RenderFlex.performLayout (package:flutter/src/rendering/flex.dart:1016:32)
+#1      RenderObject.layout (package:flutter/src/rendering/object.dart:2656:7)
+'''));
+
+      expect(frames, hasLength(2));
+      expect(frames.first.file, 'package:flutter/src/rendering/flex.dart');
+    });
+
+    test('names closures and skips the VM fold marker', () {
+      final frames = parseCrashFrames(StackTrace.fromString('''
+#0      _PlayerScreenState.build.<anonymous closure> (package:player/presentation/screens/player/player_screen.dart:900:13)
+...
+#1      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1224:21)
+'''));
+
+      expect(frames.map((f) => f.function), [
+        '_PlayerScreenState.build.<fn>',
+        '_InkResponseState.handleTap',
+      ]);
+    });
+
+    test('keeps at most 64 frames, from the top', () {
+      final trace = [
+        for (var i = 0; i < 100; i++)
+          '#$i      F$i (package:player/f.dart:${i + 1})',
+      ].join('\n');
+
+      final frames = parseCrashFrames(StackTrace.fromString(trace));
+
+      expect(frames, hasLength(kMaxCrashFrames));
+      expect(frames.first.line, 1);
+    });
+
+    test('parses a live stack trace', () {
+      final frames = parseCrashFrames(StackTrace.current);
+
+      expect(frames, isNotEmpty);
+      expect(frames.every((f) => f.line > 0), isTrue);
+    });
+
+    test('returns no frames without a stack', () {
+      expect(parseCrashFrames(null), isEmpty);
+    });
+  });
+
+  group('CrashReport', () {
+    test('serializes to the body both relays accept', () {
+      final report = CrashReport.fromError(
+        StateError('No element'),
+        StackTrace.fromString(_releaseTrace),
+        capture: CrashCapture.zone,
+        context: _context,
+        occurredAt: DateTime.utc(2026, 9, 10, 12),
+      );
+
+      // Mirrors PLAYER_REPORT in relay-worker/test/crashes/ingest.test.ts.
+      expect(report.toJson(), {
+        'source': 'player',
+        'error_type': 'StateError',
+        'error_message': 'Bad state: No element',
+        'stacktrace': [
+          {
+            'function': 'PlayerController.seek',
+            'file': 'package:player/core/player/player_controller.dart',
+            'line': 412,
+          },
+          {
+            'function': '_PlayerScreenState._onSeek',
+            'file':
+                'package:player/presentation/screens/player/player_screen.dart',
+            'line': 2201,
+          },
+        ],
+        'version': '0.52.1',
+        'environment': 'prod',
+        'occurred_at': '2026-09-10T12:00:00.000Z',
+        'metadata': {
+          'capture': 'zone',
+          'manual': false,
+          'platform': 'android',
+          'os_version': 'Android 15 (SDK 35)',
+          'build_number': '5201',
+          'function': 'PlayerController.seek',
+          'file': 'package:player/core/player/player_controller.dart',
+          'line': 412,
+        },
+      });
+    });
+
+    test('omits the top-frame metadata when there is no stack', () {
+      final json = CrashReport.fromError(
+        Exception('boom'),
+        null,
+        capture: CrashCapture.startup,
+        context: _context,
+        occurredAt: DateTime.utc(2026, 9, 10, 12),
+        manual: true,
+      ).toJson();
+
+      expect(json['stacktrace'], isEmpty);
+      expect(json['metadata'], {
+        'capture': 'startup',
+        'manual': true,
+        'platform': 'android',
+        'os_version': 'Android 15 (SDK 35)',
+        'build_number': '5201',
+      });
+    });
+
+    test('writes occurred_at in UTC', () {
+      final json = CrashReport.fromError(
+        Exception('boom'),
+        null,
+        capture: CrashCapture.zone,
+        context: _context,
+        occurredAt: DateTime.utc(2026, 9, 10, 12).toLocal(),
+      ).toJson();
+
+      expect(json['occurred_at'], '2026-09-10T12:00:00.000Z');
+    });
+
+    test('uses the wire names the relay stores', () {
+      expect(CrashCapture.values.map((c) => c.wireName), [
+        'flutter_error',
+        'zone',
+        'platform_dispatcher',
+        'startup',
+      ]);
+    });
+  });
+
+  group('crashDedupKey', () {
+    test('keys on type and top frame when there are frames', () {
+      expect(
+        crashDedupKey({
+          'error_type': 'StateError',
+          'error_message': 'anything',
+          'stacktrace': [
+            {'function': 'F', 'file': 'package:player/f.dart', 'line': 7},
+          ],
+        }),
+        'StateError|package:player/f.dart|7',
+      );
+    });
+
+    test('keys on type and the first 200 message characters otherwise', () {
+      final message = 'x' * 300;
+
+      expect(
+        crashDedupKey({
+          'error_type': 'StateError',
+          'error_message': message,
+          'stacktrace': <Object?>[],
+        }),
+        'StateError|${'x' * 200}',
+      );
+    });
+  });
+}

--- a/player/test/core/crash_reporting/crash_reporter_test.dart
+++ b/player/test/core/crash_reporting/crash_reporter_test.dart
@@ -1,0 +1,444 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:ui' show PlatformDispatcher;
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:player/core/crash_reporting/crash_report.dart';
+import 'package:player/core/crash_reporting/crash_reporter.dart';
+import 'package:player/core/crash_reporting/startup_report_controller.dart';
+
+const _context = CrashAppContext(
+  version: '0.52.1',
+  buildNumber: '5201',
+  platform: 'android',
+  osVersion: 'Android 15 (SDK 35)',
+  environment: 'prod',
+);
+
+/// A one-frame trace whose top frame is `package:player/<file>:<line>`, so
+/// each distinct (file, line) is a distinct crash site.
+StackTrace _at(String file, int line) => StackTrace.fromString(
+    '#0      Widget.method (package:player/$file:$line)\n');
+
+class _Harness {
+  _Harness(
+    FakeAsync async, {
+    bool consent = true,
+    Future<bool> Function()? loadConsent,
+    Future<void> Function(bool enabled)? saveConsent,
+    Future<CrashAppContext> Function()? loadAppContext,
+    List<int> statuses = const [201],
+    bool isAvailable = true,
+  }) {
+    var call = 0;
+    reporter = CrashReporter(
+      client: MockClient((request) async {
+        requests.add(jsonDecode(request.body) as Map<String, Object?>);
+        final status =
+            statuses[call < statuses.length ? call : statuses.length - 1];
+        call++;
+        return http.Response('{}', status);
+      }),
+      endpoint: Uri.parse('https://relay.test/crashes/report'),
+      loadConsent: loadConsent ?? () async => consent,
+      saveConsent: saveConsent ?? (enabled) async => saved.add(enabled),
+      loadAppContext: loadAppContext ?? () async => _context,
+      isAvailable: isAvailable,
+      now: () => DateTime.utc(2026, 9, 10, 12).add(async.elapsed),
+      presentFlutterError: presented.add,
+    );
+  }
+
+  late final CrashReporter reporter;
+  final requests = <Map<String, Object?>>[];
+  final saved = <bool>[];
+  final presented = <FlutterErrorDetails>[];
+
+  Map<Object?, Object?> metadataOf(int index) =>
+      requests[index]['metadata']! as Map<Object?, Object?>;
+}
+
+void main() {
+  group('consent', () {
+    test('sends nothing until the user opts in', () {
+      fakeAsync((async) {
+        final h = _Harness(async, consent: false);
+
+        h.reporter.report(StateError('x'), _at('a.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+
+        expect(h.requests, isEmpty);
+      });
+    });
+
+    test('a consent read that throws counts as off and is retried next time',
+        () {
+      fakeAsync((async) {
+        var reads = 0;
+        final h = _Harness(
+          async,
+          loadConsent: () async {
+            reads++;
+            if (reads == 1) throw Exception('keyring locked');
+            return true;
+          },
+        );
+
+        h.reporter.report(StateError('x'), _at('a.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+        expect(h.requests, isEmpty);
+
+        h.reporter.report(StateError('x'), _at('b.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+        expect(h.requests, hasLength(1));
+        expect(reads, 2);
+      });
+    });
+
+    test('a consent read slower than 2 seconds counts as off', () {
+      fakeAsync((async) {
+        final h = _Harness(async, loadConsent: () => Completer<bool>().future);
+
+        var completed = false;
+        h.reporter
+            .report(StateError('x'), _at('a.dart', 1),
+                capture: CrashCapture.zone)
+            .then((_) => completed = true);
+        async.elapse(const Duration(seconds: 3));
+
+        expect(completed, isTrue);
+        expect(h.requests, isEmpty);
+      });
+    });
+
+    test('caches consent after the first successful read', () {
+      fakeAsync((async) {
+        var reads = 0;
+        final h = _Harness(
+          async,
+          loadConsent: () async {
+            reads++;
+            return true;
+          },
+        );
+
+        for (var i = 0; i < 3; i++) {
+          h.reporter.report(StateError('x'), _at('f$i.dart', 1),
+              capture: CrashCapture.zone);
+          async.flushMicrotasks();
+        }
+
+        expect(reads, 1);
+        expect(h.requests, hasLength(3));
+      });
+    });
+
+    test('setEnabled stores the choice and applies it to the next report', () {
+      fakeAsync((async) {
+        final h = _Harness(async, consent: false);
+
+        h.reporter.setEnabled(true);
+        async.flushMicrotasks();
+        h.reporter.report(StateError('x'), _at('a.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+
+        expect(h.saved, [true]);
+        expect(h.requests, hasLength(1));
+      });
+    });
+
+    test('setEnabled keeps the old choice when storing fails', () {
+      fakeAsync((async) {
+        final h = _Harness(
+          async,
+          consent: false,
+          saveConsent: (_) async => throw Exception('keyring refused'),
+        );
+
+        Object? thrown;
+        h.reporter.setEnabled(true).catchError((Object e) {
+          thrown = e;
+        });
+        async.flushMicrotasks();
+        bool? enabled;
+        h.reporter.isEnabled().then((value) => enabled = value);
+        async.flushMicrotasks();
+
+        expect(thrown, isNotNull);
+        expect(enabled, isFalse);
+      });
+    });
+  });
+
+  group('payload', () {
+    test('sends a sanitized player report', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        h.reporter.report(
+          StateError(
+              'stream https://mydia.example.org/api/stream/7?token=abc123 closed'),
+          _at('core/player/player_controller.dart', 412),
+          capture: CrashCapture.zone,
+        );
+        async.flushMicrotasks();
+
+        final body = h.requests.single;
+        expect(body['source'], 'player');
+        expect(body['error_type'], 'StateError');
+        expect(
+          body['error_message'],
+          'Bad state: stream https://[HOST]/api/stream/7?[REDACTED] closed',
+        );
+        expect(body['version'], '0.52.1');
+        expect(h.metadataOf(0)['capture'], 'zone');
+        expect(h.metadataOf(0)['manual'], isFalse);
+        expect(h.metadataOf(0)['platform'], 'android');
+        expect(
+          h.metadataOf(0)['file'],
+          'package:player/core/player/player_controller.dart',
+        );
+      });
+    });
+  });
+
+  group('volume', () {
+    test('drops reports past 10 in a minute', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        for (var i = 0; i < 11; i++) {
+          h.reporter.report(StateError('x'), _at('f$i.dart', 1),
+              capture: CrashCapture.zone);
+          async.flushMicrotasks();
+        }
+        expect(h.requests, hasLength(10));
+
+        async.elapse(const Duration(seconds: 61));
+        h.reporter.report(StateError('x'), _at('late.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+        expect(h.requests, hasLength(11));
+      });
+    });
+
+    test('reports a crash site once per session', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        for (var i = 0; i < 3; i++) {
+          h.reporter.report(StateError('x$i'), _at('a.dart', 1),
+              capture: CrashCapture.zone);
+          async.flushMicrotasks();
+        }
+
+        expect(h.requests, hasLength(1));
+      });
+    });
+
+    test('dedups frameless errors on type and message', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        h.reporter.report(StateError('a'), null, capture: CrashCapture.zone);
+        async.flushMicrotasks();
+        h.reporter.report(StateError('a'), null, capture: CrashCapture.zone);
+        async.flushMicrotasks();
+        h.reporter.report(StateError('b'), null, capture: CrashCapture.zone);
+        async.flushMicrotasks();
+
+        expect(h.requests, hasLength(2));
+      });
+    });
+  });
+
+  group('handlers', () {
+    test('handleFlutterError presents the error, then reports it', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        h.reporter.handleFlutterError(
+          FlutterErrorDetails(
+              exception: StateError('x'), stack: _at('a.dart', 1)),
+        );
+        async.flushMicrotasks();
+
+        expect(h.presented, hasLength(1));
+        expect(h.metadataOf(0)['capture'], 'flutter_error');
+      });
+    });
+
+    test('handleFlutterError presents silent errors but does not report them',
+        () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        h.reporter.handleFlutterError(
+          FlutterErrorDetails(
+            exception: StateError('image failed'),
+            stack: _at('a.dart', 1),
+            silent: true,
+          ),
+        );
+        async.flushMicrotasks();
+
+        expect(h.presented, hasLength(1));
+        expect(h.requests, isEmpty);
+      });
+    });
+
+    test('handlePlatformError reports and marks the error handled', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        final handled =
+            h.reporter.handlePlatformError(StateError('x'), _at('a.dart', 1));
+        async.flushMicrotasks();
+
+        expect(handled, isTrue);
+        expect(h.metadataOf(0)['capture'], 'platform_dispatcher');
+      });
+    });
+
+    test('install routes both handlers to the reporter', () {
+      final originalFlutter = FlutterError.onError;
+      final originalPlatform = PlatformDispatcher.instance.onError;
+      addTearDown(() {
+        FlutterError.onError = originalFlutter;
+        PlatformDispatcher.instance.onError = originalPlatform;
+      });
+
+      fakeAsync((async) {
+        final h = _Harness(async);
+        h.reporter.install();
+
+        expect(FlutterError.onError, h.reporter.handleFlutterError);
+        expect(PlatformDispatcher.instance.onError,
+            h.reporter.handlePlatformError);
+      });
+    });
+
+    test('an error raised while reporting is contained', () {
+      fakeAsync((async) {
+        final h = _Harness(
+          async,
+          loadAppContext: () async => throw StateError('no package info'),
+        );
+
+        var completed = false;
+        h.reporter
+            .report(StateError('x'), _at('a.dart', 1),
+                capture: CrashCapture.zone)
+            .then((_) => completed = true);
+        async.flushMicrotasks();
+
+        expect(completed, isTrue);
+        expect(h.requests, isEmpty);
+      });
+    });
+
+    test('an unavailable reporter sends nothing and offers no startup report',
+        () {
+      fakeAsync((async) {
+        final h = _Harness(async, isAvailable: false);
+
+        h.reporter.report(StateError('x'), _at('a.dart', 1),
+            capture: CrashCapture.zone);
+        final controller =
+            h.reporter.reportStartupFailure(StateError('x'), _at('a.dart', 1));
+        bool? enabled;
+        h.reporter.isEnabled().then((value) => enabled = value);
+        async.flushMicrotasks();
+
+        expect(h.requests, isEmpty);
+        expect(controller, isNull);
+        expect(enabled, isFalse);
+      });
+    });
+  });
+
+  group('reportStartupFailure', () {
+    test('sends at once when the user has opted in', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        final controller = h.reporter.reportStartupFailure(
+          StateError('bridge'),
+          _at('main.dart', 124),
+        )!;
+        async.flushMicrotasks();
+
+        expect(controller.value, StartupReportState.sent);
+        expect(h.metadataOf(0)['capture'], 'startup');
+        expect(h.metadataOf(0)['manual'], isFalse);
+      });
+    });
+
+    test('waits for a tap when the user has not opted in', () {
+      fakeAsync((async) {
+        final h = _Harness(async, consent: false);
+
+        final controller = h.reporter.reportStartupFailure(
+          StateError('bridge'),
+          _at('main.dart', 124),
+        )!;
+        async.flushMicrotasks();
+        expect(controller.value, StartupReportState.idle);
+        expect(h.requests, isEmpty);
+
+        controller.send();
+        async.flushMicrotasks();
+
+        expect(controller.value, StartupReportState.sent);
+        expect(h.metadataOf(0)['manual'], isTrue);
+      });
+    });
+
+    test('a failed send can be retried', () {
+      fakeAsync((async) {
+        final h = _Harness(async, consent: false, statuses: [503, 201]);
+
+        final controller = h.reporter.reportStartupFailure(
+          StateError('bridge'),
+          _at('main.dart', 124),
+        )!;
+        controller.send();
+        async.flushMicrotasks();
+        expect(controller.value, StartupReportState.failed);
+
+        controller.send();
+        async.flushMicrotasks();
+        expect(controller.value, StartupReportState.sent);
+        expect(h.requests, hasLength(2));
+      });
+    });
+
+    test('skips the throttle and the session dedup', () {
+      fakeAsync((async) {
+        final h = _Harness(async);
+
+        for (var i = 0; i < 11; i++) {
+          h.reporter.report(StateError('x'), _at('f$i.dart', 1),
+              capture: CrashCapture.zone);
+          async.flushMicrotasks();
+        }
+        expect(h.requests, hasLength(10));
+
+        // f0.dart:1 was reported above, and the window is spent.
+        h.reporter.reportStartupFailure(StateError('x'), _at('f0.dart', 1));
+        async.flushMicrotasks();
+
+        expect(h.requests, hasLength(11));
+        expect(h.metadataOf(10)['capture'], 'startup');
+      });
+    });
+  });
+}

--- a/player/test/core/crash_reporting/crash_reporter_test.dart
+++ b/player/test/core/crash_reporting/crash_reporter_test.dart
@@ -176,6 +176,54 @@ void main() {
         expect(enabled, isFalse);
       });
     });
+
+    test('a consent read in flight cannot undo an opt-out', () {
+      fakeAsync((async) {
+        final read = Completer<bool>();
+        final h = _Harness(async, loadConsent: () => read.future);
+
+        h.reporter.report(StateError('x'), _at('a.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+        h.reporter.setEnabled(false);
+        async.flushMicrotasks();
+        // The stored value from before the opt-out arrives late.
+        read.complete(true);
+        async.flushMicrotasks();
+        h.reporter.report(StateError('x'), _at('b.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+
+        expect(h.requests, isEmpty);
+      });
+    });
+
+    test('the later of two overlapping choices wins', () {
+      fakeAsync((async) {
+        final saves = <Completer<void>>[];
+        final h = _Harness(
+          async,
+          consent: false,
+          saveConsent: (_) {
+            final save = Completer<void>();
+            saves.add(save);
+            return save.future;
+          },
+        );
+
+        h.reporter.setEnabled(true);
+        h.reporter.setEnabled(false);
+        async.flushMicrotasks();
+        saves[1].complete();
+        saves[0].complete();
+        async.flushMicrotasks();
+        h.reporter.report(StateError('x'), _at('a.dart', 1),
+            capture: CrashCapture.zone);
+        async.flushMicrotasks();
+
+        expect(h.requests, isEmpty);
+      });
+    });
   });
 
   group('payload', () {

--- a/player/test/core/crash_reporting/crash_sanitizer_test.dart
+++ b/player/test/core/crash_reporting/crash_sanitizer_test.dart
@@ -1,0 +1,247 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/crash_reporting/crash_sanitizer.dart';
+
+void main() {
+  // Ported from test/mydia/crash_reporter/sanitizer_test.exs, so the player
+  // redacts at least what the server does. Cases whose expectation differs
+  // from the server say why.
+  group('sanitizeString, server parity', () {
+    test('redacts usernames in Unix, macOS and Windows paths', () {
+      expect(
+        sanitizeString('File not found: /home/user/mydia/data/file.txt'),
+        'File not found: /home/[USER]/mydia/data/file.txt',
+      );
+      expect(
+        sanitizeString('Cannot read /Users/jane/Library/Caches/x'),
+        'Cannot read /Users/[USER]/Library/Caches/x',
+      );
+      expect(
+        sanitizeString(r'Access denied: C:\Users\john\Documents\file.txt'),
+        r'Access denied: C:\Users\[USER]\Documents\file.txt',
+      );
+    });
+
+    test('keeps paths without usernames', () {
+      expect(
+        sanitizeString('Error in /app/lib/mydia/app.ex:42'),
+        'Error in /app/lib/mydia/app.ex:42',
+      );
+    });
+
+    test('redacts API keys', () {
+      expect(
+        sanitizeString('API key abc123def456ghi789jkl012mno345pqr is invalid'),
+        'API key [REDACTED] is invalid',
+      );
+    });
+
+    test('redacts bearer tokens', () {
+      expect(
+        sanitizeString('Authentication failed with Bearer abc123def456ghi789'),
+        'Authentication failed with Bearer [REDACTED]',
+      );
+    });
+
+    test('redacts JWTs', () {
+      expect(
+        sanitizeString(
+          'Invalid token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'
+          'eyJzdWIiOiIxMjM0NTY3ODkwIn0.'
+          'dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U',
+        ),
+        'Invalid token: [REDACTED]',
+      );
+    });
+
+    test('redacts password values', () {
+      expect(
+        sanitizeString('Database connection failed: password: secret123'),
+        'Database connection failed: password: [REDACTED]',
+      );
+    });
+
+    test('redacts URL credentials, and the host as well on the player', () {
+      expect(
+        sanitizeString(
+          'Failed to connect to https://user:pass123@example.com/api',
+        ),
+        'Failed to connect to https://[REDACTED]:[REDACTED]@[HOST]/api',
+      );
+    });
+
+    test('redacts connection-string credentials and keeps localhost', () {
+      expect(
+        sanitizeString(
+          'Connection failed: postgres://user:password@localhost/db',
+        ),
+        'Connection failed: postgres://[REDACTED]:[REDACTED]@localhost/db',
+      );
+    });
+
+    test('keeps bare IP addresses', () {
+      expect(
+        sanitizeString('Connection from 192.168.1.100 denied'),
+        'Connection from 192.168.1.100 denied',
+      );
+    });
+  });
+
+  group('sanitizeString, player rules', () {
+    test('redacts the host and query of a stream URL, keeping the port', () {
+      expect(
+        sanitizeString(
+          'GET https://mydia.example.org:4443/api/stream/7/index.m3u8'
+          '?token=abc123 failed',
+        ),
+        'GET https://[HOST]:4443/api/stream/7/index.m3u8?[REDACTED] failed',
+      );
+    });
+
+    test('drops URL fragments', () {
+      expect(
+        sanitizeString('at http://10.0.0.4:4000/player#/settings'),
+        'at http://[HOST]:4000/player',
+      );
+    });
+
+    test('keeps mydia.dev hosts and loopback', () {
+      const relay = 'POST https://relay.mydia.dev/crashes/report timed out';
+      const proxy = 'GET http://127.0.0.1:53412/hls/master.m3u8 failed';
+      expect(sanitizeString(relay), relay);
+      expect(sanitizeString(proxy), proxy);
+      expect(
+        sanitizeString('http://[::1]:8080/x'),
+        'http://[::1]:8080/x',
+      );
+    });
+
+    test("redacts the host in dart:io's SocketException wording", () {
+      expect(
+        sanitizeString(
+          "SocketException: Failed host lookup: 'mydia.example.org' "
+          '(OS Error: No address associated with hostname, errno = 7)',
+        ),
+        "SocketException: Failed host lookup: '[HOST]' "
+        '(OS Error: No address associated with hostname, errno = 7)',
+      );
+      expect(
+        sanitizeString(
+          'SocketException: Connection refused (OS Error: Connection '
+          'refused, errno = 111), address = 192.168.1.5, port = 43210',
+        ),
+        'SocketException: Connection refused (OS Error: Connection '
+        'refused, errno = 111), address = [HOST], port = 43210',
+      );
+    });
+
+    test('keeps long identifiers with no digit', () {
+      const message = 'setState() called after dispose(): '
+          '_OfflineSentinelStreamingFallbackState#1a2b3';
+      expect(sanitizeString(message), message);
+    });
+
+    test('redacts a 64-character hex node id', () {
+      final nodeId = 'a1' * 32;
+      expect(sanitizeString('dial $nodeId failed'), 'dial [REDACTED] failed');
+    });
+
+    test('leaves file URIs to the home-directory rule', () {
+      expect(
+        sanitizeString('file:///home/alex/.local/share/x.db locked'),
+        'file:///home/[USER]/.local/share/x.db locked',
+      );
+    });
+  });
+
+  group('sanitizeReport', () {
+    test('sanitizes the message and truncates after redacting', () {
+      final jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.'
+          'c2lnbmF0dXJlMTIzNDU2Nzg5MA';
+      final message = '${'a' * 4090} $jwt';
+
+      final out = sanitizeReport({'error_message': message});
+      final sanitized = out['error_message']! as String;
+
+      expect(sanitized, isNot(contains('eyJ')));
+      expect(sanitized, endsWith('...[truncated]'));
+      expect(
+        sanitized.length,
+        kMaxCrashMessageChars + '...[truncated]'.length,
+      );
+    });
+
+    test('leaves a short message untruncated', () {
+      expect(
+        sanitizeReport({'error_message': 'Bad state: No element'}),
+        {'error_message': 'Bad state: No element'},
+      );
+    });
+
+    test('redacts home directories in frame files and leaves functions', () {
+      final out = sanitizeReport({
+        'stacktrace': [
+          {
+            'function': '_OfflineSentinelStreamingFallbackState1234.build',
+            'file': 'file:///home/alex/player/lib/x.dart',
+            'line': 3,
+          },
+        ],
+      });
+
+      expect(out['stacktrace'], [
+        {
+          'function': '_OfflineSentinelStreamingFallbackState1234.build',
+          'file': 'file:///home/[USER]/player/lib/x.dart',
+          'line': 3,
+        },
+      ]);
+    });
+
+    test('applies frame rules to the metadata copy of the top frame', () {
+      final out = sanitizeReport({
+        'metadata': {
+          'function': '_OfflineSentinelStreamingFallbackState1234.build',
+          'file': '/home/alex/x.dart',
+          'line': 3,
+          'os_version': 'Android 15 (SDK 35)',
+          'manual': false,
+        },
+      });
+
+      expect(out['metadata'], {
+        'function': '_OfflineSentinelStreamingFallbackState1234.build',
+        'file': '/home/[USER]/x.dart',
+        'line': 3,
+        'os_version': 'Android 15 (SDK 35)',
+        'manual': false,
+      });
+    });
+
+    test('redacts metadata keys that look sensitive', () {
+      final out = sanitizeReport({
+        'metadata': {
+          'api_key': 'secret123',
+          'password': 'pass456',
+          'secret_token': 'token789',
+          'normal_value': 'ok',
+        },
+      });
+
+      expect(out['metadata'], {
+        'api_key': '[REDACTED]',
+        'password': '[REDACTED]',
+        'secret_token': '[REDACTED]',
+        'normal_value': 'ok',
+      });
+    });
+
+    test('passes through keys it has no rule for', () {
+      final report = {
+        'source': 'player',
+        'error_type': 'StateError',
+        'version': '0.52.1',
+      };
+      expect(sanitizeReport(report), report);
+    });
+  });
+}

--- a/player/test/core/crash_reporting/crash_sanitizer_test.dart
+++ b/player/test/core/crash_reporting/crash_sanitizer_test.dart
@@ -151,6 +151,21 @@ void main() {
         'file:///home/[USER]/.local/share/x.db locked',
       );
     });
+
+    test('redacts Windows profiles on any drive, separator and case', () {
+      expect(
+        sanitizeString(r'Cannot open D:\Users\alice\AppData\x.log'),
+        r'Cannot open D:\Users\[USER]\AppData\x.log',
+      );
+      expect(
+        sanitizeString(r'Cannot open c:\users\bob\y.db'),
+        r'Cannot open c:\users\[USER]\y.db',
+      );
+      expect(
+        sanitizeString('Cannot open file:///C:/Users/carol/z.db'),
+        'Cannot open file:///C:/Users/[USER]/z.db',
+      );
+    });
   });
 
   group('sanitizeReport', () {

--- a/player/test/core/crash_reporting/startup_report_controller_test.dart
+++ b/player/test/core/crash_reporting/startup_report_controller_test.dart
@@ -1,0 +1,82 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/crash_reporting/startup_report_controller.dart';
+
+void main() {
+  test('goes idle, sending, sent', () async {
+    final gate = Completer<bool>();
+    final controller = StartupReportController(
+      send: ({required bool manual}) => gate.future,
+    );
+    expect(controller.value, StartupReportState.idle);
+
+    final sending = controller.send();
+    expect(controller.value, StartupReportState.sending);
+
+    gate.complete(true);
+    await sending;
+    expect(controller.value, StartupReportState.sent);
+  });
+
+  test('passes manual through, defaulting to true for a tap', () async {
+    final seen = <bool>[];
+    final controller = StartupReportController(
+      send: ({required bool manual}) async {
+        seen.add(manual);
+        return false;
+      },
+    );
+
+    await controller.send(manual: false);
+    await controller.send();
+
+    expect(seen, [false, true]);
+  });
+
+  test('ignores a second send while one is in flight', () async {
+    final gate = Completer<bool>();
+    var calls = 0;
+    final controller = StartupReportController(
+      send: ({required bool manual}) {
+        calls++;
+        return gate.future;
+      },
+    );
+
+    final first = controller.send();
+    await controller.send();
+    gate.complete(true);
+    await first;
+
+    expect(calls, 1);
+  });
+
+  test('ignores send once the report is sent', () async {
+    var calls = 0;
+    final controller = StartupReportController(
+      send: ({required bool manual}) async {
+        calls++;
+        return true;
+      },
+    );
+
+    await controller.send();
+    await controller.send();
+
+    expect(calls, 1);
+  });
+
+  test('a failed send can be retried', () async {
+    final results = [false, true];
+    final controller = StartupReportController(
+      send: ({required bool manual}) async => results.removeAt(0),
+    );
+
+    await controller.send();
+    expect(controller.value, StartupReportState.failed);
+
+    await controller.send();
+    expect(controller.value, StartupReportState.sent);
+  });
+}

--- a/player/test/core/settings/settings_service_crash_reporting_test.dart
+++ b/player/test/core/settings/settings_service_crash_reporting_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/settings/settings_service.dart';
+
+import '../../test_utils/mock_auth_storage.dart';
+
+void main() {
+  test('crash reporting is off until the user opts in', () async {
+    final service = SettingsService(storage: MockAuthStorage());
+
+    expect(await service.getCrashReportingEnabled(), isFalse);
+  });
+
+  test('the choice round-trips through storage', () async {
+    final storage = MockAuthStorage();
+    final service = SettingsService(storage: storage);
+
+    await service.setCrashReportingEnabled(true);
+    expect(await service.getCrashReportingEnabled(), isTrue);
+    expect(storage.contents, {'crash_reporting_enabled': 'true'});
+
+    await service.setCrashReportingEnabled(false);
+    expect(await service.getCrashReportingEnabled(), isFalse);
+  });
+
+  // A device-level choice, not an account preference: signing out of one
+  // server must not silently opt the device back out, or in.
+  test('clearSettings leaves the crash-reporting choice alone', () async {
+    final storage = MockAuthStorage();
+    final service = SettingsService(storage: storage);
+
+    await service.setCrashReportingEnabled(true);
+    await service.setAutoSkipSegments(true);
+    await service.clearSettings();
+
+    expect(storage.contents, {'crash_reporting_enabled': 'true'});
+  });
+}

--- a/player/test/core/startup/startup_error_app_test.dart
+++ b/player/test/core/startup/startup_error_app_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/crash_reporting/startup_report_controller.dart';
 import 'package:player/core/startup/startup_error_app.dart';
 
 void main() {
@@ -35,6 +38,105 @@ void main() {
 
       expect(find.byType(MaterialApp), findsOneWidget);
       expect(find.byType(Scaffold), findsOneWidget);
+    });
+
+    const buttonKey = Key('startup-report-button');
+
+    bool buttonEnabled(WidgetTester tester) =>
+        tester.widget<ButtonStyleButton>(find.byKey(buttonKey)).enabled;
+
+    testWidgets('generic without a controller shows no report button',
+        (tester) async {
+      await tester.pumpWidget(StartupErrorApp.generic(Exception('boom')));
+
+      expect(find.byKey(buttonKey), findsNothing);
+    });
+
+    testWidgets('alreadyRunning never shows a report button', (tester) async {
+      await tester.pumpWidget(
+        StartupErrorApp.alreadyRunning(Exception('lock failed')),
+      );
+
+      expect(find.byKey(buttonKey), findsNothing);
+    });
+
+    testWidgets('Send report sends as a tap, shows progress, then Report sent',
+        (tester) async {
+      final gate = Completer<bool>();
+      final sends = <bool>[];
+      final controller = StartupReportController(
+        send: ({required bool manual}) {
+          sends.add(manual);
+          return gate.future;
+        },
+      );
+
+      await tester.pumpWidget(
+        StartupErrorApp.generic(Exception('boom'), report: controller),
+      );
+      expect(find.text('Send report'), findsOneWidget);
+      expect(buttonEnabled(tester), isTrue);
+
+      await tester.tap(find.byKey(buttonKey));
+      await tester.pump();
+      expect(find.text('Sending report'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(buttonEnabled(tester), isFalse);
+
+      gate.complete(true);
+      await tester.pumpAndSettle();
+      expect(find.text('Report sent'), findsOneWidget);
+      expect(buttonEnabled(tester), isFalse);
+      expect(sends, [true]);
+    });
+
+    testWidgets('a failed send offers a retry', (tester) async {
+      final results = [false, true];
+      final controller = StartupReportController(
+        send: ({required bool manual}) async => results.removeAt(0),
+      );
+
+      await tester.pumpWidget(
+        StartupErrorApp.generic(Exception('boom'), report: controller),
+      );
+      await tester.tap(find.byKey(buttonKey));
+      await tester.pumpAndSettle();
+      expect(find.text("Couldn't send. Try again"), findsOneWidget);
+      expect(buttonEnabled(tester), isTrue);
+
+      await tester.tap(find.byKey(buttonKey));
+      await tester.pumpAndSettle();
+      expect(find.text('Report sent'), findsOneWidget);
+    });
+
+    testWidgets('opens on Report sent when the report already went out',
+        (tester) async {
+      final controller = StartupReportController(
+        send: ({required bool manual}) async => true,
+      );
+      await controller.send(manual: false);
+
+      await tester.pumpWidget(
+        StartupErrorApp.generic(Exception('boom'), report: controller),
+      );
+
+      expect(find.text('Report sent'), findsOneWidget);
+      expect(buttonEnabled(tester), isFalse);
+    });
+
+    testWidgets('uses no em dashes in its copy', (tester) async {
+      final controller = StartupReportController(
+        send: ({required bool manual}) async => false,
+      );
+      await tester.pumpWidget(
+        StartupErrorApp.generic(Exception('boom'), report: controller),
+      );
+      await tester.tap(find.byKey(buttonKey));
+      await tester.pumpAndSettle();
+
+      for (final text in tester.widgetList<Text>(find.byType(Text))) {
+        expect(text.data ?? '', isNot(contains('—')));
+      }
     });
   });
 }

--- a/player/test/presentation/screens/settings/settings_screen_test.dart
+++ b/player/test/presentation/screens/settings/settings_screen_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:hive_ce/hive.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:player/core/auth/auth_status.dart';
 import 'package:player/core/connection/connection_provider.dart';
 import 'package:player/core/graphql/graphql_provider.dart';
@@ -14,6 +16,9 @@ import 'package:player/core/p2p/p2p_service.dart';
 import 'package:player/core/remote/node_registration_providers.dart';
 import 'package:player/core/remote/registration_status.dart';
 import 'package:player/core/remote/remote_control_settings.dart';
+import 'package:player/core/crash_reporting/crash_report.dart';
+import 'package:player/core/crash_reporting/crash_reporter.dart';
+import 'package:player/core/crash_reporting/crash_reporter_provider.dart';
 import 'package:player/core/update/update_backend.dart';
 import 'package:player/core/update/update_provider.dart';
 import 'package:player/domain/models/user_settings.dart';
@@ -156,6 +161,7 @@ Future<void> _pump(
   Size size = const Size(1000, 1400),
   RegistrationStatus registration = const RegistrationIdle(),
   UpdateState? updateState,
+  CrashReporter? crashReporter,
 }) async {
   await tester.binding.setSurfaceSize(size);
   addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -196,6 +202,8 @@ Future<void> _pump(
         nodeRegistrationProvider.overrideWith(
           () => _StubRegistration(registration),
         ),
+        if (crashReporter != null)
+          crashReporterProvider.overrideWithValue(crashReporter),
       ],
       child: MaterialApp.router(
         routerConfig: GoRouter(
@@ -551,5 +559,35 @@ void main() {
       expect(find.byKey(const Key('remote-control-retry-row')), findsNothing);
       expect(find.text('Discoverable by your other devices'), findsOneWidget);
     });
+  });
+
+  testWidgets('hides the crash-reporting row when the reporter cannot send',
+      (tester) async {
+    // The default, inert reporter: what web builds and whole-app tests get.
+    await _pump(tester);
+
+    expect(find.byKey(const Key('crash-reporting-switch')), findsNothing);
+  });
+
+  testWidgets('shows the crash-reporting row when the reporter can send',
+      (tester) async {
+    await _pump(
+      tester,
+      crashReporter: CrashReporter(
+        client: MockClient((_) async => http.Response('{}', 201)),
+        endpoint: Uri.parse('https://relay.test/crashes/report'),
+        loadConsent: () async => false,
+        saveConsent: (_) async {},
+        loadAppContext: () async => const CrashAppContext(
+          version: '',
+          buildNumber: '',
+          platform: '',
+          osVersion: '',
+          environment: '',
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('crash-reporting-switch')), findsOneWidget);
   });
 }

--- a/player/test/presentation/screens/settings/widgets/crash_reporting_row_test.dart
+++ b/player/test/presentation/screens/settings/widgets/crash_reporting_row_test.dart
@@ -1,0 +1,117 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:player/core/crash_reporting/crash_report.dart';
+import 'package:player/core/crash_reporting/crash_reporter.dart';
+import 'package:player/core/crash_reporting/crash_reporter_provider.dart';
+import 'package:player/presentation/screens/settings/widgets/crash_reporting_row.dart';
+import 'package:player/presentation/screens/settings/widgets/settings_row.dart';
+
+CrashReporter _reporter({
+  bool stored = false,
+  Future<void> Function(bool enabled)? save,
+}) =>
+    CrashReporter(
+      client: MockClient((_) async => http.Response('{}', 201)),
+      endpoint: Uri.parse('https://relay.test/crashes/report'),
+      loadConsent: () async => stored,
+      saveConsent: save ?? (_) async {},
+      loadAppContext: () async => const CrashAppContext(
+        version: '0.52.1',
+        buildNumber: '5201',
+        platform: 'linux',
+        osVersion: 'Ubuntu 24.04',
+        environment: 'prod',
+      ),
+    );
+
+void main() {
+  Future<void> pump(WidgetTester tester, CrashReporter reporter) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [crashReporterProvider.overrideWithValue(reporter)],
+        child: const MaterialApp(home: Scaffold(body: CrashReportingRow())),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  SettingsRow row(WidgetTester tester) => tester
+      .widget<SettingsRow>(find.byKey(const Key('crash-reporting-switch')));
+
+  testWidgets('starts off when the user has not opted in', (tester) async {
+    await pump(tester, _reporter());
+
+    expect(row(tester).toggleValue, isFalse);
+  });
+
+  testWidgets('reflects an existing opt-in', (tester) async {
+    await pump(tester, _reporter(stored: true));
+
+    expect(row(tester).toggleValue, isTrue);
+  });
+
+  testWidgets('turning it on stores the choice and the reporter applies it',
+      (tester) async {
+    final stored = <bool>[];
+    final reporter = _reporter(save: (enabled) async => stored.add(enabled));
+    await pump(tester, reporter);
+
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    expect(stored, [true]);
+    expect(row(tester).toggleValue, isTrue);
+    expect(await reporter.isEnabled(), isTrue);
+  });
+
+  testWidgets('reverts when the choice cannot be stored', (tester) async {
+    // Gated so the optimistic value is observable before the write fails,
+    // as in beta_channel_row_test.dart.
+    final gate = Completer<void>();
+    await pump(
+      tester,
+      _reporter(
+        save: (_) async {
+          await gate.future;
+          throw Exception('keyring refused');
+        },
+      ),
+    );
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    expect(row(tester).toggleValue, isTrue,
+        reason: 'the switch should move optimistically');
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(row(tester).toggleValue, isFalse,
+        reason: 'a write that did not land must revert');
+  });
+
+  testWidgets('uses the server wording and says what is sent', (tester) async {
+    await pump(tester, _reporter());
+
+    expect(find.text('Share crashes with developers'), findsOneWidget);
+    expect(
+      find.text(
+        'Sends error details, app version and platform to the Mydia '
+        'developers when the app hits an error.',
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('uses no em dashes in its copy', (tester) async {
+    await pump(tester, _reporter());
+
+    for (final text in tester.widgetList<Text>(find.byType(Text))) {
+      expect(text.data ?? '', isNot(contains('—')));
+    }
+  });
+}

--- a/relay-worker/migrations/0005_crash_source.sql
+++ b/relay-worker/migrations/0005_crash_source.sql
@@ -4,8 +4,8 @@
 -- install that predates the field, which is why the default is 'server'
 -- rather than NULL. src/crashes/ingest.ts's crashSourceOf is the only writer.
 --
--- On `errors` it is the source of the report that first created the group.
--- Player frames are package:player/ URIs and server frames are lib/mydia/
--- paths, so a fingerprint never mixes the two in practice.
+-- On `errors` it is the source of the report that created the group. Player
+-- fingerprints are salted with the source in src/crashes/ingest.ts, so a
+-- group never mixes the two clients.
 ALTER TABLE errors ADD COLUMN source TEXT NOT NULL DEFAULT 'server';
 ALTER TABLE occurrences ADD COLUMN source TEXT NOT NULL DEFAULT 'server';

--- a/relay-worker/migrations/0005_crash_source.sql
+++ b/relay-worker/migrations/0005_crash_source.sql
@@ -1,0 +1,11 @@
+-- Which client sent a crash: 'server' (Mydia.CrashReporter in the mydia
+-- server) or 'player' (the Flutter player's CrashReporter). Every row written
+-- before this migration came from a server, and so does every report from an
+-- install that predates the field, which is why the default is 'server'
+-- rather than NULL. src/crashes/ingest.ts's crashSourceOf is the only writer.
+--
+-- On `errors` it is the source of the report that first created the group.
+-- Player frames are package:player/ URIs and server frames are lib/mydia/
+-- paths, so a fingerprint never mixes the two in practice.
+ALTER TABLE errors ADD COLUMN source TEXT NOT NULL DEFAULT 'server';
+ALTER TABLE occurrences ADD COLUMN source TEXT NOT NULL DEFAULT 'server';

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -8,6 +8,16 @@ export interface CrashFrame {
   line: number | null;
 }
 
+// Which client sent a report. Mydia.CrashReporter never sends the field, so
+// its absence means a server; the Flutter player sends "player". A closed set
+// because POST /crashes/report is unauthenticated and the value is stored and
+// rendered. metadata-relay's router.ex crash_source/1 mirrors this.
+export type CrashSource = "server" | "player";
+
+export function crashSourceOf(value: unknown): CrashSource {
+  return value === "player" ? "player" : "server";
+}
+
 export interface NormalizedCrash {
   kind: string;
   message: string;
@@ -18,6 +28,7 @@ export interface NormalizedCrash {
   environment: string | null;
   occurredAt: number;
   context: Record<string, unknown>;
+  source: CrashSource;
 }
 
 export interface ErrorRow {
@@ -34,6 +45,8 @@ export interface ErrorRow {
   // saturates, never reset back to 0. See 0002_crash_reports.sql for why
   // this can't be answered from ingest_buckets.saturated alone.
   count_is_floor: number;
+  // 'server' or 'player'; see 0005_crash_source.sql.
+  source: string;
 }
 
 export interface OccurrenceRow {
@@ -45,6 +58,7 @@ export interface OccurrenceRow {
   instance_key: string | null;
   context: string;
   stacktrace: string;
+  source: string;
 }
 
 // Occurrence rows written per fingerprint per instance per hour. Beyond this
@@ -279,6 +293,7 @@ export function normalizeCrashReport(
     environment: truncateOrNull(body.environment, MAX_FRAME_STRING_CHARS),
     occurredAt: parseOccurredAt(body.occurred_at),
     context: boundContext(isPlainObject(body.metadata) ? body.metadata : {}),
+    source: crashSourceOf(body.source),
   };
 }
 
@@ -526,8 +541,8 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
       c.env.DB.prepare(
         `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
                              status, first_seen_at, last_seen_at, occurrence_count,
-                             count_is_floor)
-         VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1, ?)
+                             count_is_floor, source)
+         VALUES (?, ?, ?, ?, ?, 'unresolved', ?, ?, 1, ?, ?)
          ON CONFLICT(fingerprint) DO UPDATE SET
            last_seen_at = excluded.last_seen_at,
            occurrence_count = errors.occurrence_count + 1,
@@ -542,11 +557,12 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
         crash.occurredAt,
         crash.occurredAt,
         bucket.saturated,
+        crash.source,
       ),
       c.env.DB.prepare(
         `INSERT INTO occurrences
-           (id, fingerprint, occurred_at, version, environment, instance_key, context, stacktrace)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+           (id, fingerprint, occurred_at, version, environment, instance_key, context, stacktrace, source)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ).bind(
         crypto.randomUUID(),
         fingerprint,
@@ -556,6 +572,7 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
         instanceKey,
         JSON.stringify(crash.context),
         JSON.stringify(crash.stacktrace),
+        crash.source,
       ),
     ]);
     const writes = bucket.writes + errorsResult.meta.rows_written + occurrenceResult.meta.rows_written;

--- a/relay-worker/src/crashes/ingest.ts
+++ b/relay-worker/src/crashes/ingest.ts
@@ -460,7 +460,15 @@ export function registerCrashRoutes(app: Hono<{ Bindings: Env }>): void {
     const topKey = top
       ? `${top.module ?? ""}:${top.function ?? ""}:${top.file ?? ""}:${top.line ?? ""}`
       : "no-frame";
-    const fingerprint = await fingerprintOf(crash.kind, topKey);
+    // Player reports get groups of their own. Otherwise a frameless Dart
+    // ArgumentError and a frameless Elixir one share a fingerprint, and the
+    // group's source (fixed by its first insert) hides the other client's
+    // crashes behind the dashboard's source filter. Server fingerprints are
+    // unchanged, so every existing group keeps its identity.
+    const fingerprint = await fingerprintOf(
+      crash.kind,
+      crash.source === "player" ? `${topKey}|player` : topKey,
+    );
 
     const instanceKey =
       c.req.header("cf-connecting-ip") ?? crash.version ?? "unknown";

--- a/relay-worker/src/crashes/queries.ts
+++ b/relay-worker/src/crashes/queries.ts
@@ -1,20 +1,27 @@
 import type { Env } from "../env";
-import type { ErrorRow, OccurrenceRow } from "./ingest";
+import type { CrashSource, ErrorRow, OccurrenceRow } from "./ingest";
 
 export async function listErrors(
   env: Env,
-  opts: { status?: string; limit: number; offset: number },
+  opts: { status?: string; source?: CrashSource; limit: number; offset: number },
 ): Promise<ErrorRow[]> {
-  const stmt = opts.status
-    ? env.DB.prepare(
-        `SELECT * FROM errors WHERE status = ?
-         ORDER BY last_seen_at DESC LIMIT ? OFFSET ?`,
-      ).bind(opts.status, opts.limit, opts.offset)
-    : env.DB.prepare(
-        `SELECT * FROM errors ORDER BY last_seen_at DESC LIMIT ? OFFSET ?`,
-      ).bind(opts.limit, opts.offset);
+  const clauses: string[] = [];
+  const binds: unknown[] = [];
+  if (opts.status) {
+    clauses.push("status = ?");
+    binds.push(opts.status);
+  }
+  if (opts.source) {
+    clauses.push("source = ?");
+    binds.push(opts.source);
+  }
+  const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
 
-  const { results } = await stmt.all<ErrorRow>();
+  const { results } = await env.DB.prepare(
+    `SELECT * FROM errors ${where} ORDER BY last_seen_at DESC LIMIT ? OFFSET ?`,
+  )
+    .bind(...binds, opts.limit, opts.offset)
+    .all<ErrorRow>();
   return results;
 }
 

--- a/relay-worker/src/dashboards/errors.tsx
+++ b/relay-worker/src/dashboards/errors.tsx
@@ -1,11 +1,44 @@
 import type { Hono } from "hono";
 import type { Env } from "../env";
-import type { ErrorRow, OccurrenceRow } from "../crashes/ingest";
+import type { CrashSource, ErrorRow, OccurrenceRow } from "../crashes/ingest";
 import { listErrors, getError, setErrorStatus } from "../crashes/queries";
 import { page, when, parsePage } from "./layout";
 import { Tabs, DataTable, Badge, PostButton, Pager, FLOOR_TITLE } from "./ui";
 
 const PAGE_SIZE = 50;
+
+// The two values crashSourceOf (src/crashes/ingest.ts) can store. Anything
+// else in ?source= is ignored rather than passed to D1, so the tabs and the
+// query never disagree about what a source is.
+const SOURCES: readonly CrashSource[] = ["server", "player"];
+
+function parseSource(value: string | undefined): CrashSource | undefined {
+  return SOURCES.find((candidate) => candidate === value);
+}
+
+// Every list link on this page is built here. URLSearchParams percent-encodes
+// each value for the URL layer, which is what `status` needs: it is
+// unvalidated caller input, and an HTML entity in its place would be decoded
+// back to a raw "&" before the browser parses the query, splitting one
+// parameter into two (the pager test in test/dashboards/errors.test.ts pins
+// this). hono/jsx still escapes the finished string for the HTML attribute;
+// the two encodings guard different layers and neither replaces the other.
+function errorsHref(params: { status?: string; source?: CrashSource; page?: number }): string {
+  const query = new URLSearchParams();
+  if (params.page) query.set("page", String(params.page));
+  if (params.status) query.set("status", params.status);
+  if (params.source) query.set("source", params.source);
+  const qs = query.toString();
+  return qs === "" ? "/admin/errors" : `/admin/errors?${qs}`;
+}
+
+const PLAYER_TITLE = "Sent by the Flutter player, not a mydia server";
+
+// Server rows are the default and carry no badge, so the list reads exactly
+// as it did before for every existing install. Only a player report is marked.
+function SourceBadge({ source }: { source: string }) {
+  return source === "player" ? <Badge label="player" title={PLAYER_TITLE} /> : null;
+}
 
 // fingerprintOf (src/crashes/ingest.ts) always produces exactly 32 lowercase
 // hex characters (the first 32 hex chars of a SHA-256 digest). Anything else
@@ -59,7 +92,8 @@ function ErrorTableRow({ error }: { error: ErrorRow }) {
   return (
     <tr>
       <td>
-        <a href={`/admin/errors/${error.fingerprint}`}>{error.kind}</a>
+        <a href={`/admin/errors/${error.fingerprint}`}>{error.kind}</a>{" "}
+        <SourceBadge source={error.source} />
       </td>
       <td class="wrap">{error.message}</td>
       <td class="muted">{sourceRef(error)}</td>
@@ -77,37 +111,47 @@ const HEADERS = ["Kind", "Message", "Source", "Count", "Last seen", "Status"];
 function ErrorsPage({
   rows,
   status,
+  source,
   page: pageNumber,
 }: {
   rows: ErrorRow[];
   status: string | undefined;
+  source: CrashSource | undefined;
   page: number;
 }) {
-  // Deliberate, reviewed departure from a byte-for-byte port: the replaced
-  // errors.ts ran `status` through escapeHtml here, which is the wrong tool
-  // for this position. `status` is unvalidated caller input straight from
-  // `c.req.query("status")` -- unlike `fingerprint`, it carries no shape
-  // guard -- and it is being placed inside a URL query string, not HTML
-  // markup. HTML-escaping doesn't protect a query string: a literal "&" in
-  // `status` would survive escapeHtml as "&amp;", the browser decodes that
-  // back to "&" before parsing the query, and one parameter silently splits
-  // into two. `encodeURIComponent` is the correct encoding for this
-  // position. hono/jsx still escapes the finished href string for the HTML
-  // attribute layer on top of this -- the two encodings guard different
-  // layers (URL structure vs. HTML markup) and neither substitutes for the
-  // other.
   const next =
-    rows.length === PAGE_SIZE
-      ? `/admin/errors?page=${pageNumber + 1}${status ? `&status=${encodeURIComponent(status)}` : ""}`
-      : null;
+    rows.length === PAGE_SIZE ? errorsHref({ page: pageNumber + 1, status, source }) : null;
 
   return (
     <>
       <Tabs
         links={[
-          { href: "/admin/errors", label: "all", active: status === undefined },
-          { href: "/admin/errors?status=unresolved", label: "unresolved", active: status === "unresolved" },
-          { href: "/admin/errors?status=resolved", label: "resolved", active: status === "resolved" },
+          { href: errorsHref({ source }), label: "all", active: status === undefined },
+          {
+            href: errorsHref({ status: "unresolved", source }),
+            label: "unresolved",
+            active: status === "unresolved",
+          },
+          {
+            href: errorsHref({ status: "resolved", source }),
+            label: "resolved",
+            active: status === "resolved",
+          },
+        ]}
+      />
+      <Tabs
+        links={[
+          { href: errorsHref({ status }), label: "all sources", active: source === undefined },
+          {
+            href: errorsHref({ status, source: "server" }),
+            label: "server",
+            active: source === "server",
+          },
+          {
+            href: errorsHref({ status, source: "player" }),
+            label: "player",
+            active: source === "player",
+          },
         ]}
       />
       <DataTable headers={HEADERS}>
@@ -124,8 +168,8 @@ function OccurrenceDetails({ occurrence }: { occurrence: OccurrenceRow }) {
   return (
     <details>
       <summary>
-        {when(occurrence.occurred_at)} &middot; {occurrence.version ?? "unknown"} &middot;{" "}
-        {occurrence.environment ?? ""}
+        {when(occurrence.occurred_at)} &middot; {occurrence.source} &middot;{" "}
+        {occurrence.version ?? "unknown"} &middot; {occurrence.environment ?? ""}
       </summary>
       <pre>{occurrence.stacktrace}</pre>
       <pre>{occurrence.context}</pre>
@@ -146,7 +190,7 @@ function ErrorDetailPage({
   return (
     <>
       <p>
-        <strong>{error.kind}</strong>: {error.message}
+        <strong>{error.kind}</strong>: {error.message} <SourceBadge source={error.source} />
         <br />
         <span class="muted">
           <Count count={error.occurrence_count} isFloor={error.count_is_floor === 1} /> occurrences,
@@ -168,14 +212,18 @@ function ErrorDetailPage({
 export function registerErrorDashboard(app: Hono<{ Bindings: Env }>): void {
   app.get("/admin/errors", async (c) => {
     const status = c.req.query("status") ?? undefined;
+    const source = parseSource(c.req.query("source"));
     const pageNumber = parsePage(c.req.query("page"));
     const rows = await listErrors(c.env, {
       status,
+      source,
       limit: PAGE_SIZE,
       offset: pageNumber * PAGE_SIZE,
     });
 
-    return c.html(page("Errors", <ErrorsPage rows={rows} status={status} page={pageNumber} />));
+    return c.html(
+      page("Errors", <ErrorsPage rows={rows} status={status} source={source} page={pageNumber} />),
+    );
   });
 
   app.get("/admin/errors/:fingerprint", async (c) => {

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -5,6 +5,40 @@ import { normalizeCrashReport, MAX_OCCURRENCE_ROWS_PER_BUCKET } from "../../src/
 const json = { "content-type": "application/json" };
 const REPORT_URL = "https://relay.mydia.dev/crashes/report";
 
+// The body the Flutter player's CrashReporter sends (see
+// player/lib/core/crash_reporting/crash_report.dart). Literal rather than
+// generated, so drift on either side shows up as a failing test here.
+const PLAYER_REPORT = {
+  source: "player",
+  error_type: "StateError",
+  error_message: "Bad state: No element",
+  stacktrace: [
+    {
+      function: "PlayerController.seek",
+      file: "package:player/core/player/player_controller.dart",
+      line: 412,
+    },
+    {
+      function: "_PlayerScreenState._onSeek",
+      file: "package:player/presentation/screens/player/player_screen.dart",
+      line: 2201,
+    },
+  ],
+  version: "0.52.1",
+  environment: "prod",
+  occurred_at: "2026-09-10T12:00:00.000Z",
+  metadata: {
+    capture: "zone",
+    manual: false,
+    platform: "android",
+    os_version: "Android 15 (SDK 35)",
+    build_number: "5201",
+    function: "PlayerController.seek",
+    file: "package:player/core/player/player_controller.dart",
+    line: 412,
+  },
+};
+
 interface ReportResponse {
   status: string;
   message: string;
@@ -300,6 +334,33 @@ describe("normalizeCrashReport", () => {
     });
 
     expect(out.context).toEqual(metadata);
+  });
+
+  it("labels a report without a source as a server report", () => {
+    const out = normalizeCrashReport({
+      error_type: "RuntimeError",
+      error_message: "boom",
+      stacktrace: [],
+    });
+    expect(out.source).toBe("server");
+  });
+
+  it("labels a player report as a player report", () => {
+    expect(normalizeCrashReport(PLAYER_REPORT).source).toBe("player");
+  });
+
+  // POST /crashes/report is unauthenticated and the value is stored and
+  // rendered, so only the two known values survive.
+  it("falls back to server for any source outside the closed set", () => {
+    for (const source of ["Player", "web", 1, null, { player: true }]) {
+      const out = normalizeCrashReport({
+        source,
+        error_type: "E",
+        error_message: "m",
+        stacktrace: [],
+      });
+      expect(out.source).toBe("server");
+    }
   });
 });
 
@@ -653,5 +714,78 @@ describe("POST /crashes/report", () => {
       .first<{ written: number; saturated: number }>();
     expect(bucket!.written).toBe(MAX_OCCURRENCE_ROWS_PER_BUCKET);
     expect(bucket!.saturated).toBe(1);
+  });
+
+  it("stores a player report's source on the error group and the occurrence", async () => {
+    const res = await SELF.fetch(REPORT_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify(PLAYER_REPORT),
+    });
+    expect(res.status).toBe(201);
+    const { id } = await res.json<ReportResponse>();
+
+    const error = await env.DB.prepare(
+      "SELECT source, kind, source_file, source_line FROM errors WHERE fingerprint = ?",
+    )
+      .bind(id)
+      .first();
+    expect(error).toMatchObject({
+      source: "player",
+      kind: "StateError",
+      source_file: "package:player/core/player/player_controller.dart",
+      source_line: 412,
+    });
+
+    const occurrence = await env.DB.prepare(
+      "SELECT source, context FROM occurrences WHERE fingerprint = ?",
+    )
+      .bind(id)
+      .first<{ source: string; context: string }>();
+    expect(occurrence!.source).toBe("player");
+    expect(JSON.parse(occurrence!.context)).toMatchObject({
+      capture: "zone",
+      platform: "android",
+    });
+  });
+
+  it("stores a report without a source as a server report", async () => {
+    const res = await SELF.fetch(REPORT_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({
+        error_type: "SourcelessError",
+        error_message: "boom",
+        stacktrace: [{ module: "M", function: "f/0", file: "sourceless.ex", line: 7 }],
+      }),
+    });
+    expect(res.status).toBe(201);
+    const { id } = await res.json<ReportResponse>();
+
+    const error = await env.DB.prepare("SELECT source FROM errors WHERE fingerprint = ?")
+      .bind(id)
+      .first<{ source: string }>();
+    expect(error!.source).toBe("server");
+
+    const occurrence = await env.DB.prepare(
+      "SELECT source FROM occurrences WHERE fingerprint = ?",
+    )
+      .bind(id)
+      .first<{ source: string }>();
+    expect(occurrence!.source).toBe("server");
+  });
+});
+
+describe("0005_crash_source migration", () => {
+  it("adds a NOT NULL source defaulting to server on errors and occurrences", async () => {
+    for (const table of ["errors", "occurrences"]) {
+      const { results } = await env.DB.prepare(`PRAGMA table_info(${table})`).all<{
+        name: string;
+        notnull: number;
+        dflt_value: string | null;
+      }>();
+      const column = results.find((c) => c.name === "source");
+      expect(column, `${table}.source`).toMatchObject({ notnull: 1, dflt_value: "'server'" });
+    }
   });
 });

--- a/relay-worker/test/crashes/ingest.test.ts
+++ b/relay-worker/test/crashes/ingest.test.ts
@@ -774,6 +774,34 @@ describe("POST /crashes/report", () => {
       .first<{ source: string }>();
     expect(occurrence!.source).toBe("server");
   });
+
+  it("keeps a player crash and a server crash with the same kind and top frame in separate groups", async () => {
+    const shared = { error_type: "SharedSiteError", error_message: "bad", stacktrace: [] };
+
+    const serverRes = await SELF.fetch(REPORT_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify(shared),
+    });
+    const playerRes = await SELF.fetch(REPORT_URL, {
+      method: "POST",
+      headers: json,
+      body: JSON.stringify({ ...shared, source: "player" }),
+    });
+    const serverId = (await serverRes.json<ReportResponse>()).id;
+    const playerId = (await playerRes.json<ReportResponse>()).id;
+
+    expect(playerId).not.toBe(serverId);
+    const { results } = await env.DB.prepare(
+      "SELECT fingerprint, source FROM errors WHERE fingerprint IN (?, ?)",
+    )
+      .bind(serverId, playerId)
+      .all<{ fingerprint: string; source: string }>();
+    expect(Object.fromEntries(results.map((r) => [r.fingerprint, r.source]))).toEqual({
+      [serverId]: "server",
+      [playerId]: "player",
+    });
+  });
 });
 
 describe("0005_crash_source migration", () => {

--- a/relay-worker/test/dashboards/errors.test.ts
+++ b/relay-worker/test/dashboards/errors.test.ts
@@ -449,3 +449,67 @@ describe("GET /admin/errors pager link encodes the status filter for the URL, no
     expect(html).not.toContain("status=custom&amp;type");
   });
 });
+
+describe("GET /admin/errors source filter", () => {
+  const PLAYER_FP = "b1c2d3e4f5a60718293a4b5c6d7e8f90";
+  const PLAYER_MESSAGE = "Bad state: No element";
+
+  beforeAll(async () => {
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO errors (fingerprint, kind, message, source_file, source_line,
+                           status, first_seen_at, last_seen_at, occurrence_count, source)
+       VALUES (?, 'StateError', ?, 'package:player/core/player/player_controller.dart', 412,
+               'unresolved', ?, ?, 2, 'player')`,
+    )
+      .bind(PLAYER_FP, PLAYER_MESSAGE, now, now)
+      .run();
+  });
+
+  async function html(query: string): Promise<string> {
+    const res = await SELF.fetch(`https://relay.mydia.dev/admin/errors${query}`);
+    expect(res.status).toBe(200);
+    return res.text();
+  }
+
+  it("lists only player crashes under ?source=player", async () => {
+    const body = await html("?source=player");
+    expect(body).toContain(PLAYER_MESSAGE);
+    expect(body).not.toContain(`/admin/errors/${FP1}`);
+  });
+
+  // status=unresolved keeps the pager describe's 50 newer 'custom&type' rows
+  // from pushing FP1 off the first page if storage is not isolated between
+  // describe blocks.
+  it("lists only server crashes under ?source=server", async () => {
+    const body = await html("?status=unresolved&source=server");
+    expect(body).toContain(`/admin/errors/${FP1}`);
+    expect(body).not.toContain(PLAYER_MESSAGE);
+  });
+
+  it("ignores a source outside the closed set", async () => {
+    const body = await html("?status=unresolved&source=web");
+    expect(body).toContain(`/admin/errors/${FP1}`);
+    expect(body).toContain(PLAYER_MESSAGE);
+  });
+
+  it("badges player rows and only player rows", async () => {
+    expect(await html("?source=player")).toContain(
+      'title="Sent by the Flutter player, not a mydia server"',
+    );
+    expect(await html("?source=server")).not.toContain(
+      'title="Sent by the Flutter player, not a mydia server"',
+    );
+  });
+
+  it("keeps the source filter on the status tabs and the status filter on the source tabs", async () => {
+    const body = await html("?status=unresolved&source=player");
+    expect(body).toContain('href="/admin/errors?status=resolved&amp;source=player"');
+    expect(body).toContain('href="/admin/errors?status=unresolved&amp;source=server"');
+  });
+
+  it("badges a player error's detail page", async () => {
+    const body = await html(`/${PLAYER_FP}`);
+    expect(body).toContain('title="Sent by the Flutter player, not a mydia server"');
+  });
+});


### PR DESCRIPTION
## Summary

The Flutter player now reports crashes to the relay's `POST /crashes/report`, the endpoint the mydia server already uses, with the same payload shape and the same safeguards.

- Opt-in: a "Share crashes with developers" switch in player Settings, off by default, device-level, kept across sign-out.
- Captures unhandled Dart errors (`FlutterError.onError`, the root zone, `PlatformDispatcher.onError`) and Rust bridge startup failures. The startup-error screen gets a Send report button, so a player that never started can still report. The "already running" screen reports nothing.
- Mirrors `Mydia.CrashReporter`: 10 reports a minute, a per-session dedup, the server's sanitizer rules plus player ones (server hosts, stream-URL query strings, `SocketException` hosts), and a retrying in-memory queue with the server's backoff and give-up limits. Reporting runs in its own error zone, so it can never report itself.
- Relays: reports carry `source: player`. relay-worker stores it in a new column (migration `0005_crash_source.sql`) and filters the errors dashboard by it; metadata-relay records it in each occurrence's context. A missing source means `server`, so every existing install is unaffected.
- Web builds install the handlers but send nothing (minified traces, no CORS on the endpoint).

## Compatibility

No deploy order. Until either relay ships this, player reports are still accepted and stored, just not labelled `player`. metadata-relay deploys on a `metadata-relay-v*` tag and relay-worker on `relay-worker-v*`; neither is tagged here.

## Test plan

- [x] `./dev flutter test --concurrency=1`: 3434 passed, 7 skipped
- [x] `./dev flutter analyze`: 0 errors, 0 warnings
- [x] relay-worker: `npm test` 375 passed (43 skipped), `npm run typecheck` clean
- [x] metadata-relay: `mix test` 315 tests, 0 failures; `mix format --check-formatted`; `mix compile --warnings-as-errors`
- [ ] Manual, optional: run the player with `--dart-define=RELAY_URL=http://localhost:4001` against a local metadata-relay, turn the switch on, trigger an error, and see it under `/errors` with `source: player` in its context.

## Notes

- `player/pubspec.lock` changes one line: `stack_trace` moves from transitive to a direct dependency.
- Files that historically change with these but were left alone on purpose: `metadata-relay/lib/metadata_relay/plug/cache.ex` (the router change is crash handling only), `relay-worker/migrations/0002_crash_reports.sql` (the schema change belongs in the new append-only `0005`), and `metadata-relay/test/metadata_relay/subdl/router_test.exs` (subtitle routes; the full relay suite passes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in crash reporting for player errors, startup failures, and platform issues.
  * Added privacy protections that redact sensitive information before reports are sent.
  * Added a crash-reporting toggle in Settings.
  * Added “Send report” and retry actions to the startup error screen.
  * Added crash-source labels and server/player filtering to the errors dashboard.
* **Bug Fixes**
  * Crash reports are now categorized consistently as player or server reports.
  * Improved report delivery reliability with timeouts, retries, and duplicate prevention.
  * Prevented outdated consent operations from overriding newer choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->