### PR TITLE
feat(library-api): mutations, the events feed and the keys page

### DIFF
--- a/docs/using/reference/library-api.md
+++ b/docs/using/reference/library-api.md
@@ -36,17 +36,13 @@ Two kinds of key work.
 
 ### A database API key
 
-There is no dedicated admin page for these yet; one is planned for a later
-release. Until then, authenticate to `/api/graphql` as an admin user (a
-browser session, a bearer access token, or an existing API key all work) and
-call the player API's `createApiKey` mutation with `permissions: ["admin"]`.
-The owning user must be an admin. The plain key is shown once, in the
-mutation's response.
+Create one under **Configuration → API Keys**. Give it a name, an expiry (never,
+30, 90 or 365 days) and the *Library API* scope, which is stored as the `admin`
+permission. The owner must be an admin. The plain key is shown once, when you
+create it; copy it then. Revoke or delete a key from the same page.
 
-With the player turned off (`ENABLE_PLAYER=false`) the player API answers 404, so
-this route is closed. Keys created earlier still work on the Library API.
-
-Alternatively, skip database keys entirely and set `LIBRARY_API_KEY` (below).
+Keys created through the player API's `createApiKey` mutation also work, as
+long as they carry the `admin` permission.
 
 ### `LIBRARY_API_KEY`
 
@@ -70,6 +66,7 @@ See [Environment Variables](environment-variables.md) for the full entry.
 | `mediaItem(id \| tmdbId \| tvdbId \| imdbId)` | One item with its availability status and episodes |
 | `mediaItems(first, after, updatedSince)` | A page of items, oldest change first (`updatedSince` is inclusive) |
 | `downloads(filter)` | The download queue and history |
+| `events(first, after, types)` | Library activity, oldest first (see [Events](#events)) |
 | `qualityProfiles` | Profiles available to assign |
 | `libraryPaths` | Library paths available to add into |
 
@@ -85,6 +82,79 @@ curl -s http://localhost:4000/api/library/graphql \
 There is no GraphiQL or Playground page on this endpoint. Use any GraphQL client
 that can set a request header.
 
+## Mutations
+
+| Field | Does |
+| --- | --- |
+| `addMovie(input: {tmdbId, qualityProfileId, libraryPathId, monitored, searchNow})` | Adds a movie; `searchNow` queues an automatic search |
+| `addTvShow(input: {tvdbId \| tmdbId, qualityProfileId, libraryPathId, monitored, seasonMonitoring, searchNow})` | Adds a show; `tvdbId` wins when both ids are given |
+| `removeMediaItem(input: {id, deleteFiles})` | Removes an item, and its files when `deleteFiles` is true. `filesNotDeleted` counts files that could not be removed from disk |
+| `setMediaItemMonitored(id, monitored)` | Monitoring for a movie or show |
+| `setSeasonMonitored(mediaItemId, season, monitored)` | Monitoring for every episode of a season |
+| `setEpisodeMonitored(id, monitored)` | Monitoring for one episode |
+| `applyEpisodeMonitoring(mediaItemId, preset)` | `ALL`, `MISSING`, `EXISTING`, `FUTURE` or `NONE` |
+| `searchMediaItem(id)` | Queues an automatic search for a movie or a whole show |
+| `searchSeason(mediaItemId, season)` | Queues a search for one season, preferring a season pack |
+| `searchEpisode(id)` | Queues a search for one episode |
+| `cancelDownload(id)` | Removes a download from its client and the queue |
+| `rejectRelease(id, blocklistDays)` | Removes a download, blocklists its release and searches again |
+
+Each returns a payload with the thing it changed and a `userErrors` list. An
+expected failure leaves the main field null and fills `userErrors`, each with a
+`code`, a `message`, and the `field` path of the argument that caused it:
+
+```json
+{
+  "data": {
+    "addMovie": {
+      "mediaItem": null,
+      "userErrors": [
+        {"field": ["input", "qualityProfileId"], "code": "INVALID_INPUT", "message": "Not a valid id"}
+      ]
+    }
+  }
+}
+```
+
+| Code | Meaning |
+| --- | --- |
+| `ALREADY_IN_LIBRARY` | The title is already there; `mediaItem` is the existing item |
+| `NOT_FOUND` | An id names nothing |
+| `INVALID_INPUT` | The arguments cannot be satisfied |
+| `METADATA_UNAVAILABLE` | The metadata relay could not provide the title |
+| `CLIENT_UNAVAILABLE` | `cancelDownload` only: the download client could not remove it, so the download is still queued |
+
+`searchMediaItem`, `searchSeason` and `searchEpisode` report `queued: true` when
+the job is inserted. A repeat within 60 seconds is merged into the first and
+still reports `true`. `cancelDownload` and `rejectRelease` return `removedId`,
+because both delete the download row. `rejectRelease` removes the item from its
+client on a best-effort basis, as the Downloads page does.
+
+## Events
+
+`events` pages through library activity, oldest first:
+
+```graphql
+{ events(first: 100, after: "…") { edges { node { type occurredAt data } } pageInfo { endCursor } } }
+```
+
+Keep `endCursor` and pass it as `after` next time. On an empty page `endCursor`
+repeats the `after` you sent, so you can always pass it back. `types` narrows
+the feed to the types you name; by default you get every published type, and a
+type outside that list is `INVALID_INPUT`. `data`'s keys depend on the type and
+may change during beta.
+
+The feed is best-effort. Use it to learn that something happened, then read
+`mediaItems(updatedSince:)` or `downloads` for the state:
+
+- Events can be missing. Mydia drops events under heavy load and loses a batch
+  whose write fails.
+- An event appears about 35 seconds after it happens, a delay longer than the
+  database's own write timeout, so an event written during a library scan still
+  lands before the feed hands out a cursor past it.
+- Events are kept for 90 days. A cursor older than that resumes at the oldest
+  event left.
+
 ## Cost
 
 - `downloads` contacts **every** configured download client on each call, so it is
@@ -96,11 +166,14 @@ that can set a request header.
   or dedupe by `id` if you re-poll from the last seen `updatedAt`.
 - `mediaItems` computes availability per item. `first` accepts 1 to 200; a value
   outside that range is rejected with `INVALID_INPUT` rather than clamped to it.
+- `addMovie` and `addTvShow` each ask the metadata relay for the title, and are
+  priced like `lookup`.
+- `events` takes `first` from 1 to 200 (default 100), priced like `mediaItems`.
 
 ## Errors
 
-Expected failures come back as GraphQL errors carrying a code in
-`extensions.code`:
+Queries report expected failures as GraphQL errors carrying a code in
+`extensions.code` (mutations use `userErrors`, above):
 
 | Code | Meaning |
 | --- | --- |

--- a/lib/mydia/library_api/event_feed.ex
+++ b/lib/mydia/library_api/event_feed.ex
@@ -12,10 +12,12 @@ defmodule Mydia.LibraryApi.EventFeed do
     * `Mydia.Events.Writer` drops events under overload and loses a batch whose
       insert fails, so the feed can have gaps. `mediaItems(updatedSince:)` and
       `downloads` stay the source of truth.
-    * `inserted_at` is second-precision and ids are random UUIDs, so an event
-      written late within a second could sort before a cursor already handed
-      out. Rows younger than the settle window are withheld, which covers the
-      writer's 200 ms flush; a long transaction can still outlast it.
+    * `inserted_at` is stamped in the caller's process before the event is
+      flushed; the writer can block in Repo.insert_all/2 for up to the
+      database's busy_timeout (30 seconds). Rows younger than the settle window
+      (35 seconds) are withheld, which is longer than the write timeout, so an
+      event written during a library scan still lands before the feed hands out
+      a cursor past it.
     * The existing cleanup deletes events after 90 days. A cursor older than that
       resumes at the oldest remaining event.
   """
@@ -26,7 +28,7 @@ defmodule Mydia.LibraryApi.EventFeed do
   alias Mydia.Plugins.Manifest
   alias Mydia.Repo
 
-  @settle_seconds 10
+  @settle_seconds 35
 
   @doc """
   Lists events oldest first.

--- a/lib/mydia/library_api/event_feed.ex
+++ b/lib/mydia/library_api/event_feed.ex
@@ -35,9 +35,14 @@ defmodule Mydia.LibraryApi.EventFeed do
 
   Options: `:limit` (required), `:after` (an `{inserted_at, id}` pair from
   `Mydia.LibraryApi.Cursor.decode/1`), `:types` (defaults to the plugin event
-  catalog; a type outside it is refused), `:now` (the clock, for tests).
+  catalog; a type outside it is refused, and an empty list is refused too,
+  rather than compiling to `WHERE type IN ()` and returning an empty feed
+  forever), `:now` (the clock, for tests).
   """
-  @spec list(keyword()) :: {:ok, [Event.t()]} | {:error, {:unknown_types, [String.t()]}}
+  @spec list(keyword()) ::
+          {:ok, [Event.t()]}
+          | {:error, {:unknown_types, [String.t()]}}
+          | {:error, :empty_types}
   def list(opts) do
     with {:ok, types} <- types(Keyword.get(opts, :types)) do
       settled =
@@ -64,6 +69,7 @@ defmodule Mydia.LibraryApi.EventFeed do
   def settle_seconds, do: @settle_seconds
 
   defp types(nil), do: {:ok, Manifest.event_catalog()}
+  defp types([]), do: {:error, :empty_types}
 
   defp types(requested) do
     catalog = Manifest.event_catalog()

--- a/lib/mydia/library_api/event_feed.ex
+++ b/lib/mydia/library_api/event_feed.ex
@@ -1,0 +1,84 @@
+defmodule Mydia.LibraryApi.EventFeed do
+  @moduledoc """
+  A forward-only keyset feed over the existing `events` table.
+
+  Oldest first, ordered by `(inserted_at, id)`, strictly after the cursor. The
+  comparison is spelled out (`inserted_at > ts or (inserted_at == ts and id > id)`)
+  so it runs on SQLite and PostgreSQL alike. The existing `inserted_at` index
+  serves the range; ties within a second are few.
+
+  Best-effort, and the API says so:
+
+    * `Mydia.Events.Writer` drops events under overload and loses a batch whose
+      insert fails, so the feed can have gaps. `mediaItems(updatedSince:)` and
+      `downloads` stay the source of truth.
+    * `inserted_at` is second-precision and ids are random UUIDs, so an event
+      written late within a second could sort before a cursor already handed
+      out. Rows younger than the settle window are withheld, which covers the
+      writer's 200 ms flush; a long transaction can still outlast it.
+    * The existing cleanup deletes events after 90 days. A cursor older than that
+      resumes at the oldest remaining event.
+  """
+
+  import Ecto.Query
+
+  alias Mydia.Events.Event
+  alias Mydia.Plugins.Manifest
+  alias Mydia.Repo
+
+  @settle_seconds 10
+
+  @doc """
+  Lists events oldest first.
+
+  Options: `:limit` (required), `:after` (an `{inserted_at, id}` pair from
+  `Mydia.LibraryApi.Cursor.decode/1`), `:types` (defaults to the plugin event
+  catalog; a type outside it is refused), `:now` (the clock, for tests).
+  """
+  @spec list(keyword()) :: {:ok, [Event.t()]} | {:error, {:unknown_types, [String.t()]}}
+  def list(opts) do
+    with {:ok, types} <- types(Keyword.get(opts, :types)) do
+      settled =
+        opts
+        |> Keyword.get(:now, DateTime.utc_now())
+        |> DateTime.add(-@settle_seconds, :second)
+        |> DateTime.truncate(:second)
+
+      events =
+        Event
+        |> where([e], e.type in ^types)
+        |> where([e], e.inserted_at <= ^settled)
+        |> after_cursor(Keyword.get(opts, :after))
+        |> order_by([e], asc: e.inserted_at, asc: e.id)
+        |> limit(^Keyword.fetch!(opts, :limit))
+        |> Repo.all()
+
+      {:ok, events}
+    end
+  end
+
+  @doc "Seconds a new event is withheld before the feed returns it."
+  @spec settle_seconds() :: pos_integer()
+  def settle_seconds, do: @settle_seconds
+
+  defp types(nil), do: {:ok, Manifest.event_catalog()}
+
+  defp types(requested) do
+    catalog = Manifest.event_catalog()
+
+    case Enum.reject(requested, &(&1 in catalog)) do
+      [] -> {:ok, requested}
+      unknown -> {:error, {:unknown_types, unknown}}
+    end
+  end
+
+  defp after_cursor(query, nil), do: query
+
+  defp after_cursor(query, {inserted_at, id}) do
+    where(
+      query,
+      [e],
+      e.inserted_at > ^inserted_at or (e.inserted_at == ^inserted_at and e.id > ^id)
+    )
+  end
+end

--- a/lib/mydia/library_api/policy.ex
+++ b/lib/mydia/library_api/policy.ex
@@ -9,7 +9,14 @@ defmodule Mydia.LibraryApi.Policy do
 
   alias Mydia.LibraryApi.Principal
 
-  @actions [:read_library, :read_downloads]
+  @actions [
+    :read_library,
+    :read_downloads,
+    :read_events,
+    :manage_library,
+    :search,
+    :manage_downloads
+  ]
 
   @doc "Every action a Library API field may declare."
   @spec actions() :: [atom()]

--- a/lib/mydia/library_api/principal.ex
+++ b/lib/mydia/library_api/principal.ex
@@ -16,4 +16,16 @@ defmodule Mydia.LibraryApi.Principal do
           user: Mydia.Accounts.User.t() | nil,
           api_key_id: binary() | nil
         }
+
+  @doc """
+  The `actor_type`/`actor_id` options for context functions that record who acted.
+
+  A database key acts as its owner. The environment key has no user behind it, so
+  it acts as the system under a fixed name that says where the change came from.
+  """
+  @spec actor_opts(t()) :: keyword()
+  def actor_opts(%__MODULE__{source: :api_key, user: %{id: user_id}}),
+    do: [actor_type: :user, actor_id: user_id]
+
+  def actor_opts(%__MODULE__{}), do: [actor_type: :system, actor_id: "library_api_key"]
 end

--- a/lib/mydia_web/components/admin_components.ex
+++ b/lib/mydia_web/components/admin_components.ex
@@ -142,6 +142,9 @@ defmodule MydiaWeb.AdminComponents do
           Remote Access
         </.tab_link>
       <% end %>
+      <.tab_link active={@active_tab == :api_keys} to="/admin/config/api-keys" icon="hero-key">
+        API Keys
+      </.tab_link>
     </div>
     """
   end

--- a/lib/mydia_web/library_schema.ex
+++ b/lib/mydia_web/library_schema.ex
@@ -18,6 +18,8 @@ defmodule MydiaWeb.LibrarySchema do
   import_types(MydiaWeb.LibrarySchema.QueryTypes)
   import_types(MydiaWeb.LibrarySchema.MediaTypes)
   import_types(MydiaWeb.LibrarySchema.DownloadTypes)
+  import_types(MydiaWeb.LibrarySchema.PayloadTypes)
+  import_types(MydiaWeb.LibrarySchema.MutationTypes)
 
   @introspection_fields [:__schema, :__type, :__typename]
 
@@ -27,7 +29,7 @@ defmodule MydiaWeb.LibrarySchema do
   A root field without one is an error rather than a default: authorization has
   to fail closed, and a field nobody marked is a field nobody decided about.
   """
-  def middleware(middleware, field, %{identifier: :query}) do
+  def middleware(middleware, field, %{identifier: root}) when root in [:query, :mutation] do
     if field.identifier in @introspection_fields do
       middleware
     else
@@ -48,5 +50,9 @@ defmodule MydiaWeb.LibrarySchema do
 
   query do
     import_fields(:library_queries)
+  end
+
+  mutation do
+    import_fields(:library_mutations)
   end
 end

--- a/lib/mydia_web/library_schema.ex
+++ b/lib/mydia_web/library_schema.ex
@@ -20,6 +20,7 @@ defmodule MydiaWeb.LibrarySchema do
   import_types(MydiaWeb.LibrarySchema.DownloadTypes)
   import_types(MydiaWeb.LibrarySchema.PayloadTypes)
   import_types(MydiaWeb.LibrarySchema.MutationTypes)
+  import_types(MydiaWeb.LibrarySchema.EventTypes)
 
   @introspection_fields [:__schema, :__type, :__typename]
 

--- a/lib/mydia_web/library_schema/enum_types.ex
+++ b/lib/mydia_web/library_schema/enum_types.ex
@@ -76,4 +76,13 @@ defmodule MydiaWeb.LibrarySchema.EnumTypes do
     value(:future, description: "Episodes that have not aired")
     value(:none, description: "No episodes")
   end
+
+  @desc "Which seasons of a newly added show to monitor"
+  enum :season_monitoring do
+    value(:all, description: "Every season")
+    value(:future, description: "Only episodes that have not aired")
+    value(:latest, description: "Only the latest season")
+    value(:first, description: "Only the first season")
+    value(:none, description: "No seasons")
+  end
 end

--- a/lib/mydia_web/library_schema/enum_types.ex
+++ b/lib/mydia_web/library_schema/enum_types.ex
@@ -67,4 +67,13 @@ defmodule MydiaWeb.LibrarySchema.EnumTypes do
     value(:series, description: "TV series library")
     value(:mixed, description: "Mixed content library")
   end
+
+  @desc "Which of a show's episodes to monitor"
+  enum :episode_monitoring_preset do
+    value(:all, description: "Every episode")
+    value(:missing, description: "Episodes without a file")
+    value(:existing, description: "Episodes with a file")
+    value(:future, description: "Episodes that have not aired")
+    value(:none, description: "No episodes")
+  end
 end

--- a/lib/mydia_web/library_schema/event_types.ex
+++ b/lib/mydia_web/library_schema/event_types.ex
@@ -1,0 +1,51 @@
+defmodule MydiaWeb.LibrarySchema.EventTypes do
+  @moduledoc """
+  Types for the events feed.
+
+  `resourceType` and `resourceId` stay scalars because they outlive what they
+  point at: a `media_item.removed` event names a row that no longer exists. A
+  `resource` union can be added beside them later, and a typed payload beside
+  `data`.
+  """
+
+  use Absinthe.Schema.Notation
+
+  @desc "Arbitrary JSON, returned as stored"
+  scalar :json, name: "JSON" do
+    serialize(& &1)
+    # Output only: no argument takes JSON.
+    parse(fn _input -> :error end)
+  end
+
+  @desc "How serious an event is"
+  enum :severity do
+    value(:info, description: "Routine")
+    value(:warning, description: "Worth a look")
+    value(:error, description: "Something failed")
+  end
+
+  @desc "Something that happened in the library"
+  object :event do
+    field :id, non_null(:id)
+    field :type, non_null(:string)
+    field :occurred_at, non_null(:datetime), description: "When Mydia recorded it, to the second"
+    field :severity, non_null(:severity)
+    field :resource_type, :string
+    field :resource_id, :id
+
+    field :data, non_null(:json),
+      description: "Type-specific details. Keys may change during beta."
+  end
+
+  @desc "One event in a page"
+  object :event_edge do
+    field :node, non_null(:event)
+    field :cursor, non_null(:string)
+  end
+
+  @desc "A page of events"
+  object :event_connection do
+    field :edges, non_null(list_of(non_null(:event_edge)))
+    field :page_info, non_null(:page_info)
+  end
+end

--- a/lib/mydia_web/library_schema/loaders.ex
+++ b/lib/mydia_web/library_schema/loaders.ex
@@ -7,6 +7,8 @@ defmodule MydiaWeb.LibrarySchema.Loaders do
   run, so they live here once.
   """
 
+  alias Mydia.Downloads
+  alias Mydia.Downloads.Download
   alias Mydia.Library.MediaFile
   alias Mydia.Media
   alias Mydia.Media.Episode
@@ -51,6 +53,17 @@ defmodule MydiaWeb.LibrarySchema.Loaders do
         {:ok, Media.get_episode!(id, preload: [media_files: MediaFile.versions()])}
       rescue
         Ecto.NoResultsError -> {:error, UserError.not_found("episode", field)}
+      end
+    end
+  end
+
+  @doc "The download `id` names."
+  @spec download(term(), [String.t()]) :: {:ok, Download.t()} | {:error, UserError.t()}
+  def download(id, field) do
+    with {:ok, id} <- UserError.cast_id(id, field) do
+      case Downloads.get_download(id) do
+        nil -> {:error, UserError.not_found("download", field)}
+        download -> {:ok, download}
       end
     end
   end

--- a/lib/mydia_web/library_schema/loaders.ex
+++ b/lib/mydia_web/library_schema/loaders.ex
@@ -1,0 +1,71 @@
+defmodule MydiaWeb.LibrarySchema.Loaders do
+  @moduledoc """
+  Loads what a mutation's arguments name, or the `UserError` to report instead.
+
+  Every mutation that takes an id needs the same three answers (malformed, names
+  nothing, found) and the same preloads before `MediaItemView.item_map/1` can
+  run, so they live here once.
+  """
+
+  alias Mydia.Library.MediaFile
+  alias Mydia.Media
+  alias Mydia.Media.Episode
+  alias Mydia.Media.MediaItem
+  alias MydiaWeb.LibrarySchema.MediaItemView
+  alias MydiaWeb.LibrarySchema.UserError
+
+  @doc "The media item `id` names, preloaded for `MediaItemView.item_map/1`."
+  @spec item(term(), [String.t()]) :: {:ok, MediaItem.t()} | {:error, UserError.t()}
+  def item(id, field) do
+    with {:ok, id} <- UserError.cast_id(id, field) do
+      case load(id) do
+        nil -> {:error, UserError.not_found("media item", field)}
+        item -> {:ok, item}
+      end
+    end
+  end
+
+  @doc """
+  The GraphQL map for a freshly reloaded item, or nil when it is gone.
+
+  Reloaded rather than reusing a struct a context function returned: the payload
+  must carry the preloads `item_map/1` reads, and updates do not return them.
+  """
+  @spec item_map(Ecto.UUID.t()) :: map() | nil
+  def item_map(id) do
+    case load(id) do
+      nil -> nil
+      item -> MediaItemView.item_map(item)
+    end
+  end
+
+  @doc """
+  The episode `id` names, with the media files `hasFile` reads.
+
+  `get_episode!/2` is the context's only single-episode getter, hence the rescue.
+  """
+  @spec episode(term(), [String.t()]) :: {:ok, Episode.t()} | {:error, UserError.t()}
+  def episode(id, field) do
+    with {:ok, id} <- UserError.cast_id(id, field) do
+      try do
+        {:ok, Media.get_episode!(id, preload: [media_files: MediaFile.versions()])}
+      rescue
+        Ecto.NoResultsError -> {:error, UserError.not_found("episode", field)}
+      end
+    end
+  end
+
+  @doc "Refuses anything but a TV show, for season and episode operations."
+  @spec require_show(MediaItem.t(), [String.t()]) :: :ok | {:error, UserError.t()}
+  def require_show(%MediaItem{type: "tv_show"}, _field), do: :ok
+
+  def require_show(%MediaItem{}, field),
+    do: {:error, UserError.new(:invalid_input, "Only TV shows have seasons and episodes", field)}
+
+  defp load(id) do
+    case Media.list_media_items(ids: [id], preload: MediaItemView.preloads()) do
+      [item | _] -> item
+      [] -> nil
+    end
+  end
+end

--- a/lib/mydia_web/library_schema/mutation_types.ex
+++ b/lib/mydia_web/library_schema/mutation_types.ex
@@ -1,0 +1,21 @@
+defmodule MydiaWeb.LibrarySchema.MutationTypes do
+  @moduledoc """
+  The Library API's mutations.
+
+  Every field declares an `action` that the schema's `middleware/3` turns into an
+  `Authorize` step, exactly as queries do. Each resolver calls the context
+  function the UI calls, so a change made here is the same change the UI makes.
+  """
+
+  use Absinthe.Schema.Notation
+
+  object :library_mutations do
+    @desc "Turn monitoring on or off for a movie or show"
+    field :set_media_item_monitored, non_null(:media_item_payload) do
+      meta(action: :manage_library)
+      arg(:id, non_null(:id))
+      arg(:monitored, non_null(:boolean))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Monitoring.set_media_item_monitored/3)
+    end
+  end
+end

--- a/lib/mydia_web/library_schema/mutation_types.ex
+++ b/lib/mydia_web/library_schema/mutation_types.ex
@@ -92,5 +92,27 @@ defmodule MydiaWeb.LibrarySchema.MutationTypes do
       arg(:input, non_null(:remove_media_item_input))
       resolve(&MydiaWeb.LibrarySchema.Resolvers.LibraryWrites.remove_media_item/3)
     end
+
+    @desc "Queue an automatic search for a movie, or for a whole show"
+    field :search_media_item, non_null(:search_payload) do
+      meta(action: :search)
+      arg(:id, non_null(:id))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Search.search_media_item/3)
+    end
+
+    @desc "Queue a search for one season of a show, preferring a season pack"
+    field :search_season, non_null(:search_payload) do
+      meta(action: :search)
+      arg(:media_item_id, non_null(:id))
+      arg(:season, non_null(:integer))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Search.search_season/3)
+    end
+
+    @desc "Queue a search for one episode"
+    field :search_episode, non_null(:search_payload) do
+      meta(action: :search)
+      arg(:id, non_null(:id))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Search.search_episode/3)
+    end
   end
 end

--- a/lib/mydia_web/library_schema/mutation_types.ex
+++ b/lib/mydia_web/library_schema/mutation_types.ex
@@ -17,5 +17,30 @@ defmodule MydiaWeb.LibrarySchema.MutationTypes do
       arg(:monitored, non_null(:boolean))
       resolve(&MydiaWeb.LibrarySchema.Resolvers.Monitoring.set_media_item_monitored/3)
     end
+
+    @desc "Turn monitoring on or off for every episode of one season"
+    field :set_season_monitored, non_null(:media_item_payload) do
+      meta(action: :manage_library)
+      arg(:media_item_id, non_null(:id))
+      arg(:season, non_null(:integer))
+      arg(:monitored, non_null(:boolean))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Monitoring.set_season_monitored/3)
+    end
+
+    @desc "Turn monitoring on or off for one episode"
+    field :set_episode_monitored, non_null(:episode_payload) do
+      meta(action: :manage_library)
+      arg(:id, non_null(:id))
+      arg(:monitored, non_null(:boolean))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Monitoring.set_episode_monitored/3)
+    end
+
+    @desc "Apply a monitoring preset to a show's episodes"
+    field :apply_episode_monitoring, non_null(:media_item_payload) do
+      meta(action: :manage_library)
+      arg(:media_item_id, non_null(:id))
+      arg(:preset, non_null(:episode_monitoring_preset))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Monitoring.apply_episode_monitoring/3)
+    end
   end
 end

--- a/lib/mydia_web/library_schema/mutation_types.ex
+++ b/lib/mydia_web/library_schema/mutation_types.ex
@@ -114,5 +114,24 @@ defmodule MydiaWeb.LibrarySchema.MutationTypes do
       arg(:id, non_null(:id))
       resolve(&MydiaWeb.LibrarySchema.Resolvers.Search.search_episode/3)
     end
+
+    @desc "Stop a download and remove it from its client and the queue"
+    field :cancel_download, non_null(:remove_download_payload) do
+      meta(action: :manage_downloads)
+      arg(:id, non_null(:id))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Downloads.cancel_download/3)
+    end
+
+    @desc "Remove a download, blocklist its release, and search again"
+    field :reject_release, non_null(:remove_download_payload) do
+      meta(action: :manage_downloads)
+      arg(:id, non_null(:id))
+
+      arg(:blocklist_days, :integer,
+        description: "Days to blocklist the release. Defaults to the configured period."
+      )
+
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Downloads.reject_release/3)
+    end
   end
 end

--- a/lib/mydia_web/library_schema/mutation_types.ex
+++ b/lib/mydia_web/library_schema/mutation_types.ex
@@ -9,6 +9,32 @@ defmodule MydiaWeb.LibrarySchema.MutationTypes do
 
   use Absinthe.Schema.Notation
 
+  @desc "A movie to add"
+  input_object :add_movie_input do
+    field :tmdb_id, non_null(:integer)
+    field :quality_profile_id, :id
+    field :library_path_id, :id
+    field :monitored, :boolean, default_value: true
+    field :search_now, :boolean, default_value: false
+  end
+
+  @desc "A TV show to add. Give tvdbId or tmdbId; tvdbId wins when both are set."
+  input_object :add_tv_show_input do
+    field :tvdb_id, :integer
+    field :tmdb_id, :integer
+    field :quality_profile_id, :id
+    field :library_path_id, :id
+    field :monitored, :boolean, default_value: true
+    field :season_monitoring, :season_monitoring, default_value: :all
+    field :search_now, :boolean, default_value: false
+  end
+
+  @desc "A media item to remove"
+  input_object :remove_media_item_input do
+    field :id, non_null(:id)
+    field :delete_files, :boolean, default_value: false
+  end
+
   object :library_mutations do
     @desc "Turn monitoring on or off for a movie or show"
     field :set_media_item_monitored, non_null(:media_item_payload) do
@@ -41,6 +67,30 @@ defmodule MydiaWeb.LibrarySchema.MutationTypes do
       arg(:media_item_id, non_null(:id))
       arg(:preset, non_null(:episode_monitoring_preset))
       resolve(&MydiaWeb.LibrarySchema.Resolvers.Monitoring.apply_episode_monitoring/3)
+    end
+
+    @desc "Add a movie by its TMDB id"
+    field :add_movie, non_null(:add_media_payload) do
+      meta(action: :manage_library)
+      arg(:input, non_null(:add_movie_input))
+      # Fetches the title from the metadata relay, like lookup.
+      complexity(20)
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.LibraryWrites.add_movie/3)
+    end
+
+    @desc "Add a TV show by its TVDB or TMDB id"
+    field :add_tv_show, non_null(:add_media_payload) do
+      meta(action: :manage_library)
+      arg(:input, non_null(:add_tv_show_input))
+      complexity(20)
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.LibraryWrites.add_tv_show/3)
+    end
+
+    @desc "Remove a movie or show from the library"
+    field :remove_media_item, non_null(:remove_media_item_payload) do
+      meta(action: :manage_library)
+      arg(:input, non_null(:remove_media_item_input))
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.LibraryWrites.remove_media_item/3)
     end
   end
 end

--- a/lib/mydia_web/library_schema/paging.ex
+++ b/lib/mydia_web/library_schema/paging.ex
@@ -1,0 +1,51 @@
+defmodule MydiaWeb.LibrarySchema.Paging do
+  @moduledoc """
+  The `first` and `after` rules every Library API connection shares, and its cost.
+
+  `first` reaches Ecto's `limit`, where 0 and negative values are invalid or
+  surprising, so they are refused rather than clamped: a client that asks for 0
+  has a bug worth surfacing. Pricing is the exception. Complexity analysis runs
+  before any resolver refuses a bad `first`, so the cost clamps it to 1..cap; a
+  zero or negative cost would offset expensive sibling fields.
+  """
+
+  alias Mydia.LibraryApi.Cursor
+
+  @doc "Validates `first`, defaulting nil."
+  @spec page_size(term(), pos_integer(), pos_integer()) :: {:ok, pos_integer()} | {:error, map()}
+  def page_size(nil, default, _cap), do: {:ok, default}
+
+  def page_size(first, _default, cap) when is_integer(first) and first >= 1 and first <= cap,
+    do: {:ok, first}
+
+  def page_size(first, _default, cap) when is_integer(first) do
+    {:error,
+     %{
+       message: "first must be between 1 and #{cap}, got #{first}",
+       extensions: %{code: "INVALID_INPUT"}
+     }}
+  end
+
+  def page_size(_first, _default, _cap) do
+    {:error, %{message: "first must be an integer", extensions: %{code: "INVALID_INPUT"}}}
+  end
+
+  @doc "Decodes an `after` cursor, passing nil through."
+  @spec decode_cursor(String.t() | nil) ::
+          {:ok, {DateTime.t(), String.t()} | nil} | {:error, map()}
+  def decode_cursor(nil), do: {:ok, nil}
+
+  def decode_cursor(cursor) do
+    case Cursor.decode(cursor) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, %{message: "Invalid cursor", extensions: %{code: "INVALID_INPUT"}}}
+    end
+  end
+
+  @doc "A connection field's complexity: `first` clamped to 1..cap, times its child's."
+  @spec cost(map(), pos_integer(), pos_integer(), non_neg_integer()) :: non_neg_integer()
+  def cost(args, default, cap, child_complexity) do
+    first = (Map.get(args, :first) || default) |> min(cap) |> max(1)
+    first * child_complexity
+  end
+end

--- a/lib/mydia_web/library_schema/payload_types.ex
+++ b/lib/mydia_web/library_schema/payload_types.ex
@@ -53,4 +53,12 @@ defmodule MydiaWeb.LibrarySchema.PayloadTypes do
 
     field :user_errors, non_null(list_of(non_null(:user_error)))
   end
+
+  @desc "Whether a search job was queued"
+  object :search_payload do
+    field :queued, non_null(:boolean),
+      description: "True when the job was inserted, including a repeat merged by the worker"
+
+    field :user_errors, non_null(list_of(non_null(:user_error)))
+  end
 end

--- a/lib/mydia_web/library_schema/payload_types.ex
+++ b/lib/mydia_web/library_schema/payload_types.ex
@@ -37,4 +37,16 @@ defmodule MydiaWeb.LibrarySchema.PayloadTypes do
     field :episode, :episode
     field :user_errors, non_null(list_of(non_null(:user_error)))
   end
+
+  @desc "The media item an add created, or the one already in the library"
+  object :add_media_payload do
+    field :media_item, :media_item
+    field :user_errors, non_null(list_of(non_null(:user_error)))
+  end
+
+  @desc "The id of the media item a remove deleted"
+  object :remove_media_item_payload do
+    field :removed_id, :id
+    field :user_errors, non_null(list_of(non_null(:user_error)))
+  end
 end

--- a/lib/mydia_web/library_schema/payload_types.ex
+++ b/lib/mydia_web/library_schema/payload_types.ex
@@ -47,6 +47,10 @@ defmodule MydiaWeb.LibrarySchema.PayloadTypes do
   @desc "The id of the media item a remove deleted"
   object :remove_media_item_payload do
     field :removed_id, :id
+
+    field :files_not_deleted, :integer,
+      description: "Files that could not be removed from disk. 0 when deleteFiles was false."
+
     field :user_errors, non_null(list_of(non_null(:user_error)))
   end
 end

--- a/lib/mydia_web/library_schema/payload_types.ex
+++ b/lib/mydia_web/library_schema/payload_types.ex
@@ -61,4 +61,10 @@ defmodule MydiaWeb.LibrarySchema.PayloadTypes do
 
     field :user_errors, non_null(list_of(non_null(:user_error)))
   end
+
+  @desc "The id of the download a mutation removed from the queue"
+  object :remove_download_payload do
+    field :removed_id, :id
+    field :user_errors, non_null(list_of(non_null(:user_error)))
+  end
 end

--- a/lib/mydia_web/library_schema/payload_types.ex
+++ b/lib/mydia_web/library_schema/payload_types.ex
@@ -31,4 +31,10 @@ defmodule MydiaWeb.LibrarySchema.PayloadTypes do
     field :media_item, :media_item
     field :user_errors, non_null(list_of(non_null(:user_error)))
   end
+
+  @desc "The episode a mutation changed"
+  object :episode_payload do
+    field :episode, :episode
+    field :user_errors, non_null(list_of(non_null(:user_error)))
+  end
 end

--- a/lib/mydia_web/library_schema/payload_types.ex
+++ b/lib/mydia_web/library_schema/payload_types.ex
@@ -1,0 +1,34 @@
+defmodule MydiaWeb.LibrarySchema.PayloadTypes do
+  @moduledoc """
+  Mutation payloads and the user errors they carry.
+
+  An expected failure (the title is already in the library, the relay is down, an
+  id names nothing) comes back in `userErrors` with the payload's main field
+  null, so a client branches on `code` without parsing messages. Top-level
+  GraphQL errors stay reserved for authorization and for bugs.
+  """
+
+  use Absinthe.Schema.Notation
+
+  @desc "Why a mutation could not do what it was asked"
+  enum :user_error_code do
+    value(:already_in_library, description: "The title is already in the library")
+    value(:not_found, description: "An id names nothing")
+    value(:invalid_input, description: "The arguments cannot be satisfied")
+    value(:metadata_unavailable, description: "The metadata relay could not provide the title")
+    value(:client_unavailable, description: "A download client could not do what was asked")
+  end
+
+  @desc "An expected failure, tied to the argument that caused it when there is one"
+  object :user_error do
+    field :field, list_of(non_null(:string)), description: "Path to the argument, as sent"
+    field :code, non_null(:user_error_code)
+    field :message, non_null(:string)
+  end
+
+  @desc "The media item a mutation changed"
+  object :media_item_payload do
+    field :media_item, :media_item
+    field :user_errors, non_null(list_of(non_null(:user_error)))
+  end
+end

--- a/lib/mydia_web/library_schema/query_types.ex
+++ b/lib/mydia_web/library_schema/query_types.ex
@@ -60,8 +60,7 @@ defmodule MydiaWeb.LibrarySchema.QueryTypes do
       # 1 matters because analysis runs before the resolver rejects a bad
       # `first`: a zero or negative cost would offset expensive siblings.
       complexity(fn args, child_complexity ->
-        first = (Map.get(args, :first) || 50) |> min(200) |> max(1)
-        first * child_complexity
+        MydiaWeb.LibrarySchema.Paging.cost(args, 50, 200, child_complexity)
       end)
 
       resolve(&MydiaWeb.LibrarySchema.Resolvers.Library.media_items/3)
@@ -76,6 +75,20 @@ defmodule MydiaWeb.LibrarySchema.QueryTypes do
       complexity(50)
 
       resolve(&MydiaWeb.LibrarySchema.Resolvers.Downloads.downloads/3)
+    end
+
+    @desc "Library activity, oldest first. Best-effort: the docs explain the limits."
+    field :events, non_null(:event_connection) do
+      meta(action: :read_events)
+      arg(:first, :integer, default_value: 100)
+      arg(:after, :string)
+      arg(:types, list_of(non_null(:string)), description: "Defaults to every published type")
+
+      complexity(fn args, child_complexity ->
+        MydiaWeb.LibrarySchema.Paging.cost(args, 100, 200, child_complexity)
+      end)
+
+      resolve(&MydiaWeb.LibrarySchema.Resolvers.Events.events/3)
     end
   end
 end

--- a/lib/mydia_web/library_schema/resolvers/downloads.ex
+++ b/lib/mydia_web/library_schema/resolvers/downloads.ex
@@ -10,9 +10,12 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Downloads do
   lookup.
   """
 
+  require Logger
+
   alias Mydia.Downloads
   alias Mydia.Media
   alias Mydia.LibraryApi.Principal
+  alias MydiaWeb.LibrarySchema.Loaders
   alias MydiaWeb.LibrarySchema.MediaItemView
   alias MydiaWeb.LibrarySchema.UserError
 
@@ -53,7 +56,7 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Downloads do
   def cancel_download(_parent, %{id: id}, resolution) do
     opts = Principal.actor_opts(resolution.context.principal)
 
-    with {:ok, download} <- load_download(id),
+    with {:ok, download} <- Loaders.download(id, ["id"]),
          {:ok, _cancelled} <- Downloads.cancel_download(download, opts) do
       {:ok, removed(download.id)}
     else
@@ -61,9 +64,14 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Downloads do
         {:ok, not_removed(error)}
 
       # cancel_download/2 stops at the client and keeps the row when the client
-      # cannot remove the item, so the download is still there to retry.
+      # cannot remove the item, so the download is still there to retry. The
+      # reason can carry a raw adapter response, so it is logged, not returned.
       {:error, reason} ->
-        message = "The download client could not remove it: #{inspect(reason)}"
+        Logger.warning(
+          "Library API cancelDownload failed to remove from client: #{inspect(reason)}"
+        )
+
+        message = "The download client could not remove it"
         {:ok, not_removed(UserError.new(:client_unavailable, message, ["id"]))}
     end
   end
@@ -72,22 +80,17 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Downloads do
           {:ok, map()} | {:error, String.t()}
   def reject_release(_parent, %{id: id} = args, resolution) do
     with {:ok, days} <- blocklist_days(Map.get(args, :blocklist_days)),
-         {:ok, download} <- load_download(id),
+         {:ok, download} <- Loaders.download(id, ["id"]),
          opts = reject_opts(resolution.context.principal, days),
          {:ok, :rejected} <- Downloads.reject_release(download, opts) do
       {:ok, removed(download.id)}
     else
-      {:error, %UserError{} = error} -> {:ok, not_removed(error)}
-      {:error, reason} -> {:error, "Could not reject the release: #{inspect(reason)}"}
-    end
-  end
+      {:error, %UserError{} = error} ->
+        {:ok, not_removed(error)}
 
-  defp load_download(id) do
-    with {:ok, id} <- UserError.cast_id(id, ["id"]) do
-      case Downloads.get_download(id) do
-        nil -> {:error, UserError.not_found("download", ["id"])}
-        download -> {:ok, download}
-      end
+      {:error, reason} ->
+        Logger.warning("Library API rejectRelease failed: #{inspect(reason)}")
+        {:error, "Could not reject the release"}
     end
   end
 

--- a/lib/mydia_web/library_schema/resolvers/downloads.ex
+++ b/lib/mydia_web/library_schema/resolvers/downloads.ex
@@ -1,6 +1,6 @@
 defmodule MydiaWeb.LibrarySchema.Resolvers.Downloads do
   @moduledoc """
-  Resolves `downloads`.
+  Resolves `downloads`, `cancelDownload` and `rejectRelease`.
 
   Not paged on purpose: `list_downloads_with_status/1` loads every row and asks
   each enabled client for live status, so the work is per-call rather than
@@ -12,7 +12,9 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Downloads do
 
   alias Mydia.Downloads
   alias Mydia.Media
+  alias Mydia.LibraryApi.Principal
   alias MydiaWeb.LibrarySchema.MediaItemView
+  alias MydiaWeb.LibrarySchema.UserError
 
   @status_map %{
     "queued" => :queued,
@@ -46,6 +48,64 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Downloads do
 
     {:ok, Enum.map(rows, &download_map(&1, items, episodes))}
   end
+
+  @spec cancel_download(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def cancel_download(_parent, %{id: id}, resolution) do
+    opts = Principal.actor_opts(resolution.context.principal)
+
+    with {:ok, download} <- load_download(id),
+         {:ok, _cancelled} <- Downloads.cancel_download(download, opts) do
+      {:ok, removed(download.id)}
+    else
+      {:error, %UserError{} = error} ->
+        {:ok, not_removed(error)}
+
+      # cancel_download/2 stops at the client and keeps the row when the client
+      # cannot remove the item, so the download is still there to retry.
+      {:error, reason} ->
+        message = "The download client could not remove it: #{inspect(reason)}"
+        {:ok, not_removed(UserError.new(:client_unavailable, message, ["id"]))}
+    end
+  end
+
+  @spec reject_release(any(), map(), Absinthe.Resolution.t()) ::
+          {:ok, map()} | {:error, String.t()}
+  def reject_release(_parent, %{id: id} = args, resolution) do
+    with {:ok, days} <- blocklist_days(Map.get(args, :blocklist_days)),
+         {:ok, download} <- load_download(id),
+         opts = reject_opts(resolution.context.principal, days),
+         {:ok, :rejected} <- Downloads.reject_release(download, opts) do
+      {:ok, removed(download.id)}
+    else
+      {:error, %UserError{} = error} -> {:ok, not_removed(error)}
+      {:error, reason} -> {:error, "Could not reject the release: #{inspect(reason)}"}
+    end
+  end
+
+  defp load_download(id) do
+    with {:ok, id} <- UserError.cast_id(id, ["id"]) do
+      case Downloads.get_download(id) do
+        nil -> {:error, UserError.not_found("download", ["id"])}
+        download -> {:ok, download}
+      end
+    end
+  end
+
+  defp blocklist_days(nil), do: {:ok, nil}
+  defp blocklist_days(days) when is_integer(days) and days >= 1, do: {:ok, days}
+
+  defp blocklist_days(_days),
+    do: {:error, UserError.new(:invalid_input, "Must be at least 1", ["blocklistDays"])}
+
+  # Only an explicit value is forwarded, so an omitted one keeps reject_release/2's
+  # configured default.
+  defp reject_opts(principal, nil), do: Principal.actor_opts(principal)
+
+  defp reject_opts(principal, days),
+    do: Keyword.put(Principal.actor_opts(principal), :ttl_days, days)
+
+  defp removed(id), do: %{removed_id: id, user_errors: []}
+  defp not_removed(error), do: %{removed_id: nil, user_errors: [error]}
 
   # History only preloads episode.media_item. Batch the standard API preloads
   # so nested availability and episode.hasFile never read unloaded associations.

--- a/lib/mydia_web/library_schema/resolvers/events.ex
+++ b/lib/mydia_web/library_schema/resolvers/events.ex
@@ -35,6 +35,14 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Events do
            message: "Unknown event types: #{Enum.join(unknown, ", ")}",
            extensions: %{code: "INVALID_INPUT"}
          }}
+
+      {:error, :empty_types} ->
+        {:error,
+         %{
+           message:
+             "types must name at least one event type, or be omitted entirely to receive every published type",
+           extensions: %{code: "INVALID_INPUT"}
+         }}
     end
   end
 

--- a/lib/mydia_web/library_schema/resolvers/events.ex
+++ b/lib/mydia_web/library_schema/resolvers/events.ex
@@ -1,0 +1,67 @@
+defmodule MydiaWeb.LibrarySchema.Resolvers.Events do
+  @moduledoc """
+  Resolves `events` over `Mydia.LibraryApi.EventFeed`.
+
+  The feed is best-effort (see EventFeed's moduledoc): `mediaItems(updatedSince:)`
+  and `downloads` stay the source of truth.
+  """
+
+  alias Mydia.LibraryApi.Cursor
+  alias Mydia.LibraryApi.EventFeed
+  alias MydiaWeb.LibrarySchema.Paging
+
+  @default_first 100
+  @max_first 200
+
+  @spec events(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()} | {:error, map()}
+  def events(_parent, args, _info) do
+    with {:ok, first} <- Paging.page_size(Map.get(args, :first), @default_first, @max_first),
+         {:ok, after_cursor} <- Paging.decode_cursor(Map.get(args, :after)),
+         {:ok, rows} <- feed(first, after_cursor, Map.get(args, :types)) do
+      {page, rest} = Enum.split(rows, first)
+      {:ok, connection(page, rest != [], Map.get(args, :after))}
+    end
+  end
+
+  # One extra row decides hasNextPage without a second count query.
+  defp feed(first, after_cursor, types) do
+    case EventFeed.list(limit: first + 1, after: after_cursor, types: types) do
+      {:ok, rows} ->
+        {:ok, rows}
+
+      {:error, {:unknown_types, unknown}} ->
+        {:error,
+         %{
+           message: "Unknown event types: #{Enum.join(unknown, ", ")}",
+           extensions: %{code: "INVALID_INPUT"}
+         }}
+    end
+  end
+
+  # An empty page repeats the cursor the client sent, so a poller that always
+  # passes endCursor back never restarts from the beginning.
+  defp connection([], _has_next, after_cursor),
+    do: %{edges: [], page_info: %{has_next_page: false, end_cursor: after_cursor}}
+
+  defp connection(page, has_next, _after_cursor) do
+    last = List.last(page)
+
+    %{
+      edges:
+        Enum.map(page, &%{node: event_map(&1), cursor: Cursor.encode(&1.inserted_at, &1.id)}),
+      page_info: %{has_next_page: has_next, end_cursor: Cursor.encode(last.inserted_at, last.id)}
+    }
+  end
+
+  defp event_map(event) do
+    %{
+      id: event.id,
+      type: event.type,
+      occurred_at: event.inserted_at,
+      severity: event.severity,
+      resource_type: event.resource_type,
+      resource_id: event.resource_id,
+      data: event.metadata || %{}
+    }
+  end
+end

--- a/lib/mydia_web/library_schema/resolvers/library.ex
+++ b/lib/mydia_web/library_schema/resolvers/library.ex
@@ -12,6 +12,7 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Library do
   alias Mydia.Media
   alias Mydia.Media.MediaItem
   alias MydiaWeb.LibrarySchema.MediaItemView
+  alias MydiaWeb.LibrarySchema.Paging
 
   @default_first 50
   @max_first 200
@@ -28,8 +29,8 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Library do
 
   @spec media_items(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()} | {:error, term()}
   def media_items(_parent, args, _info) do
-    with {:ok, first} <- page_size(Map.get(args, :first)),
-         {:ok, after_cursor} <- decode_cursor(Map.get(args, :after)) do
+    with {:ok, first} <- Paging.page_size(Map.get(args, :first), @default_first, @max_first),
+         {:ok, after_cursor} <- Paging.decode_cursor(Map.get(args, :after)) do
       # One extra row decides hasNextPage without a second count query.
       page_opts =
         [limit: first + 1]
@@ -51,28 +52,8 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Library do
       # Keep `page` as the cursor source: hydration can see a newer updated_at,
       # or miss a row deleted after the keyset query. A cursor from either state
       # could skip rows or crash pagination on a concurrent change.
-      {:ok, connection(page, hydrated_by_id, length(rows) > first)}
+      {:ok, connection(page, hydrated_by_id, length(rows) > first, Map.get(args, :after))}
     end
-  end
-
-  # `first` reaches Ecto's `limit`, where 0 and negative values do not mean
-  # "no rows": they are invalid or surprising, so they are refused rather than
-  # clamped. A client that asks for 0 has a bug worth surfacing.
-  defp page_size(nil), do: {:ok, @default_first}
-
-  defp page_size(first) when is_integer(first) and first >= 1 and first <= @max_first,
-    do: {:ok, first}
-
-  defp page_size(first) when is_integer(first) do
-    {:error,
-     %{
-       message: "first must be between 1 and #{@max_first}, got #{first}",
-       extensions: %{code: "INVALID_INPUT"}
-     }}
-  end
-
-  defp page_size(_first) do
-    {:error, %{message: "first must be an integer", extensions: %{code: "INVALID_INPUT"}}}
   end
 
   # Exactly one identifier, because two of them could name different items and
@@ -142,19 +123,12 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Library do
   defp external_key(:tvdb_id), do: :tvdb
   defp external_key(:imdb_id), do: :imdb
 
-  defp decode_cursor(nil), do: {:ok, nil}
+  # An empty page repeats the cursor the client sent, so a poller that always
+  # passes endCursor back never restarts from the beginning.
+  defp connection([], _hydrated_by_id, _has_next, after_cursor),
+    do: %{edges: [], page_info: %{has_next_page: false, end_cursor: after_cursor}}
 
-  defp decode_cursor(cursor) do
-    case Cursor.decode(cursor) do
-      {:ok, value} -> {:ok, value}
-      :error -> {:error, %{message: "Invalid cursor", extensions: %{code: "INVALID_INPUT"}}}
-    end
-  end
-
-  defp connection([], _hydrated_by_id, _has_next),
-    do: %{edges: [], page_info: %{has_next_page: false, end_cursor: nil}}
-
-  defp connection(page, hydrated_by_id, has_next) do
+  defp connection(page, hydrated_by_id, has_next, _after_cursor) do
     edges =
       for boundary <- page,
           {:ok, item} <- [Map.fetch(hydrated_by_id, boundary.id)] do

--- a/lib/mydia_web/library_schema/resolvers/library_writes.ex
+++ b/lib/mydia_web/library_schema/resolvers/library_writes.ex
@@ -34,14 +34,19 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.LibraryWrites do
         [delete_files: input[:delete_files] == true]
 
     with {:ok, item} <- Loaders.item(input.id, ["input", "id"]),
-         {:ok, _deleted, _disk_errors} <- Media.delete_media_item(item, opts) do
-      {:ok, %{removed_id: item.id, user_errors: []}}
+         {:ok, _deleted, disk_error_count} <- Media.delete_media_item(item, opts) do
+      {:ok, %{removed_id: item.id, files_not_deleted: disk_error_count, user_errors: []}}
     else
       {:error, %UserError{} = error} ->
-        {:ok, %{removed_id: nil, user_errors: [error]}}
+        {:ok, %{removed_id: nil, files_not_deleted: nil, user_errors: [error]}}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        {:ok, %{removed_id: nil, user_errors: UserError.from_changeset(changeset, ["input"])}}
+        {:ok,
+         %{
+           removed_id: nil,
+           files_not_deleted: nil,
+           user_errors: UserError.from_changeset(changeset, ["input"])
+         }}
     end
   end
 

--- a/lib/mydia_web/library_schema/resolvers/library_writes.ex
+++ b/lib/mydia_web/library_schema/resolvers/library_writes.ex
@@ -1,0 +1,116 @@
+defmodule MydiaWeb.LibrarySchema.Resolvers.LibraryWrites do
+  @moduledoc """
+  Resolves `addMovie`, `addTvShow` and `removeMediaItem`.
+
+  Adding goes through `Mydia.Media.Add.from_provider/4`, the entry point the
+  search page's Add button uses, then `Mydia.Search.maybe_queue_search/2` for
+  `searchNow`, as the UI does. Removing is `Mydia.Media.delete_media_item/2`.
+  """
+
+  alias Mydia.LibraryApi.Principal
+  alias Mydia.Media
+  alias Mydia.Media.Add
+  alias Mydia.Search
+  alias MydiaWeb.LibrarySchema.Loaders
+  alias MydiaWeb.LibrarySchema.UserError
+
+  @spec add_movie(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def add_movie(_parent, %{input: input}, resolution) do
+    add({:tmdb, input.tmdb_id}, :movie, input, resolution.context.principal)
+  end
+
+  @spec add_tv_show(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def add_tv_show(_parent, %{input: input}, resolution) do
+    case show_ref(input) do
+      {:ok, ref} -> add(ref, :tv_show, input, resolution.context.principal)
+      {:error, error} -> {:ok, add_failure([error])}
+    end
+  end
+
+  @spec remove_media_item(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def remove_media_item(_parent, %{input: input}, resolution) do
+    opts =
+      Principal.actor_opts(resolution.context.principal) ++
+        [delete_files: input[:delete_files] == true]
+
+    with {:ok, item} <- Loaders.item(input.id, ["input", "id"]),
+         {:ok, _deleted, _disk_errors} <- Media.delete_media_item(item, opts) do
+      {:ok, %{removed_id: item.id, user_errors: []}}
+    else
+      {:error, %UserError{} = error} ->
+        {:ok, %{removed_id: nil, user_errors: [error]}}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:ok, %{removed_id: nil, user_errors: UserError.from_changeset(changeset, ["input"])}}
+    end
+  end
+
+  defp add(ref, media_type, input, principal) do
+    case add_opts(input, principal) do
+      {:ok, opts} ->
+        ref
+        |> Add.from_provider(media_type, nil, opts)
+        |> added(input[:search_now] == true)
+
+      {:error, error} ->
+        {:ok, add_failure([error])}
+    end
+  end
+
+  defp added({:ok, item}, search_now?) do
+    :ok = Search.maybe_queue_search(item, search_now?)
+    {:ok, %{media_item: Loaders.item_map(item.id), user_errors: []}}
+  end
+
+  # The existing item comes back beside the error, so a client that only needed
+  # the title present can carry on with its id.
+  defp added({:error, {:already_in_library, existing}}, _search_now?) do
+    error = UserError.new(:already_in_library, "#{existing.title} is already in the library")
+    {:ok, %{media_item: Loaders.item_map(existing.id), user_errors: [error]}}
+  end
+
+  defp added({:error, {:metadata, _reason}}, _search_now?) do
+    error =
+      UserError.new(:metadata_unavailable, "The metadata relay could not provide this title")
+
+    {:ok, add_failure([error])}
+  end
+
+  defp added({:error, {:changeset, changeset}}, _search_now?) do
+    {:ok, add_failure(UserError.from_changeset(changeset, ["input"]))}
+  end
+
+  defp add_opts(input, principal) do
+    with {:ok, profile_id} <-
+           optional_id(input[:quality_profile_id], ["input", "qualityProfileId"]),
+         {:ok, path_id} <- optional_id(input[:library_path_id], ["input", "libraryPathId"]) do
+      opts =
+        principal
+        |> Principal.actor_opts()
+        |> Keyword.put(:monitored, input[:monitored] != false)
+        |> put_present(:quality_profile_id, profile_id)
+        |> put_present(:library_path_id, path_id)
+        |> put_present(:season_monitoring, season_monitoring(input[:season_monitoring]))
+
+      {:ok, opts}
+    end
+  end
+
+  defp show_ref(%{tvdb_id: tvdb_id}) when is_integer(tvdb_id), do: {:ok, {:tvdb, tvdb_id}}
+  defp show_ref(%{tmdb_id: tmdb_id}) when is_integer(tmdb_id), do: {:ok, {:tmdb, tmdb_id}}
+
+  defp show_ref(_input),
+    do: {:error, UserError.new(:invalid_input, "Give tvdbId or tmdbId", ["input"])}
+
+  defp optional_id(nil, _field), do: {:ok, nil}
+  defp optional_id(value, field), do: UserError.cast_id(value, field)
+
+  # Add and Media.create_media_item/2 take the preset as a string.
+  defp season_monitoring(nil), do: nil
+  defp season_monitoring(preset), do: Atom.to_string(preset)
+
+  defp put_present(opts, _key, nil), do: opts
+  defp put_present(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp add_failure(errors), do: %{media_item: nil, user_errors: errors}
+end

--- a/lib/mydia_web/library_schema/resolvers/monitoring.ex
+++ b/lib/mydia_web/library_schema/resolvers/monitoring.ex
@@ -11,6 +11,7 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Monitoring do
   alias Mydia.LibraryApi.Principal
   alias Mydia.Media
   alias MydiaWeb.LibrarySchema.Loaders
+  alias MydiaWeb.LibrarySchema.MediaItemView
   alias MydiaWeb.LibrarySchema.UserError
 
   @spec set_media_item_monitored(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
@@ -25,6 +26,59 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Monitoring do
     end
   end
 
+  @spec set_season_monitored(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def set_season_monitored(_parent, args, _resolution) do
+    %{media_item_id: id, season: season, monitored: monitored} = args
+
+    with {:ok, item} <- Loaders.item(id, ["mediaItemId"]),
+         :ok <- Loaders.require_show(item, ["mediaItemId"]),
+         {:ok, count} <- Media.update_season_monitoring(item.id, season, monitored),
+         :ok <- require_updated(count, season) do
+      {:ok, item_payload(item.id)}
+    else
+      error -> {:ok, item_failure(error)}
+    end
+  end
+
+  @spec set_episode_monitored(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def set_episode_monitored(_parent, %{id: id, monitored: monitored}, _resolution) do
+    with {:ok, episode} <- Loaders.episode(id, ["id"]),
+         {:ok, _updated} <- Media.update_episode(episode, %{monitored: monitored}),
+         {:ok, reloaded} <- Loaders.episode(episode.id, ["id"]) do
+      {:ok, %{episode: MediaItemView.episode_map(reloaded), user_errors: []}}
+    else
+      {:error, %UserError{} = error} ->
+        {:ok, %{episode: nil, user_errors: [error]}}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:ok, %{episode: nil, user_errors: UserError.from_changeset(changeset, [])}}
+    end
+  end
+
+  @spec apply_episode_monitoring(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def apply_episode_monitoring(_parent, %{media_item_id: id, preset: preset}, _resolution) do
+    with {:ok, item} <- Loaders.item(id, ["mediaItemId"]),
+         {:ok, _count} <- Media.apply_episode_monitoring(item, preset) do
+      {:ok, item_payload(item.id)}
+    else
+      {:error, {:invalid_type, message}} ->
+        {:ok, item_failure({:error, UserError.new(:invalid_input, message, ["mediaItemId"])})}
+
+      {:error, {:invalid_preset, message}} ->
+        {:ok, item_failure({:error, UserError.new(:invalid_input, message, ["preset"])})}
+
+      error ->
+        {:ok, item_failure(error)}
+    end
+  end
+
+  # update_season_monitoring/3 updates every episode row in the season, so zero
+  # means the season has no episodes; succeeding silently would hide a typo.
+  defp require_updated(0, season),
+    do: {:error, UserError.new(:not_found, "Season #{season} has no episodes", ["season"])}
+
+  defp require_updated(_count, _season), do: :ok
+
   # The strings the media page's own toggles pass, so the activity feed reads the
   # same whichever surface made the change.
   defp reason(true), do: "Monitoring enabled"
@@ -36,4 +90,10 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Monitoring do
 
   defp item_failure({:error, %Ecto.Changeset{} = changeset}),
     do: %{media_item: nil, user_errors: UserError.from_changeset(changeset, [])}
+
+  defp item_failure({:error, _reason}),
+    do: %{
+      media_item: nil,
+      user_errors: [UserError.new(:invalid_input, "The change could not be saved")]
+    }
 end

--- a/lib/mydia_web/library_schema/resolvers/monitoring.ex
+++ b/lib/mydia_web/library_schema/resolvers/monitoring.ex
@@ -1,0 +1,39 @@
+defmodule MydiaWeb.LibrarySchema.Resolvers.Monitoring do
+  @moduledoc """
+  Resolves the monitoring mutations.
+
+  Each calls the function the media page's own toggle calls, with the same
+  arguments. Only `update_media_item/3` records who acted;
+  `update_season_monitoring/3`, `update_episode/2` and
+  `apply_episode_monitoring/2` take no actor.
+  """
+
+  alias Mydia.LibraryApi.Principal
+  alias Mydia.Media
+  alias MydiaWeb.LibrarySchema.Loaders
+  alias MydiaWeb.LibrarySchema.UserError
+
+  @spec set_media_item_monitored(any(), map(), Absinthe.Resolution.t()) :: {:ok, map()}
+  def set_media_item_monitored(_parent, %{id: id, monitored: monitored}, resolution) do
+    opts = Principal.actor_opts(resolution.context.principal) ++ [reason: reason(monitored)]
+
+    with {:ok, item} <- Loaders.item(id, ["id"]),
+         {:ok, _updated} <- Media.update_media_item(item, %{monitored: monitored}, opts) do
+      {:ok, item_payload(item.id)}
+    else
+      error -> {:ok, item_failure(error)}
+    end
+  end
+
+  # The strings the media page's own toggles pass, so the activity feed reads the
+  # same whichever surface made the change.
+  defp reason(true), do: "Monitoring enabled"
+  defp reason(false), do: "Monitoring disabled"
+
+  defp item_payload(id), do: %{media_item: Loaders.item_map(id), user_errors: []}
+
+  defp item_failure({:error, %UserError{} = error}), do: %{media_item: nil, user_errors: [error]}
+
+  defp item_failure({:error, %Ecto.Changeset{} = changeset}),
+    do: %{media_item: nil, user_errors: UserError.from_changeset(changeset, [])}
+end

--- a/lib/mydia_web/library_schema/resolvers/search.ex
+++ b/lib/mydia_web/library_schema/resolvers/search.ex
@@ -1,0 +1,56 @@
+defmodule MydiaWeb.LibrarySchema.Resolvers.Search do
+  @moduledoc """
+  Resolves the search mutations by enqueuing the jobs the media page's own
+  buttons enqueue, with the arguments each worker documents.
+
+  `queued` is true whenever the insert succeeds. The search workers are unique
+  for 60 seconds on their arguments, so a repeat inside that window is merged by
+  Oban and still reports true.
+  """
+
+  alias Mydia.Jobs.TVShowSearch
+  alias Mydia.Search
+  alias MydiaWeb.LibrarySchema.Loaders
+  alias MydiaWeb.LibrarySchema.UserError
+
+  @spec search_media_item(any(), map(), Absinthe.Resolution.t()) ::
+          {:ok, map()} | {:error, String.t()}
+  def search_media_item(_parent, %{id: id}, _resolution) do
+    with {:ok, item} <- Loaders.item(id, ["id"]),
+         {:ok, count} <- Search.queue_auto_searches([item]) do
+      {:ok, %{queued: count > 0, user_errors: []}}
+    else
+      {:error, %UserError{} = error} -> {:ok, not_queued(error)}
+      {:error, _reason} -> {:error, "Could not queue the search"}
+    end
+  end
+
+  @spec search_season(any(), map(), Absinthe.Resolution.t()) ::
+          {:ok, map()} | {:error, String.t()}
+  def search_season(_parent, %{media_item_id: id, season: season}, _resolution) do
+    with {:ok, item} <- Loaders.item(id, ["mediaItemId"]),
+         :ok <- Loaders.require_show(item, ["mediaItemId"]) do
+      insert(%{mode: "season", media_item_id: item.id, season_number: season})
+    else
+      {:error, %UserError{} = error} -> {:ok, not_queued(error)}
+    end
+  end
+
+  @spec search_episode(any(), map(), Absinthe.Resolution.t()) ::
+          {:ok, map()} | {:error, String.t()}
+  def search_episode(_parent, %{id: id}, _resolution) do
+    case Loaders.episode(id, ["id"]) do
+      {:ok, episode} -> insert(%{mode: "specific", episode_id: episode.id})
+      {:error, %UserError{} = error} -> {:ok, not_queued(error)}
+    end
+  end
+
+  defp insert(args) do
+    case args |> TVShowSearch.new() |> Oban.insert() do
+      {:ok, _job} -> {:ok, %{queued: true, user_errors: []}}
+      {:error, _reason} -> {:error, "Could not queue the search"}
+    end
+  end
+
+  defp not_queued(error), do: %{queued: false, user_errors: [error]}
+end

--- a/lib/mydia_web/library_schema/resolvers/search.ex
+++ b/lib/mydia_web/library_schema/resolvers/search.ex
@@ -17,8 +17,12 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Search do
           {:ok, map()} | {:error, String.t()}
   def search_media_item(_parent, %{id: id}, _resolution) do
     with {:ok, item} <- Loaders.item(id, ["id"]),
-         {:ok, count} <- Search.queue_auto_searches([item]) do
-      {:ok, %{queued: count > 0, user_errors: []}}
+         {:ok, _count} <- Search.queue_auto_searches([item]) do
+      # Any successful insert (including a repeat merged by Oban's uniqueness
+      # constraint) should report queued: true. queue_auto_searches returns
+      # count: 0 when the job was deduped (conflict?: true), but the job is
+      # still merged into the queue.
+      {:ok, %{queued: true, user_errors: []}}
     else
       {:error, %UserError{} = error} -> {:ok, not_queued(error)}
       {:error, _reason} -> {:error, "Could not queue the search"}

--- a/lib/mydia_web/library_schema/resolvers/search.ex
+++ b/lib/mydia_web/library_schema/resolvers/search.ex
@@ -33,7 +33,8 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Search do
           {:ok, map()} | {:error, String.t()}
   def search_season(_parent, %{media_item_id: id, season: season}, _resolution) do
     with {:ok, item} <- Loaders.item(id, ["mediaItemId"]),
-         :ok <- Loaders.require_show(item, ["mediaItemId"]) do
+         :ok <- Loaders.require_show(item, ["mediaItemId"]),
+         {:ok, season} <- validate_season(season) do
       insert(%{mode: "season", media_item_id: item.id, season_number: season})
     else
       {:error, %UserError{} = error} -> {:ok, not_queued(error)}
@@ -48,6 +49,16 @@ defmodule MydiaWeb.LibrarySchema.Resolvers.Search do
       {:error, %UserError{} = error} -> {:ok, not_queued(error)}
     end
   end
+
+  # Season 0 is specials, so it stays valid; only negative seasons are
+  # rejected. TVShowSearch's "season" mode otherwise accepts a negative
+  # season_number, matches no episodes (season_number is never negative in
+  # the DB), and completes having searched nothing - see load_episodes_for_season/2
+  # and the "season" perform/1 clause in lib/mydia/jobs/tv_show_search.ex.
+  defp validate_season(season) when is_integer(season) and season >= 0, do: {:ok, season}
+
+  defp validate_season(_season),
+    do: {:error, UserError.new(:invalid_input, "Must be 0 or greater", ["season"])}
 
   defp insert(args) do
     case args |> TVShowSearch.new() |> Oban.insert() do

--- a/lib/mydia_web/library_schema/user_error.ex
+++ b/lib/mydia_web/library_schema/user_error.ex
@@ -1,0 +1,69 @@
+defmodule MydiaWeb.LibrarySchema.UserError do
+  @moduledoc """
+  One entry in a mutation payload's `userErrors`.
+
+  A struct, not a map, so a resolver's `with` can tell a user error from any other
+  `{:error, reason}` by pattern. One module so every mutation reports a failure
+  the same way: a code a client can branch on, a message a person can read, and,
+  when an argument caused it, that argument's path spelled the way the client
+  wrote it (`["input", "qualityProfileId"]`, not `quality_profile_id`).
+  """
+
+  @enforce_keys [:code, :message]
+  defstruct [:field, :code, :message]
+
+  @type t :: %__MODULE__{field: [String.t()] | nil, code: atom(), message: String.t()}
+
+  @doc "One user error."
+  @spec new(atom(), String.t(), [String.t()] | nil) :: t()
+  def new(code, message, field \\ nil),
+    do: %__MODULE__{field: field, code: code, message: message}
+
+  @doc "The error for an id that names nothing."
+  @spec not_found(String.t(), [String.t()]) :: t()
+  def not_found(thing, field), do: new(:not_found, "No #{thing} has that id", field)
+
+  @doc "Casts `value` to a UUID, or returns the INVALID_INPUT error for `field`."
+  @spec cast_id(term(), [String.t()]) :: {:ok, Ecto.UUID.t()} | {:error, t()}
+  def cast_id(value, field) do
+    case Ecto.UUID.cast(value) do
+      {:ok, id} -> {:ok, id}
+      :error -> {:error, new(:invalid_input, "Not a valid id", field)}
+    end
+  end
+
+  @doc """
+  One INVALID_INPUT error per changeset message, each under `prefix` with the
+  field name camelCased as the schema spells it.
+  """
+  @spec from_changeset(Ecto.Changeset.t(), [String.t()]) :: [t()]
+  def from_changeset(%Ecto.Changeset{} = changeset, prefix) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(&interpolate/1)
+    |> Enum.flat_map(fn {field, messages} ->
+      path = prefix ++ [camelize(field)]
+
+      messages
+      |> List.wrap()
+      |> Enum.map(fn
+        message when is_binary(message) -> new(:invalid_input, "#{field} #{message}", path)
+        _nested -> new(:invalid_input, "#{field} is invalid", path)
+      end)
+    end)
+  end
+
+  # Ecto's placeholder syntax, e.g. "should be at least %{count} character(s)".
+  defp interpolate({message, opts}) do
+    Regex.replace(~r/%{(\w+)}/, message, fn whole, key ->
+      case Enum.find(opts, fn {opt, _value} -> Atom.to_string(opt) == key end) do
+        {_opt, value} -> to_string(value)
+        nil -> whole
+      end
+    end)
+  end
+
+  defp camelize(field) do
+    [first | rest] = field |> Atom.to_string() |> String.split("_")
+    Enum.join([first | Enum.map(rest, &String.capitalize/1)])
+  end
+end

--- a/lib/mydia_web/live/admin_api_keys_live/components.ex
+++ b/lib/mydia_web/live/admin_api_keys_live/components.ex
@@ -1,0 +1,254 @@
+defmodule MydiaWeb.AdminApiKeysLive.Components do
+  @moduledoc "Components for the API keys admin page."
+  use MydiaWeb, :html
+
+  alias Mydia.Accounts.ApiKey
+
+  attr :api_keys, :list, required: true
+  attr :env_key_set, :boolean, required: true
+
+  def api_keys_tab(assigns) do
+    ~H"""
+    <div class="p-4 sm:p-6 space-y-4">
+      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <h2 class="text-lg font-semibold flex items-center gap-2">
+          <.icon name="hero-key" class="w-5 h-5 opacity-60" /> API Keys
+          <span class="badge badge-ghost">{length(@api_keys)}</span>
+        </h2>
+        <button id="new-api-key" class="btn btn-sm btn-primary" phx-click="new_api_key">
+          <.icon name="hero-plus" class="w-4 h-4" /> New
+        </button>
+      </div>
+
+      <p class="text-sm text-base-content/70">
+        Keys for the Library API at <code>/api/library/graphql</code>, sent as the
+        <code>x-api-key</code>
+        header. Each key acts as you.
+      </p>
+
+      <div
+        :if={@env_key_set}
+        id="env-library-api-key"
+        class="bg-base-200 rounded-box p-4 flex items-center gap-3"
+      >
+        <.icon name="hero-lock-closed" class="w-5 h-5 opacity-60" />
+        <div class="flex-1">
+          <div class="font-medium flex items-center gap-2">
+            LIBRARY_API_KEY <MydiaWeb.AdminComponents.config_source_badge source={:env} />
+          </div>
+          <p class="text-sm text-base-content/70">
+            Set by LIBRARY_API_KEY. Remove the variable and restart to revoke.
+          </p>
+        </div>
+      </div>
+
+      <%= if @api_keys == [] do %>
+        <div id="api-keys-empty" class="alert alert-info">
+          <.icon name="hero-information-circle" class="w-5 h-5" />
+          <span>No API keys yet. Create one to use the Library API.</span>
+        </div>
+      <% else %>
+        <div id="api-keys" class="bg-base-200 rounded-box divide-y divide-base-300">
+          <.api_key_row :for={key <- @api_keys} key={key} />
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  attr :key, ApiKey, required: true
+
+  defp api_key_row(assigns) do
+    assigns = assign(assigns, :state, state(assigns.key))
+
+    ~H"""
+    <div id={"api-key-#{@key.id}"} class="p-4 flex flex-col sm:flex-row sm:items-center gap-3">
+      <div class="flex-1 min-w-0">
+        <div class="font-medium flex items-center gap-2 flex-wrap">
+          {@key.name}
+          <span class="badge badge-sm badge-ghost">{scope(@key)}</span>
+          <span class={["badge badge-sm", state_class(@state)]}>{state_label(@state)}</span>
+        </div>
+        <div class="text-sm text-base-content/60 font-mono">{@key.key_prefix}...</div>
+        <div class="text-xs text-base-content/60 mt-1">
+          Created {date(@key.inserted_at)} · Last used {date(@key.last_used_at) || "never"} · Expires {date(
+            @key.expires_at
+          ) || "never"}
+        </div>
+      </div>
+      <div class="join">
+        <button
+          :if={@state == :active}
+          id={"revoke-api-key-#{@key.id}"}
+          class="btn btn-sm btn-ghost join-item"
+          phx-click="confirm_revoke_api_key"
+          phx-value-id={@key.id}
+          title="Revoke"
+        >
+          <.icon name="hero-no-symbol" class="w-4 h-4" />
+        </button>
+        <button
+          id={"delete-api-key-#{@key.id}"}
+          class="btn btn-sm btn-ghost join-item text-error"
+          phx-click="confirm_delete_api_key"
+          phx-value-id={@key.id}
+          title="Delete"
+        >
+          <.icon name="hero-trash" class="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  attr :form, Phoenix.HTML.Form, required: true
+
+  def api_key_modal(assigns) do
+    ~H"""
+    <div id="api-key-modal" class="modal modal-open">
+      <div class="modal-box max-w-lg">
+        <.form for={@form} id="api-key-form" phx-change="validate_api_key" phx-submit="save_api_key">
+          <h3 class="font-bold text-lg mb-4">New API key</h3>
+          <.input field={@form[:name]} type="text" label="Name" placeholder="Home automation" />
+          <.input
+            field={@form[:expiry]}
+            type="select"
+            label="Expires"
+            options={[
+              {"Never", "never"},
+              {"In 30 days", "30"},
+              {"In 90 days", "90"},
+              {"In 365 days", "365"}
+            ]}
+          />
+          <.input
+            field={@form[:scope]}
+            type="select"
+            label="Scope"
+            options={[{"Library API", "library"}]}
+          />
+          <div class="modal-action mt-6 pt-4 border-t border-base-300">
+            <button type="button" class="btn btn-ghost" phx-click="close_api_key_modal">
+              Cancel
+            </button>
+            <button type="submit" id="save-api-key" class="btn btn-primary">Create key</button>
+          </div>
+        </.form>
+      </div>
+      <div class="modal-backdrop bg-black/50" phx-click="close_api_key_modal"></div>
+    </div>
+    """
+  end
+
+  attr :key, :string, required: true
+
+  def created_key_modal(assigns) do
+    ~H"""
+    <div id="created-api-key-modal" class="modal modal-open">
+      <div class="modal-box max-w-lg">
+        <h3 class="font-bold text-lg">Your new API key</h3>
+        <p class="py-2 text-sm text-base-content/70">
+          Copy it now. It is shown only once and cannot be recovered.
+        </p>
+        <div class="join w-full">
+          <input
+            id="created-api-key"
+            type="text"
+            readonly
+            value={@key}
+            class="input join-item w-full font-mono"
+          />
+          <%!-- The key rides in an escaped data attribute, never inside the
+               onclick string, so no character in it can break out into script.
+               Same pattern as the devices page's claim code. --%>
+          <button
+            id="copy-api-key"
+            class="btn join-item"
+            phx-click="copy_api_key"
+            data-key={@key}
+            onclick="navigator.clipboard?.writeText(this.dataset.key)"
+            title="Copy key"
+          >
+            <.icon name="hero-clipboard-document" class="w-4 h-4" />
+          </button>
+        </div>
+        <div class="alert alert-warning mt-4">
+          <.icon name="hero-exclamation-triangle" class="w-5 h-5" />
+          <span>
+            This key also authenticates on the player API as you. Treat it like your password.
+          </span>
+        </div>
+        <div class="modal-action">
+          <button id="close-created-api-key" class="btn btn-primary" phx-click="close_created_api_key">
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :confirm, :any, required: true, doc: "{:revoke | :delete, %ApiKey{}}"
+
+  def confirm_modal(%{confirm: {action, key}} = assigns) do
+    assigns = assign(assigns, action: action, key: key)
+
+    ~H"""
+    <div id="api-key-confirm-modal" class="modal modal-open">
+      <div class="modal-box">
+        <h3 class="text-lg font-bold">
+          {if @action == :revoke, do: "Revoke", else: "Delete"} '{@key.name}'?
+        </h3>
+        <p class="py-2">
+          <%= if @action == :revoke do %>
+            Anything using this key stops working immediately. It stays listed as revoked.
+          <% else %>
+            Anything using this key stops working immediately, and it leaves this list.
+          <% end %>
+        </p>
+        <div class="modal-action">
+          <button id="cancel-api-key-confirm" class="btn btn-ghost" phx-click="cancel_api_key_confirm">
+            Cancel
+          </button>
+          <button
+            id="confirm-api-key-action"
+            class="btn btn-error"
+            phx-click={"#{@action}_api_key"}
+            phx-disable-with="Working..."
+          >
+            {if @action == :revoke, do: "Revoke key", else: "Delete key"}
+          </button>
+        </div>
+      </div>
+      <div class="modal-backdrop" phx-click="cancel_api_key_confirm"></div>
+    </div>
+    """
+  end
+
+  @doc false
+  # Mirrors Mydia.Accounts' private not_expired?/1: a key expires at its
+  # expires_at instant.
+  def state(%ApiKey{revoked_at: %DateTime{}}), do: :revoked
+
+  def state(%ApiKey{expires_at: %DateTime{} = expires_at}) do
+    if DateTime.compare(DateTime.utc_now(), expires_at) == :lt, do: :active, else: :expired
+  end
+
+  def state(%ApiKey{}), do: :active
+
+  defp state_label(:active), do: "Active"
+  defp state_label(:revoked), do: "Revoked"
+  defp state_label(:expired), do: "Expired"
+
+  defp state_class(:active), do: "badge-success"
+  defp state_class(_state), do: "badge-ghost"
+
+  # Keys minted elsewhere (the player API's createApiKey) default to read/write,
+  # which the Library API refuses.
+  defp scope(%ApiKey{permissions: permissions}) do
+    if "admin" in (permissions || []), do: "Library API", else: "Player API"
+  end
+
+  defp date(nil), do: nil
+  defp date(%DateTime{} = value), do: Calendar.strftime(value, "%Y-%m-%d")
+end

--- a/lib/mydia_web/live/admin_api_keys_live/index.ex
+++ b/lib/mydia_web/live/admin_api_keys_live/index.ex
@@ -1,0 +1,154 @@
+defmodule MydiaWeb.AdminApiKeysLive.Index do
+  @moduledoc """
+  The admin page for Library API keys.
+
+  Lists the signed-in admin's own keys, creates Library API keys, and revokes or
+  deletes them. A new key's plain value exists only while it is being created
+  (`Mydia.Accounts.create_api_key/2` stores a hash), so the page shows it once,
+  in a modal, and never again.
+
+  A plain list rather than a stream, like the other `/admin/config` pages: an
+  admin's keys are a handful, and the confirm flow looks keys up in it.
+  """
+  use MydiaWeb, :live_view
+
+  alias Mydia.Accounts
+  alias MydiaWeb.AdminApiKeysLive.Components
+
+  @expiry_days %{"30" => 30, "90" => 90, "365" => 365}
+  @form_types %{name: :string, expiry: :string, scope: :string}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign(:page_title, "Configuration - API Keys")
+     |> assign(:active_tab, :api_keys)
+     |> assign(:env_key_set, is_binary(Application.get_env(:mydia, :library_api_key)))
+     |> assign(:show_api_key_modal, false)
+     |> assign(:created_key, nil)
+     |> assign(:confirm, nil)
+     |> assign(:api_key_form, new_form())
+     |> load_keys()}
+  end
+
+  @impl true
+  def handle_event("new_api_key", _params, socket) do
+    {:noreply, socket |> assign(:api_key_form, new_form()) |> assign(:show_api_key_modal, true)}
+  end
+
+  def handle_event("close_api_key_modal", _params, socket) do
+    {:noreply, assign(socket, :show_api_key_modal, false)}
+  end
+
+  def handle_event("validate_api_key", %{"api_key" => params}, socket) do
+    form = params |> changeset() |> Map.put(:action, :validate) |> to_form(as: :api_key)
+    {:noreply, assign(socket, :api_key_form, form)}
+  end
+
+  def handle_event("save_api_key", %{"api_key" => params}, socket) do
+    case params |> changeset() |> Ecto.Changeset.apply_action(:insert) do
+      {:ok, attrs} ->
+        create(socket, attrs)
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :api_key_form, to_form(changeset, as: :api_key))}
+    end
+  end
+
+  def handle_event("close_created_api_key", _params, socket) do
+    {:noreply, assign(socket, :created_key, nil)}
+  end
+
+  def handle_event("copy_api_key", _params, socket) do
+    {:noreply, put_flash(socket, :info, "Key copied to clipboard")}
+  end
+
+  def handle_event("confirm_revoke_api_key", %{"id" => id}, socket),
+    do: confirm(socket, :revoke, id)
+
+  def handle_event("confirm_delete_api_key", %{"id" => id}, socket),
+    do: confirm(socket, :delete, id)
+
+  def handle_event("cancel_api_key_confirm", _params, socket) do
+    {:noreply, assign(socket, :confirm, nil)}
+  end
+
+  def handle_event("revoke_api_key", _params, %{assigns: %{confirm: {:revoke, key}}} = socket) do
+    socket |> assign(:confirm, nil) |> finish(Accounts.revoke_api_key(key), "Key revoked")
+  end
+
+  def handle_event("delete_api_key", _params, %{assigns: %{confirm: {:delete, key}}} = socket) do
+    socket |> assign(:confirm, nil) |> finish(Accounts.delete_api_key(key), "Key deleted")
+  end
+
+  # A second click after the modal closed has nothing to act on.
+  def handle_event(event, _params, socket) when event in ["revoke_api_key", "delete_api_key"] do
+    {:noreply, socket}
+  end
+
+  # Only a key already in this admin's own list can be acted on. The Accounts
+  # functions check no ownership, so this lookup is what stops one admin from
+  # revoking another's key by posting its id.
+  defp confirm(socket, action, id) do
+    case Enum.find(socket.assigns.api_keys, &(&1.id == id)) do
+      nil -> {:noreply, put_flash(socket, :error, "That key no longer exists")}
+      key -> {:noreply, assign(socket, :confirm, {action, key})}
+    end
+  end
+
+  defp finish(socket, {:ok, _key}, message) do
+    {:noreply, socket |> put_flash(:info, message) |> load_keys()}
+  end
+
+  defp finish(socket, {:error, _reason}, _message) do
+    {:noreply, socket |> put_flash(:error, "Could not update the key") |> load_keys()}
+  end
+
+  # v1 offers one scope, the Library API, stored as the admin permission the
+  # Library API's authentication plug requires.
+  defp create(socket, attrs) do
+    params = %{name: attrs.name, permissions: ["admin"], expires_at: expires_at(attrs.expiry)}
+
+    case Accounts.create_api_key(socket.assigns.current_user.id, params) do
+      {:ok, _key, plain_key} ->
+        {:noreply,
+         socket
+         |> assign(:show_api_key_modal, false)
+         |> assign(:created_key, plain_key)
+         |> load_keys()}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not create the key")}
+    end
+  end
+
+  defp expires_at("never"), do: nil
+
+  defp expires_at(days) do
+    DateTime.utc_now()
+    |> DateTime.add(Map.fetch!(@expiry_days, days) * 86_400, :second)
+    |> DateTime.truncate(:second)
+  end
+
+  # Schemaless: ApiKey's own changeset requires the key and its hash, which do
+  # not exist until create_api_key/2 generates them.
+  defp changeset(params) do
+    {%{}, @form_types}
+    |> Ecto.Changeset.cast(params, Map.keys(@form_types))
+    |> Ecto.Changeset.validate_required([:name, :expiry, :scope])
+    |> Ecto.Changeset.validate_length(:name, min: 1, max: 100)
+    |> Ecto.Changeset.validate_inclusion(:expiry, ["never" | Map.keys(@expiry_days)])
+    |> Ecto.Changeset.validate_inclusion(:scope, ["library"])
+  end
+
+  defp new_form do
+    %{"name" => "", "expiry" => "never", "scope" => "library"}
+    |> changeset()
+    |> to_form(as: :api_key)
+  end
+
+  defp load_keys(socket) do
+    assign(socket, :api_keys, Accounts.list_api_keys(socket.assigns.current_user.id))
+  end
+end

--- a/lib/mydia_web/live/admin_api_keys_live/index.html.heex
+++ b/lib/mydia_web/live/admin_api_keys_live/index.html.heex
@@ -1,0 +1,8 @@
+<Layouts.app {assigns}>
+  <.admin_page active_tab={@active_tab}>
+    <Components.api_keys_tab api_keys={@api_keys} env_key_set={@env_key_set} />
+    <Components.api_key_modal :if={@show_api_key_modal} form={@api_key_form} />
+    <Components.created_key_modal :if={@created_key} key={@created_key} />
+    <Components.confirm_modal :if={@confirm} confirm={@confirm} />
+  </.admin_page>
+</Layouts.app>

--- a/lib/mydia_web/router.ex
+++ b/lib/mydia_web/router.ex
@@ -250,6 +250,7 @@ defmodule MydiaWeb.Router do
       live "/config/plugins", AdminPluginsLive.Index, :index
       live "/config/path-mappings", AdminPathMappingsLive.Index, :index
       live "/config/remote-access", AdminRemoteAccessLive.Index, :index
+      live "/config/api-keys", AdminApiKeysLive.Index, :index
       live "/import-lists", AdminImportListsLive.Index, :index
       live "/jobs", JobsLive.Index, :index
       live "/transcodes", TranscodesLive.Index, :index

--- a/priv/graphql/library.graphql
+++ b/priv/graphql/library.graphql
@@ -42,6 +42,41 @@ type RootMutationType {
 
   "Apply a monitoring preset to a show's episodes"
   applyEpisodeMonitoring(mediaItemId: ID!, preset: EpisodeMonitoringPreset!): MediaItemPayload!
+
+  "Add a movie by its TMDB id"
+  addMovie(input: AddMovieInput!): AddMediaPayload!
+
+  "Add a TV show by its TVDB or TMDB id"
+  addTvShow(input: AddTvShowInput!): AddMediaPayload!
+
+  "Remove a movie or show from the library"
+  removeMediaItem(input: RemoveMediaItemInput!): RemoveMediaItemPayload!
+}
+
+"A movie to add"
+input AddMovieInput {
+  tmdbId: Int!
+  qualityProfileId: ID
+  libraryPathId: ID
+  monitored: Boolean
+  searchNow: Boolean
+}
+
+"A TV show to add. Give tvdbId or tmdbId; tvdbId wins when both are set."
+input AddTvShowInput {
+  tvdbId: Int
+  tmdbId: Int
+  qualityProfileId: ID
+  libraryPathId: ID
+  monitored: Boolean
+  seasonMonitoring: SeasonMonitoring
+  searchNow: Boolean
+}
+
+"A media item to remove"
+input RemoveMediaItemInput {
+  id: ID!
+  deleteFiles: Boolean
 }
 
 "Why a mutation could not do what it was asked"
@@ -81,6 +116,18 @@ type MediaItemPayload {
 "The episode a mutation changed"
 type EpisodePayload {
   episode: Episode
+  userErrors: [UserError!]!
+}
+
+"The media item an add created, or the one already in the library"
+type AddMediaPayload {
+  mediaItem: MediaItem
+  userErrors: [UserError!]!
+}
+
+"The id of the media item a remove deleted"
+type RemoveMediaItemPayload {
+  removedId: ID
   userErrors: [UserError!]!
 }
 
@@ -362,6 +409,24 @@ enum EpisodeMonitoringPreset {
   FUTURE
 
   "No episodes"
+  NONE
+}
+
+"Which seasons of a newly added show to monitor"
+enum SeasonMonitoring {
+  "Every season"
+  ALL
+
+  "Only episodes that have not aired"
+  FUTURE
+
+  "Only the latest season"
+  LATEST
+
+  "Only the first season"
+  FIRST
+
+  "No seasons"
   NONE
 }
 

--- a/priv/graphql/library.graphql
+++ b/priv/graphql/library.graphql
@@ -60,6 +60,17 @@ type RootMutationType {
 
   "Queue a search for one episode"
   searchEpisode(id: ID!): SearchPayload!
+
+  "Stop a download and remove it from its client and the queue"
+  cancelDownload(id: ID!): RemoveDownloadPayload!
+
+  "Remove a download, blocklist its release, and search again"
+  rejectRelease(
+    id: ID!
+
+    "Days to blocklist the release. Defaults to the configured period."
+    blocklistDays: Int
+  ): RemoveDownloadPayload!
 }
 
 "A movie to add"
@@ -149,6 +160,12 @@ type SearchPayload {
   "True when the job was inserted, including a repeat merged by the worker"
   queued: Boolean!
 
+  userErrors: [UserError!]!
+}
+
+"The id of the download a mutation removed from the queue"
+type RemoveDownloadPayload {
+  removedId: ID
   userErrors: [UserError!]!
 }
 

--- a/priv/graphql/library.graphql
+++ b/priv/graphql/library.graphql
@@ -28,6 +28,16 @@ type RootQueryType {
 
   "The download queue and history. Contacts every configured client."
   downloads(filter: DownloadFilter): [Download!]!
+
+  "Library activity, oldest first. Best-effort: the docs explain the limits."
+  events(
+    first: Int
+
+    after: String
+
+    "Defaults to every published type"
+    types: [String!]
+  ): EventConnection!
 }
 
 type RootMutationType {
@@ -71,6 +81,52 @@ type RootMutationType {
     "Days to blocklist the release. Defaults to the configured period."
     blocklistDays: Int
   ): RemoveDownloadPayload!
+}
+
+"Arbitrary JSON, returned as stored"
+scalar JSON
+
+"How serious an event is"
+enum Severity {
+  "Routine"
+  INFO
+
+  "Worth a look"
+  WARNING
+
+  "Something failed"
+  ERROR
+}
+
+"Something that happened in the library"
+type Event {
+  id: ID!
+
+  type: String!
+
+  "When Mydia recorded it, to the second"
+  occurredAt: DateTime!
+
+  severity: Severity!
+
+  resourceType: String
+
+  resourceId: ID
+
+  "Type-specific details. Keys may change during beta."
+  data: JSON!
+}
+
+"One event in a page"
+type EventEdge {
+  node: Event!
+  cursor: String!
+}
+
+"A page of events"
+type EventConnection {
+  edges: [EventEdge!]!
+  pageInfo: PageInfo!
 }
 
 "A movie to add"

--- a/priv/graphql/library.graphql
+++ b/priv/graphql/library.graphql
@@ -1,4 +1,5 @@
 schema {
+  mutation: RootMutationType
   query: RootQueryType
 }
 
@@ -27,6 +28,45 @@ type RootQueryType {
 
   "The download queue and history. Contacts every configured client."
   downloads(filter: DownloadFilter): [Download!]!
+}
+
+type RootMutationType {
+  "Turn monitoring on or off for a movie or show"
+  setMediaItemMonitored(id: ID!, monitored: Boolean!): MediaItemPayload!
+}
+
+"Why a mutation could not do what it was asked"
+enum UserErrorCode {
+  "The title is already in the library"
+  ALREADY_IN_LIBRARY
+
+  "An id names nothing"
+  NOT_FOUND
+
+  "The arguments cannot be satisfied"
+  INVALID_INPUT
+
+  "The metadata relay could not provide the title"
+  METADATA_UNAVAILABLE
+
+  "A download client could not do what was asked"
+  CLIENT_UNAVAILABLE
+}
+
+"An expected failure, tied to the argument that caused it when there is one"
+type UserError {
+  "Path to the argument, as sent"
+  field: [String!]
+
+  code: UserErrorCode!
+
+  message: String!
+}
+
+"The media item a mutation changed"
+type MediaItemPayload {
+  mediaItem: MediaItem
+  userErrors: [UserError!]!
 }
 
 "The download client a row belongs to"

--- a/priv/graphql/library.graphql
+++ b/priv/graphql/library.graphql
@@ -128,6 +128,10 @@ type AddMediaPayload {
 "The id of the media item a remove deleted"
 type RemoveMediaItemPayload {
   removedId: ID
+
+  "Files that could not be removed from disk. 0 when deleteFiles was false."
+  filesNotDeleted: Int
+
   userErrors: [UserError!]!
 }
 

--- a/priv/graphql/library.graphql
+++ b/priv/graphql/library.graphql
@@ -33,6 +33,15 @@ type RootQueryType {
 type RootMutationType {
   "Turn monitoring on or off for a movie or show"
   setMediaItemMonitored(id: ID!, monitored: Boolean!): MediaItemPayload!
+
+  "Turn monitoring on or off for every episode of one season"
+  setSeasonMonitored(mediaItemId: ID!, season: Int!, monitored: Boolean!): MediaItemPayload!
+
+  "Turn monitoring on or off for one episode"
+  setEpisodeMonitored(id: ID!, monitored: Boolean!): EpisodePayload!
+
+  "Apply a monitoring preset to a show's episodes"
+  applyEpisodeMonitoring(mediaItemId: ID!, preset: EpisodeMonitoringPreset!): MediaItemPayload!
 }
 
 "Why a mutation could not do what it was asked"
@@ -66,6 +75,12 @@ type UserError {
 "The media item a mutation changed"
 type MediaItemPayload {
   mediaItem: MediaItem
+  userErrors: [UserError!]!
+}
+
+"The episode a mutation changed"
+type EpisodePayload {
+  episode: Episode
   userErrors: [UserError!]!
 }
 
@@ -330,6 +345,24 @@ enum LibraryPathType {
 
   "Mixed content library"
   MIXED
+}
+
+"Which of a show's episodes to monitor"
+enum EpisodeMonitoringPreset {
+  "Every episode"
+  ALL
+
+  "Episodes without a file"
+  MISSING
+
+  "Episodes with a file"
+  EXISTING
+
+  "Episodes that have not aired"
+  FUTURE
+
+  "No episodes"
+  NONE
 }
 
 """

--- a/priv/graphql/library.graphql
+++ b/priv/graphql/library.graphql
@@ -51,6 +51,15 @@ type RootMutationType {
 
   "Remove a movie or show from the library"
   removeMediaItem(input: RemoveMediaItemInput!): RemoveMediaItemPayload!
+
+  "Queue an automatic search for a movie, or for a whole show"
+  searchMediaItem(id: ID!): SearchPayload!
+
+  "Queue a search for one season of a show, preferring a season pack"
+  searchSeason(mediaItemId: ID!, season: Int!): SearchPayload!
+
+  "Queue a search for one episode"
+  searchEpisode(id: ID!): SearchPayload!
 }
 
 "A movie to add"
@@ -131,6 +140,14 @@ type RemoveMediaItemPayload {
 
   "Files that could not be removed from disk. 0 when deleteFiles was false."
   filesNotDeleted: Int
+
+  userErrors: [UserError!]!
+}
+
+"Whether a search job was queued"
+type SearchPayload {
+  "True when the job was inserted, including a repeat merged by the worker"
+  queued: Boolean!
 
   userErrors: [UserError!]!
 }

--- a/test/mydia/library_api/event_feed_test.exs
+++ b/test/mydia/library_api/event_feed_test.exs
@@ -73,4 +73,10 @@ defmodule Mydia.LibraryApi.EventFeedTest do
     assert EventFeed.list(limit: 10, types: ["media_item.added", "nope.nope"], now: @now) ==
              {:error, {:unknown_types, ["nope.nope"]}}
   end
+
+  test "refuses an empty types list instead of returning an empty feed forever" do
+    _added = event!("media_item.added", 50)
+
+    assert EventFeed.list(limit: 10, types: [], now: @now) == {:error, :empty_types}
+  end
 end

--- a/test/mydia/library_api/event_feed_test.exs
+++ b/test/mydia/library_api/event_feed_test.exs
@@ -1,0 +1,76 @@
+defmodule Mydia.LibraryApi.EventFeedTest do
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Events.Event
+  alias Mydia.LibraryApi.Cursor
+  alias Mydia.LibraryApi.EventFeed
+  alias Mydia.Repo
+
+  # Far in the past, so nothing the app writes while the suite runs sorts
+  # between these rows.
+  @now ~U[2020-01-01 12:00:00Z]
+
+  defp event!(type, seconds_ago, attrs \\ %{}) do
+    %Event{
+      category: "media",
+      type: type,
+      severity: :info,
+      metadata: %{},
+      inserted_at: DateTime.add(@now, -seconds_ago, :second)
+    }
+    |> struct!(attrs)
+    |> Repo.insert!()
+  end
+
+  defp ids({:ok, events}), do: Enum.map(events, & &1.id)
+
+  test "returns events oldest first, ties broken by id" do
+    oldest = event!("media_item.added", 60)
+    tie_a = event!("media_item.updated", 30)
+    tie_b = event!("media_item.removed", 30)
+
+    [first_tie, second_tie] = Enum.sort([tie_a.id, tie_b.id])
+
+    assert ids(EventFeed.list(limit: 10, now: @now)) == [oldest.id, first_tie, second_tie]
+  end
+
+  test "withholds events younger than the settle window" do
+    settled = event!("media_item.added", EventFeed.settle_seconds() + 1)
+    _fresh = event!("media_item.added", EventFeed.settle_seconds() - 5)
+
+    assert ids(EventFeed.list(limit: 10, now: @now)) == [settled.id]
+  end
+
+  test "resumes strictly after the cursor, including within one second" do
+    rows =
+      for type <- ~w(media_item.added media_item.updated media_item.removed), do: event!(type, 30)
+
+    [first, second, third] = Enum.sort_by(rows, & &1.id)
+
+    assert {:ok, [^first]} = EventFeed.list(limit: 1, now: @now)
+
+    {:ok, cursor} = first.inserted_at |> Cursor.encode(first.id) |> Cursor.decode()
+
+    assert ids(EventFeed.list(limit: 10, after: cursor, now: @now)) == [second.id, third.id]
+  end
+
+  test "defaults to the plugin event catalog" do
+    listed = event!("media_item.added", 30)
+    _unlisted = event!("library.scan.finished", 30)
+
+    assert ids(EventFeed.list(limit: 10, now: @now)) == [listed.id]
+  end
+
+  test "filters to the requested types" do
+    _added = event!("media_item.added", 30)
+    removed = event!("media_item.removed", 30)
+
+    assert ids(EventFeed.list(limit: 10, types: ["media_item.removed"], now: @now)) ==
+             [removed.id]
+  end
+
+  test "refuses a type outside the catalog" do
+    assert EventFeed.list(limit: 10, types: ["media_item.added", "nope.nope"], now: @now) ==
+             {:error, {:unknown_types, ["nope.nope"]}}
+  end
+end

--- a/test/mydia/library_api/event_feed_test.exs
+++ b/test/mydia/library_api/event_feed_test.exs
@@ -26,8 +26,8 @@ defmodule Mydia.LibraryApi.EventFeedTest do
 
   test "returns events oldest first, ties broken by id" do
     oldest = event!("media_item.added", 60)
-    tie_a = event!("media_item.updated", 30)
-    tie_b = event!("media_item.removed", 30)
+    tie_a = event!("media_item.updated", 50)
+    tie_b = event!("media_item.removed", 50)
 
     [first_tie, second_tie] = Enum.sort([tie_a.id, tie_b.id])
 
@@ -43,7 +43,7 @@ defmodule Mydia.LibraryApi.EventFeedTest do
 
   test "resumes strictly after the cursor, including within one second" do
     rows =
-      for type <- ~w(media_item.added media_item.updated media_item.removed), do: event!(type, 30)
+      for type <- ~w(media_item.added media_item.updated media_item.removed), do: event!(type, 50)
 
     [first, second, third] = Enum.sort_by(rows, & &1.id)
 
@@ -55,15 +55,15 @@ defmodule Mydia.LibraryApi.EventFeedTest do
   end
 
   test "defaults to the plugin event catalog" do
-    listed = event!("media_item.added", 30)
-    _unlisted = event!("library.scan.finished", 30)
+    listed = event!("media_item.added", 50)
+    _unlisted = event!("library.scan.finished", 50)
 
     assert ids(EventFeed.list(limit: 10, now: @now)) == [listed.id]
   end
 
   test "filters to the requested types" do
-    _added = event!("media_item.added", 30)
-    removed = event!("media_item.removed", 30)
+    _added = event!("media_item.added", 50)
+    removed = event!("media_item.removed", 50)
 
     assert ids(EventFeed.list(limit: 10, types: ["media_item.removed"], now: @now)) ==
              [removed.id]

--- a/test/mydia/library_api/principal_test.exs
+++ b/test/mydia/library_api/principal_test.exs
@@ -1,0 +1,17 @@
+defmodule Mydia.LibraryApi.PrincipalTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Accounts.User
+  alias Mydia.LibraryApi.Principal
+
+  test "a database key acts as its owner" do
+    principal = %Principal{role: "admin", source: :api_key, user: %User{id: "owner-id"}}
+
+    assert Principal.actor_opts(principal) == [actor_type: :user, actor_id: "owner-id"]
+  end
+
+  test "the environment key acts as the system under a fixed name" do
+    assert Principal.actor_opts(%Principal{role: "admin", source: :env}) ==
+             [actor_type: :system, actor_id: "library_api_key"]
+  end
+end

--- a/test/mydia_web/library_schema/download_writes_test.exs
+++ b/test/mydia_web/library_schema/download_writes_test.exs
@@ -1,0 +1,178 @@
+defmodule MydiaWeb.LibrarySchema.DownloadWritesTest do
+  # async: false: registers an adapter in the global download-client Registry,
+  # as test/mydia/downloads_test.exs does.
+  use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Mydia.AccountsFixtures
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+  import Mydia.SettingsFixtures
+
+  alias Mydia.Downloads.Blacklists
+  alias Mydia.Downloads.Client.Registry
+  alias Mydia.Downloads.Download
+  alias Mydia.Downloads.ReleaseBlacklist
+  alias Mydia.LibraryApi.Principal
+  alias Mydia.Repo
+
+  @moduletag :capture_log
+
+  @admin %Principal{role: "admin", source: :env}
+
+  defmodule RemovingAdapter do
+    @moduledoc "A download client that accepts every request, so cancel can succeed."
+    @behaviour Mydia.Downloads.Client
+
+    @impl true
+    def supported_protocols, do: [:torrent]
+
+    @impl true
+    def test_connection(_config), do: {:ok, %{version: "1.0.0", api_version: "1.0"}}
+
+    @impl true
+    def add_torrent(_config, _torrent, _opts), do: {:ok, "removing-adapter-id"}
+
+    @impl true
+    def get_status(_config, _client_id), do: {:ok, %{}}
+
+    @impl true
+    def list_torrents(_config, _opts), do: {:ok, []}
+
+    @impl true
+    def remove_torrent(_config, _client_id, _opts), do: :ok
+
+    @impl true
+    def pause_torrent(_config, _client_id), do: :ok
+
+    @impl true
+    def resume_torrent(_config, _client_id), do: :ok
+  end
+
+  setup do
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    original =
+      case Registry.get_adapter(:qbittorrent) do
+        {:ok, adapter} -> adapter
+        {:error, _} -> nil
+      end
+
+    Registry.register(:qbittorrent, RemovingAdapter)
+    on_exit(fn -> if original, do: Registry.register(:qbittorrent, original) end)
+
+    user = user_fixture()
+
+    download_client_config_fixture(%{
+      name: "api-test-client",
+      type: "qbittorrent",
+      enabled: true,
+      host: "localhost",
+      port: 8080,
+      updated_by_id: user.id
+    })
+
+    :ok
+  end
+
+  defp run(document, variables) do
+    Absinthe.run(document, MydiaWeb.LibrarySchema,
+      variables: variables,
+      context: %{principal: @admin}
+    )
+  end
+
+  @cancel """
+  mutation C($id: ID!) { cancelDownload(id: $id) { removedId userErrors { field code } } }
+  """
+
+  @reject """
+  mutation R($id: ID!, $days: Int) {
+    rejectRelease(id: $id, blocklistDays: $days) { removedId userErrors { field code } }
+  }
+  """
+
+  describe "cancelDownload" do
+    test "removes the download from its client and the queue" do
+      item = media_item_fixture()
+      download = download_fixture(%{media_item_id: item.id, download_client: "api-test-client"})
+
+      assert {:ok, %{data: %{"cancelDownload" => payload}}} = run(@cancel, %{"id" => download.id})
+
+      assert payload == %{"removedId" => download.id, "userErrors" => []}
+      refute Repo.get(Download, download.id)
+    end
+
+    test "a client that is not configured is CLIENT_UNAVAILABLE and keeps the row" do
+      item = media_item_fixture()
+      download = download_fixture(%{media_item_id: item.id, download_client: "gone-client"})
+
+      assert {:ok, %{data: %{"cancelDownload" => payload}}} = run(@cancel, %{"id" => download.id})
+
+      assert payload["removedId"] == nil
+      assert [%{"code" => "CLIENT_UNAVAILABLE", "field" => ["id"]}] = payload["userErrors"]
+      assert Repo.get(Download, download.id)
+    end
+
+    test "an id that names nothing is NOT_FOUND" do
+      assert {:ok, %{data: %{"cancelDownload" => payload}}} =
+               run(@cancel, %{"id" => Ecto.UUID.generate()})
+
+      assert [%{"code" => "NOT_FOUND", "field" => ["id"]}] = payload["userErrors"]
+    end
+  end
+
+  describe "rejectRelease" do
+    test "blocklists the release, removes the row and searches again" do
+      show = media_item_fixture(%{type: "tv_show"})
+
+      download =
+        download_fixture(%{
+          media_item_id: show.id,
+          indexer: "1337x",
+          metadata: %{"guid" => "api-guid"}
+        })
+
+      assert {:ok, %{data: %{"rejectRelease" => payload}}} = run(@reject, %{"id" => download.id})
+
+      assert payload == %{"removedId" => download.id, "userErrors" => []}
+      assert Blacklists.blacklisted?("1337x", "api-guid")
+      refute Repo.get(Download, download.id)
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{"mode" => "show", "media_item_id" => show.id}
+      )
+    end
+
+    test "blocklistDays sets how long the release stays blocked" do
+      item = media_item_fixture()
+
+      download =
+        download_fixture(%{
+          media_item_id: item.id,
+          indexer: "1337x",
+          metadata: %{"guid" => "ttl-api-guid"}
+        })
+
+      assert {:ok, %{data: %{"rejectRelease" => %{"userErrors" => []}}}} =
+               run(@reject, %{"id" => download.id, "days" => 7})
+
+      row = Repo.get_by!(ReleaseBlacklist, indexer: "1337x", guid: "ttl-api-guid")
+      expected = DateTime.add(DateTime.utc_now(), 7 * 86_400, :second)
+      assert abs(DateTime.diff(row.expires_at, expected, :second)) < 60
+    end
+
+    test "a blocklistDays below 1 is INVALID_INPUT and changes nothing" do
+      item = media_item_fixture()
+      download = download_fixture(%{media_item_id: item.id})
+
+      assert {:ok, %{data: %{"rejectRelease" => payload}}} =
+               run(@reject, %{"id" => download.id, "days" => 0})
+
+      assert [%{"code" => "INVALID_INPUT", "field" => ["blocklistDays"]}] = payload["userErrors"]
+      assert Repo.get(Download, download.id)
+    end
+  end
+end

--- a/test/mydia_web/library_schema/download_writes_test.exs
+++ b/test/mydia_web/library_schema/download_writes_test.exs
@@ -53,14 +53,16 @@ defmodule MydiaWeb.LibrarySchema.DownloadWritesTest do
     engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
     start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
 
-    original =
-      case Registry.get_adapter(:qbittorrent) do
-        {:ok, adapter} -> adapter
-        {:error, _} -> nil
-      end
+    original = Registry.get_adapter(:qbittorrent)
 
     Registry.register(:qbittorrent, RemovingAdapter)
-    on_exit(fn -> if original, do: Registry.register(:qbittorrent, original) end)
+
+    on_exit(fn ->
+      case original do
+        {:ok, adapter} -> Registry.register(:qbittorrent, adapter)
+        {:error, _} -> Registry.unregister(:qbittorrent)
+      end
+    end)
 
     user = user_fixture()
 

--- a/test/mydia_web/library_schema/events_test.exs
+++ b/test/mydia_web/library_schema/events_test.exs
@@ -1,0 +1,116 @@
+defmodule MydiaWeb.LibrarySchema.EventsTest do
+  use MydiaWeb.ConnCase, async: false
+
+  alias Mydia.Events.Event
+  alias Mydia.LibraryApi.Principal
+  alias Mydia.Repo
+
+  @admin %Principal{role: "admin", source: :env}
+
+  @events """
+  query E($first: Int, $after: String, $types: [String!]) {
+    events(first: $first, after: $after, types: $types) {
+      edges { cursor node { id type occurredAt severity resourceType resourceId data } }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+  """
+
+  defp run(variables, principal \\ @admin) do
+    Absinthe.run(@events, MydiaWeb.LibrarySchema,
+      variables: variables,
+      context: %{principal: principal}
+    )
+  end
+
+  # 2020 is past the settle window and older than anything the app writes while
+  # the suite runs, so these rows come first.
+  defp event!(type, second, attrs \\ %{}) do
+    %Event{
+      category: "media",
+      type: type,
+      severity: :info,
+      metadata: %{},
+      inserted_at: DateTime.add(~U[2020-01-01 00:00:00Z], second, :second)
+    }
+    |> struct!(attrs)
+    |> Repo.insert!()
+  end
+
+  test "returns events oldest first with their fields" do
+    resource_id = Ecto.UUID.generate()
+
+    first =
+      event!("media_item.added", 0, %{
+        severity: :warning,
+        resource_type: "media_item",
+        resource_id: resource_id,
+        metadata: %{"title" => "Harbor Lights"}
+      })
+
+    second = event!("media_item.removed", 5)
+
+    assert {:ok, %{data: %{"events" => %{"edges" => [a, b]}}}} = run(%{"first" => 2})
+
+    assert a["node"] == %{
+             "id" => first.id,
+             "type" => "media_item.added",
+             "occurredAt" => "2020-01-01T00:00:00Z",
+             "severity" => "WARNING",
+             "resourceType" => "media_item",
+             "resourceId" => resource_id,
+             "data" => %{"title" => "Harbor Lights"}
+           }
+
+    assert b["node"]["id"] == second.id
+  end
+
+  test "pages forward with the cursor" do
+    one = event!("playback.unwatched", 0)
+    two = event!("playback.unwatched", 1)
+    types = ["playback.unwatched"]
+
+    assert {:ok, %{data: %{"events" => page1}}} = run(%{"first" => 1, "types" => types})
+    assert [%{"node" => %{"id" => id1}}] = page1["edges"]
+    assert id1 == one.id
+    assert page1["pageInfo"]["hasNextPage"]
+
+    assert {:ok, %{data: %{"events" => page2}}} =
+             run(%{"first" => 1, "types" => types, "after" => page1["pageInfo"]["endCursor"]})
+
+    assert [%{"node" => %{"id" => id2}}] = page2["edges"]
+    assert id2 == two.id
+  end
+
+  test "an empty page repeats the cursor it was given" do
+    event!("playback.unwatched", 0)
+    types = ["playback.unwatched"]
+
+    {:ok, %{data: %{"events" => page1}}} = run(%{"first" => 200, "types" => types})
+    cursor = page1["pageInfo"]["endCursor"]
+
+    assert {:ok, %{data: %{"events" => page2}}} =
+             run(%{"first" => 200, "types" => types, "after" => cursor})
+
+    assert page2 == %{
+             "edges" => [],
+             "pageInfo" => %{"hasNextPage" => false, "endCursor" => cursor}
+           }
+  end
+
+  test "a type outside the catalog is INVALID_INPUT" do
+    assert {:ok, %{errors: [error]}} = run(%{"types" => ["nope.nope"]})
+    assert error.extensions.code == "INVALID_INPUT"
+    assert error.message =~ "nope.nope"
+  end
+
+  test "a first outside 1..200 is INVALID_INPUT" do
+    assert {:ok, %{errors: [error]}} = run(%{"first" => 201})
+    assert error.extensions.code == "INVALID_INPUT"
+  end
+
+  test "a non-admin is refused" do
+    assert {:ok, %{errors: errors}} = run(%{}, %Principal{role: "user", source: :api_key})
+    assert Enum.any?(errors, &(&1.extensions[:code] == "FORBIDDEN"))
+  end
+end

--- a/test/mydia_web/library_schema/events_test.exs
+++ b/test/mydia_web/library_schema/events_test.exs
@@ -109,6 +109,13 @@ defmodule MydiaWeb.LibrarySchema.EventsTest do
     assert error.extensions.code == "INVALID_INPUT"
   end
 
+  test "an empty types list is INVALID_INPUT, not an empty page" do
+    event!("media_item.added", 0)
+
+    assert {:ok, %{errors: [error]}} = run(%{"types" => []})
+    assert error.extensions.code == "INVALID_INPUT"
+  end
+
   test "a non-admin is refused" do
     assert {:ok, %{errors: errors}} = run(%{}, %Principal{role: "user", source: :api_key})
     assert Enum.any?(errors, &(&1.extensions[:code] == "FORBIDDEN"))

--- a/test/mydia_web/library_schema/library_writes_test.exs
+++ b/test/mydia_web/library_schema/library_writes_test.exs
@@ -1,0 +1,235 @@
+defmodule MydiaWeb.LibrarySchema.LibraryWritesTest do
+  # async: false: the relay URL is global application env.
+  use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.LibraryApi.Principal
+  alias Mydia.Media
+
+  # A TV add logs when its episode refresh finds nothing; keep that out of the
+  # test output.
+  @moduletag :capture_log
+
+  @admin %Principal{role: "admin", source: :env}
+
+  setup do
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+
+    bypass = Bypass.open()
+    previous = Application.get_env(:mydia, :metadata_relay_url)
+    Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
+    on_exit(fn -> Application.put_env(:mydia, :metadata_relay_url, previous) end)
+
+    %{bypass: bypass}
+  end
+
+  defp run(document, variables) do
+    Absinthe.run(document, MydiaWeb.LibrarySchema,
+      variables: variables,
+      context: %{principal: @admin}
+    )
+  end
+
+  # Same bodies test/mydia/media/add_test.exs stubs, so the relay answers the way
+  # Add already expects.
+  defp stub_tmdb_movie(bypass, id, title) do
+    body = %{
+      "id" => id,
+      "title" => title,
+      "release_date" => "2021-03-04",
+      "poster_path" => "/poster.jpg",
+      "overview" => "x",
+      "credits" => %{"cast" => [], "crew" => []},
+      "genres" => []
+    }
+
+    Bypass.stub(bypass, "GET", "/tmdb/movies/#{id}", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  defp stub_tvdb_series(bypass, tvdb_id, title) do
+    body = %{
+      "data" => %{
+        "id" => tvdb_id,
+        "name" => title,
+        "firstAired" => "2011-04-17",
+        "seasons" => [],
+        "remoteIds" => []
+      }
+    }
+
+    Bypass.stub(bypass, "GET", "/tvdb/series/#{tvdb_id}/extended", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.resp(200, Jason.encode!(body))
+    end)
+  end
+
+  @add_movie """
+  mutation Add($input: AddMovieInput!) {
+    addMovie(input: $input) {
+      mediaItem { id title tmdbId monitored type }
+      userErrors { field code message }
+    }
+  }
+  """
+
+  describe "addMovie" do
+    test "adds the movie and returns it", %{bypass: bypass} do
+      id = System.unique_integer([:positive])
+      stub_tmdb_movie(bypass, id, "Harbor Lights")
+
+      assert {:ok, %{data: %{"addMovie" => payload}}} =
+               run(@add_movie, %{"input" => %{"tmdbId" => id}})
+
+      assert payload["userErrors"] == []
+
+      assert %{
+               "title" => "Harbor Lights",
+               "tmdbId" => ^id,
+               "monitored" => true,
+               "type" => "MOVIE"
+             } =
+               payload["mediaItem"]
+
+      assert Media.find_by_external_ids(%{tmdb: id}, type: "movie")
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch)
+    end
+
+    test "searchNow queues the automatic search the Add button queues", %{bypass: bypass} do
+      id = System.unique_integer([:positive])
+      stub_tmdb_movie(bypass, id, "Harbor Lights")
+
+      assert {:ok, %{data: %{"addMovie" => %{"mediaItem" => %{"id" => item_id}}}}} =
+               run(@add_movie, %{"input" => %{"tmdbId" => id, "searchNow" => true}})
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{"mode" => "specific", "media_item_id" => item_id}
+      )
+    end
+
+    test "monitored: false is passed through", %{bypass: bypass} do
+      id = System.unique_integer([:positive])
+      stub_tmdb_movie(bypass, id, "Harbor Lights")
+
+      assert {:ok, %{data: %{"addMovie" => payload}}} =
+               run(@add_movie, %{"input" => %{"tmdbId" => id, "monitored" => false}})
+
+      assert payload["mediaItem"]["monitored"] == false
+    end
+
+    test "a title already in the library is ALREADY_IN_LIBRARY with the existing item",
+         %{bypass: bypass} do
+      id = System.unique_integer([:positive])
+      stub_tmdb_movie(bypass, id, "Harbor Lights")
+      existing = insert(:media_item, tmdb_id: id, title: "Harbor Lights")
+
+      assert {:ok, %{data: %{"addMovie" => payload}}} =
+               run(@add_movie, %{"input" => %{"tmdbId" => id}})
+
+      assert payload["mediaItem"]["id"] == existing.id
+      assert [%{"code" => "ALREADY_IN_LIBRARY"}] = payload["userErrors"]
+    end
+
+    test "an unreachable relay is METADATA_UNAVAILABLE", %{bypass: bypass} do
+      Bypass.down(bypass)
+
+      assert {:ok, %{data: %{"addMovie" => payload}}} =
+               run(@add_movie, %{"input" => %{"tmdbId" => 42}})
+
+      assert payload["mediaItem"] == nil
+      assert [%{"code" => "METADATA_UNAVAILABLE"}] = payload["userErrors"]
+    end
+
+    test "a malformed qualityProfileId is refused before the relay is asked" do
+      assert {:ok, %{data: %{"addMovie" => payload}}} =
+               run(@add_movie, %{"input" => %{"tmdbId" => 42, "qualityProfileId" => "nope"}})
+
+      assert [%{"code" => "INVALID_INPUT", "field" => ["input", "qualityProfileId"]}] =
+               payload["userErrors"]
+    end
+
+    test "a qualityProfileId that names no profile is INVALID_INPUT on that argument",
+         %{bypass: bypass} do
+      id = System.unique_integer([:positive])
+      stub_tmdb_movie(bypass, id, "Harbor Lights")
+
+      assert {:ok, %{data: %{"addMovie" => payload}}} =
+               run(@add_movie, %{
+                 "input" => %{"tmdbId" => id, "qualityProfileId" => Ecto.UUID.generate()}
+               })
+
+      assert payload["mediaItem"] == nil
+
+      assert Enum.any?(
+               payload["userErrors"],
+               &(&1["code"] == "INVALID_INPUT" and &1["field"] == ["input", "qualityProfileId"])
+             )
+    end
+  end
+
+  @add_show """
+  mutation Add($input: AddTvShowInput!) {
+    addTvShow(input: $input) {
+      mediaItem { id title tvdbId type }
+      userErrors { field code }
+    }
+  }
+  """
+
+  describe "addTvShow" do
+    test "adds a show by its TVDB id", %{bypass: bypass} do
+      tvdb_id = System.unique_integer([:positive])
+      stub_tvdb_series(bypass, tvdb_id, "Quiet Harbor")
+
+      assert {:ok, %{data: %{"addTvShow" => payload}}} =
+               run(@add_show, %{"input" => %{"tvdbId" => tvdb_id, "seasonMonitoring" => "NONE"}})
+
+      assert payload["userErrors"] == []
+
+      assert %{"title" => "Quiet Harbor", "tvdbId" => ^tvdb_id, "type" => "TV_SHOW"} =
+               payload["mediaItem"]
+    end
+
+    test "neither id is INVALID_INPUT on input" do
+      assert {:ok, %{data: %{"addTvShow" => payload}}} = run(@add_show, %{"input" => %{}})
+
+      assert payload["mediaItem"] == nil
+      assert [%{"code" => "INVALID_INPUT", "field" => ["input"]}] = payload["userErrors"]
+    end
+  end
+
+  @remove """
+  mutation Remove($input: RemoveMediaItemInput!) {
+    removeMediaItem(input: $input) {
+      removedId
+      userErrors { field code }
+    }
+  }
+  """
+
+  describe "removeMediaItem" do
+    test "removes the item and returns its id" do
+      item = insert(:media_item)
+
+      assert {:ok, %{data: %{"removeMediaItem" => payload}}} =
+               run(@remove, %{"input" => %{"id" => item.id}})
+
+      assert payload == %{"removedId" => item.id, "userErrors" => []}
+      assert Media.list_media_items(ids: [item.id]) == []
+    end
+
+    test "an id that names nothing is NOT_FOUND on input.id" do
+      assert {:ok, %{data: %{"removeMediaItem" => payload}}} =
+               run(@remove, %{"input" => %{"id" => Ecto.UUID.generate()}})
+
+      assert payload["removedId"] == nil
+      assert [%{"code" => "NOT_FOUND", "field" => ["input", "id"]}] = payload["userErrors"]
+    end
+  end
+end

--- a/test/mydia_web/library_schema/library_writes_test.exs
+++ b/test/mydia_web/library_schema/library_writes_test.exs
@@ -17,9 +17,15 @@ defmodule MydiaWeb.LibrarySchema.LibraryWritesTest do
     start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
 
     bypass = Bypass.open()
-    previous = Application.get_env(:mydia, :metadata_relay_url)
+    previous = Application.fetch_env(:mydia, :metadata_relay_url)
     Application.put_env(:mydia, :metadata_relay_url, "http://localhost:#{bypass.port}")
-    on_exit(fn -> Application.put_env(:mydia, :metadata_relay_url, previous) end)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:mydia, :metadata_relay_url, value)
+        :error -> Application.delete_env(:mydia, :metadata_relay_url)
+      end
+    end)
 
     %{bypass: bypass}
   end

--- a/test/mydia_web/library_schema/library_writes_test.exs
+++ b/test/mydia_web/library_schema/library_writes_test.exs
@@ -208,6 +208,7 @@ defmodule MydiaWeb.LibrarySchema.LibraryWritesTest do
   mutation Remove($input: RemoveMediaItemInput!) {
     removeMediaItem(input: $input) {
       removedId
+      filesNotDeleted
       userErrors { field code }
     }
   }
@@ -220,7 +221,12 @@ defmodule MydiaWeb.LibrarySchema.LibraryWritesTest do
       assert {:ok, %{data: %{"removeMediaItem" => payload}}} =
                run(@remove, %{"input" => %{"id" => item.id}})
 
-      assert payload == %{"removedId" => item.id, "userErrors" => []}
+      assert payload == %{
+               "removedId" => item.id,
+               "filesNotDeleted" => 0,
+               "userErrors" => []
+             }
+
       assert Media.list_media_items(ids: [item.id]) == []
     end
 
@@ -230,6 +236,38 @@ defmodule MydiaWeb.LibrarySchema.LibraryWritesTest do
 
       assert payload["removedId"] == nil
       assert [%{"code" => "NOT_FOUND", "field" => ["input", "id"]}] = payload["userErrors"]
+    end
+
+    test "deleteFiles: true reports a file that could not be removed from disk" do
+      tmp =
+        Path.join(
+          System.tmp_dir!(),
+          "mydia_library_writes_del_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(tmp)
+      on_exit(fn -> File.rm_rf(tmp) end)
+
+      library_path = insert(:library_path, path: tmp, type: :movies)
+      item = insert(:media_item, type: "movie")
+
+      # A directory at the file's relative path makes `File.rm` fail
+      # (`:eisdir`), the same trick test/mydia/media_test.exs uses to force a
+      # non-zero disk_error_count out of Media.delete_media_item/2.
+      File.mkdir_p!(Path.join(tmp, "as_dir.mkv"))
+
+      insert(:media_file,
+        media_item: item,
+        episode: nil,
+        library_path: library_path,
+        relative_path: "as_dir.mkv"
+      )
+
+      assert {:ok, %{data: %{"removeMediaItem" => payload}}} =
+               run(@remove, %{"input" => %{"id" => item.id, "deleteFiles" => true}})
+
+      assert payload["userErrors"] == []
+      assert payload["filesNotDeleted"] == 1
     end
   end
 end

--- a/test/mydia_web/library_schema/monitoring_test.exs
+++ b/test/mydia_web/library_schema/monitoring_test.exs
@@ -49,4 +49,116 @@ defmodule MydiaWeb.LibrarySchema.MonitoringTest do
       assert [%{"code" => "INVALID_INPUT", "field" => ["id"]}] = payload["userErrors"]
     end
   end
+
+  @set_season """
+  mutation Season($id: ID!, $season: Int!, $monitored: Boolean!) {
+    setSeasonMonitored(mediaItemId: $id, season: $season, monitored: $monitored) {
+      mediaItem { id episodes { seasonNumber episodeNumber monitored } }
+      userErrors { field code }
+    }
+  }
+  """
+
+  describe "setSeasonMonitored" do
+    test "changes every episode in the season and no other" do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, season_number: 1, episode_number: 1, monitored: true)
+      insert(:episode, media_item: show, season_number: 1, episode_number: 2, monitored: true)
+      insert(:episode, media_item: show, season_number: 2, episode_number: 1, monitored: true)
+
+      assert {:ok, %{data: %{"setSeasonMonitored" => payload}}} =
+               run(@set_season, %{"id" => show.id, "season" => 1, "monitored" => false})
+
+      assert payload["userErrors"] == []
+
+      monitored =
+        Map.new(payload["mediaItem"]["episodes"], fn e ->
+          {{e["seasonNumber"], e["episodeNumber"]}, e["monitored"]}
+        end)
+
+      assert monitored == %{{1, 1} => false, {1, 2} => false, {2, 1} => true}
+    end
+
+    test "a season with no episodes is NOT_FOUND on season" do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, season_number: 1, episode_number: 1)
+
+      assert {:ok, %{data: %{"setSeasonMonitored" => payload}}} =
+               run(@set_season, %{"id" => show.id, "season" => 9, "monitored" => false})
+
+      assert payload["mediaItem"] == nil
+      assert [%{"code" => "NOT_FOUND", "field" => ["season"]}] = payload["userErrors"]
+    end
+
+    test "a movie is INVALID_INPUT on mediaItemId" do
+      movie = insert(:media_item)
+
+      assert {:ok, %{data: %{"setSeasonMonitored" => payload}}} =
+               run(@set_season, %{"id" => movie.id, "season" => 1, "monitored" => false})
+
+      assert [%{"code" => "INVALID_INPUT", "field" => ["mediaItemId"]}] = payload["userErrors"]
+    end
+  end
+
+  @set_episode """
+  mutation Episode($id: ID!, $monitored: Boolean!) {
+    setEpisodeMonitored(id: $id, monitored: $monitored) {
+      episode { id monitored hasFile }
+      userErrors { field code }
+    }
+  }
+  """
+
+  describe "setEpisodeMonitored" do
+    test "changes one episode and returns it" do
+      episode = insert(:episode, monitored: true)
+
+      assert {:ok, %{data: %{"setEpisodeMonitored" => payload}}} =
+               run(@set_episode, %{"id" => episode.id, "monitored" => false})
+
+      assert payload["userErrors"] == []
+      assert payload["episode"] == %{"id" => episode.id, "monitored" => false, "hasFile" => false}
+      refute Media.get_episode!(episode.id).monitored
+    end
+
+    test "an id that names nothing is NOT_FOUND on id" do
+      assert {:ok, %{data: %{"setEpisodeMonitored" => payload}}} =
+               run(@set_episode, %{"id" => Ecto.UUID.generate(), "monitored" => false})
+
+      assert payload["episode"] == nil
+      assert [%{"code" => "NOT_FOUND", "field" => ["id"]}] = payload["userErrors"]
+    end
+  end
+
+  @apply_preset """
+  mutation Preset($id: ID!, $preset: EpisodeMonitoringPreset!) {
+    applyEpisodeMonitoring(mediaItemId: $id, preset: $preset) {
+      mediaItem { id episodes { monitored } }
+      userErrors { field code }
+    }
+  }
+  """
+
+  describe "applyEpisodeMonitoring" do
+    test "NONE unmonitors every episode" do
+      show = insert(:tv_show)
+      insert(:episode, media_item: show, season_number: 1, episode_number: 1, monitored: true)
+      insert(:episode, media_item: show, season_number: 1, episode_number: 2, monitored: true)
+
+      assert {:ok, %{data: %{"applyEpisodeMonitoring" => payload}}} =
+               run(@apply_preset, %{"id" => show.id, "preset" => "NONE"})
+
+      assert payload["userErrors"] == []
+      assert Enum.all?(payload["mediaItem"]["episodes"], &(&1["monitored"] == false))
+    end
+
+    test "a movie is INVALID_INPUT on mediaItemId" do
+      movie = insert(:media_item)
+
+      assert {:ok, %{data: %{"applyEpisodeMonitoring" => payload}}} =
+               run(@apply_preset, %{"id" => movie.id, "preset" => "ALL"})
+
+      assert [%{"code" => "INVALID_INPUT", "field" => ["mediaItemId"]}] = payload["userErrors"]
+    end
+  end
 end

--- a/test/mydia_web/library_schema/monitoring_test.exs
+++ b/test/mydia_web/library_schema/monitoring_test.exs
@@ -1,0 +1,52 @@
+defmodule MydiaWeb.LibrarySchema.MonitoringTest do
+  use MydiaWeb.ConnCase
+
+  alias Mydia.LibraryApi.Principal
+  alias Mydia.Media
+
+  @admin %Principal{role: "admin", source: :env}
+
+  defp run(document, variables) do
+    Absinthe.run(document, MydiaWeb.LibrarySchema,
+      variables: variables,
+      context: %{principal: @admin}
+    )
+  end
+
+  @set_item """
+  mutation Set($id: ID!, $monitored: Boolean!) {
+    setMediaItemMonitored(id: $id, monitored: $monitored) {
+      mediaItem { id monitored }
+      userErrors { field code message }
+    }
+  }
+  """
+
+  describe "setMediaItemMonitored" do
+    test "turns monitoring off and returns the reloaded item" do
+      item = insert(:media_item, monitored: true)
+
+      assert {:ok, %{data: %{"setMediaItemMonitored" => payload}}} =
+               run(@set_item, %{"id" => item.id, "monitored" => false})
+
+      assert payload["userErrors"] == []
+      assert payload["mediaItem"] == %{"id" => item.id, "monitored" => false}
+      refute Media.get_media_item!(item.id).monitored
+    end
+
+    test "an id that names nothing is NOT_FOUND on id" do
+      assert {:ok, %{data: %{"setMediaItemMonitored" => payload}}} =
+               run(@set_item, %{"id" => Ecto.UUID.generate(), "monitored" => true})
+
+      assert payload["mediaItem"] == nil
+      assert [%{"code" => "NOT_FOUND", "field" => ["id"]}] = payload["userErrors"]
+    end
+
+    test "a malformed id is INVALID_INPUT on id" do
+      assert {:ok, %{data: %{"setMediaItemMonitored" => payload}}} =
+               run(@set_item, %{"id" => "not-a-uuid", "monitored" => true})
+
+      assert [%{"code" => "INVALID_INPUT", "field" => ["id"]}] = payload["userErrors"]
+    end
+  end
+end

--- a/test/mydia_web/library_schema/mutation_authorization_test.exs
+++ b/test/mydia_web/library_schema/mutation_authorization_test.exs
@@ -1,0 +1,47 @@
+defmodule MydiaWeb.LibrarySchema.MutationAuthorizationTest do
+  @moduledoc """
+  Mutations pass through the same fail-closed gate as queries: every root
+  mutation field declares an action Policy knows, and a principal without it is
+  refused before the resolver runs.
+  """
+  use MydiaWeb.ConnCase
+
+  alias Mydia.LibraryApi.Policy
+  alias Mydia.LibraryApi.Principal
+
+  @user %Principal{role: "user", source: :api_key}
+
+  test "every root mutation field declares an action Policy knows" do
+    fields = Absinthe.Schema.lookup_type(MydiaWeb.LibrarySchema, :library_mutations).fields
+
+    undeclared =
+      for {name, field} <- fields,
+          name not in [:__schema, :__type, :__typename],
+          Absinthe.Type.meta(field, :action) not in Policy.actions(),
+          do: name
+
+    assert undeclared == []
+  end
+
+  test "an admin holds every mutation action" do
+    admin = %Principal{role: "admin", source: :env}
+
+    for action <- [:manage_library, :search, :manage_downloads, :read_events] do
+      assert Policy.permit?(admin, action)
+    end
+  end
+
+  test "a non-admin is refused before the resolver runs" do
+    item = insert(:media_item, monitored: true)
+
+    document = """
+    mutation { setMediaItemMonitored(id: "#{item.id}", monitored: false) { mediaItem { id } } }
+    """
+
+    assert {:ok, %{errors: errors}} =
+             Absinthe.run(document, MydiaWeb.LibrarySchema, context: %{principal: @user})
+
+    assert Enum.any?(errors, &(&1.extensions[:code] == "FORBIDDEN"))
+    assert Mydia.Media.get_media_item!(item.id).monitored
+  end
+end

--- a/test/mydia_web/library_schema/paging_test.exs
+++ b/test/mydia_web/library_schema/paging_test.exs
@@ -1,0 +1,66 @@
+defmodule MydiaWeb.LibrarySchema.PagingTest do
+  use MydiaWeb.ConnCase
+
+  alias Mydia.LibraryApi.Principal
+  alias MydiaWeb.LibrarySchema.Paging
+
+  describe "page_size/3" do
+    test "nil takes the default and 1..cap passes" do
+      assert Paging.page_size(nil, 50, 200) == {:ok, 50}
+      assert Paging.page_size(1, 50, 200) == {:ok, 1}
+      assert Paging.page_size(200, 50, 200) == {:ok, 200}
+    end
+
+    test "outside 1..cap is INVALID_INPUT, not clamped" do
+      assert {:error, %{extensions: %{code: "INVALID_INPUT"}, message: message}} =
+               Paging.page_size(0, 50, 200)
+
+      assert message == "first must be between 1 and 200, got 0"
+      assert {:error, %{extensions: %{code: "INVALID_INPUT"}}} = Paging.page_size(201, 50, 200)
+    end
+  end
+
+  describe "decode_cursor/1" do
+    test "nil passes through and garbage is INVALID_INPUT" do
+      assert Paging.decode_cursor(nil) == {:ok, nil}
+
+      assert {:error, %{message: "Invalid cursor", extensions: %{code: "INVALID_INPUT"}}} =
+               Paging.decode_cursor("not a cursor")
+    end
+  end
+
+  describe "cost/4" do
+    test "prices first clamped to 1..cap" do
+      assert Paging.cost(%{}, 50, 200, 3) == 150
+      assert Paging.cost(%{first: 10}, 50, 200, 3) == 30
+      assert Paging.cost(%{first: 10_000}, 50, 200, 3) == 600
+      assert Paging.cost(%{first: -5}, 50, 200, 3) == 3
+    end
+  end
+
+  test "mediaItems repeats the cursor it was given on an empty page" do
+    insert(:media_item)
+    admin = %Principal{role: "admin", source: :env}
+
+    page = fn variables ->
+      {:ok, %{data: %{"mediaItems" => connection}}} =
+        Absinthe.run(
+          """
+          query P($after: String) {
+            mediaItems(first: 200, after: $after) { edges { node { id } } pageInfo { endCursor } }
+          }
+          """,
+          MydiaWeb.LibrarySchema,
+          variables: variables,
+          context: %{principal: admin}
+        )
+
+      connection
+    end
+
+    cursor = page.(%{})["pageInfo"]["endCursor"]
+    assert is_binary(cursor)
+
+    assert page.(%{"after" => cursor}) == %{"edges" => [], "pageInfo" => %{"endCursor" => cursor}}
+  end
+end

--- a/test/mydia_web/library_schema/search_test.exs
+++ b/test/mydia_web/library_schema/search_test.exs
@@ -110,6 +110,28 @@ defmodule MydiaWeb.LibrarySchema.SearchTest do
       assert [%{"code" => "INVALID_INPUT", "field" => ["mediaItemId"]}] = payload["userErrors"]
       refute_enqueued(worker: Mydia.Jobs.TVShowSearch)
     end
+
+    test "a negative season is INVALID_INPUT on season and queues nothing" do
+      show = insert(:tv_show)
+
+      assert {:ok, %{data: %{"searchSeason" => payload}}} =
+               run(@search_season, %{"id" => show.id, "season" => -1})
+
+      assert [%{"code" => "INVALID_INPUT", "field" => ["season"]}] = payload["userErrors"]
+      refute_enqueued(worker: Mydia.Jobs.TVShowSearch)
+    end
+
+    test "season 0 (specials) queues TVShowSearch" do
+      show = insert(:tv_show)
+
+      assert {:ok, %{data: %{"searchSeason" => %{"queued" => true, "userErrors" => []}}}} =
+               run(@search_season, %{"id" => show.id, "season" => 0})
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{"mode" => "season", "media_item_id" => show.id, "season_number" => 0}
+      )
+    end
   end
 
   describe "searchEpisode" do

--- a/test/mydia_web/library_schema/search_test.exs
+++ b/test/mydia_web/library_schema/search_test.exs
@@ -1,0 +1,124 @@
+defmodule MydiaWeb.LibrarySchema.SearchTest do
+  use MydiaWeb.ConnCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  alias Mydia.LibraryApi.Principal
+
+  @admin %Principal{role: "admin", source: :env}
+
+  setup do
+    engine = if Mydia.DB.postgres?(), do: Oban.Engines.Basic, else: Oban.Engines.Lite
+    start_supervised!({Oban, repo: Mydia.Repo, engine: engine, testing: :manual})
+    :ok
+  end
+
+  defp run(document, variables) do
+    Absinthe.run(document, MydiaWeb.LibrarySchema,
+      variables: variables,
+      context: %{principal: @admin}
+    )
+  end
+
+  @search_item """
+  mutation S($id: ID!) { searchMediaItem(id: $id) { queued userErrors { field code } } }
+  """
+
+  @search_season """
+  mutation S($id: ID!, $season: Int!) {
+    searchSeason(mediaItemId: $id, season: $season) { queued userErrors { field code } }
+  }
+  """
+
+  @search_episode """
+  mutation S($id: ID!) { searchEpisode(id: $id) { queued userErrors { field code } } }
+  """
+
+  describe "searchMediaItem" do
+    test "a movie queues MovieSearch in specific mode" do
+      movie = insert(:media_item)
+
+      assert {:ok, %{data: %{"searchMediaItem" => %{"queued" => true, "userErrors" => []}}}} =
+               run(@search_item, %{"id" => movie.id})
+
+      assert_enqueued(
+        worker: Mydia.Jobs.MovieSearch,
+        args: %{"mode" => "specific", "media_item_id" => movie.id}
+      )
+    end
+
+    test "a show queues TVShowSearch in show mode" do
+      show = insert(:tv_show)
+
+      assert {:ok, %{data: %{"searchMediaItem" => %{"queued" => true}}}} =
+               run(@search_item, %{"id" => show.id})
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{"mode" => "show", "media_item_id" => show.id}
+      )
+    end
+
+    test "an id that names nothing is NOT_FOUND and queues nothing" do
+      assert {:ok, %{data: %{"searchMediaItem" => payload}}} =
+               run(@search_item, %{"id" => Ecto.UUID.generate()})
+
+      assert payload["queued"] == false
+      assert [%{"code" => "NOT_FOUND", "field" => ["id"]}] = payload["userErrors"]
+      refute_enqueued(worker: Mydia.Jobs.MovieSearch)
+    end
+  end
+
+  describe "searchSeason" do
+    test "queues TVShowSearch in season mode" do
+      show = insert(:tv_show)
+
+      assert {:ok, %{data: %{"searchSeason" => %{"queued" => true, "userErrors" => []}}}} =
+               run(@search_season, %{"id" => show.id, "season" => 2})
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{"mode" => "season", "media_item_id" => show.id, "season_number" => 2}
+      )
+    end
+
+    test "a repeat inside the worker's uniqueness window still reports queued" do
+      show = insert(:tv_show)
+
+      for _ <- 1..2 do
+        assert {:ok, %{data: %{"searchSeason" => %{"queued" => true}}}} =
+                 run(@search_season, %{"id" => show.id, "season" => 1})
+      end
+    end
+
+    test "a movie is INVALID_INPUT on mediaItemId" do
+      movie = insert(:media_item)
+
+      assert {:ok, %{data: %{"searchSeason" => payload}}} =
+               run(@search_season, %{"id" => movie.id, "season" => 1})
+
+      assert [%{"code" => "INVALID_INPUT", "field" => ["mediaItemId"]}] = payload["userErrors"]
+      refute_enqueued(worker: Mydia.Jobs.TVShowSearch)
+    end
+  end
+
+  describe "searchEpisode" do
+    test "queues TVShowSearch in specific mode" do
+      episode = insert(:episode)
+
+      assert {:ok, %{data: %{"searchEpisode" => %{"queued" => true}}}} =
+               run(@search_episode, %{"id" => episode.id})
+
+      assert_enqueued(
+        worker: Mydia.Jobs.TVShowSearch,
+        args: %{"mode" => "specific", "episode_id" => episode.id}
+      )
+    end
+
+    test "an id that names nothing is NOT_FOUND" do
+      assert {:ok, %{data: %{"searchEpisode" => payload}}} =
+               run(@search_episode, %{"id" => Ecto.UUID.generate()})
+
+      assert [%{"code" => "NOT_FOUND", "field" => ["id"]}] = payload["userErrors"]
+    end
+  end
+end

--- a/test/mydia_web/library_schema/search_test.exs
+++ b/test/mydia_web/library_schema/search_test.exs
@@ -66,6 +66,17 @@ defmodule MydiaWeb.LibrarySchema.SearchTest do
       assert [%{"code" => "NOT_FOUND", "field" => ["id"]}] = payload["userErrors"]
       refute_enqueued(worker: Mydia.Jobs.MovieSearch)
     end
+
+    test "a repeat inside the worker's uniqueness window still reports queued" do
+      movie = insert(:media_item)
+
+      for _ <- 1..2 do
+        assert {:ok, %{data: %{"searchMediaItem" => %{"queued" => true}}}} =
+                 run(@search_item, %{"id" => movie.id})
+      end
+
+      assert length(all_enqueued(worker: Mydia.Jobs.MovieSearch)) == 1
+    end
   end
 
   describe "searchSeason" do

--- a/test/mydia_web/library_schema/user_error_test.exs
+++ b/test/mydia_web/library_schema/user_error_test.exs
@@ -1,0 +1,43 @@
+defmodule MydiaWeb.LibrarySchema.UserErrorTest do
+  use ExUnit.Case, async: true
+
+  import Ecto.Changeset
+
+  alias MydiaWeb.LibrarySchema.UserError
+
+  test "changeset errors become INVALID_INPUT with a camelCased path and Ecto's placeholders filled" do
+    changeset =
+      {%{}, %{quality_profile_id: :string, name: :string}}
+      |> cast(%{name: "ab"}, [:quality_profile_id, :name])
+      |> validate_required([:quality_profile_id])
+      |> validate_length(:name, min: 3)
+
+    errors = UserError.from_changeset(changeset, ["input"])
+
+    assert %UserError{
+             code: :invalid_input,
+             field: ["input", "qualityProfileId"],
+             message: "quality_profile_id can't be blank"
+           } in errors
+
+    assert %UserError{
+             code: :invalid_input,
+             field: ["input", "name"],
+             message: "name should be at least 3 character(s)"
+           } in errors
+  end
+
+  test "cast_id accepts a UUID and refuses anything else" do
+    id = Ecto.UUID.generate()
+
+    assert UserError.cast_id(id, ["id"]) == {:ok, id}
+
+    assert UserError.cast_id("nope", ["id"]) ==
+             {:error, %UserError{code: :invalid_input, field: ["id"], message: "Not a valid id"}}
+  end
+
+  test "not_found names the thing and the argument" do
+    assert UserError.not_found("episode", ["id"]) ==
+             %UserError{code: :not_found, field: ["id"], message: "No episode has that id"}
+  end
+end

--- a/test/mydia_web/library_schema_sdl_test.exs
+++ b/test/mydia_web/library_schema_sdl_test.exs
@@ -38,11 +38,14 @@ defmodule MydiaWeb.LibrarySchemaSdlTest do
     object_names = ~w(
       MediaItem Episode AvailabilityStatus LookupResult Download DownloadClient Indexer
       QualityProfile LibraryPath PageInfo MediaItemEdge MediaItemConnection
+      UserError MediaItemPayload EpisodePayload AddMediaPayload RemoveMediaItemPayload
+      SearchPayload RemoveDownloadPayload Event EventEdge EventConnection
     )
 
     enum_names = ~w(
       MediaType MetadataProvider AvailabilityState DownloadFilter DownloadStatus
-      ClientConfigState LibraryPathType
+      ClientConfigState LibraryPathType UserErrorCode SeasonMonitoring
+      EpisodeMonitoringPreset Severity
     )
 
     for name <- object_names do
@@ -91,6 +94,44 @@ defmodule MydiaWeb.LibrarySchemaSdlTest do
 
     assert fields == approved,
            "the RootQueryType fields differ from the approved set. Missing: " <>
+             "#{inspect(approved |> MapSet.difference(fields) |> Enum.sort())}, unexpected: " <>
+             "#{inspect(fields |> MapSet.difference(approved) |> Enum.sort())}"
+  end
+
+  test "inputs and scalars are named as the contract says" do
+    sdl = Absinthe.Schema.to_sdl(MydiaWeb.LibrarySchema)
+
+    for name <- ~w(AddMovieInput AddTvShowInput RemoveMediaItemInput) do
+      assert sdl =~ ~r/^input #{name}\b/m, "the SDL has no `input #{name}`"
+    end
+
+    assert sdl =~ ~r/^scalar JSON\b/m
+  end
+
+  test "the root mutation fields are exactly the approved ones" do
+    sdl = Absinthe.Schema.to_sdl(MydiaWeb.LibrarySchema)
+
+    assert [_, block] = Regex.run(~r/type RootMutationType \{(.*?)\n\}/s, sdl),
+           "could not find the RootMutationType block in the SDL"
+
+    # Fields sit at exactly two spaces; arguments of a multi-line field sit
+    # deeper and descriptions start with a quote.
+    fields =
+      ~r/^  ([A-Za-z_][A-Za-z0-9_]*)[:(]/m
+      |> Regex.scan(block, capture: :all_but_first)
+      |> List.flatten()
+      |> MapSet.new()
+
+    approved =
+      MapSet.new(~w(
+        setMediaItemMonitored setSeasonMonitored setEpisodeMonitored applyEpisodeMonitoring
+        addMovie addTvShow removeMediaItem
+        searchMediaItem searchSeason searchEpisode
+        cancelDownload rejectRelease
+      ))
+
+    assert fields == approved,
+           "the RootMutationType fields differ from the approved set. Missing: " <>
              "#{inspect(approved |> MapSet.difference(fields) |> Enum.sort())}, unexpected: " <>
              "#{inspect(fields |> MapSet.difference(approved) |> Enum.sort())}"
   end

--- a/test/mydia_web/library_schema_sdl_test.exs
+++ b/test/mydia_web/library_schema_sdl_test.exs
@@ -86,7 +86,8 @@ defmodule MydiaWeb.LibrarySchemaSdlTest do
       |> List.flatten()
       |> MapSet.new()
 
-    approved = MapSet.new(~w(lookup mediaItem mediaItems downloads qualityProfiles libraryPaths))
+    approved =
+      MapSet.new(~w(lookup mediaItem mediaItems downloads events qualityProfiles libraryPaths))
 
     assert fields == approved,
            "the RootQueryType fields differ from the approved set. Missing: " <>

--- a/test/mydia_web/live/admin_api_keys_live_test.exs
+++ b/test/mydia_web/live/admin_api_keys_live_test.exs
@@ -1,0 +1,141 @@
+defmodule MydiaWeb.AdminApiKeysLiveTest do
+  use MydiaWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Mydia.AccountsFixtures
+
+  alias Mydia.Accounts
+  alias Mydia.Accounts.ApiKey
+  alias Mydia.Repo
+
+  setup %{conn: conn} do
+    admin = admin_user_fixture()
+    %{conn: log_in_user(conn, admin), admin: admin}
+  end
+
+  defp created_key(view) do
+    view
+    |> element("#created-api-key")
+    |> render()
+    |> LazyHTML.from_fragment()
+    |> LazyHTML.attribute("value")
+    |> List.first()
+  end
+
+  test "a non-admin is sent away" do
+    conn = log_in_user(build_conn(), user_fixture())
+    assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/admin/config/api-keys")
+  end
+
+  test "the page has its own active tab", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+    assert has_element?(view, ~s|a[href="/admin/config/api-keys"].tab-active|)
+    assert has_element?(view, "#api-keys-empty")
+  end
+
+  test "creates a Library API key and shows it exactly once", %{conn: conn, admin: admin} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+
+    view |> element("#new-api-key") |> render_click()
+
+    view
+    |> form("#api-key-form", api_key: %{name: "Automation", expiry: "30", scope: "library"})
+    |> render_submit()
+
+    plain = created_key(view)
+    assert "mydia_ak_" <> _ = plain
+    assert has_element?(view, "#created-api-key-modal", "Treat it like your password")
+
+    assert {:ok, user, key} = Accounts.verify_api_key(plain)
+    assert user.id == admin.id
+    assert key.permissions == ["admin"]
+    assert DateTime.diff(key.expires_at, DateTime.utc_now(), :day) in 29..30
+
+    view |> element("#close-created-api-key") |> render_click()
+
+    refute has_element?(view, "#created-api-key-modal")
+    refute render(view) =~ plain
+    assert has_element?(view, "#api-key-#{key.id}", "Automation")
+    assert has_element?(view, "#api-key-#{key.id}", "Library API")
+  end
+
+  test "a blank name is refused and nothing is created", %{conn: conn, admin: admin} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+    view |> element("#new-api-key") |> render_click()
+
+    view
+    |> form("#api-key-form", api_key: %{name: "", expiry: "never", scope: "library"})
+    |> render_submit()
+
+    assert has_element?(view, "#api-key-form", "can't be blank")
+    assert Accounts.list_api_keys(admin.id) == []
+  end
+
+  test "revokes a key after confirmation", %{conn: conn, admin: admin} do
+    {:ok, key, _plain} = Accounts.create_api_key(admin.id, %{name: "Old", permissions: ["admin"]})
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+
+    view |> element("#revoke-api-key-#{key.id}") |> render_click()
+    assert has_element?(view, "#api-key-confirm-modal", "Old")
+
+    view |> element("#confirm-api-key-action") |> render_click()
+
+    assert Repo.get!(ApiKey, key.id).revoked_at
+    assert has_element?(view, "#api-key-#{key.id}", "Revoked")
+    refute has_element?(view, "#revoke-api-key-#{key.id}")
+  end
+
+  test "deletes a key after confirmation", %{conn: conn, admin: admin} do
+    {:ok, key, _plain} =
+      Accounts.create_api_key(admin.id, %{name: "Gone", permissions: ["admin"]})
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+
+    view |> element("#delete-api-key-#{key.id}") |> render_click()
+    view |> element("#confirm-api-key-action") |> render_click()
+
+    refute Repo.get(ApiKey, key.id)
+    refute has_element?(view, "#api-key-#{key.id}")
+  end
+
+  test "cancelling the confirmation leaves the key alone", %{conn: conn, admin: admin} do
+    {:ok, key, _plain} =
+      Accounts.create_api_key(admin.id, %{name: "Kept", permissions: ["admin"]})
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+
+    view |> element("#delete-api-key-#{key.id}") |> render_click()
+    view |> element("#cancel-api-key-confirm") |> render_click()
+
+    refute has_element?(view, "#api-key-confirm-modal")
+    assert Repo.get(ApiKey, key.id)
+  end
+
+  test "lists only the signed-in admin's keys", %{conn: conn} do
+    other = admin_user_fixture()
+
+    {:ok, theirs, _plain} =
+      Accounts.create_api_key(other.id, %{name: "Theirs", permissions: ["admin"]})
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+
+    refute has_element?(view, "#api-key-#{theirs.id}")
+  end
+
+  test "shows the LIBRARY_API_KEY row only while the variable is set", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+    refute has_element?(view, "#env-library-api-key")
+
+    previous = Application.get_env(:mydia, :library_api_key)
+    on_exit(fn -> Application.put_env(:mydia, :library_api_key, previous) end)
+    Application.put_env(:mydia, :library_api_key, String.duplicate("k", 32))
+
+    {:ok, view, _html} = live(conn, ~p"/admin/config/api-keys")
+
+    assert has_element?(
+             view,
+             "#env-library-api-key",
+             "Set by LIBRARY_API_KEY. Remove the variable and restart to revoke."
+           )
+  end
+end


### PR DESCRIPTION
Refs #773. The second of the two PRs the issue stages, on top of #781: every mutation, the events feed, and the admin API keys page. Stacked, so it reads best after #781.

## What it adds

**Mutations.** Twelve fields, each calling the context function the UI calls, so a change made through the API is the same change the UI makes:

- `addMovie`, `addTvShow`, `removeMediaItem`
- `setMediaItemMonitored`, `setSeasonMonitored`, `setEpisodeMonitored`, `applyEpisodeMonitoring`
- `searchMediaItem`, `searchSeason`, `searchEpisode`
- `cancelDownload`, `rejectRelease`

Mutations pass the same gate queries do: every root field declares `meta action:`, and the schema's `middleware/3` now covers `:mutation`, so a field nobody marked fails the build rather than shipping unauthenticated. An expected failure comes back in `userErrors` with a code and the camelCase path of the argument that caused it, and the payload's main field null. Top-level errors stay reserved for authorization and for bugs.

**Events.** `events(first, after, types)` pages a keyset feed over the existing `events` table, oldest first, through a new `Mydia.LibraryApi.EventFeed`. No migration: the existing `inserted_at` index serves the range.

**Keys page.** `/admin/config/api-keys` lists the signed-in admin's keys, creates a Library API key (stored as the `admin` permission), shows its plain value once with a copy button and the warning that it also acts on the player API, and revokes or deletes behind a confirmation. When `LIBRARY_API_KEY` is set, a read-only row says so and how to revoke it. This closes the gap #781 documented: until now the only way to mint a key was the player API's `createApiKey` mutation, which is unreachable when `ENABLE_PLAYER=false`.

## Decisions worth a look

- **`cancelDownload` and `rejectRelease` return `removedId`, not a `Download`.** Both context functions delete the row, so there is nothing left to describe and an invented status would mislead. `cancelDownload` reports `CLIENT_UNAVAILABLE` and keeps the row when the client refuses; `rejectRelease` removes from the client best-effort, exactly as the Downloads page does, so a client failure cannot surface there.
- **`removeMediaItem` reports `filesNotDeleted`.** `delete_media_item/2` returns how many files it could not remove from disk and the media page shows that to a person, so the API does too rather than reporting plain success.
- **A deduped search still reports `queued: true`.** The search workers are unique for 60 seconds; `queue_auto_searches/1` deliberately does not count a merged insert, so the count cannot stand in for "queued".
- **The events settle window is 35 seconds.** An event's `inserted_at` is stamped before the row is flushed, and the writer can block for the database's 30 second busy timeout during a library scan. At the 10 seconds the design called for, a poller could advance past an event that had not committed yet and skip it permanently.
- **An empty page repeats the cursor you sent**, for `events` and `mediaItems` alike, so a poller that always passes `endCursor` back never restarts from the beginning.
- **Client failures are logged, not returned.** Adapter errors can carry raw responses, so the resolvers log them and return fixed text, which is what the sibling resolvers already do.

## Two lines outside the Library API

Per the issue's Principle 1, everything else is new files. The exceptions are additive:

- `lib/mydia_web/router.ex`: one `live` route for the keys page.
- `lib/mydia_web/components/admin_components.ex`: one `tab_link`.

`git diff --numstat --diff-filter=M` against #781 shows no other pre-existing file losing a line, and `player/`, `server/` and `priv/graphql/schema.graphql` are untouched.

## Verification

- `mix precommit`: compile, unused deps, format, credo `--strict` and the full suite.
- Library API, keys page, auth plug and player contract suites: 370 tests, 0 failures.
- `cargo test -p mydia-api --test sdl_parity`: ok.
- `mkdocs build --strict`: clean.
- The SDL contract is regenerated in the commit that changes it, and the drift test now also pins every new type, input and scalar name plus the exact root mutation set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin page for creating, viewing, revoking, and deleting Library API keys.
  * Expanded the Library API with paginated event history and event-type filtering.
  * Added mutations for monitoring media, adding or removing titles, searching, and managing downloads.
  * Added structured user errors with actionable codes and field details.
  * Added support for movie and TV show monitoring preferences.

* **Documentation**
  * Updated Library API documentation with events, mutations, authentication, costs, pagination, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->