### PR TITLE
fix(player): stop copying every decoded frame through the CPU on Android

### DIFF
--- a/player/lib/core/player/video_output_config.dart
+++ b/player/lib/core/player/video_output_config.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart' show TargetPlatform;
+import 'package:media_kit_video/media_kit_video.dart'
+    show VideoControllerConfiguration;
+
+/// mpv's hardware decoder for Android that keeps the frame on the GPU.
+///
+/// The name is mpv's, not media_kit's: media_kit passes `hwdec` through to
+/// libmpv untouched.
+const androidZeroCopyHwdec = 'mediacodec';
+
+/// How the decoded frame should reach mpv's renderer on this platform.
+///
+/// media_kit's Android default is `hwdec=auto-safe`, which resolves to
+/// `mediacodec-copy`: the hardware codec decodes, then every frame is read
+/// back into CPU memory before mpv uploads it as a texture. That readback
+/// comes off a GPU/codec buffer rather than ordinary RAM, so it costs far more
+/// than the ~75 MB/s that 1080p24 NV12 suggests. On a Chromecast with Google
+/// TV (Amlogic, 4x Cortex-A55) it saturates the single `CodecLooper` thread,
+/// measured at 91% of one core with three cores sitting idle, and playback
+/// settles at 0.78x realtime, which is the stutter. Nothing upstream was
+/// short: the server had hundreds of segments already encoded and answered
+/// every request in under 160ms.
+///
+/// [androidZeroCopyHwdec] is the same hardware decoder with the readback
+/// removed. The frame stays on the GPU and reaches mpv as a SurfaceTexture.
+/// mpv documents it as requiring `--vo=gpu --gpu-context=android`, and
+/// media_kit already sets `gpu-context: android` and `opengl-es: yes` on
+/// Android, so `vo` stays `gpu` and mpv keeps compositing.
+///
+/// mpv keeping the compositing is the whole reason this is not
+/// `vo=mediacodec_embed`. Embedding hands frames straight to a SurfaceView and
+/// mpv never draws, which silently removes subtitles and the OSD, and this
+/// player renders both through mpv. Embedding also cannot accept
+/// software-decoded frames, so a hwdec failure has nowhere to fall back to.
+/// With `vo=gpu` a failure just drops to software decode and still renders.
+///
+/// Android only, for two reasons. `hwdec` values are platform specific, and
+/// mpv deliberately leaves `mediacodec` out of `auto-safe` because it converts
+/// to RGB and its handling of unusual colorspaces is unverified. Every other
+/// platform keeps media_kit's own default.
+VideoControllerConfiguration videoControllerConfigurationFor(
+  TargetPlatform platform, {
+  required bool isWeb,
+}) {
+  if (!isWeb && platform == TargetPlatform.android) {
+    return const VideoControllerConfiguration(hwdec: androidZeroCopyHwdec);
+  }
+  return const VideoControllerConfiguration();
+}

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show kIsWeb, listEquals;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, listEquals;
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -18,6 +19,7 @@ import '../../../core/player/audio_language.dart';
 import '../../../core/player/codec_support.dart';
 import '../../../core/player/progress_service.dart';
 import '../../../core/player/subtitle_delay.dart';
+import '../../../core/player/video_output_config.dart';
 import '../../../core/playback/playback_progress_providers.dart';
 import '../../../core/playback/playback_progress_store.dart';
 import '../../../core/utils/file_utils.dart' as file_utils;
@@ -1806,7 +1808,13 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
     // Create media_kit player
     final player = widget.createPlayer?.call() ?? Player();
     _player = player;
-    _videoController = VideoController(player);
+    _videoController = VideoController(
+      player,
+      configuration: videoControllerConfigurationFor(
+        defaultTargetPlatform,
+        isWeb: kIsWeb,
+      ),
+    );
     // Hands the backend the media_kit player so the web backend can reach the
     // underlying HTMLVideoElement. A no-op on native.
     //

--- a/player/test/core/player/video_output_config_test.dart
+++ b/player/test/core/player/video_output_config_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/foundation.dart' show TargetPlatform;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/core/player/video_output_config.dart';
+
+void main() {
+  group('videoControllerConfigurationFor', () {
+    test('Android asks for the zero-copy hardware decoder', () {
+      final config = videoControllerConfigurationFor(
+        TargetPlatform.android,
+        isWeb: false,
+      );
+
+      // `mediacodec-copy` reads every frame back into CPU memory, which
+      // saturates one core on low-power Android TV hardware and caps playback
+      // below realtime. See the module doc for the measurements.
+      expect(config.hwdec, androidZeroCopyHwdec);
+      expect(config.hwdec, isNot(contains('copy')));
+    });
+
+    test('Android keeps media_kit rendering the video, not a SurfaceView', () {
+      final config = videoControllerConfigurationFor(
+        TargetPlatform.android,
+        isWeb: false,
+      );
+
+      // `vo=mediacodec_embed` would be faster still, but mpv then stops
+      // compositing and subtitles and the OSD disappear. Leaving `vo` unset
+      // keeps media_kit's `gpu`, which is what makes the zero-copy decoder
+      // safe to use here.
+      expect(config.vo, isNull);
+    });
+
+    test('web keeps the media_kit default even though it reports Android', () {
+      // A mobile browser reports TargetPlatform.android, but there is no
+      // libmpv there to hand an hwdec name to.
+      final config = videoControllerConfigurationFor(
+        TargetPlatform.android,
+        isWeb: true,
+      );
+
+      expect(config.hwdec, isNull);
+    });
+
+    for (final platform in const [
+      TargetPlatform.iOS,
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+      TargetPlatform.windows,
+      TargetPlatform.fuchsia,
+    ]) {
+      test('$platform keeps the media_kit default', () {
+        // `mediacodec` is an Android-only decoder name.
+        final config = videoControllerConfigurationFor(
+          platform,
+          isWeb: false,
+        );
+
+        expect(config.hwdec, isNull);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## The bug

Playback on a Chromecast with Google TV runs at **0.78x realtime**, so roughly one second in five is a stall. That is the stutter.

It is not the server, the network, or the decoder. Measured live against a 1080p episode:

| Suspect | Measurement | Verdict |
| --- | --- | --- |
| Transcode speed | Server produced 101 to 293 segments in 49s (**23.5x realtime**), hundreds queued ahead | Not it |
| Network | 46-100 Mbps, segments delivered in 1-159ms | Not it |
| Video decode | `c2.amlogic.avc.decoder` (hardware) active throughout; software AVC never instantiated | Not it |
| Thermal | 43-48C, no throttling | Not it |
| Memory | Zero swap-out during playback, 1.7 major faults/s, ~710MB available | Not it |
| **Frame readback** | **`CodecLooper` pegged at 91.4% of one core**, every other thread under 7% | **This** |

## Root cause

`VideoController(player)` was constructed with no configuration, so on Android media_kit defaults to `hwdec=auto-safe`, which resolves to `mediacodec-copy`. The hardware codec decodes, then every frame is read back into CPU memory before mpv uploads it as a texture. That readback comes off a GPU/codec buffer rather than ordinary RAM, so it costs far more than the ~75 MB/s that 1080p24 NV12 suggests. One thread saturates while three cores sit idle.

This is why direct play stutters identically to a transcoded stream: the render path is the same regardless of source.

## The fix

`hwdec=mediacodec` is the same hardware decoder with the readback removed. The frame stays on the GPU and reaches mpv as a SurfaceTexture.

mpv documents it as requiring `--vo=gpu --gpu-context=android`, and media_kit already sets `gpu-context: android` and `opengl-es: yes` on Android, so `vo` stays `gpu` and **mpv keeps compositing**.

### Why not `vo=mediacodec_embed`

Embedding is the more obvious "zero copy" answer and it is the wrong one here. It hands frames straight to a SurfaceView and mpv never draws, which silently removes subtitles and the OSD. This player renders both through mpv (`setSubtitleTrack`), and there is no Flutter-side subtitle renderer to fall back on. Embedding also cannot accept software-decoded frames, so a hwdec failure has nowhere to go. With `vo=gpu` a failure just drops to software decode and still renders.

A test pins `vo` to null so a later switch to embedding, which would quietly kill subtitles, fails the suite instead of shipping.

### Why Android only

`hwdec` values are platform specific, and mpv deliberately leaves `mediacodec` out of `auto-safe` because it converts to RGB and its handling of unusual colorspaces is unverified. Every other platform keeps media_kit's default.

## How other players do this

ExoPlayer/Media3 apps decode straight into a SurfaceView and layer subtitles as a separate Android view, so they never pay this cost. mpv-android ships `vo=gpu` + `gpu-context=android` with `hwdec=mediacodec` available and `mediacodec-copy` as fallback. `mediacodec-copy` with a texture-backed `vo` is the one configuration that drags every frame through the CPU, and it was ours by default.

## Testing

- 8 unit tests covering Android, web reporting as Android, and the four other native platforms.
- Device verification on the Chromecast (sabrina, armeabi-v7a) is in progress; before/after playback rate will be posted to this PR before merge.

The residual risk is colour artifacts on some Amlogic hardware rather than a crash, which is exactly what the device check is for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Video playback now uses platform-specific output settings.
  * Android playback uses zero-copy hardware decoding for improved rendering efficiency.
  * Web and other supported platforms continue using the default video configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->