### PR TITLE
fix(downloads): remove and blacklist finished downloads their import proved junk

### DIFF
--- a/lib/mydia/downloads/import_candidates.ex
+++ b/lib/mydia/downloads/import_candidates.ex
@@ -103,6 +103,36 @@ defmodule Mydia.Downloads.ImportCandidates do
     end
   end
 
+  @doc """
+  True when a failed import's candidate listing proves the download holds
+  nothing worth keeping.
+
+  Takes the list `build/3` stores at `metadata["import_candidates"]`. Every
+  file must have been dropped on its extension alone and then ruled out as
+  media: ffprobe called it `not_media`, or it is under `probe_size_floor/0`
+  and so was never probed.
+
+  Anything an operator could still salvage by hand makes the answer false: a
+  file with a video extension (sample and extra drops included, since sample
+  detection can be wrong), a `media` verdict (a real video under the wrong
+  extension), an `unknown` verdict (ffprobe was not available), or a large
+  file that was never probed (past `probe_cap/0`, or a listing written before
+  probing existed). Anything that is not a non-empty list is false too.
+  """
+  @spec provably_junk?(term()) :: boolean()
+  def provably_junk?([_ | _] = candidates), do: Enum.all?(candidates, &junk_candidate?/1)
+  def provably_junk?(_candidates), do: false
+
+  defp junk_candidate?(%{"skip_reason" => "not_video_extension"} = candidate),
+    do: ruled_out_as_media?(candidate)
+
+  defp junk_candidate?(_candidate), do: false
+
+  defp ruled_out_as_media?(%{"probe" => %{"status" => "not_media"}}), do: true
+  defp ruled_out_as_media?(%{"probe" => _verdict}), do: false
+  defp ruled_out_as_media?(%{"size" => size}) when is_integer(size), do: size < @probe_size_floor
+  defp ruled_out_as_media?(_candidate), do: false
+
   # Only files rejected purely on extension are worth probing: everything else
   # either imported fine or was correctly identified as a sample.
   defp add_probes(candidates) do

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -195,6 +195,13 @@ defmodule Mydia.Jobs.DownloadMonitor do
     # importable, before they finish downloading.
     Enum.each(bad_content, &reject_bad_content/1)
 
+    # And the ones that finished anyway, once their import has proved them
+    # junk. This runs every poll rather than at import time, so rows left
+    # behind before this pass existed are cleaned up too.
+    downloads
+    |> Enum.filter(&sweepable_junk?/1)
+    |> Enum.each(&reject_junk/1)
+
     # Self-heal abandoned grabs (persist the timeout so occupancy is released)
     Enum.each(stale_grabs, &handle_stale_grab/1)
 
@@ -573,6 +580,77 @@ defmodule Mydia.Jobs.DownloadMonitor do
       {:error, reason} ->
         Logger.warning("Could not auto-reject bad-content download",
           download_id: download_map.id,
+          reason: inspect(reason)
+        )
+
+        :ok
+    end
+  end
+
+  # --- Post-import junk sweep --------------------------------------------
+
+  # A completed download the importer gave up on because nothing in it was
+  # importable, and whose failure snapshot also proves nothing in it could be
+  # matched by hand (see `ImportCandidates.provably_junk?/1`). The
+  # pre-completion check above rejects most of these early, but the
+  # auto-reject cap deliberately lets a download finish once that check has
+  # fired too often for one media item, in case the check is wrong. A failed
+  # import on a payload ffprobe could not read settles that, so reject it the
+  # way an operator would from the Issues tab.
+  #
+  # Only for a client that answered this poll: `Queue.reject_release/2`
+  # deletes the row even when removing the torrent fails, so rejecting against
+  # a client that is down, disabled or removed would leave the torrent and its
+  # data behind with nothing tracking them. Those rows wait for a later poll.
+  defp sweepable_junk?(download_map) do
+    download_map.client_config_state == :present and
+      not is_nil(download_map.in_client?) and
+      junk_failure?(download_map)
+  end
+
+  # Shared by the poll-time filter and the re-check after reloading, so a row
+  # an operator retried in between (retrying clears `import_failed_at`) is left
+  # alone.
+  defp junk_failure?(download) do
+    is_nil(download.imported_at) and
+      not is_nil(download.import_failed_at) and
+      is_nil(download.import_next_retry_at) and
+      download.import_failure_reason == "no_importable_files" and
+      ImportCandidates.provably_junk?(import_candidates(download))
+  end
+
+  defp import_candidates(%{metadata: %{"import_candidates" => candidates}}), do: candidates
+  defp import_candidates(_download), do: nil
+
+  defp reject_junk(download_map) do
+    with_download(download_map, :reject_junk, [preload: [:media_item]], fn download ->
+      if junk_failure?(download), do: do_reject_junk(download)
+    end)
+  end
+
+  defp do_reject_junk(download) do
+    Logger.warning(
+      "Rejecting completed download: its import found nothing importable or salvageable",
+      download_id: download.id,
+      title: download.title,
+      files_sample:
+        download
+        |> import_candidates()
+        |> Enum.take(@bad_content_log_sample)
+        |> Enum.map(& &1["name"])
+    )
+
+    case Queue.reject_release(download,
+           actor_type: :system,
+           actor_id: "download_monitor",
+           failure_reason: "no_importable_files"
+         ) do
+      {:ok, :rejected} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Could not reject junk download",
+          download_id: download.id,
           reason: inspect(reason)
         )
 

--- a/test/mydia/downloads/import_candidates_test.exs
+++ b/test/mydia/downloads/import_candidates_test.exs
@@ -562,6 +562,88 @@ defmodule Mydia.Downloads.ImportCandidatesTest do
     end
   end
 
+  describe "provably_junk?/1" do
+    # The shape `build/3` stores at metadata["import_candidates"] after a failed
+    # import: string keys, and a "probe" verdict only on extension-rejected
+    # files at or above probe_size_floor/0.
+    defp snapshot(name, size, attrs \\ %{}) do
+      Map.merge(
+        %{
+          "path" => Path.join("/downloads", name),
+          "name" => name,
+          "size" => size,
+          "skip_reason" => "not_video_extension",
+          "parsed_season" => nil,
+          "parsed_episode" => nil
+        },
+        attrs
+      )
+    end
+
+    defp probed(status), do: %{"probe" => %{"status" => status, "detail" => "test verdict"}}
+
+    defp big, do: ImportCandidates.probe_size_floor() * 100
+
+    test "a lone archive ffprobe could not read is junk" do
+      assert ImportCandidates.provably_junk?([
+               snapshot(
+                 "Harbor.Lights.S02E06.1080p.WEB-DL.DDP5.1.Atmos.zipx",
+                 1_102_185_571,
+                 probed("not_media")
+               )
+             ])
+    end
+
+    test "unreadable archive parts plus a small unprobed nfo are junk" do
+      assert ImportCandidates.provably_junk?([
+               snapshot("release.part1.rar", big(), probed("not_media")),
+               snapshot("release.part2.rar", big(), probed("not_media")),
+               snapshot("release.nfo", 2_048)
+             ])
+    end
+
+    test "a file with a video extension is never junk, even one dropped as a sample" do
+      archive = snapshot("release.zipx", big(), probed("not_media"))
+
+      refute ImportCandidates.provably_junk?([
+               archive,
+               snapshot("release-sample.mkv", 40_000_000, %{
+                 "skip_reason" => "Sample file (detected from filename)"
+               })
+             ])
+
+      refute ImportCandidates.provably_junk?([
+               archive,
+               snapshot("episode.mkv", big(), %{"skip_reason" => nil})
+             ])
+    end
+
+    test "a media verdict means a real video under the wrong extension" do
+      refute ImportCandidates.provably_junk?([
+               snapshot("release.zipx", big(), probed("not_media")),
+               snapshot("a1b2c3d4.bin", big(), probed("media"))
+             ])
+    end
+
+    test "an unknown verdict proves nothing" do
+      refute ImportCandidates.provably_junk?([snapshot("release.zipx", big(), probed("unknown"))])
+    end
+
+    test "a large file that was never probed proves nothing" do
+      refute ImportCandidates.provably_junk?([
+               snapshot("release.zipx", big(), probed("not_media")),
+               snapshot("release.part21.rar", big())
+             ])
+    end
+
+    test "anything that is not a non-empty candidate list is not junk" do
+      refute ImportCandidates.provably_junk?(nil)
+      refute ImportCandidates.provably_junk?([])
+      refute ImportCandidates.provably_junk?(%{"name" => "release.zipx"})
+      refute ImportCandidates.provably_junk?([Map.delete(snapshot("release.nfo", 2_048), "size")])
+    end
+  end
+
   ## Helpers
 
   # A resolvable download client config whose download_directory is

--- a/test/mydia/jobs/download_monitor_test.exs
+++ b/test/mydia/jobs/download_monitor_test.exs
@@ -1546,6 +1546,200 @@ defmodule Mydia.Jobs.DownloadMonitorTest do
     end
   end
 
+  describe "post-import junk sweep" do
+    # A finished torrent the importer already gave up on. Transmission status 6
+    # is seeding; the row's failure snapshot is what the sweep judges. Uses the
+    # DB-backed client from `start_transmission_bypass/1` for the same reason
+    # the pre-completion tests do.
+    @junk_title "Harbor.Lights.S02E06.1080p.WEB-DL.DDP5.1.Atmos.zipx"
+
+    defp seeding_torrent(hash) do
+      %{
+        "hashString" => hash,
+        "name" => @junk_title,
+        "status" => 6,
+        "percentDone" => 1.0,
+        "downloadDir" => "/downloads"
+      }
+    end
+
+    # Answers torrent-get with `torrents` and tells the test process about
+    # every torrent-remove, so a test can check the data went with it.
+    defp mock_transmission_recording_removes(bypass, torrents) do
+      test_pid = self()
+
+      Bypass.stub(bypass, "POST", "/transmission/rpc", fn conn ->
+        case Plug.Conn.get_req_header(conn, "x-transmission-session-id") do
+          [] ->
+            conn
+            |> Plug.Conn.put_resp_header("x-transmission-session-id", "test-session")
+            |> Plug.Conn.resp(409, "")
+
+          ["test-session"] ->
+            {:ok, body, conn} = Plug.Conn.read_body(conn, length: 1_000_000)
+            decoded = Jason.decode!(body)
+
+            case decoded["method"] do
+              "torrent-get" ->
+                json_resp(conn, 200, %{
+                  "result" => "success",
+                  "arguments" => %{"torrents" => torrents}
+                })
+
+              "torrent-remove" ->
+                send(test_pid, {:torrent_remove, decoded["arguments"]})
+                json_resp(conn, 200, %{"result" => "success", "arguments" => %{}})
+            end
+        end
+      end)
+    end
+
+    defp zipx_candidate(probe_status) do
+      %{
+        "path" => "/downloads/" <> @junk_title,
+        "name" => @junk_title,
+        "size" => 1_102_185_571,
+        "skip_reason" => "not_video_extension",
+        "parsed_season" => 2,
+        "parsed_episode" => 6,
+        "probe" => %{
+          "status" => probe_status,
+          "detail" => "Invalid data found when processing input"
+        }
+      }
+    end
+
+    # The row a terminal `no_importable_files` import failure leaves behind.
+    defp failed_import_download(client_config, hash, candidates, overrides \\ %{}) do
+      media_item = media_item_fixture()
+      now = DateTime.utc_now()
+
+      download =
+        download_fixture(
+          Map.merge(
+            %{
+              media_item_id: media_item.id,
+              title: @junk_title,
+              indexer: "1337x",
+              download_client: client_config.name,
+              download_client_id: hash,
+              completed_at: now,
+              import_retry_count: 1,
+              import_last_error: "No importable files found for TV show episode.",
+              import_failure_reason: "no_importable_files",
+              import_failed_at: now,
+              import_next_retry_at: nil,
+              metadata: %{
+                "indexer" => "1337x",
+                "guid" => "guid-" <> hash,
+                "import_candidates" => candidates
+              }
+            },
+            overrides
+          )
+        )
+
+      {media_item, download}
+    end
+
+    test "removes, blacklists and deletes a finished download its import proved junk" do
+      {bypass, client_config} = start_transmission_bypass()
+      mock_transmission_recording_removes(bypass, [seeding_torrent("junk-hash")])
+
+      {media_item, download} =
+        failed_import_download(client_config, "junk-hash", [zipx_candidate("not_media")])
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Repo.get(Download, download.id)
+
+      row = Repo.get_by!(ReleaseBlacklist, indexer: "1337x", guid: "guid-junk-hash")
+      assert row.failure_reason == "no_importable_files"
+
+      assert_received {:torrent_remove, %{"ids" => ["junk-hash"], "delete-local-data" => true}}
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{"mode" => "specific", "media_item_id" => media_item.id}
+      )
+
+      # Proven junk is not a guess, so it must not count toward the cap that
+      # suppresses cheap early rejections.
+      assert Mydia.Search.get_backoff_info("auto_reject", media_item.id) == nil
+    end
+
+    test "rejects the row even when the torrent is already gone from a reachable client" do
+      {bypass, client_config} = start_transmission_bypass()
+      mock_transmission_recording_removes(bypass, [])
+
+      {_media_item, download} =
+        failed_import_download(client_config, "gone-hash", [zipx_candidate("not_media")])
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      refute Repo.get(Download, download.id)
+      assert Blacklists.blacklisted?("1337x", "guid-gone-hash")
+    end
+
+    test "leaves a failed download alone when ffprobe found real video in it" do
+      {bypass, client_config} = start_transmission_bypass()
+      mock_transmission_recording_removes(bypass, [seeding_torrent("hidden-hash")])
+
+      {_media_item, download} =
+        failed_import_download(client_config, "hidden-hash", [zipx_candidate("media")])
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Repo.get(Download, download.id)
+      refute Blacklists.blacklisted?("1337x", "guid-hidden-hash")
+      refute_received {:torrent_remove, _}
+    end
+
+    test "leaves a failed download alone when ffprobe could not give a verdict" do
+      {bypass, client_config} = start_transmission_bypass()
+      mock_transmission_recording_removes(bypass, [seeding_torrent("unknown-hash")])
+
+      {_media_item, download} =
+        failed_import_download(client_config, "unknown-hash", [zipx_candidate("unknown")])
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Repo.get(Download, download.id)
+      refute Blacklists.blacklisted?("1337x", "guid-unknown-hash")
+      refute_received {:torrent_remove, _}
+    end
+
+    test "leaves a download alone while an import retry is still scheduled" do
+      {bypass, client_config} = start_transmission_bypass()
+      mock_transmission_recording_removes(bypass, [seeding_torrent("retry-hash")])
+
+      {_media_item, download} =
+        failed_import_download(client_config, "retry-hash", [zipx_candidate("not_media")], %{
+          import_next_retry_at: DateTime.add(DateTime.utc_now(), 3_600, :second)
+        })
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Repo.get(Download, download.id)
+      refute Blacklists.blacklisted?("1337x", "guid-retry-hash")
+      refute_received {:torrent_remove, _}
+    end
+
+    test "waits for a later poll when the client cannot be reached" do
+      {bypass, client_config} = start_transmission_bypass()
+
+      {_media_item, download} =
+        failed_import_download(client_config, "down-hash", [zipx_candidate("not_media")])
+
+      Bypass.down(bypass)
+
+      assert :ok = perform_job(DownloadMonitor, %{})
+
+      assert Repo.get(Download, download.id)
+      refute Blacklists.blacklisted?("1337x", "guid-down-hash")
+    end
+  end
+
   describe "handle_failure/1 with a classified debrid failure" do
     setup do
       alias Mydia.Downloads.Client.Debrid.StubProvider


### PR DESCRIPTION
## Problem

A completed download whose import fails with `no_importable_files` was marked
terminally failed and then never touched again. The release was not
blacklisted, the torrent and its data stayed in the client, and the row stayed
on the Queue tab (as seeding, with an "Import failed" badge) and on the Issues
tab.

The pre-completion content check normally rejects these early, but the per-item
auto-reject cap deliberately lets a download finish once that check has fired
too often, in case the check is wrong. When the finished download then fails to
import, nothing acted on the answer. Production hit this with a `.zipx` release
whose only entry was an executable: it completed, failed to import, and was
still seeding a day later after a clean release for the same episode had
imported.

## Change

- `ImportCandidates.provably_junk?/1` reads the failure snapshot a failed
  import already stores. It is true only when every file was dropped for its
  extension and ffprobe called it `not_media`, or it is under the 10 MiB probe
  floor. A `media` or `unknown` verdict, any file with a video extension
  (sample drops included), or a large unprobed file keeps it false, so an
  obfuscated release or a sample misdetection stays in Issues for hand-matching.
- `DownloadMonitor` rejects such rows every poll through the existing
  `Queue.reject_release/2`: blacklist with reason `no_importable_files`, remove
  the torrent with its data, delete the row, queue the replacement search.
  It only acts when the row's client answered this poll, re-checks each row
  after reloading it, and does not touch the auto-reject counter.

Rows already stuck in this state are cleaned up on the first poll after
upgrading. No migration or configuration.

## Tests

- `test/mydia/downloads/import_candidates_test.exs`: every branch of the rule.
- `test/mydia/jobs/download_monitor_test.exs`: a junk row is removed with
  `delete-local-data`, blacklisted and deleted, with the replacement search
  queued and the counter untouched; a row whose torrent is already gone is
  still cleaned up; `media` and `unknown` verdicts, a scheduled retry, and an
  unreachable client leave the row alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically cleans up completed downloads that failed to import and are confirmed to contain no usable media.
  * Removes confirmed junk, records the failure, and starts replacement searches when appropriate.
  * Safely handles already-removed downloads and unavailable download clients.
  * Preserves downloads when media is detected or the available evidence is inconclusive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->