### PR TITLE
fix(player): let Auto transcode at the source until the link says otherwise

### DIFF
--- a/player/docs/playback.md
+++ b/player/docs/playback.md
@@ -28,11 +28,16 @@ verification or a quality change, logs a different line; see
 
 The viewer's choice is Auto (the default), Original, or a fixed rung. Auto
 direct plays or copies when the rules below allow it, and otherwise
-transcodes at the top rung of the adaptive ladder that fits remembered
-throughput (the top rung when throughput is unknown). Original is the
-viewer's override: it bypasses remembered decode failures, wherever that
-choice came from. A fixed rung pins its own caps and always transcodes,
-skipping both checks below.
+transcodes at the source resolution, like Original, unless remembered
+throughput says the file will not fit, in which case it asks for the highest
+adaptive rung that does. Knowing nothing about the connection is not evidence
+against it, so a first play, and every web play (web never measures
+throughput), transcodes uncapped. A fallback after a playback failure is a
+different case: it steps down deliberately rather than waiting for evidence
+(`fallbackPlan`; see "Verification" below). Original is the viewer's
+override: it bypasses remembered decode failures, wherever that choice came
+from. A fixed rung pins its own caps and always transcodes, skipping both
+checks below.
 
 Three rules, in order, decide between direct play, copy and transcode for
 Auto and Original alike. Direct play needs native, a leading DIRECT_PLAY or

--- a/player/docs/playback.md
+++ b/player/docs/playback.md
@@ -107,10 +107,11 @@ restart path.
 The quality picker offers Auto above Original, then the ladder
 `deriveQualityLadder` builds for the source. Auto's subtitle names what it is
 doing right now: `Auto · Direct Play`, `Auto · Original, no re-encoding`, or
-`Auto · <rung>` for a transcode (`Auto · Original, re-encoding required` when
-the adaptive ladder has nothing to offer for this source). Settings shows the
-same Auto row with the neutral `Adapts to your connection`, since there is no
-plan to describe there.
+`Auto · <rung>` for a transcode (`Auto · Original, re-encoding required`
+mainly when nothing says the connection cannot carry the file, since that is
+when Auto transcodes uncapped; also when the adaptive ladder has nothing to
+offer for this source). Settings shows the same Auto row with the neutral
+`Adapts to your connection`, since there is no plan to describe there.
 
 A quality change logs `[PlayerScreen] Quality change: <plan>` and switches,
 unless the new plan delivers the same bytes as what is already playing:

--- a/player/lib/core/playback/playback_planner.dart
+++ b/player/lib/core/playback/playback_planner.dart
@@ -188,9 +188,12 @@ PlaybackPlan planPlayback(PlanInputs inputs) {
     );
   }
 
-  // Rule 3: transcode.
+  // Rule 3: transcode. Auto caps only on evidence that the link cannot
+  // carry the file: a remembered throughput its bitrate does not fit. Knowing
+  // nothing is not evidence, so a first play, and every web play (web never
+  // measures throughput), transcodes at the source resolution like Original.
   final adaptive = choice.kind == QualityChoiceKind.auto;
-  final rung = adaptive
+  final rung = adaptive && !fits
       ? startingRung(
           deriveAdaptiveLadder(sourceHeight: inputs.sourceHeight),
           inputs.knownThroughputKbps,

--- a/player/test/core/playback/playback_planner_test.dart
+++ b/player/test/core/playback/playback_planner_test.dart
@@ -250,9 +250,9 @@ void main() {
       ));
       expect((plan as HlsPlan).strategy, HlsStrategy.transcode);
       expect(plan.reason, PlanReason.shapeKnownToFail);
-      expect(plan.rung.height, 1080,
-          reason: 'Auto transcodes at the top of the adaptive ladder when '
-              'throughput is unknown');
+      expect(plan.rung, QualityRung.original,
+          reason: 'nothing here says the link cannot carry the file, so '
+              'Auto transcodes at the source resolution, like Original');
     });
 
     test('a leading HLS_COPY is the needs_transcoding verdict, never taken',
@@ -315,22 +315,76 @@ void main() {
       expect(plan.adaptive, isFalse);
     });
 
-    test('Auto under transcode starts at the top of the adaptive ladder', () {
+    test('Auto under transcode sends no caps when throughput is unknown', () {
+      // Knowing nothing about the connection is not evidence against it, so
+      // a first play, and every web play, transcodes at the source
+      // resolution, like Original.
       final plan = planPlayback(
         _inputs(candidates: _transcodeOnly, choice: QualityChoice.auto),
       );
-      expect((plan as HlsPlan).rung.label, '1080p');
+      expect((plan as HlsPlan).rung, QualityRung.original);
       expect(plan.adaptive, isTrue);
     });
 
-    test('Auto with known throughput starts at the highest rung that fits', () {
-      // 4000 * 1.3 = 5200 <= 6000; 8000 * 1.3 = 10400 > 6000.
+    test('Auto transcodes uncapped on a 4K file when throughput is unknown',
+        () {
+      final plan = planPlayback(_inputs(
+        candidates: _transcodeOnly,
+        sourceHeight: 2160,
+        choice: QualityChoice.auto,
+      ));
+      expect(plan, isA<HlsPlan>());
+      expect((plan as HlsPlan).strategy, HlsStrategy.transcode);
+      expect(plan.rung, QualityRung.original);
+      expect(plan.adaptive, isTrue);
+    });
+
+    test('Auto transcodes uncapped when the file fits remembered throughput',
+        () {
+      // 5000 * 1.3 = 6500 <= 10000.
+      final plan = planPlayback(_inputs(
+        candidates: _transcodeOnly,
+        choice: QualityChoice.auto,
+        fileBitrateKbps: 5000,
+        knownThroughputKbps: 10000,
+      ));
+      expect((plan as HlsPlan).rung, QualityRung.original);
+    });
+
+    test('Auto caps to the highest fitting rung when the file does not fit',
+        () {
+      // 1080p needs 8000 * 1.3 = 10400 > 6000; 720p needs 4000 * 1.3 = 5200
+      // <= 6000.
+      final plan = planPlayback(_inputs(
+        candidates: _transcodeOnly,
+        sourceHeight: 2160,
+        choice: QualityChoice.auto,
+        fileBitrateKbps: 20000,
+        knownThroughputKbps: 6000,
+      ));
+      expect((plan as HlsPlan).rung.label, '720p');
+    });
+
+    test(
+        'Auto transcodes uncapped when the file has a bitrate but '
+        'throughput is unknown', () {
+      final plan = planPlayback(_inputs(
+        candidates: _transcodeOnly,
+        choice: QualityChoice.auto,
+        fileBitrateKbps: 5000,
+      ));
+      expect((plan as HlsPlan).rung, QualityRung.original);
+    });
+
+    test(
+        "Auto transcodes uncapped when throughput is known but the file's "
+        'bitrate is not', () {
       final plan = planPlayback(_inputs(
         candidates: _transcodeOnly,
         choice: QualityChoice.auto,
         knownThroughputKbps: 6000,
       ));
-      expect((plan as HlsPlan).rung.label, '720p');
+      expect((plan as HlsPlan).rung, QualityRung.original);
     });
 
     test('an empty candidate list transcodes at Original', () {

--- a/player/test/presentation/screens/player/player_screen_quality_caps_test.dart
+++ b/player/test/presentation/screens/player/player_screen_quality_caps_test.dart
@@ -92,8 +92,8 @@ void main() {
   });
 
   testWidgets(
-      'falls back to Auto when the source cannot offer the '
-      'stored rung', (tester) async {
+      'falls back to Auto, transcoding at the source, when the source '
+      'cannot offer the stored rung', (tester) async {
     final link = StubLink.responses([
       movieDetailResponse(),
       movieSegmentsResponse(),
@@ -118,10 +118,11 @@ void main() {
     await pumpUntilSessionStarted(tester, link);
 
     final variables = sessionRequests(link).single.variables;
-    expect(variables['maxHeight'], 720,
+    expect(variables.containsKey('maxHeight'), isFalse,
         reason: 'a stored rung that would upscale falls back to Auto, which '
-            "starts at the top of this 720p file's adaptive ladder");
-    expect(variables['maxBitrate'], 4000);
+            'transcodes at the source resolution: nothing here says this '
+            "720p file's link cannot carry it");
+    expect(variables.containsKey('maxBitrate'), isFalse);
   });
 
   testWidgets('a chosen rung takes precedence over direct play',
@@ -274,8 +275,9 @@ void main() {
         reason: 'the rung in effect wins over whatever storage now holds');
   });
 
-  testWidgets('an unreadable preference plays at Auto rather than failing',
-      (tester) async {
+  testWidgets(
+      'an unreadable preference plays at Auto, transcoding at the '
+      'source, rather than failing', (tester) async {
     final link = StubLink.responses([
       movieDetailResponse(),
       movieSegmentsResponse(),
@@ -301,10 +303,11 @@ void main() {
     await pumpUntilSessionStarted(tester, link);
 
     final variables = sessionRequests(link).single.variables;
-    expect(variables['maxHeight'], 1080,
+    expect(variables.containsKey('maxHeight'), isFalse,
         reason: 'a locked keyring costs the preference, not the playback; '
-            'Auto, the default, starts at the top of the adaptive ladder');
-    expect(variables['maxBitrate'], 8000);
+            'Auto, the default, transcodes at the source resolution when '
+            'nothing says the connection cannot carry it');
+    expect(variables.containsKey('maxBitrate'), isFalse);
   });
 
   testWidgets('does not retry a genuine failure', (tester) async {
@@ -386,7 +389,50 @@ void main() {
     expect(sessionRequests(link), hasLength(1),
         reason: 'Auto must respect the remembered failure and transcode '
             'instead of direct playing');
-    expect(sessionRequests(link).single.variables['maxHeight'], 1080);
+    // No remembered throughput says this link cannot carry the file, so the
+    // transcode Auto falls back to is uncapped, like Original.
+    final variables = sessionRequests(link).single.variables;
+    expect(variables.containsKey('maxHeight'), isFalse);
+    expect(variables.containsKey('maxBitrate'), isFalse);
+  });
+
+  testWidgets(
+      'Auto caps to the highest fitting rung when remembered throughput '
+      'says the file will not fit', (tester) async {
+    final link = StubLink.responses([
+      movieDetailResponse(),
+      movieSegmentsResponse(),
+      subtitleTrackSettingsResponse(),
+      // 20000000 bps = 20000 kbps. 1080p needs 8000 * 1.3 = 10400 > 6000;
+      // 720p needs 4000 * 1.3 = 5200 <= 6000.
+      streamingCandidatesResponse(
+          duration: 5400, height: 2160, bitrate: 20000000),
+      startStreamingSessionResponse(maxBitrate: 4000, maxHeight: 720),
+      endStreamingSessionResponse(),
+    ]);
+
+    final container = buildPlayerScreenContainer(
+      link: link,
+      connectionState: conn.ConnectionState.direct(),
+      castManager: CapturingCastSessionManager(),
+      proxyService: TrackingLocalProxyService(),
+    );
+    addTearDown(container.dispose);
+
+    // Seeded before the screen ever reads memory, at the same key
+    // `serverUrlProvider` resolves to for a non-p2p connection.
+    final memory = await container.read(playbackMemoryProvider.future);
+    await memory.observeThroughput('https://mydia.test', 6000);
+
+    await pumpPlayerScreen(tester, container);
+    await pumpUntilSessionStarted(tester, link);
+
+    final variables = sessionRequests(link).single.variables;
+    expect(variables['maxHeight'], 720,
+        reason: 'remembered throughput says this file will not fit, which '
+            'is evidence Auto acts on: it asks for the highest adaptive '
+            'rung that does');
+    expect(variables['maxBitrate'], 4000);
   });
 
   testWidgets(


### PR DESCRIPTION
#769 made Auto the default quality. When Auto has to transcode, it asked for
the top rung of the adaptive ladder whenever it had no remembered throughput,
which is every first play and every web play (web never measures throughput).
That ladder stops at 1080p, so a 4K file that needed a transcode came out at
1080p, and a 1080p file got an 8000 kbps cap, where the old default
(Original) sent no caps at all. The mid-session adaptation that would justify
starting at a rung does not exist yet, so the cap was a downgrade with nothing
in return.

Knowing nothing about the connection is not evidence against it. Auto now
transcodes uncapped, like Original, and only asks for a lower rung when
remembered throughput says the file will not fit (the same 30% headroom rule
direct play uses). Then it asks for the highest adaptive rung that does fit.

The change is one condition in `playback_planner.dart`, rule 3: Auto caps only
when `!fits`, the flag the planner already computes for direct play, which is
true only when both the file bitrate and a remembered throughput are known and
the file does not fit.

Unchanged on purpose: a fallback after a failure (`fallbackPlan`) still steps
down to a lower rung, since it follows evidence that something went wrong.
Relay clamps still apply server-side, and the "Limited to ... by your
connection" note still names them.

## Testing

- Planner: Auto with no throughput, with a fitting file, with a bitrate but
  no throughput, and with a throughput but no bitrate all transcode uncapped;
  a 20000 kbps 4K file against 6000 kbps of remembered throughput asks for
  720p.
- Screen: the caps tests that assumed Auto's old caps now expect none, and a
  new one seeds 6000 kbps of remembered throughput for a 20 Mbps 4K file and
  sees `maxHeight 720` / `maxBitrate 4000` reach `startStreamingSession`.
- `flutter test --concurrency=1`: 3597 passed, 7 skipped, 0 failed.
- `flutter analyze`: no errors or warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Playback**
  - Auto quality now preserves the source resolution when connection capacity is unknown or sufficient.
  - When remembered throughput cannot support the file, Auto selects the highest adaptive quality that fits.
  - Playback failures now step down through a deliberate fallback plan.
  - Auto may transcode without quality caps when no suitable adaptive option is available.

- **Documentation**
  - Updated playback guidance to clarify Auto quality selection and subtitle labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->