### PR TITLE
build(player): drop the x86_64 ABI from the Android APK

### DIFF
--- a/.github/workflows/ci-player.yml
+++ b/.github/workflows/ci-player.yml
@@ -576,7 +576,11 @@ jobs:
       - name: Build APK
         if: needs.changes.outputs.player == 'true'
         working-directory: player
-        run: flutter build apk --release
+        run: flutter build apk --release --target-platform android-arm,android-arm64
+
+      - name: Check APK ABIs
+        if: needs.changes.outputs.player == 'true'
+        run: ./scripts/check-apk-abis.sh player/build/app/outputs/flutter-apk/app-release.apk
 
       - name: Upload artifact
         if: needs.changes.outputs.player == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,6 +500,9 @@ jobs:
       - name: Check APK ABIs
         run: ./scripts/check-apk-abis.sh ${{ env.PLAYER_PATH }}/build/app/outputs/flutter-apk/app-release.apk
 
+      - name: Check AAB ABIs
+        run: ./scripts/check-apk-abis.sh ${{ env.PLAYER_PATH }}/build/app/outputs/bundle/release/app-release.aab
+
       - name: Setup Ruby for Fastlane
         if: ${{ !inputs.dry_run && env.PLAY_STORE_CREDENTIALS != '' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,11 +491,14 @@ jobs:
 
       - name: Build APK
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter build apk --release
+        run: flutter build apk --release --target-platform android-arm,android-arm64
 
       - name: Build AAB
         working-directory: ${{ env.PLAYER_PATH }}
-        run: flutter build appbundle --release
+        run: flutter build appbundle --release --target-platform android-arm,android-arm64
+
+      - name: Check APK ABIs
+        run: ./scripts/check-apk-abis.sh ${{ env.PLAYER_PATH }}/build/app/outputs/flutter-apk/app-release.apk
 
       - name: Setup Ruby for Fastlane
         if: ${{ !inputs.dry_run && env.PLAY_STORE_CREDENTIALS != '' }}

--- a/dev
+++ b/dev
@@ -619,7 +619,7 @@ case "$COMMAND" in
                         # Dart file is gitignored, so a fresh checkout has none and
                         # the build fails with hundreds of unrelated-looking Dart
                         # errors. Idempotent, so running it every time is safe.
-                        nix develop .#android --command bash -c "cd player && flutter pub get && flutter pub run build_runner build && flutter build apk --release"
+                        nix develop .#android --command bash -c "cd player && flutter pub get && flutter pub run build_runner build && flutter build apk --release --target-platform android-arm,android-arm64"
                         if [ $? -eq 0 ]; then
                             echo -e "${GREEN}APK built successfully!${NC}"
                             echo "Output: player/build/app/outputs/flutter-apk/app-release.apk"

--- a/player/android/app/build.gradle.kts
+++ b/player/android/app/build.gradle.kts
@@ -36,6 +36,23 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        ndk {
+            // x86_64 reaches emulators and Intel Chromebooks only, and cost
+            // 62 MB of a 165 MB APK. Dropping it takes the download to
+            // ~103 MB, which matters: a Chromecast with Google TV has a 4 GB
+            // /data and routinely sits near full, and an install there failed
+            // outright with 517 MB free.
+            //
+            // Both remaining ABIs are load-bearing. armeabi-v7a is the only
+            // one Chromecast with Google TV and most Android TV boxes can run
+            // (they have no arm64 userspace); arm64-v8a is the only one Pixel
+            // 7 and later can run (they have no 32-bit runtime).
+            //
+            // Requires disable-abi-filtering=true in ../gradle.properties, or
+            // the Flutter Gradle plugin overwrites this list.
+            abiFilters += listOf("armeabi-v7a", "arm64-v8a")
+        }
     }
 
     signingConfigs {

--- a/player/android/gradle.properties
+++ b/player/android/gradle.properties
@@ -4,3 +4,10 @@ android.useAndroidX=true
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator
 android.newDsl=false
+
+# Flutter's Gradle plugin clears defaultConfig.ndk.abiFilters and re-adds its
+# own fixed list (armeabi-v7a, arm64-v8a, x86_64) in FlutterPlugin.kt's
+# configureAbiWithoutSplits. Without this property the abiFilters declared in
+# app/build.gradle.kts are silently discarded, with no warning and no build
+# failure -- the APK simply still contains x86_64.
+disable-abi-filtering=true

--- a/scripts/check-apk-abis.sh
+++ b/scripts/check-apk-abis.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Assert that a built player APK ships exactly the ABIs we intend.
+# Assert that a built player APK or AAB ships exactly the ABIs we intend.
 #
 # Flutter's Gradle plugin sets defaultConfig.ndk.abiFilters to its own fixed
 # list (armeabi-v7a, arm64-v8a, x86_64) in FlutterPlugin.kt's
@@ -32,15 +32,17 @@ if [ ! -f "$apk" ]; then
   exit 1
 fi
 
-# Directory names directly under lib/ are the ABI set. zipinfo -1 lists bare
-# paths, so the ^lib/ anchor cannot match a path with lib/ somewhere in the
-# middle. The [^/]+/ after it requires an ABI segment to actually be present,
-# so a bare "lib/" directory record (some zip tools store one, Flutter's own
-# output does not) can't match and contribute an empty ABI ahead of the real
-# names once sorted. The C locale is pinned so a runner's locale cannot
-# reorder the comparison string.
+# Directory names directly under lib/ are the ABI set. An Android App Bundle
+# (.aab) nests the same native libs one level deeper, under base/lib/<abi>/,
+# so both layouts are matched. zipinfo -1 lists bare paths, so the ^lib/ (or
+# ^base\/lib\/) anchor cannot match a path with lib/ somewhere in the middle.
+# The [^/]+/ after it requires an ABI segment to actually be present, so a
+# bare "lib/" or "base/lib/" directory record (some zip tools store one,
+# Flutter's own output does not) can't match and contribute an empty ABI
+# ahead of the real names once sorted. The C locale is pinned so a runner's
+# locale cannot reorder the comparison string.
 actual="$(unzip -Z1 "$apk" \
-  | awk -F/ '/^lib\/[^/]+\//{print $2}' \
+  | awk -F/ '/^lib\/[^/]+\//{print $2} /^base\/lib\/[^/]+\//{print $3}' \
   | LC_ALL=C sort -u | paste -sd, -)"
 
 # An APK with no lib/ entries yields an empty string and fails here, which is

--- a/scripts/check-apk-abis.sh
+++ b/scripts/check-apk-abis.sh
@@ -34,10 +34,13 @@ fi
 
 # Directory names directly under lib/ are the ABI set. zipinfo -1 lists bare
 # paths, so the ^lib/ anchor cannot match a path with lib/ somewhere in the
-# middle. The C locale is pinned so a runner's locale cannot reorder the
-# comparison string.
+# middle. The [^/]+/ after it requires an ABI segment to actually be present,
+# so a bare "lib/" directory record (some zip tools store one, Flutter's own
+# output does not) can't match and contribute an empty ABI ahead of the real
+# names once sorted. The C locale is pinned so a runner's locale cannot
+# reorder the comparison string.
 actual="$(unzip -Z1 "$apk" \
-  | awk -F/ '/^lib\//{print $2}' \
+  | awk -F/ '/^lib\/[^/]+\//{print $2}' \
   | LC_ALL=C sort -u | paste -sd, -)"
 
 # An APK with no lib/ entries yields an empty string and fails here, which is

--- a/scripts/check-apk-abis.sh
+++ b/scripts/check-apk-abis.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Assert that a built player APK ships exactly the ABIs we intend.
+#
+# Flutter's Gradle plugin sets defaultConfig.ndk.abiFilters to its own fixed
+# list (armeabi-v7a, arm64-v8a, x86_64) in FlutterPlugin.kt's
+# configureAbiWithoutSplits, clearing whatever the project declared first. The
+# player holds that off with disable-abi-filtering=true in
+# player/android/gradle.properties. That property is internal to Flutter, and
+# nothing warns if a future version renames or drops it -- at which point
+# x86_64 silently returns and the download grows by about 62 MB.
+#
+# This asserts an exact set rather than a blocklist, so it catches three
+# distinct regressions:
+#
+#   - x86_64 coming back, after a Flutter upgrade or a reverted property
+#   - armeabi-v7a going missing, which would quietly end Android TV support:
+#     Chromecast with Google TV and most TV boxes are 32-bit, no arm64
+#   - the partial-APK state where --target-platform is applied but the
+#     abiFilters are not, which strips the Flutter engine's x86_64 slices while
+#     leaving third-party x86_64 libraries behind. That APK still advertises
+#     x86_64 and crashes on launch there.
+set -euo pipefail
+
+# Sorted under LC_ALL=C and comma-joined. "arm64" sorts before "armeabi"
+# because '6' precedes 'e'.
+expected="arm64-v8a,armeabi-v7a"
+
+apk="${1:-player/build/app/outputs/flutter-apk/app-release.apk}"
+
+if [ ! -f "$apk" ]; then
+  printf '::error::%s does not exist, so its ABIs cannot be checked\n' "$apk"
+  exit 1
+fi
+
+# Directory names directly under lib/ are the ABI set. zipinfo -1 lists bare
+# paths, so the ^lib/ anchor cannot match a path with lib/ somewhere in the
+# middle. The C locale is pinned so a runner's locale cannot reorder the
+# comparison string.
+actual="$(unzip -Z1 "$apk" \
+  | awk -F/ '/^lib\//{print $2}' \
+  | LC_ALL=C sort -u | paste -sd, -)"
+
+# An APK with no lib/ entries yields an empty string and fails here, which is
+# intended: a check that passes because it found nothing is worse than no
+# check at all.
+if [ "$actual" != "$expected" ]; then
+  printf '::error::%s ships ABIs [%s], expected [%s]\n' "$apk" "$actual" "$expected"
+  printf '\n'
+  printf 'Check that disable-abi-filtering=true is still honoured by the current\n'
+  printf 'Flutter version (player/android/gradle.properties) and that the\n'
+  printf 'abiFilters in player/android/app/build.gradle.kts are intact.\n'
+  exit 1
+fi
+
+printf 'OK: %s ships exactly [%s]\n' "$apk" "$actual"


### PR DESCRIPTION
Drops the x86_64 ABI slice from the Android player APK, taking the download from
**165 MB to 103 MB** (-37%).

## Why

A Chromecast with Google TV 4K (`sabrina`, Android 14) refused to install
v0.14.0, showing "There was a problem parsing the package". The APK was not
corrupt. That device reports `abilist = armeabi-v7a,armeabi` — 32-bit only — and
had 517 MB free of a 4 GB `/data`. `adb install` failed in 27s with an **empty**
error string, which the TV's installer renders as a parse error. After a reboot
freed 78 MB, the identical APK installed. It was storage exhaustion.

The APK is 165 MB, of which native libraries are 161 MB:

| Slice | Compressed |
| --- | --- |
| `arm64-v8a` | 54.5 MB |
| `armeabi-v7a` | 44.3 MB |
| `x86_64` | 61.9 MB |
| dex, assets, resources | 4.0 MB |

Because `.so` entries are stored uncompressed with `extractNativeLibs=false`,
Android keeps the whole APK resident in `/data/app` rather than extracting the
one slice it needs. On that device 116 MB of the installed footprint could never
execute. x86_64 is the only slice with no real hardware behind it — emulators and
Intel Chromebooks. Both others are load-bearing: Android TV boxes are largely
32-bit with no arm64 userspace, and Pixel 7 and later are arm64-only with no
32-bit runtime.

## Why it takes two settings, not one

Flutter's Gradle plugin calls `abiFilters.clear()` and re-adds its own fixed
three-ABI list in `FlutterPlugin.kt`'s `configureAbiWithoutSplits`. So:

- `ndk.abiFilters` alone is **silently discarded**.
- `--target-platform` alone is **worse than doing nothing**: it drops the Flutter
  engine's x86_64 slices while leaving third-party x86_64 libraries from the mpv
  and MLKit AARs in place, producing an APK that still advertises x86_64 and
  crashes on launch there.

The pair that works is `disable-abi-filtering=true` plus explicit `abiFilters`.
`--target-platform` is added separately at all four build call sites purely to
stop cargokit cross-compiling a Rust core that `abiFilters` then discards.

## Verification

Built locally and installed on the 32-bit Chromecast:

- APK 173,120,321 → 108,532,921 bytes
- `lib/` contains exactly `arm64-v8a` and `armeabi-v7a`
- installs, launches, `MainActivity` visible, no `UnsatisfiedLinkError` or
  `dlopen failed`, p2p core connects to the relay
- on-device footprint 104 MB, down from 165 MB

`scripts/check-apk-abis.sh` asserts the exact ABI set and runs in CI and before
the Play Store upload. It is an exact match, not a blocklist, so it also catches
`armeabi-v7a` going missing and the partial-APK state described above.

## Not in this change

`--split-per-abi` would take armeabi-v7a to ~48 MB, but publishing three APKs
breaks `site/src/lib/release-assets.ts`, where `findAsset` returns the first
prefix match and would serve an arbitrary ABI from the download page. Separate
piece of work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build Improvements**
  - Android release builds now target ARM 32-bit and ARM 64-bit devices only.
  - Release packages use consistent ARM architecture filtering across APK and AAB builds.
- **Quality Checks**
  - Automated validation confirms that APK and AAB packages contain exactly the supported ARM architectures.
  - Builds now report an error when package architecture contents do not match expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->