### PR TITLE
feat(player): TV-native pairing screen with curated keypad and D-pad traversal

### DIFF
--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -313,7 +313,8 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
               setState(() => _showAdvancedSettings = false);
               return KeyEventResult.handled;
             }
-            if (_claimCodeController.text.isNotEmpty) {
+            if (!_showDirectConnection &&
+                _claimCodeController.text.isNotEmpty) {
               _handleTvDeletePressed();
               return KeyEventResult.handled;
             }
@@ -324,12 +325,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
       child: PopScope(
         canPop: !_showAdvancedSettings &&
             (!InputCapabilities.directionalPrimary ||
+                _showDirectConnection ||
                 _claimCodeController.text.isEmpty),
         onPopInvokedWithResult: (didPop, _) {
           if (didPop) return;
           if (_showAdvancedSettings) {
             setState(() => _showAdvancedSettings = false);
-          } else if (_claimCodeController.text.isNotEmpty) {
+          } else if (!_showDirectConnection &&
+              _claimCodeController.text.isNotEmpty) {
             _handleTvDeletePressed();
           }
         },

--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -7,12 +7,13 @@ import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../core/auth/auth_service.dart';
-import '../../core/p2p/p2p_service.dart' show defaultRelayUrl;
 import '../../core/player/input_capabilities.dart';
 import '../../core/theme/colors.dart';
 import '../widgets/focus_highlight.dart';
 import '../widgets/glass_surface.dart';
+import '../widgets/pin_code_display.dart';
 import '../widgets/storage_unavailable_dialog.dart';
+import '../widgets/tv_keypad.dart';
 import 'login/login_controller.dart';
 
 class LoginScreen extends ConsumerStatefulWidget {
@@ -61,9 +62,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
   @override
   void initState() {
     super.initState();
+    _claimCodeController.addListener(_onClaimCodeChanged);
     _loadSavedServerUrl();
     _loadSavedRelayUrl();
     _setupAnimations();
+  }
+
+  void _onClaimCodeChanged() {
+    if (mounted) setState(() {});
   }
 
   void _setupAnimations() {
@@ -156,6 +162,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
 
   @override
   void dispose() {
+    _claimCodeController.removeListener(_onClaimCodeChanged);
     _animationController.dispose();
     _serverUrlController.dispose();
     _usernameController.dispose();
@@ -262,67 +269,125 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     await _completePairing();
   }
 
+  void _handleTvCharacterPressed(String char) {
+    if (_claimCodeController.text.length < 6) {
+      final updated = _claimCodeController.text + char;
+      setState(() {
+        _claimCodeController.text = updated;
+      });
+      if (updated.length == 6) {
+        _handleClaimCodeSubmit();
+      }
+    }
+  }
+
+  void _handleTvDeletePressed() {
+    final text = _claimCodeController.text;
+    if (text.isNotEmpty) {
+      setState(() {
+        _claimCodeController.text = text.substring(0, text.length - 1);
+      });
+    }
+  }
+
+  void _handleTvClearPressed() {
+    setState(() {
+      _claimCodeController.clear();
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final loginState = ref.watch(loginControllerProvider);
     final size = MediaQuery.of(context).size;
     final isCompact = size.height < 700;
 
-    return Scaffold(
-      body: Container(
-        width: size.width,
-        height: size.height,
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              AppColors.background,
-              Color(0xFF0E1828),
-              AppColors.background,
-            ],
-            stops: [0.0, 0.5, 1.0],
-          ),
-        ),
-        child: Stack(
-          children: [
-            _buildBackgroundDecoration(),
-            SafeArea(
-              child: Center(
-                child: SingleChildScrollView(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: 20,
-                    vertical: isCompact ? 16 : 24,
-                  ),
-                  child: FadeTransition(
-                    opacity: _fadeAnimation,
-                    child: SlideTransition(
-                      position: _slideAnimation,
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          _buildLogo(isCompact),
-                          SizedBox(height: isCompact ? 24 : 32),
-                          _buildContent(loginState, isCompact),
-                          const SizedBox(height: 16),
-                          _buildFooter(loginState),
-                        ],
+    return Focus(
+      canRequestFocus: false,
+      skipTraversal: true,
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && InputCapabilities.directionalPrimary) {
+          if (event.logicalKey == LogicalKeyboardKey.escape ||
+              event.logicalKey == LogicalKeyboardKey.goBack) {
+            if (_claimCodeController.text.isNotEmpty) {
+              _handleTvDeletePressed();
+              return KeyEventResult.handled;
+            }
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+      child: PopScope(
+        canPop: !InputCapabilities.directionalPrimary ||
+            _claimCodeController.text.isEmpty,
+        onPopInvokedWithResult: (didPop, _) {
+          if (didPop) return;
+          if (_claimCodeController.text.isNotEmpty) {
+            _handleTvDeletePressed();
+          }
+        },
+        child: Scaffold(
+          body: Container(
+            width: size.width,
+            height: size.height,
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  AppColors.background,
+                  Color(0xFF0E1828),
+                  AppColors.background,
+                ],
+                stops: [0.0, 0.5, 1.0],
+              ),
+            ),
+            child: Stack(
+              children: [
+                _buildBackgroundDecoration(),
+                SafeArea(
+                  child: Center(
+                    child: SingleChildScrollView(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 20,
+                        vertical: isCompact ? 16 : 24,
+                      ),
+                      child: FadeTransition(
+                        opacity: _fadeAnimation,
+                        child: SlideTransition(
+                          position: _slideAnimation,
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (!InputCapabilities.directionalPrimary) ...[
+                                _buildLogo(isCompact),
+                                SizedBox(height: isCompact ? 24 : 32),
+                              ],
+                              _buildContent(loginState, isCompact),
+                              const SizedBox(height: 16),
+                              _buildFooter(loginState),
+                            ],
+                          ),
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
+                if (_showQrScanner) _buildQrScannerOverlay(),
+                if (_showAdvancedSettings) _buildAdvancedSettingsOverlay(),
+              ],
             ),
-            if (_showQrScanner) _buildQrScannerOverlay(),
-            if (_showAdvancedSettings) _buildAdvancedSettingsOverlay(),
-          ],
+          ),
         ),
       ),
     );
   }
 
   Widget _buildContent(LoginState loginState, bool isCompact) {
+    if (InputCapabilities.directionalPrimary) {
+      return _buildTvPairingLayout(loginState, isCompact);
+    }
     // Always show the claim code card which now contains
     // the direct connection form as an expandable section
     return _buildClaimCodeCard(loginState, isCompact);
@@ -497,6 +562,340 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
           ),
         ),
       ],
+    );
+  }
+
+  // ===== TV TWO-COLUMN LAYOUT =====
+  Widget _buildTvPairingLayout(LoginState loginState, bool isCompact) {
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 1020),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            flex: 5,
+            child: _buildTvLeftCard(loginState, isCompact),
+          ),
+          const SizedBox(width: 20),
+          Expanded(
+            flex: 6,
+            child: _buildTvRightCard(loginState),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTvLeftCard(LoginState loginState, bool isCompact) {
+    return GlassSurface.modal(
+      child: Padding(
+        padding: EdgeInsets.all(isCompact ? 16 : 22),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildTvHeader(),
+            SizedBox(height: isCompact ? 12 : 16),
+            _buildSegmentedControl(loginState),
+            SizedBox(height: isCompact ? 14 : 18),
+            if (!_showDirectConnection) ...[
+              _buildTvInstructions(),
+              SizedBox(height: isCompact ? 14 : 18),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                child: PinCodeDisplay(
+                  code: _claimCodeController.text,
+                  hasError: loginState.error != null &&
+                      loginState.mode != ConnectionMode.direct,
+                  isLoading: loginState.isLoading,
+                ),
+              ),
+              if (loginState.claimCodeMessage != null &&
+                  loginState.claimCodeStatus != ClaimCodeStatus.error) ...[
+                const SizedBox(height: 12),
+                _buildTvLoadingIndicator(loginState),
+              ],
+              if (loginState.error != null &&
+                  loginState.mode != ConnectionMode.direct) ...[
+                const SizedBox(height: 12),
+                _buildErrorMessage(loginState.error!),
+              ],
+              SizedBox(height: isCompact ? 16 : 20),
+              Row(
+                children: [
+                  Expanded(
+                    flex: 3,
+                    child: _buildTvConnectButton(loginState),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    flex: 2,
+                    child: _buildTvClearButton(loginState),
+                  ),
+                ],
+              ),
+            ] else ...[
+              _buildDirectConnectionContent(loginState, isCompact),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTvRightCard(LoginState loginState) {
+    return GlassSurface.modal(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: TvKeypad(
+          enabled: !loginState.isLoading && !_showDirectConnection,
+          onCharacterPressed: _handleTvCharacterPressed,
+          onDeletePressed: _handleTvDeletePressed,
+          onClearPressed: _handleTvClearPressed,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTvHeader() {
+    return Row(
+      children: [
+        Container(
+          width: 44,
+          height: 44,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            gradient: const LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [AppColors.primary, AppColors.primaryFocus],
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.primary.withValues(alpha: 0.25),
+                blurRadius: 12,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: const Icon(
+            Icons.play_circle_filled_rounded,
+            size: 24,
+            color: Colors.white,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Mydia Player',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: AppColors.textPrimary,
+                  letterSpacing: -0.5,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                _showDirectConnection
+                    ? 'Sign in directly with your server credentials'
+                    : 'Pair with your server using claim code',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: AppColors.textSecondary.withValues(alpha: 0.7),
+                ),
+              ),
+            ],
+          ),
+        ),
+        IconButton(
+          onPressed: () => setState(() => _showAdvancedSettings = true),
+          icon: const Icon(Icons.settings_outlined, size: 20),
+          color: AppColors.textSecondary,
+          tooltip: 'Relay & Network Settings',
+          style: IconButton.styleFrom(
+            backgroundColor: AppColors.surfaceVariant.withValues(alpha: 0.3),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTvInstructions() {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.surfaceVariant.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+          color: AppColors.border.withValues(alpha: 0.1),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildInstructionStep(1, 'Open Mydia on phone or PC'),
+          const SizedBox(height: 6),
+          _buildInstructionStep(
+              2, 'Go to Settings \u2192 Devices \u2192 Pair device'),
+          const SizedBox(height: 6),
+          _buildInstructionStep(3, 'Enter the 6-character code below'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInstructionStep(int number, String text) {
+    return Row(
+      children: [
+        Container(
+          width: 18,
+          height: 18,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: AppColors.primary.withValues(alpha: 0.2),
+            shape: BoxShape.circle,
+          ),
+          child: Text(
+            '$number',
+            style: const TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.bold,
+              color: AppColors.primary,
+            ),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: TextStyle(
+              fontSize: 12,
+              color: AppColors.textSecondary.withValues(alpha: 0.85),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTvLoadingIndicator(LoginState loginState) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.2)),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (loginState.isLoading) ...[
+            const SizedBox(
+              width: 14,
+              height: 14,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: AppColors.primary,
+              ),
+            ),
+            const SizedBox(width: 8),
+          ],
+          Flexible(
+            child: Text(
+              loginState.claimCodeMessage ?? '',
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTvConnectButton(LoginState loginState) {
+    final canConnect =
+        _claimCodeController.text.length == 6 && !loginState.isLoading;
+    return FocusHighlight(
+      onActivate: canConnect ? _handleClaimCodeSubmit : null,
+      borderRadius: BorderRadius.circular(10),
+      child: ElevatedButton(
+        onPressed: canConnect ? _handleClaimCodeSubmit : null,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          foregroundColor: Colors.white,
+          disabledBackgroundColor: AppColors.primary.withValues(alpha: 0.4),
+          disabledForegroundColor: Colors.white.withValues(alpha: 0.4),
+          elevation: 0,
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+        ),
+        child: loginState.isLoading
+            ? const SizedBox(
+                height: 18,
+                width: 18,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: Colors.white,
+                ),
+              )
+            : const Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    'Connect',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600),
+                  ),
+                  SizedBox(width: 6),
+                  Icon(Icons.link_rounded, size: 18),
+                ],
+              ),
+      ),
+    );
+  }
+
+  Widget _buildTvClearButton(LoginState loginState) {
+    final canClear =
+        _claimCodeController.text.isNotEmpty && !loginState.isLoading;
+    return FocusHighlight(
+      onActivate: canClear ? _handleTvClearPressed : null,
+      borderRadius: BorderRadius.circular(10),
+      child: OutlinedButton(
+        onPressed: canClear ? _handleTvClearPressed : null,
+        style: OutlinedButton.styleFrom(
+          foregroundColor: AppColors.textSecondary,
+          disabledForegroundColor: AppColors.textDisabled,
+          side: BorderSide(
+            color: AppColors.border.withValues(alpha: 0.3),
+          ),
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
+        ),
+        child: const Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.refresh_rounded, size: 16),
+            SizedBox(width: 6),
+            Text(
+              'Clear',
+              style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -46,6 +46,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
   final _passwordFocus = FocusNode();
   final _claimCodeFocus = FocusNode();
   final _relayUrlFocus = FocusNode();
+  final _tvSettingsFocusNode = FocusNode(debugLabel: 'tv-settings-button');
+  final _closeSettingsFocusNode =
+      FocusNode(debugLabel: 'settings-close-button');
+  final _settingsOverlayScopeNode =
+      FocusScopeNode(debugLabel: 'settings-overlay-scope');
 
   bool _isLoadingSavedUrl = true;
   bool _obscurePassword = true;
@@ -174,6 +179,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     _passwordFocus.dispose();
     _claimCodeFocus.dispose();
     _relayUrlFocus.dispose();
+    _tvSettingsFocusNode.dispose();
+    _closeSettingsFocusNode.dispose();
+    _settingsOverlayScopeNode.dispose();
     _scannerController?.dispose();
     super.dispose();
   }
@@ -296,6 +304,25 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
     });
   }
 
+  void _openAdvancedSettings() {
+    setState(() => _showAdvancedSettings = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_showAdvancedSettings) return;
+      _closeSettingsFocusNode.requestFocus();
+    });
+  }
+
+  void _closeAdvancedSettings() {
+    setState(() => _showAdvancedSettings = false);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _showAdvancedSettings) return;
+      if (InputCapabilities.directionalPrimary &&
+          _tvSettingsFocusNode.canRequestFocus) {
+        _tvSettingsFocusNode.requestFocus();
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final loginState = ref.watch(loginControllerProvider);
@@ -310,10 +337,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
           if (event.logicalKey == LogicalKeyboardKey.escape ||
               event.logicalKey == LogicalKeyboardKey.goBack) {
             if (_showAdvancedSettings) {
-              setState(() => _showAdvancedSettings = false);
+              _closeAdvancedSettings();
               return KeyEventResult.handled;
             }
-            if (!_showDirectConnection &&
+            if (!loginState.isLoading &&
+                !_showDirectConnection &&
                 _claimCodeController.text.isNotEmpty) {
               _handleTvDeletePressed();
               return KeyEventResult.handled;
@@ -325,13 +353,15 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
       child: PopScope(
         canPop: !_showAdvancedSettings &&
             (!InputCapabilities.directionalPrimary ||
+                loginState.isLoading ||
                 _showDirectConnection ||
                 _claimCodeController.text.isEmpty),
         onPopInvokedWithResult: (didPop, _) {
           if (didPop) return;
           if (_showAdvancedSettings) {
-            setState(() => _showAdvancedSettings = false);
-          } else if (!_showDirectConnection &&
+            _closeAdvancedSettings();
+          } else if (!loginState.isLoading &&
+              !_showDirectConnection &&
               _claimCodeController.text.isNotEmpty) {
             _handleTvDeletePressed();
           }
@@ -346,38 +376,40 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                 end: Alignment.bottomRight,
                 colors: [
                   AppColors.background,
-                  Color(0xFF0E1828),
-                  AppColors.background,
+                  Color(0xFF0F172A),
+                  Color(0xFF0A0F1D),
                 ],
-                stops: [0.0, 0.5, 1.0],
               ),
             ),
             child: Stack(
               children: [
                 _buildBackgroundDecoration(),
-                SafeArea(
-                  child: Center(
-                    child: SingleChildScrollView(
-                      padding: EdgeInsets.symmetric(
-                        horizontal: 20,
-                        vertical: isCompact ? 16 : 24,
-                      ),
-                      child: FadeTransition(
-                        opacity: _fadeAnimation,
-                        child: SlideTransition(
-                          position: _slideAnimation,
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              if (!InputCapabilities.directionalPrimary) ...[
-                                _buildLogo(isCompact),
-                                SizedBox(height: isCompact ? 24 : 32),
+                ExcludeFocus(
+                  excluding: _showAdvancedSettings || _showQrScanner,
+                  child: SafeArea(
+                    child: Center(
+                      child: SingleChildScrollView(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: 20,
+                          vertical: isCompact ? 16 : 24,
+                        ),
+                        child: FadeTransition(
+                          opacity: _fadeAnimation,
+                          child: SlideTransition(
+                            position: _slideAnimation,
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                if (!InputCapabilities.directionalPrimary) ...[
+                                  _buildLogo(isCompact),
+                                  SizedBox(height: isCompact ? 24 : 32),
+                                ],
+                                _buildContent(loginState, isCompact),
+                                const SizedBox(height: 16),
+                                _buildFooter(loginState),
                               ],
-                              _buildContent(loginState, isCompact),
-                              const SizedBox(height: 16),
-                              _buildFooter(loginState),
-                            ],
+                            ),
                           ),
                         ),
                       ),
@@ -722,10 +754,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
           ),
         ),
         FocusHighlight(
-          onActivate: () => setState(() => _showAdvancedSettings = true),
+          focusNode: _tvSettingsFocusNode,
+          onActivate: _openAdvancedSettings,
           borderRadius: BorderRadius.circular(8),
           child: IconButton(
-            onPressed: () => setState(() => _showAdvancedSettings = true),
+            onPressed: _openAdvancedSettings,
             icon: const Icon(Icons.settings_outlined, size: 20),
             color: AppColors.textSecondary,
             tooltip: 'Relay & Network Settings',
@@ -970,7 +1003,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
         ),
         const SizedBox(width: 8),
         IconButton(
-          onPressed: () => setState(() => _showAdvancedSettings = true),
+          onPressed: _openAdvancedSettings,
           icon: const Icon(Icons.settings_outlined, size: 20),
           color: AppColors.textSecondary,
           tooltip: 'Relay & Network Settings',
@@ -1569,243 +1602,250 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
 
   Widget _buildAdvancedSettingsOverlay() {
     return Positioned.fill(
-      child: GestureDetector(
-        onTap: () => setState(() => _showAdvancedSettings = false),
-        child: Container(
-          color: Colors.black.withValues(alpha: 0.7),
-          child: Center(
-            child: GestureDetector(
-              onTap: () {}, // Prevent tap from closing
-              child: Container(
-                margin: const EdgeInsets.all(24),
-                constraints: const BoxConstraints(maxWidth: 400),
-                decoration: BoxDecoration(
-                  color: AppColors.surface,
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                    color: AppColors.border.withValues(alpha: 0.2),
+      child: FocusScope(
+        node: _settingsOverlayScopeNode,
+        child: GestureDetector(
+          onTap: _closeAdvancedSettings,
+          child: Container(
+            color: Colors.black.withValues(alpha: 0.7),
+            child: Center(
+              child: GestureDetector(
+                onTap: () {}, // Prevent tap from closing
+                child: Container(
+                  margin: const EdgeInsets.all(24),
+                  constraints: const BoxConstraints(maxWidth: 400),
+                  decoration: BoxDecoration(
+                    color: AppColors.surface,
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(
+                      color: AppColors.border.withValues(alpha: 0.2),
+                    ),
                   ),
-                ),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    // Header
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Row(
-                        children: [
-                          const Icon(
-                            Icons.settings_outlined,
-                            color: AppColors.textSecondary,
-                            size: 20,
-                          ),
-                          const SizedBox(width: 12),
-                          const Expanded(
-                            child: Text(
-                              'Advanced Settings',
-                              style: TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w600,
-                                color: AppColors.textPrimary,
-                              ),
-                            ),
-                          ),
-                          IconButton(
-                            onPressed: () =>
-                                setState(() => _showAdvancedSettings = false),
-                            icon: const Icon(
-                              Icons.close,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Header
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          children: [
+                            const Icon(
+                              Icons.settings_outlined,
                               color: AppColors.textSecondary,
                               size: 20,
                             ),
-                            padding: EdgeInsets.zero,
-                            constraints: const BoxConstraints(),
-                          ),
-                        ],
-                      ),
-                    ),
-                    Container(
-                      height: 1,
-                      color: AppColors.border.withValues(alpha: 0.15),
-                    ),
-                    // Content
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            'Relay URL',
-                            style: TextStyle(
-                              fontSize: 13,
-                              fontWeight: FontWeight.w500,
-                              color: AppColors.textSecondary,
+                            const SizedBox(width: 12),
+                            const Expanded(
+                              child: Text(
+                                'Advanced Settings',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w600,
+                                  color: AppColors.textPrimary,
+                                ),
+                              ),
                             ),
-                          ),
-                          const SizedBox(height: 8),
-                          Container(
-                            padding: const EdgeInsets.all(10),
-                            decoration: BoxDecoration(
-                              color: AppColors.surfaceVariant
-                                  .withValues(alpha: 0.25),
+                            FocusHighlight(
+                              focusNode: _closeSettingsFocusNode,
+                              onActivate: _closeAdvancedSettings,
                               borderRadius: BorderRadius.circular(8),
-                              border: Border.all(
-                                color: AppColors.border.withValues(alpha: 0.1),
-                              ),
-                            ),
-                            child: Row(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Icon(
-                                  Icons.info_outline_rounded,
-                                  size: 14,
-                                  color: AppColors.textSecondary
-                                      .withValues(alpha: 0.7),
+                              child: IconButton(
+                                onPressed: _closeAdvancedSettings,
+                                icon: const Icon(
+                                  Icons.close,
+                                  color: AppColors.textSecondary,
+                                  size: 20,
                                 ),
-                                const SizedBox(width: 8),
-                                Expanded(
-                                  child: Text(
-                                    'Change this if using a custom or self-hosted P2P relay server. Both your Mydia server and Mydia Player must be connected to the exact same relay for Quick Pair to work.',
-                                    style: TextStyle(
-                                      fontSize: 11,
-                                      height: 1.35,
-                                      color: AppColors.textSecondary
-                                          .withValues(alpha: 0.75),
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: 12),
-                          TextFormField(
-                            controller: _relayUrlController,
-                            focusNode: _relayUrlFocus,
-                            style: const TextStyle(
-                              fontSize: 13,
-                              color: AppColors.textPrimary,
-                            ),
-                            decoration: InputDecoration(
-                              hintText: defaultRelayUrl,
-                              hintStyle: TextStyle(
-                                color: AppColors.textDisabled
-                                    .withValues(alpha: 0.5),
-                                fontSize: 13,
+                                padding: EdgeInsets.zero,
+                                constraints: const BoxConstraints(),
                               ),
-                              filled: true,
-                              fillColor: AppColors.surfaceVariant
-                                  .withValues(alpha: 0.4),
-                              isDense: true,
-                              contentPadding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                                vertical: 10,
-                              ),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: BorderSide.none,
-                              ),
-                              enabledBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: BorderSide(
-                                  color:
-                                      AppColors.border.withValues(alpha: 0.15),
-                                ),
-                              ),
-                              focusedBorder: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: const BorderSide(
-                                  color: AppColors.primary,
-                                  width: 1.5,
-                                ),
-                              ),
-                              suffixIcon:
-                                  _relayUrlController.text != defaultRelayUrl
-                                      ? IconButton(
-                                          onPressed: _resetRelayUrlToDefault,
-                                          icon: const Icon(
-                                            Icons.refresh,
-                                            size: 18,
-                                            color: AppColors.textSecondary,
-                                          ),
-                                          tooltip: 'Reset to default',
-                                        )
-                                      : null,
-                            ),
-                            onChanged: (_) => setState(() {}),
-                          ),
-                          if (_isRelayUrlModified) ...[
-                            const SizedBox(height: 8),
-                            Row(
-                              children: [
-                                Icon(
-                                  Icons.info_outline,
-                                  size: 12,
-                                  color:
-                                      AppColors.primary.withValues(alpha: 0.7),
-                                ),
-                                const SizedBox(width: 6),
-                                Expanded(
-                                  child: Text(
-                                    'Using custom relay URL',
-                                    style: TextStyle(
-                                      fontSize: 11,
-                                      color: AppColors.primary
-                                          .withValues(alpha: 0.7),
-                                    ),
-                                  ),
-                                ),
-                              ],
                             ),
                           ],
-                        ],
+                        ),
                       ),
-                    ),
-                    Container(
-                      height: 1,
-                      color: AppColors.border.withValues(alpha: 0.15),
-                    ),
-                    // Actions
-                    Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          TextButton(
-                            onPressed: () =>
-                                setState(() => _showAdvancedSettings = false),
-                            child: const Text('Cancel'),
-                          ),
-                          const SizedBox(width: 12),
-                          ElevatedButton(
-                            onPressed: () {
-                              _saveRelayUrl();
-                              setState(() => _showAdvancedSettings = false);
-                            },
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: AppColors.primary,
-                              foregroundColor: Colors.white,
-                              elevation: 0,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 20,
-                                vertical: 10,
-                              ),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                            ),
-                            child: const Text(
-                              'Save',
+                      Container(
+                        height: 1,
+                        color: AppColors.border.withValues(alpha: 0.15),
+                      ),
+                      // Content
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'Relay URL',
                               style: TextStyle(
                                 fontSize: 13,
-                                fontWeight: FontWeight.w600,
+                                fontWeight: FontWeight.w500,
+                                color: AppColors.textSecondary,
                               ),
                             ),
-                          ),
-                        ],
+                            const SizedBox(height: 8),
+                            Container(
+                              padding: const EdgeInsets.all(10),
+                              decoration: BoxDecoration(
+                                color: AppColors.surfaceVariant
+                                    .withValues(alpha: 0.25),
+                                borderRadius: BorderRadius.circular(8),
+                                border: Border.all(
+                                  color:
+                                      AppColors.border.withValues(alpha: 0.1),
+                                ),
+                              ),
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Icon(
+                                    Icons.info_outline_rounded,
+                                    size: 14,
+                                    color: AppColors.textSecondary
+                                        .withValues(alpha: 0.7),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Expanded(
+                                    child: Text(
+                                      'Change this if using a custom or self-hosted P2P relay server. Both your Mydia server and Mydia Player must be connected to the exact same relay for Quick Pair to work.',
+                                      style: TextStyle(
+                                        fontSize: 11,
+                                        height: 1.35,
+                                        color: AppColors.textSecondary
+                                            .withValues(alpha: 0.75),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            TextFormField(
+                              controller: _relayUrlController,
+                              focusNode: _relayUrlFocus,
+                              style: const TextStyle(
+                                fontSize: 13,
+                                color: AppColors.textPrimary,
+                              ),
+                              decoration: InputDecoration(
+                                hintText: defaultRelayUrl,
+                                hintStyle: TextStyle(
+                                  color: AppColors.textDisabled
+                                      .withValues(alpha: 0.5),
+                                  fontSize: 13,
+                                ),
+                                filled: true,
+                                fillColor: AppColors.surfaceVariant
+                                    .withValues(alpha: 0.4),
+                                isDense: true,
+                                contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 12,
+                                  vertical: 10,
+                                ),
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                  borderSide: BorderSide.none,
+                                ),
+                                enabledBorder: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                  borderSide: BorderSide(
+                                    color: AppColors.border
+                                        .withValues(alpha: 0.15),
+                                  ),
+                                ),
+                                focusedBorder: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                  borderSide: const BorderSide(
+                                    color: AppColors.primary,
+                                    width: 1.5,
+                                  ),
+                                ),
+                                suffixIcon:
+                                    _relayUrlController.text != defaultRelayUrl
+                                        ? IconButton(
+                                            onPressed: _resetRelayUrlToDefault,
+                                            icon: const Icon(
+                                              Icons.refresh,
+                                              size: 18,
+                                              color: AppColors.textSecondary,
+                                            ),
+                                            tooltip: 'Reset to default',
+                                          )
+                                        : null,
+                              ),
+                              onChanged: (_) => setState(() {}),
+                            ),
+                            if (_isRelayUrlModified) ...[
+                              const SizedBox(height: 8),
+                              Row(
+                                children: [
+                                  Icon(
+                                    Icons.info_outline,
+                                    size: 12,
+                                    color: AppColors.primary
+                                        .withValues(alpha: 0.7),
+                                  ),
+                                  const SizedBox(width: 6),
+                                  Expanded(
+                                    child: Text(
+                                      'Using custom relay URL',
+                                      style: TextStyle(
+                                        fontSize: 11,
+                                        color: AppColors.primary
+                                            .withValues(alpha: 0.7),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
+                      Container(
+                        height: 1,
+                        color: AppColors.border.withValues(alpha: 0.15),
+                      ),
+                      // Actions
+                      Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            TextButton(
+                              onPressed: _closeAdvancedSettings,
+                              child: const Text('Cancel'),
+                            ),
+                            const SizedBox(width: 12),
+                            ElevatedButton(
+                              onPressed: () {
+                                _saveRelayUrl();
+                                _closeAdvancedSettings();
+                              },
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.primary,
+                                foregroundColor: Colors.white,
+                                elevation: 0,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 20,
+                                  vertical: 10,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                              ),
+                              child: const Text(
+                                'Save',
+                                style: TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -309,6 +309,10 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
         if (event is KeyDownEvent && InputCapabilities.directionalPrimary) {
           if (event.logicalKey == LogicalKeyboardKey.escape ||
               event.logicalKey == LogicalKeyboardKey.goBack) {
+            if (_showAdvancedSettings) {
+              setState(() => _showAdvancedSettings = false);
+              return KeyEventResult.handled;
+            }
             if (_claimCodeController.text.isNotEmpty) {
               _handleTvDeletePressed();
               return KeyEventResult.handled;
@@ -318,11 +322,14 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
         return KeyEventResult.ignored;
       },
       child: PopScope(
-        canPop: !InputCapabilities.directionalPrimary ||
-            _claimCodeController.text.isEmpty,
+        canPop: !_showAdvancedSettings &&
+            (!InputCapabilities.directionalPrimary ||
+                _claimCodeController.text.isEmpty),
         onPopInvokedWithResult: (didPop, _) {
           if (didPop) return;
-          if (_claimCodeController.text.isNotEmpty) {
+          if (_showAdvancedSettings) {
+            setState(() => _showAdvancedSettings = false);
+          } else if (_claimCodeController.text.isNotEmpty) {
             _handleTvDeletePressed();
           }
         },
@@ -711,15 +718,19 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
             ],
           ),
         ),
-        IconButton(
-          onPressed: () => setState(() => _showAdvancedSettings = true),
-          icon: const Icon(Icons.settings_outlined, size: 20),
-          color: AppColors.textSecondary,
-          tooltip: 'Relay & Network Settings',
-          style: IconButton.styleFrom(
-            backgroundColor: AppColors.surfaceVariant.withValues(alpha: 0.3),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
+        FocusHighlight(
+          onActivate: () => setState(() => _showAdvancedSettings = true),
+          borderRadius: BorderRadius.circular(8),
+          child: IconButton(
+            onPressed: () => setState(() => _showAdvancedSettings = true),
+            icon: const Icon(Icons.settings_outlined, size: 20),
+            color: AppColors.textSecondary,
+            tooltip: 'Relay & Network Settings',
+            style: IconButton.styleFrom(
+              backgroundColor: AppColors.surfaceVariant.withValues(alpha: 0.3),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
             ),
           ),
         ),

--- a/player/lib/presentation/screens/login_screen.dart
+++ b/player/lib/presentation/screens/login_screen.dart
@@ -1652,6 +1652,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen>
                               borderRadius: BorderRadius.circular(8),
                               child: IconButton(
                                 onPressed: _closeAdvancedSettings,
+                                tooltip: 'Close advanced settings',
                                 icon: const Icon(
                                   Icons.close,
                                   color: AppColors.textSecondary,

--- a/player/lib/presentation/widgets/pin_code_display.dart
+++ b/player/lib/presentation/widgets/pin_code_display.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import '../../core/theme/colors.dart';
+
+class PinCodeDisplay extends StatelessWidget {
+  final String code;
+  final int length;
+  final bool hasError;
+  final bool isLoading;
+
+  const PinCodeDisplay({
+    super.key,
+    required this.code,
+    this.length = 6,
+    this.hasError = false,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      key: hasError ? const ValueKey('pin-code-error-state') : null,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(length, (index) {
+        final isFilled = index < code.length;
+        final isActive = index == code.length && !hasError && !isLoading;
+        final char = isFilled ? code[index] : '';
+
+        Color borderColor;
+        if (hasError) {
+          borderColor = AppColors.error;
+        } else if (isLoading) {
+          borderColor = AppColors.primary.withValues(alpha: 0.8);
+        } else if (isActive) {
+          borderColor = AppColors.primary;
+        } else if (isFilled) {
+          borderColor = AppColors.border.withValues(alpha: 0.6);
+        } else {
+          borderColor = AppColors.border.withValues(alpha: 0.25);
+        }
+
+        return Container(
+          key: ValueKey('pin-slot-$index${isActive ? '-active' : ''}'),
+          margin: const EdgeInsets.symmetric(horizontal: 5),
+          width: 46,
+          height: 56,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: hasError
+                ? AppColors.error.withValues(alpha: 0.08)
+                : AppColors.surfaceVariant.withValues(alpha: 0.35),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: borderColor,
+              width: isActive || hasError ? 2.0 : 1.2,
+            ),
+            boxShadow: isActive
+                ? [
+                    BoxShadow(
+                      color: AppColors.primary.withValues(alpha: 0.25),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ]
+                : null,
+          ),
+          child: Text(
+            char,
+            style: TextStyle(
+              fontSize: 26,
+              fontWeight: FontWeight.bold,
+              color: hasError ? AppColors.error : AppColors.textPrimary,
+              fontFamily: 'monospace',
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/player/lib/presentation/widgets/tv_keypad.dart
+++ b/player/lib/presentation/widgets/tv_keypad.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import '../../core/theme/colors.dart';
+import 'focus_highlight.dart';
+
+class TvKeypad extends StatelessWidget {
+  final ValueChanged<String> onCharacterPressed;
+  final VoidCallback onDeletePressed;
+  final VoidCallback onClearPressed;
+  final bool enabled;
+
+  /// The 31 ambiguous-free characters matching Mydia backend claim code alphabet:
+  /// Letters (23): A-Z omitting I, L, O
+  /// Digits (8): 2-9 omitting 0, 1
+  static const List<String> validCharacters = [
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'J',
+    'K',
+    'M',
+    'N',
+    'P',
+    'Q',
+    'R',
+    'S',
+    'T',
+    'U',
+    'V',
+    'W',
+    'X',
+    'Y',
+    'Z',
+    '2',
+    '3',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+  ];
+
+  const TvKeypad({
+    super.key,
+    required this.onCharacterPressed,
+    required this.onDeletePressed,
+    required this.onClearPressed,
+    this.enabled = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints(maxWidth: 520),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Rows 1-4: 7 characters each
+          for (int row = 0; row < 4; row++)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  for (int col = 0; col < 7; col++)
+                    _buildKey(
+                      char: validCharacters[row * 7 + col],
+                      autofocus: row == 0 && col == 0,
+                    ),
+                ],
+              ),
+            ),
+          // Row 5: 3 characters ('7', '8', '9') + Delete (span 2) + Clear (span 2)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              _buildKey(char: '7'),
+              _buildKey(char: '8'),
+              _buildKey(char: '9'),
+              _buildActionButton(
+                keyName: 'delete',
+                label: '⌫ Delete',
+                icon: Icons.backspace_outlined,
+                flex: 2,
+                onPressed: enabled ? onDeletePressed : null,
+              ),
+              _buildActionButton(
+                keyName: 'clear',
+                label: 'Clear',
+                icon: Icons.refresh_rounded,
+                flex: 2,
+                onPressed: enabled ? onClearPressed : null,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildKey({required String char, bool autofocus = false}) {
+    return Expanded(
+      flex: 1,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: FocusHighlight(
+          autofocus: autofocus,
+          onActivate: enabled ? () => onCharacterPressed(char) : null,
+          borderRadius: BorderRadius.circular(8),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: enabled ? () => onCharacterPressed(char) : null,
+            child: Container(
+              key: ValueKey('tv-key-$char'),
+              height: 48,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.35),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: AppColors.border.withValues(alpha: 0.15),
+                ),
+              ),
+              child: Text(
+                char,
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color:
+                      enabled ? AppColors.textPrimary : AppColors.textDisabled,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActionButton({
+    required String keyName,
+    required String label,
+    required IconData icon,
+    required int flex,
+    required VoidCallback? onPressed,
+  }) {
+    return Expanded(
+      flex: flex,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: FocusHighlight(
+          onActivate: onPressed,
+          borderRadius: BorderRadius.circular(8),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onPressed,
+            child: Container(
+              key: ValueKey('tv-key-$keyName'),
+              height: 48,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: AppColors.surfaceVariant.withValues(alpha: 0.35),
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(
+                  color: AppColors.border.withValues(alpha: 0.15),
+                ),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    icon,
+                    size: 16,
+                    color: enabled
+                        ? AppColors.textSecondary
+                        : AppColors.textDisabled,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: enabled
+                          ? AppColors.textPrimary
+                          : AppColors.textDisabled,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/player/test/presentation/screens/login_tv_test.dart
+++ b/player/test/presentation/screens/login_tv_test.dart
@@ -50,6 +50,8 @@ class _FakeLoginController extends LoginController {
       );
     }
   }
+
+  void setLoading(bool loading) => state = state.copyWith(isLoading: loading);
 }
 
 Widget _buildTestWidget({LoginController? controller}) => ProviderScope(
@@ -250,6 +252,102 @@ void main() {
       await tester.pump();
 
       expect(_findPinCodeText('A'), findsNothing);
+    });
+
+    testWidgets(
+        'remote Back key does not delete claim code while pairing is loading',
+        (tester) async {
+      final fakeController = _FakeLoginController();
+      await _pumpLoginScreen(tester, controller: fakeController);
+
+      for (final char in ['A', 'B', 'C', 'D', 'E', 'F']) {
+        await tester.tap(find.byKey(ValueKey('tv-key-$char')));
+        await tester.pump();
+      }
+
+      expect(fakeController.submittedClaimCode, equals('ABCDEF'));
+
+      // Simulate in-flight loading
+      fakeController.setLoading(true);
+      await tester.pump();
+
+      // Attempt remote Back key while loading
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+
+      // Characters are preserved because deletion is blocked during loading
+      for (final char in ['A', 'B', 'C', 'D', 'E', 'F']) {
+        expect(_findPinCodeText(char), findsOneWidget);
+      }
+
+      // System pop route is also blocked from deleting while loading
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      for (final char in ['A', 'B', 'C', 'D', 'E', 'F']) {
+        expect(_findPinCodeText(char), findsOneWidget);
+      }
+    });
+
+    testWidgets(
+        'advanced settings overlay traps focus in owned FocusScope and restores focus to settings button on close',
+        (tester) async {
+      FocusManager.instance.highlightStrategy =
+          FocusHighlightStrategy.alwaysTraditional;
+      addTearDown(() {
+        FocusManager.instance.highlightStrategy =
+            FocusHighlightStrategy.automatic;
+      });
+
+      await _pumpLoginScreen(tester);
+
+      final settingsButton = find.byTooltip('Relay & Network Settings');
+      expect(settingsButton, findsOneWidget);
+
+      // Open advanced settings
+      await tester.tap(settingsButton);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Advanced Settings'), findsOneWidget);
+
+      // Verify underlying TV controls are excluded from focus traversal
+      final keypadFinder = find.byType(TvKeypad);
+      expect(keypadFinder, findsOneWidget);
+      final excludedAncestor = find.ancestor(
+        of: keypadFinder,
+        matching: find.byType(ExcludeFocus),
+      );
+      expect(excludedAncestor, findsOneWidget);
+      final excludeFocusWidget =
+          tester.widget<ExcludeFocus>(excludedAncestor.first);
+      expect(excludeFocusWidget.excluding, isTrue);
+
+      // Verify overlay close button is focused
+      final closeButton = find.byIcon(Icons.close);
+      expect(closeButton, findsOneWidget);
+      final closeFocusHighlight = find.ancestor(
+        of: closeButton,
+        matching: find.byType(FocusHighlight),
+      );
+      expect(closeFocusHighlight, findsOneWidget);
+
+      // Dismiss overlay via remote Back key
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Advanced Settings'), findsNothing);
+
+      // Verify settings button on header has focus restored with ring
+      final headerSettingsHighlight = find.ancestor(
+        of: settingsButton,
+        matching: find.byType(FocusHighlight),
+      );
+      final ringFinder = find.descendant(
+        of: headerSettingsHighlight,
+        matching: find.byKey(FocusHighlight.ringKey),
+      );
+      final decorated = tester.widget<DecoratedBox>(ringFinder);
+      expect((decorated.decoration as BoxDecoration).border, isNotNull);
     });
 
     group('segment tab focus', () {

--- a/player/test/presentation/screens/login_tv_test.dart
+++ b/player/test/presentation/screens/login_tv_test.dart
@@ -20,21 +20,56 @@
 // that list with the define.
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:player/core/auth/auth_service.dart';
 import 'package:player/core/player/input_capabilities.dart';
+import 'package:player/presentation/screens/login/login_controller.dart';
 import 'package:player/presentation/screens/login_screen.dart';
 import 'package:player/presentation/widgets/focus_highlight.dart';
+import 'package:player/presentation/widgets/pin_code_display.dart';
+import 'package:player/presentation/widgets/tv_keypad.dart';
 
 import '../../test_utils/mock_auth_storage.dart';
 
-Widget _buildTestWidget() => ProviderScope(
+class _FakeLoginController extends LoginController {
+  String? submittedClaimCode;
+
+  @override
+  LoginState build() => LoginState.initial();
+
+  @override
+  Future<void> pairWithClaimCode(String claimCode) async {
+    submittedClaimCode = claimCode;
+  }
+}
+
+Widget _buildTestWidget({LoginController? controller}) => ProviderScope(
       overrides: [
         authServiceProvider
             .overrideWithValue(AuthService(storage: MockAuthStorage())),
+        if (controller != null)
+          loginControllerProvider.overrideWith(() => controller),
       ],
       child: const MaterialApp(home: LoginScreen()),
+    );
+
+Future<void> _pumpLoginScreen(
+  WidgetTester tester, {
+  LoginController? controller,
+}) async {
+  tester.view.physicalSize = const Size(1920, 1080);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  await tester.pumpWidget(_buildTestWidget(controller: controller));
+  await tester.pumpAndSettle();
+}
+
+Finder _findPinCodeText(String char) => find.descendant(
+      of: find.byType(PinCodeDisplay),
+      matching: find.text(char),
     );
 
 void main() {
@@ -49,21 +84,86 @@ void main() {
   group('LoginScreen on the directional tier (requires MYDIA_FORCE_TV=true)',
       () {
     testWidgets('withholds the camera QR scanner', (tester) async {
-      await tester.pumpWidget(_buildTestWidget());
-      await tester.pumpAndSettle();
+      await _pumpLoginScreen(tester);
 
       expect(find.textContaining('Scan QR Code'), findsNothing);
     });
 
-    testWidgets('autofocuses the claim code field on arrival', (tester) async {
-      await tester.pumpWidget(_buildTestWidget());
-      await tester.pumpAndSettle();
+    testWidgets(
+        'renders TV two-column layout without mobile text field, showing keypad and pin code display',
+        (tester) async {
+      await _pumpLoginScreen(tester);
 
-      // Quick Pair is the default tab and the Advanced Settings overlay
-      // (which owns its own TextFormField) is not built until opened, so
-      // this is the claim code field and nothing else.
-      final field = tester.widget<TextField>(find.byType(TextField));
-      expect(field.autofocus, isTrue);
+      expect(find.byType(TextField), findsNothing);
+      expect(find.byType(TvKeypad), findsOneWidget);
+      expect(find.byType(PinCodeDisplay), findsOneWidget);
+    });
+
+    testWidgets('autofocuses first keypad key [A] on arrival', (tester) async {
+      await _pumpLoginScreen(tester);
+
+      final firstKeyFinder = find.ancestor(
+        of: find.byKey(const ValueKey('tv-key-A')),
+        matching: find.byType(FocusHighlight),
+      );
+      expect(firstKeyFinder, findsOneWidget);
+      final focusHighlight = tester.widget<FocusHighlight>(firstKeyFinder);
+      expect(focusHighlight.autofocus, isTrue);
+    });
+
+    testWidgets('typing characters on keypad updates PinCodeDisplay',
+        (tester) async {
+      await _pumpLoginScreen(tester);
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-A')));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('tv-key-B')));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('tv-key-3')));
+      await tester.pump();
+
+      expect(_findPinCodeText('A'), findsOneWidget);
+      expect(_findPinCodeText('B'), findsOneWidget);
+      expect(_findPinCodeText('3'), findsOneWidget);
+    });
+
+    testWidgets('entering 6 characters triggers pairWithClaimCode',
+        (tester) async {
+      final fakeController = _FakeLoginController();
+      await _pumpLoginScreen(tester, controller: fakeController);
+
+      for (final char in ['A', 'B', 'C', 'D', 'E', 'F']) {
+        await tester.tap(find.byKey(ValueKey('tv-key-$char')));
+        await tester.pump();
+      }
+
+      expect(fakeController.submittedClaimCode, equals('ABCDEF'));
+    });
+
+    testWidgets(
+        'remote Back key deletes last character when input is non-empty',
+        (tester) async {
+      await _pumpLoginScreen(tester);
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-A')));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('tv-key-B')));
+      await tester.pump();
+
+      expect(_findPinCodeText('A'), findsOneWidget);
+      expect(_findPinCodeText('B'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+
+      expect(_findPinCodeText('A'), findsOneWidget);
+      expect(_findPinCodeText('B'), findsNothing);
+
+      // Also test system pop route (e.g. Android TV OS back)
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(_findPinCodeText('A'), findsNothing);
     });
 
     group('segment tab focus', () {
@@ -79,8 +179,7 @@ void main() {
 
       testWidgets('Direct Server tab is a D-pad focus stop with a ring',
           (tester) async {
-        await tester.pumpWidget(_buildTestWidget());
-        await tester.pumpAndSettle();
+        await _pumpLoginScreen(tester);
 
         final ringFinder = find.descendant(
           of: find.ancestor(
@@ -96,12 +195,10 @@ void main() {
           return (decorated.decoration as BoxDecoration).border != null;
         }
 
-        // The claim code field autofocuses first, so traversal does not
-        // necessarily start at the tab; step through it rather than assume
-        // a position.
+        // Stepping focus traversal through to Direct Server tab
         final scope = FocusScope.of(tester.element(find.text('Direct Server')));
         var steps = 0;
-        while (!ringShowing() && steps < 10) {
+        while (!ringShowing() && steps < 50) {
           scope.nextFocus();
           await tester.pump();
           steps++;

--- a/player/test/presentation/screens/login_tv_test.dart
+++ b/player/test/presentation/screens/login_tv_test.dart
@@ -35,6 +35,7 @@ import '../../test_utils/mock_auth_storage.dart';
 
 class _FakeLoginController extends LoginController {
   String? submittedClaimCode;
+  String? failureError;
 
   @override
   LoginState build() => LoginState.initial();
@@ -42,6 +43,12 @@ class _FakeLoginController extends LoginController {
   @override
   Future<void> pairWithClaimCode(String claimCode) async {
     submittedClaimCode = claimCode;
+    if (failureError != null) {
+      state = state.copyWith(
+        error: failureError,
+        claimCodeStatus: ClaimCodeStatus.error,
+      );
+    }
   }
 }
 
@@ -161,6 +168,85 @@ void main() {
 
       // Also test system pop route (e.g. Android TV OS back)
       await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(_findPinCodeText('A'), findsNothing);
+    });
+
+    testWidgets('settings button in TV header is wrapped in FocusHighlight',
+        (tester) async {
+      await _pumpLoginScreen(tester);
+
+      final settingsHighlightFinder = find.ancestor(
+        of: find.byTooltip('Relay & Network Settings'),
+        matching: find.byType(FocusHighlight),
+      );
+      expect(settingsHighlightFinder, findsOneWidget);
+    });
+
+    testWidgets('error state preserves entered code in PinCodeDisplay',
+        (tester) async {
+      final fakeController = _FakeLoginController()
+        ..failureError = 'Invalid or expired claim code';
+      await _pumpLoginScreen(tester, controller: fakeController);
+
+      for (final char in ['A', 'B', 'C', 'D', 'E', 'F']) {
+        await tester.tap(find.byKey(ValueKey('tv-key-$char')));
+        await tester.pump();
+      }
+
+      expect(fakeController.submittedClaimCode, equals('ABCDEF'));
+      expect(find.text('Invalid or expired claim code'), findsOneWidget);
+
+      final pinDisplay =
+          tester.widget<PinCodeDisplay>(find.byType(PinCodeDisplay));
+      expect(pinDisplay.code, equals('ABCDEF'));
+      expect(pinDisplay.hasError, isTrue);
+
+      for (final char in ['A', 'B', 'C', 'D', 'E', 'F']) {
+        expect(_findPinCodeText(char), findsOneWidget);
+      }
+    });
+
+    testWidgets(
+        'remote Back key dismisses advanced settings overlay when open instead of deleting characters',
+        (tester) async {
+      await _pumpLoginScreen(tester);
+
+      // Enter a character first to verify it is NOT deleted when Back dismisses the overlay
+      await tester.tap(find.byKey(const ValueKey('tv-key-A')));
+      await tester.pump();
+      expect(_findPinCodeText('A'), findsOneWidget);
+
+      // Open advanced settings overlay via header settings button
+      final settingsButton = find.byTooltip('Relay & Network Settings');
+      expect(settingsButton, findsOneWidget);
+      await tester.tap(settingsButton);
+      await tester.pump();
+
+      expect(find.text('Advanced Settings'), findsOneWidget);
+
+      // Remote Back key (Escape) dismisses the overlay and preserves the entered character
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+
+      expect(find.text('Advanced Settings'), findsNothing);
+      expect(_findPinCodeText('A'), findsOneWidget);
+
+      // Open again to verify system pop route (Android TV back) also dismisses overlay
+      await tester.tap(settingsButton);
+      await tester.pump();
+
+      expect(find.text('Advanced Settings'), findsOneWidget);
+
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(find.text('Advanced Settings'), findsNothing);
+      expect(_findPinCodeText('A'), findsOneWidget);
+
+      // Once overlay is dismissed, remote Back key deletes the character as normal
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
       await tester.pump();
 
       expect(_findPinCodeText('A'), findsNothing);

--- a/player/test/presentation/screens/login_tv_test.dart
+++ b/player/test/presentation/screens/login_tv_test.dart
@@ -322,9 +322,16 @@ void main() {
           tester.widget<ExcludeFocus>(excludedAncestor.first);
       expect(excludeFocusWidget.excluding, isTrue);
 
-      // Verify overlay close button is focused
-      final closeButton = find.byIcon(Icons.close);
+      // Verify overlay close button is focused and exposes accessible tooltip semantics
+      final closeButton = find.byTooltip('Close advanced settings');
       expect(closeButton, findsOneWidget);
+      expect(
+        find.descendant(
+          of: closeButton,
+          matching: find.byIcon(Icons.close),
+        ),
+        findsOneWidget,
+      );
       final closeFocusHighlight = find.ancestor(
         of: closeButton,
         matching: find.byType(FocusHighlight),

--- a/player/test/presentation/widgets/pin_code_display_test.dart
+++ b/player/test/presentation/widgets/pin_code_display_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/pin_code_display.dart';
+
+void main() {
+  group('PinCodeDisplay', () {
+    testWidgets('renders 6 slot boxes by default', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PinCodeDisplay(code: ''),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const ValueKey('pin-slot-0-active')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pin-slot-5')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pin-slot-6')), findsNothing);
+    });
+
+    testWidgets('displays entered characters in corresponding slots',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PinCodeDisplay(code: 'AB3'),
+          ),
+        ),
+      );
+
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+      expect(find.text('3'), findsOneWidget);
+    });
+
+    testWidgets('indicates active cursor on next slot to fill', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PinCodeDisplay(code: 'AB'),
+          ),
+        ),
+      );
+
+      final activeSlotFinder = find.byKey(const ValueKey('pin-slot-2-active'));
+      expect(activeSlotFinder, findsOneWidget);
+    });
+
+    testWidgets('applies error styling when hasError is true', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PinCodeDisplay(code: 'ABCDEF', hasError: true),
+          ),
+        ),
+      );
+
+      final errorIndicatorFinder =
+          find.byKey(const ValueKey('pin-code-error-state'));
+      expect(errorIndicatorFinder, findsOneWidget);
+    });
+
+    testWidgets('does not show active cursor when loading', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PinCodeDisplay(code: 'AB', isLoading: true),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const ValueKey('pin-slot-2-active')), findsNothing);
+      expect(find.byKey(const ValueKey('pin-slot-2')), findsOneWidget);
+    });
+
+    testWidgets('supports custom length', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: PinCodeDisplay(code: 'A', length: 4),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const ValueKey('pin-slot-0')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pin-slot-1-active')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pin-slot-3')), findsOneWidget);
+      expect(find.byKey(const ValueKey('pin-slot-4')), findsNothing);
+    });
+  });
+}

--- a/player/test/presentation/widgets/tv_keypad_test.dart
+++ b/player/test/presentation/widgets/tv_keypad_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/widgets/focus_highlight.dart';
+import 'package:player/presentation/widgets/tv_keypad.dart';
+
+void main() {
+  setUp(() {
+    FocusManager.instance.highlightStrategy =
+        FocusHighlightStrategy.alwaysTraditional;
+  });
+
+  tearDown(() {
+    FocusManager.instance.highlightStrategy = FocusHighlightStrategy.automatic;
+  });
+
+  group('TvKeypad', () {
+    testWidgets('renders all 31 valid characters and action keys',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TvKeypad(
+              onCharacterPressed: (_) {},
+              onDeletePressed: () {},
+              onClearPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      // Verify all 31 valid characters exist
+      for (final char in TvKeypad.validCharacters) {
+        expect(find.byKey(ValueKey('tv-key-$char')), findsOneWidget);
+      }
+      expect(TvKeypad.validCharacters.length, equals(31));
+
+      // Verify Delete and Clear keys exist
+      expect(find.byKey(const ValueKey('tv-key-delete')), findsOneWidget);
+      expect(find.byKey(const ValueKey('tv-key-clear')), findsOneWidget);
+
+      // Verify excluded ambiguous characters are NOT present
+      for (final excluded in ['0', 'O', '1', 'I', 'L']) {
+        expect(find.byKey(ValueKey('tv-key-$excluded')), findsNothing);
+      }
+    });
+
+    testWidgets('tapping a character key calls onCharacterPressed',
+        (tester) async {
+      String? pressedChar;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TvKeypad(
+              onCharacterPressed: (c) => pressedChar = c,
+              onDeletePressed: () {},
+              onClearPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-K')));
+      await tester.pump();
+
+      expect(pressedChar, equals('K'));
+    });
+
+    testWidgets('tapping delete and clear keys calls corresponding callbacks',
+        (tester) async {
+      bool deleted = false;
+      bool cleared = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TvKeypad(
+              onCharacterPressed: (_) {},
+              onDeletePressed: () => deleted = true,
+              onClearPressed: () => cleared = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-delete')));
+      await tester.pump();
+      expect(deleted, isTrue);
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-clear')));
+      await tester.pump();
+      expect(cleared, isTrue);
+    });
+
+    testWidgets('autofocuses first key A on row 0 col 0', (tester) async {
+      String? pressedChar;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TvKeypad(
+              onCharacterPressed: (c) => pressedChar = c,
+              onDeletePressed: () {},
+              onClearPressed: () {},
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Find the FocusHighlight wrapping key A and check autofocus
+      final focusHighlightWidgets = tester.widgetList<FocusHighlight>(
+        find.ancestor(
+          of: find.byKey(const ValueKey('tv-key-A')),
+          matching: find.byType(FocusHighlight),
+        ),
+      );
+      expect(focusHighlightWidgets.first.autofocus, isTrue);
+
+      // Activating via Enter / Select on the focused key invokes callback for 'A'
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(pressedChar, equals('A'));
+    });
+
+    testWidgets('disables callbacks when enabled is false', (tester) async {
+      String? pressedChar;
+      bool deleted = false;
+      bool cleared = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TvKeypad(
+              enabled: false,
+              onCharacterPressed: (c) => pressedChar = c,
+              onDeletePressed: () => deleted = true,
+              onClearPressed: () => cleared = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-A')));
+      await tester.pump();
+      expect(pressedChar, isNull);
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-delete')));
+      await tester.pump();
+      expect(deleted, isFalse);
+
+      await tester.tap(find.byKey(const ValueKey('tv-key-clear')));
+      await tester.pump();
+      expect(cleared, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Rethinks and redesigns the pairing screen for television devices (Chromecast with Google TV, Android TV, Leanback). When running on the directional tier (`InputCapabilities.directionalPrimary == true`), the mobile `TextField` is replaced with a dedicated 16:9 two-column layout featuring an on-screen curated 5×7 keypad and a 6-slot PIN code display.

### Key Changes
- **`PinCodeDisplay` component**: 6 discrete character boxes with active slot highlight, monospace typography, loading pulse, and error styling.
- **`TvKeypad` component**: Curated 5×7 on-screen grid containing exclusively the 31 valid claim characters (`A-Z` omitting `I, L, O`, and `2-9` omitting `0, 1`) plus `⌫ Delete` and `Clear`. Autofocuses on `[ A ]`.
- **D-Pad Focus Highlights**: All interactive TV elements (keys, tabs, connect/clear buttons, settings) are wrapped in `FocusHighlight` for high-contrast living-room visibility.
- **Auto-Submission & Manual Fallback**: Automatically dispatches pairing when the 6th character is entered; manual `Connect` button is enabled whenever 6 characters are present.
- **Remote Back Key Navigation**: Layered remote Back handling that acts as backspace when characters are present, dismisses advanced settings if open, and exits if input is empty.
- **Zero Protocol / Backend Impact**: Existing claim code generation, metadata-relay endpoints, and p2p handshake remain 100% untouched. Non-TV mobile/desktop card flow remains preserved with zero regression.

### Test Coverage
- Unit tests: `pin_code_display_test.dart` (6 tests), `tv_keypad_test.dart` (5 tests).
- TV-tier tests: `login_tv_test.dart` (10 tests run with `--dart-define=MYDIA_FORCE_TV=true`).
- Regression tests: `login_test.dart` (2 tests).
- All 3,634 tests in `player/test` pass cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a TV-optimized login and pairing experience with a two-column layout.
  - Added an on-screen keypad for entering pairing codes using a remote or keyboard.
  - Added visual PIN code progress, loading, and error states.
  - Added support for deleting and clearing entered characters.
  - Improved back navigation and focus handling on TV platforms.
  - Added accessible labeling for closing advanced settings.

- **Tests**
  - Added comprehensive coverage for TV pairing, keypad input, PIN display states, and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->