### PR TITLE
fix(player): resolve pubspec.lock on the pinned Flutter, not Dependabot's

### DIFF
--- a/.github/ci.md
+++ b/.github/ci.md
@@ -235,6 +235,34 @@ either alone reproduces the panic. They have to land together with a codegen
 regen. Dependabot's grouping does not know about cross-language version coupling
 and will keep splitting this.
 
+## Dependabot resolves pubspec.lock with its own Flutter
+
+Dependabot never reads `player/.fvmrc`. Its pub updater installs the newest
+stable Flutter release that `environment.sdk` and `environment.flutter` in
+`player/pubspec.yaml` allow, and resolves `pubspec.lock` on that. Each Flutter
+release pins `meta`, `matcher`, `test_api`, `vector_math` and `intl` to its own
+versions through `flutter_test` and its siblings, so a lock resolved on a newer
+minor cannot resolve on the pinned SDK.
+
+With no `environment.flutter` range, #613 and #740 were resolved on the next
+minor. CI ran plain `flutter pub get`, which quietly re-resolved those packages
+down on the `.fvmrc` SDK and passed, so the gate merged both. Every local
+`pub get` then wrote the lock back, and it showed as modified in every checkout.
+Restoring it did not help: the devenv `mydia:flutter` task reruns `pub get` on
+shell entry whenever the lock changes, so the restore was itself the trigger.
+
+Two checks now hold the line:
+
+- `environment.flutter` must read `>=<.fvmrc> <<next minor>.0`, enforced by
+  `Check / Flutter Pin`. Pub enforces only the lower bound of that range
+  (flutter/flutter#95472), so the upper bound constrains Dependabot alone, and
+  only that check notices when a `.fvmrc` bump leaves it behind.
+- Every CI and release `flutter pub get` passes `--enforce-lockfile`. A lock that
+  does not resolve on the pinned SDK fails `Test / Player`, and the gate reports
+  `BLOCKED`. The E2E runner is the exception: `player/Dockerfile.test` builds on
+  cirruslabs' floating `stable` image rather than `.fvmrc`, and cannot satisfy
+  the lock as committed.
+
 ## Quality gates
 
 PR #186 (merged 2026-06-05) removed dead-code and duplicate-code grandfathering.

--- a/.github/ci.md
+++ b/.github/ci.md
@@ -253,15 +253,18 @@ shell entry whenever the lock changes, so the restore was itself the trigger.
 
 Two checks now hold the line:
 
-- `environment.flutter` must read `>=<.fvmrc> <<next minor>.0`, enforced by
-  `Check / Flutter Pin`. Pub enforces only the lower bound of that range
-  (flutter/flutter#95472), so the upper bound constrains Dependabot alone, and
-  only that check notices when a `.fvmrc` bump leaves it behind.
+- `environment.flutter` must read `>=<minor>.0 <<next minor>.0` for the `.fvmrc`
+  minor, enforced by `Check / Flutter Pin`. Pub enforces only the lower bound of
+  that range (flutter/flutter#95472), so the upper bound constrains Dependabot
+  alone, and only that check notices when a `.fvmrc` bump leaves it behind. The
+  floor is `.0` rather than the `.fvmrc` patch because patches of one minor pin
+  the same packages, and the E2E image lags patch releases: a patch floor made
+  pub refuse it outright.
 - Every CI and release `flutter pub get` passes `--enforce-lockfile`. A lock that
   does not resolve on the pinned SDK fails `Test / Player`, and the gate reports
   `BLOCKED`. The E2E runner is the exception: `player/Dockerfile.test` builds on
-  cirruslabs' floating `stable` image rather than `.fvmrc`, and cannot satisfy
-  the lock as committed.
+  cirruslabs' floating `stable` image rather than `.fvmrc`, so the lock stops
+  resolving as committed there once that tag moves to a newer minor.
 
 ## Quality gates
 

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -24,9 +24,10 @@ jobs:
       # the exact regression this pin exists to prevent. So scan every file that
       # can select an SDK (workflows, Dockerfiles, compose files, nix modules,
       # scripts) for a version literal sitting in Flutter context. Dart package
-      # manifests are deliberately out of scope: their constraints pin packages,
-      # not the SDK this repo builds with. Needs only the checkout, so it runs
-      # first and fails in seconds.
+      # manifests are out of scope: their constraints pin packages, not the SDK
+      # this repo builds with. The one exception, environment.flutter in
+      # player/pubspec.yaml, is checked against .fvmrc by the next step. Needs
+      # only the checkout, so it runs first and fails in seconds.
       #
       # `uses:` lines are skipped because an action reference is not an SDK
       # selection. Without that, SHA-pinning the setup action in the usual
@@ -59,6 +60,35 @@ jobs:
             exit 1
           fi
           echo "OK: player/.fvmrc is the only file naming a Flutter version."
+
+      # Dependabot never reads .fvmrc. It resolves player/pubspec.lock with the
+      # newest stable Flutter that pubspec.yaml's environment.flutter allows, and
+      # every Flutter release pins several packages exactly, so that range must
+      # name the pinned minor. Otherwise Dependabot and each local `pub get`
+      # rewrite the lock in opposite directions. Pub enforces only the lower
+      # bound, so nothing else notices when a bump leaves the range behind.
+      - name: Assert pubspec.yaml bounds Dependabot to the pinned minor
+        run: |
+          set -euo pipefail
+          pinned="$(jq -r .flutter player/.fvmrc)"
+          IFS=. read -r major minor _ <<< "$pinned"
+          expected=">=$pinned <$major.$((minor + 1)).0"
+          actual="$(
+            awk '/^environment:/ { e = 1; next }
+                 /^[^[:space:]#]/ { e = 0 }
+                 e && $1 == "flutter:" { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }' \
+              player/pubspec.yaml | tr -d "\"'"
+          )"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::environment.flutter in player/pubspec.yaml does not match player/.fvmrc"
+            echo "  found:    ${actual:-<missing>}"
+            echo "  expected: $expected"
+            echo
+            echo "Set it to '$expected' and re-run \`flutter pub get\` in player/"
+            echo "so pubspec.lock is resolved against the pinned SDK."
+            exit 1
+          fi
+          echo "OK: environment.flutter is '$expected'."
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -67,12 +67,17 @@ jobs:
       # name the pinned minor. Otherwise Dependabot and each local `pub get`
       # rewrite the lock in opposite directions. Pub enforces only the lower
       # bound, so nothing else notices when a bump leaves the range behind.
+      #
+      # The floor is the minor's .0 rather than the .fvmrc patch. Patches of
+      # one minor pin the same packages, and player/Dockerfile.test builds on
+      # cirruslabs' stable tag, which lags patch releases; a patch floor made
+      # pub refuse that image outright.
       - name: Assert pubspec.yaml bounds Dependabot to the pinned minor
         run: |
           set -euo pipefail
           pinned="$(jq -r .flutter player/.fvmrc)"
           IFS=. read -r major minor _ <<< "$pinned"
-          expected=">=$pinned <$major.$((minor + 1)).0"
+          expected=">=$major.$minor.0 <$major.$((minor + 1)).0"
           actual="$(
             awk '/^environment:/ { e = 1; next }
                  /^[^[:space:]#]/ { e = 0 }

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -78,12 +78,9 @@ jobs:
           pinned="$(jq -r .flutter player/.fvmrc)"
           IFS=. read -r major minor _ <<< "$pinned"
           expected=">=$major.$minor.0 <$major.$((minor + 1)).0"
-          actual="$(
-            awk '/^environment:/ { e = 1; next }
-                 /^[^[:space:]#]/ { e = 0 }
-                 e && $1 == "flutter:" { sub(/^[^:]*:[[:space:]]*/, ""); print; exit }' \
-              player/pubspec.yaml | tr -d "\"'"
-          )"
+          # yq ships on the runner image and parses the scalar the way pub
+          # does, so quoting and a trailing comment cannot skew the comparison.
+          actual="$(yq -r '.environment.flutter // ""' player/pubspec.yaml)"
           if [ "$actual" != "$expected" ]; then
             echo "::error::environment.flutter in player/pubspec.yaml does not match player/.fvmrc"
             echo "  found:    ${actual:-<missing>}"

--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -144,9 +144,15 @@ jobs:
           channel: stable
           cache: true
 
+      # --enforce-lockfile fails the job when pubspec.lock does not resolve on
+      # the .fvmrc SDK, instead of quietly re-resolving and testing a different
+      # tree. That is how a Dependabot PR resolved against a newer Flutter went
+      # green here while every local `pub get` rewrote its lock. Every CI and
+      # release `pub get` carries the flag except the E2E runner, whose image is
+      # not on the .fvmrc SDK (see scripts/e2e/run-tests.sh).
       - name: Install dependencies
         if: needs.changes.outputs.player == 'true'
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         if: needs.changes.outputs.player == 'true'
@@ -260,7 +266,7 @@ jobs:
 
       - name: Install dependencies
         if: needs.changes.outputs.player == 'true'
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         if: needs.changes.outputs.player == 'true'
@@ -387,7 +393,7 @@ jobs:
       - name: Install dependencies
         if: steps.check_platform.outputs.enabled == 'true'
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         if: steps.check_platform.outputs.enabled == 'true'
@@ -550,7 +556,7 @@ jobs:
       - name: Install dependencies
         if: needs.changes.outputs.player == 'true'
         working-directory: player
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       # Not optional: the generated Dart files are gitignored, so without this a
       # clean checkout fails the build with hundreds of errors pointing nowhere

--- a/.github/workflows/deploy-web-player.yml
+++ b/.github/workflows/deploy-web-player.yml
@@ -105,7 +105,7 @@ jobs:
       # itself assumes they already exist (true on a developer's worktree,
       # false on a first-time runner checkout) and does not run them.
       - name: Install Flutter dependencies
-        run: devenv shell -- bash -c "cd player && flutter pub get"
+        run: devenv shell -- bash -c "cd player && flutter pub get --enforce-lockfile"
 
       - name: Run code generation
         run: devenv shell -- bash -c "cd player && flutter pub run build_runner build"

--- a/.github/workflows/player-ios.yml
+++ b/.github/workflows/player-ios.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         working-directory: ${{ env.PLAYER_PATH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,7 +463,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         working-directory: ${{ env.PLAYER_PATH }}
@@ -577,7 +577,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         working-directory: ${{ env.PLAYER_PATH }}
@@ -818,7 +818,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         working-directory: ${{ env.PLAYER_PATH }}
@@ -888,7 +888,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter pub get
+        run: flutter pub get --enforce-lockfile
 
       - name: Run code generation
         working-directory: ${{ env.PLAYER_PATH }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ COPY priv/graphql/schema.graphql ./lib/graphql/schema.graphql
 # load and playback cycle. Flutter's own build prints that its service worker
 # is deprecated and slated for removal.
 RUN --mount=type=cache,target=/root/.pub-cache,sharing=locked \
-    flutter pub get && \
+    flutter pub get --enforce-lockfile && \
     dart run build_runner build && \
     flutter build web --release --base-href /player/ --tree-shake-icons --pwa-strategy=none
 

--- a/player/pubspec.lock
+++ b/player/pubspec.lock
@@ -1826,4 +1826,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.2"
+  flutter: ">=3.44.0"

--- a/player/pubspec.lock
+++ b/player/pubspec.lock
@@ -784,10 +784,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.3"
+    version: "0.20.2"
   io:
     dependency: transitive
     description:
@@ -888,10 +888,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -976,10 +976,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1572,26 +1572,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.1"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:
@@ -1692,10 +1692,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1826,4 +1826,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  flutter: ">=3.44.2"

--- a/player/pubspec.yaml
+++ b/player/pubspec.yaml
@@ -9,6 +9,16 @@ environment:
   # newer Dart than either bound, so this only tightens what the manifest
   # *claims* to support; nothing in resolution or CI changes.
   sdk: '>=3.5.0 <4.0.0'
+  # Chooses the Flutter that Dependabot resolves pubspec.lock with. Dependabot
+  # never reads .fvmrc; it takes the newest stable release this range allows.
+  # Each Flutter release pins meta, matcher, test_api, vector_math and intl to
+  # its own versions, so with no range here Dependabot resolved against the
+  # next minor and each local `pub get` on the .fvmrc toolchain wrote them back.
+  #
+  # Pub enforces only the lower bound (flutter/flutter#95472), so the upper
+  # bound constrains Dependabot alone. ci-nix.yml's "Check / Flutter Pin" job
+  # requires exactly `>=<.fvmrc> <<next minor>.0`: bump it with .fvmrc.
+  flutter: '>=3.44.2 <3.45.0'
 
 dependencies:
   flutter:

--- a/player/pubspec.yaml
+++ b/player/pubspec.yaml
@@ -16,9 +16,12 @@ environment:
   # next minor and each local `pub get` on the .fvmrc toolchain wrote them back.
   #
   # Pub enforces only the lower bound (flutter/flutter#95472), so the upper
-  # bound constrains Dependabot alone. ci-nix.yml's "Check / Flutter Pin" job
-  # requires exactly `>=<.fvmrc> <<next minor>.0`: bump it with .fvmrc.
-  flutter: '>=3.44.2 <3.45.0'
+  # bound constrains Dependabot alone. The floor is the minor's .0, not the
+  # .fvmrc patch: patches of one minor pin the same packages, and the E2E
+  # image (cirruslabs' stable tag) lags patch releases. ci-nix.yml's
+  # "Check / Flutter Pin" job requires exactly `>=<minor>.0 <<next minor>.0`
+  # for the .fvmrc minor: bump it with .fvmrc.
+  flutter: '>=3.44.0 <3.45.0'
 
 dependencies:
   flutter:

--- a/scripts/e2e/run-tests.sh
+++ b/scripts/e2e/run-tests.sh
@@ -41,6 +41,9 @@ if [ ! -f "$TEST_TARGET" ]; then
 fi
 
 echo "Resolving Flutter dependencies..."
+# Deliberately without --enforce-lockfile, unlike every other CI `pub get`:
+# player/Dockerfile.test runs on cirruslabs' floating stable image, not the
+# .fvmrc SDK, and the SDK-pinned packages in pubspec.lock cannot resolve on it.
 flutter pub get >/tmp/flutter-pub-get.log 2>&1 || {
     echo "ERROR: flutter pub get failed" >&2
     cat /tmp/flutter-pub-get.log >&2

--- a/scripts/e2e/run-tests.sh
+++ b/scripts/e2e/run-tests.sh
@@ -43,7 +43,8 @@ fi
 echo "Resolving Flutter dependencies..."
 # Deliberately without --enforce-lockfile, unlike every other CI `pub get`:
 # player/Dockerfile.test runs on cirruslabs' floating stable image, not the
-# .fvmrc SDK, and the SDK-pinned packages in pubspec.lock cannot resolve on it.
+# .fvmrc SDK, so once that tag moves to a newer minor the SDK-pinned packages
+# in pubspec.lock no longer resolve as committed.
 flutter pub get >/tmp/flutter-pub-get.log 2>&1 || {
     echo "ERROR: flutter pub get failed" >&2
     cat /tmp/flutter-pub-get.log >&2


### PR DESCRIPTION
## Problem

`player/pubspec.lock` showed as modified in every checkout, and restoring it did not stick.

Dependabot never reads `player/.fvmrc`. Its pub updater installs the newest stable Flutter that `pubspec.yaml`'s `environment` constraints allow. With no `environment.flutter`, that was 3.47.x, while `.fvmrc` pins 3.44.2. Each Flutter release pins `meta`, `matcher`, `test_api`, `vector_math` and `intl` to its own versions (through `flutter_test` and its siblings), so #613 and #740 committed a lock that the pinned SDK cannot resolve.

- CI ran plain `flutter pub get`, which quietly re-resolved seven packages down and passed, so the Dependabot gate merged both.
- Locally, every `pub get` wrote those seven back. The devenv `mydia:flutter` task reruns `pub get` on shell entry whenever the lock changes, so `git checkout player/pubspec.lock` was itself the trigger.
- The history shows the flip: #613 moved the pins up, `a8fed2370` carried them back down, #740 moved them up again.

## Fix

- **`environment.flutter: '>=3.44.0 <3.45.0'`** makes Dependabot pick 3.44.9. No SDK `pubspec.yaml` changed anywhere in 3.44.0...3.44.9 (0 of 171 changed files), so every 3.44 patch resolves the same versions as the pinned 3.44.2. Pub enforces only the lower bound (flutter/flutter#95472), so host toolchains, such as macOS builds, are not blocked by the upper bound.
  - The floor is the minor's `.0`, not the `.fvmrc` patch. The first push used `>=3.44.2`, and `Test / Player E2E` failed with `Because player requires Flutter SDK version >=3.44.2, version solving failed`: `player/Dockerfile.test` builds on `cirruslabs/flutter:stable`, which is on 3.44.0.
- **`Check / Flutter Pin`** now asserts that range is exactly `>=<minor>.0 <<next minor>.0` for the `.fvmrc` minor, reading it with `yq` (preinstalled on the runner) so quoting and trailing comments parse as pub sees them. Nothing else would notice the range going stale after a `.fvmrc` bump.
- **`--enforce-lockfile`** on every CI, release and image `pub get` (`ci-player.yml`, `release.yml`, `player-ios.yml`, `deploy-web-player.yml`, `Dockerfile`). A lock resolved on the wrong SDK now fails `Test / Player` and the gate reports `BLOCKED` instead of merging.
- **`pubspec.lock`** re-resolved on 3.44.2: `intl`, `matcher`, `meta`, `test`, `test_api`, `test_core` and `vector_math` go back to the versions CI has been testing with all along.
- `.github/ci.md` gets a section on this.

### Not covered

The E2E runner keeps plain `pub get`. `player/Dockerfile.test` builds on `cirruslabs/flutter:stable`, a floating image that is not on `.fvmrc`. It happens to be on 3.44.0 today, but once that tag moves to a newer minor the lock stops resolving as committed there. It already runs on a different Flutter than every other job, and moving it onto the pin is a separate change.

## Verification

- Flutter 3.44.2 with the committed lock from master: `flutter pub get --enforce-lockfile` fails with "Would change 7 dependencies". With this lock it passes (exit 0), including after `release.yml`'s `sed` rewrite of `version:`.
- Dependabot's selector (newest stable allowed by the range, per `infer_sdk_versions.dart`) against `releases_linux.json` picks 3.44.9.
- New pin step, run locally with yq 4.53: passes on this pubspec and with a trailing comment, and fails with the expected message on stray literal quotes, a stale upper bound, a patch floor and a missing key.
- The existing Flutter-literal scan still passes (116 files, no hits).
- actionlint: no findings in `ci-nix.yml` or on any edited line. The remaining output is pre-existing shellcheck notes in other steps.

## After merge

- The open Dependabot PR #744 should be rebased (or recreated) so it resolves on 3.44.9.
- Existing checkouts: `git checkout player/pubspec.lock && git pull`. The lock then matches what local `pub get` writes, so it stops reappearing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release Reliability**
  * Builds now require dependencies to match the committed lockfile, preventing unexpected resolution during CI and release workflows.
  * Flutter version constraints are validated against the project’s pinned minor SDK version.
  * Dependency checks now apply consistently across web, mobile, desktop, Docker, and end-to-end test builds.

* **Documentation**
  * Updated guidance clarifies Flutter version pinning, lockfile behavior, and exceptions for floating SDKs in end-to-end test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->