### PR TITLE
feat(indexers): generic Newznab indexer with configurable API path

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -315,7 +315,8 @@ download_clients:
 # Indexer Configuration
 # ----------------------
 # Configure torrent indexers and search providers for media discovery.
-# Supports Prowlarr (aggregator), Jackett (proxy), and direct public indexers.
+# Supports Prowlarr (aggregator), Jackett (proxy), Newznab (generic NZB
+# protocol), and direct public indexers.
 indexers:
   # Prowlarr example - Indexer aggregator (recommended)
   # Prowlarr provides access to hundreds of indexers through a single API
@@ -358,3 +359,16 @@ indexers:
   #   categories: []
   #   rate_limit: 30
   #   timeout: 30000
+
+  # Generic Newznab indexer example (commented out)
+  # Works with any Newznab-compatible service, including meta aggregators
+  # such as NZBHydra2.
+  # - name: "NZB Indexer"
+  #   type: "newznab"
+  #   enabled: true
+  #   priority: 2
+  #   base_url: "https://indexer.example"
+  #   api_key: "your-api-key"
+  #   connection_settings:
+  #     # Optional; defaults to /api
+  #     api_path: "/api"

--- a/docs/using/how-to/cardigann-indexers.md
+++ b/docs/using/how-to/cardigann-indexers.md
@@ -157,5 +157,5 @@ When reporting Cardigann issues:
 
 ## Next Steps
 
-- [Indexers](connect-indexer.md) - Prowlarr, Jackett, and NZBHydra2 setup
+- [Indexers](connect-indexer.md) - Prowlarr, Jackett, and Newznab setup
 - [How a Title Becomes a File](../explanation/media-pipeline.md#why-mydia-ships-its-own-indexer-implementation) - Why Mydia has a native Cardigann engine at all, and what it trades away

--- a/docs/using/how-to/connect-indexer.md
+++ b/docs/using/how-to/connect-indexer.md
@@ -1,6 +1,6 @@
 # Indexers
 
-Indexers provide search capabilities for finding media releases. Mydia supports Prowlarr, Jackett, and built-in Cardigann indexers.
+Indexers provide search capabilities for finding media releases. Mydia supports Prowlarr, Jackett, Newznab, and built-in Cardigann indexers.
 
 See [Indexers](../reference/indexers.md) for the full list of supported indexer types.
 
@@ -42,20 +42,29 @@ Jackett is an alternative indexer proxy.
 
 Every indexer variable is listed in [Environment variables](../reference/environment-variables.md#indexers).
 
-## NZBHydra2
+## Newznab
 
-NZBHydra2 is a meta search aggregator for NZB indexers.
+Newznab is the API protocol Usenet indexers expose. Any Newznab-compatible
+service works here, including meta search aggregators such as NZBHydra2.
 
 ### Setup
 
 1. Navigate to **Admin > Configuration**, then the **Indexers** tab
 2. Click **Add Indexer**
-3. Select **NZBHydra2**
+3. Select **Newznab**
 4. Enter connection details:
-   - Base URL: `http://nzbhydra2:5076`
-   - API Key: Your NZBHydra2 API key
+   - Base URL: `https://indexer.example`, or the deployment prefix your provider
+     publishes, such as `https://indexer.example/proxy`
+   - API Path: `/api` by default. Change it only if your provider serves the
+     Newznab endpoint at another path, such as `/newznab/api`.
+   - API Key: Your provider's Newznab API key
 5. Test connection
 6. Save
+
+The Base URL identifies the service, and the API Path identifies the Newznab
+endpoint on it. Mydia joins the two, so a base URL of
+`https://indexer.example/proxy` with the default API Path requests
+`https://indexer.example/proxy/api`.
 
 ### Environment Variables
 

--- a/docs/using/reference/environment-variables.md
+++ b/docs/using/reference/environment-variables.md
@@ -256,12 +256,13 @@ Configure multiple indexers using numbered variables (`<N>` = 1, 2, 3, etc.):
 | `INDEXER_<N>_PRIORITY` | Display order only, does not affect searching | `1` |
 | `INDEXER_<N>_BASE_URL` | Indexer base URL | `http://prowlarr:9696` |
 | `INDEXER_<N>_API_KEY` | Indexer API key | - |
+| `INDEXER_<N>_API_PATH` | Newznab only. Endpoint path appended to the base URL; defaults to `/api` | `/api` |
 | `INDEXER_<N>_INDEXER_IDS` | Comma-separated indexer IDs | `1,2,3` |
 | `INDEXER_<N>_CATEGORIES` | Comma-separated categories | `movies,tv` |
 | `INDEXER_<N>_RATE_LIMIT` | Maximum requests **per minute**. Unset means no limit. | - |
 | `INDEXER_<N>_TIMEOUT` | Request timeout in milliseconds | - |
 
-**Indexer Types:** `prowlarr`, `jackett`, `nzbhydra2`, `public`
+**Indexer Types:** `prowlarr`, `jackett`, `newznab`, `public`
 
 ```bash
 # Prowlarr
@@ -276,12 +277,19 @@ INDEXER_2_TYPE=jackett
 INDEXER_2_BASE_URL=http://jackett:9117
 INDEXER_2_API_KEY=your-jackett-api-key
 
-# NZBHydra2
-INDEXER_3_NAME=NZBHydra2
-INDEXER_3_TYPE=nzbhydra2
-INDEXER_3_BASE_URL=http://nzbhydra2:5076
-INDEXER_3_API_KEY=your-nzbhydra2-api-key
+# Newznab (works with any Newznab-compatible indexer)
+INDEXER_3_NAME=NZB Indexer
+INDEXER_3_TYPE=newznab
+INDEXER_3_BASE_URL=https://indexer.example
+INDEXER_3_API_KEY=your-newznab-api-key
+# Optional; defaults to /api
+INDEXER_3_API_PATH=/api
 ```
+
+!!! note "Legacy `nzbhydra2` type"
+    Existing configurations with `INDEXER_<N>_TYPE=nzbhydra2` keep working;
+    Mydia accepts the legacy value and treats it as `newznab`. New
+    configurations should use `newznab`.
 
 ## Automatic Search
 

--- a/docs/using/reference/indexers.md
+++ b/docs/using/reference/indexers.md
@@ -6,7 +6,7 @@ Complete reference of the indexer types Mydia supports.
 |------|-------------|-------------|
 | **Prowlarr** | Indexer manager with unified API | Yes |
 | **Jackett** | Indexer proxy | Yes |
-| **NZBHydra2** | NZB meta search aggregator | Yes |
+| **Newznab** | Generic NZB indexer API; connects to any compatible Usenet indexer, including meta aggregators such as NZBHydra2 | Yes |
 | **Cardigann** | Built-in indexer support | Experimental |
 
 ## Configuration Fields
@@ -20,6 +20,7 @@ under the **Indexers** tab.
 | Type | Indexer type | `prowlarr` |
 | Base URL | Indexer URL | `http://prowlarr:9696` |
 | API Key | Authentication key | `abc123` |
+| API Path | Newznab only. Endpoint path appended to the Base URL. Blank or omitted means `/api` | `/api` |
 | Enabled | Enable or disable this indexer | `true` |
 | Priority | Orders the indexer list for display and nothing else, see below | `1` |
 | Indexer IDs | Which Prowlarr indexers to query, picked from a checklist after the connection succeeds | `1,2,3` |
@@ -41,7 +42,7 @@ Set them with environment variables:
 
 | Field | Environment variable | Effect |
 |---|---|---|
-| Categories | `INDEXER_<N>_CATEGORIES` | Default category IDs to search within, for Prowlarr and NZBHydra2 |
+| Categories | `INDEXER_<N>_CATEGORIES` | Default category IDs to search within, for Prowlarr and Newznab |
 | Rate Limit | `INDEXER_<N>_RATE_LIMIT` | Maximum requests **per minute** for this indexer. Unset means no limit. |
 
 !!! warning "Rate Limit is per minute, not per second"

--- a/lib/mydia/config/loader.ex
+++ b/lib/mydia/config/loader.ex
@@ -38,8 +38,9 @@ defmodule Mydia.Config.Loader do
     with {:ok, yaml_config} <- maybe_load_yaml(config_file, sources),
          {:ok, db_config} <- maybe_load_database_config(sources),
          env_config <- maybe_load_env(sources),
-         merged <- merge_all_configs(yaml_config, db_config, env_config) do
-      validate(merged)
+         merged <- merge_all_configs(yaml_config, db_config, env_config),
+         normalized <- normalize_legacy_indexer_types(merged) do
+      validate(normalized)
     end
   end
 
@@ -468,6 +469,11 @@ defmodule Mydia.Config.Loader do
       |> put_if_present(:categories, System.get_env("#{prefix}CATEGORIES"), &parse_string_list/1)
       |> put_if_present(:rate_limit, System.get_env("#{prefix}RATE_LIMIT"), &parse_integer/1)
       |> put_if_present(:timeout, System.get_env("#{prefix}TIMEOUT"), &parse_integer/1)
+      |> put_if_present(
+        :connection_settings,
+        System.get_env("#{prefix}API_PATH"),
+        fn value -> {:ok, %{"api_path" => value}} end
+      )
     end)
     |> Enum.reject(&(&1 == %{}))
   end
@@ -761,6 +767,25 @@ defmodule Mydia.Config.Loader do
     |> deep_merge(db_config)
     |> deep_merge(env_config)
   end
+
+  # `nzbhydra2` was the only Newznab-compatible type before the adapter was
+  # generalized. YAML, environment variables, and rows written before the
+  # rename carry it, so map it to the canonical `:newznab` at this single
+  # boundary rather than teaching the schema and adapter registry about it.
+  defp normalize_legacy_indexer_types(%{indexers: indexers} = config) when is_list(indexers) do
+    normalized =
+      Enum.map(indexers, fn indexer ->
+        if Map.get(indexer, :type) in [:nzbhydra2, "nzbhydra2"] do
+          Map.put(indexer, :type, :newznab)
+        else
+          indexer
+        end
+      end)
+
+    Map.put(config, :indexers, normalized)
+  end
+
+  defp normalize_legacy_indexer_types(config), do: config
 
   defp deep_merge(left, right) when is_map(left) and is_map(right) do
     Map.merge(left, right, fn key, left_val, right_val ->

--- a/lib/mydia/config/schema.ex
+++ b/lib/mydia/config/schema.ex
@@ -10,6 +10,7 @@ defmodule Mydia.Config.Schema do
   require Logger
 
   alias Mydia.Settings.PathMappingConfig
+  alias Mydia.Indexers.NewznabEndpoint
 
   @primary_key false
 
@@ -310,7 +311,7 @@ defmodule Mydia.Config.Schema do
 
     embeds_many :indexers, Indexer, on_replace: :delete, primary_key: false do
       field :name, :string
-      field :type, Ecto.Enum, values: [:prowlarr, :jackett, :public]
+      field :type, Ecto.Enum, values: [:prowlarr, :jackett, :newznab, :public]
       field :enabled, :boolean, default: true
       field :priority, :integer, default: 1
       field :base_url, :string
@@ -319,6 +320,7 @@ defmodule Mydia.Config.Schema do
       field :categories, {:array, :string}
       field :rate_limit, :integer
       field :timeout, :integer, default: 30000
+      field :connection_settings, :map, default: %{}
     end
 
     embeds_many :subtitle_providers, SubtitleProvider, on_replace: :delete, primary_key: false do
@@ -773,13 +775,34 @@ defmodule Mydia.Config.Schema do
       :indexer_ids,
       :categories,
       :rate_limit,
-      :timeout
+      :timeout,
+      :connection_settings
     ])
     |> validate_required([:name, :type, :base_url])
-    |> validate_inclusion(:type, [:prowlarr, :jackett, :public])
+    |> validate_inclusion(:type, [:prowlarr, :jackett, :newznab, :public])
     |> validate_number(:priority, greater_than: 0)
     |> validate_number(:rate_limit, greater_than: 0)
     |> validate_number(:timeout, greater_than: 0)
+    |> validate_newznab_api_path()
+  end
+
+  # Mirrors IndexerConfig's Newznab handling so a bad API path in YAML or an
+  # environment variable fails configuration validation instead of reaching the
+  # adapter at request time.
+  defp validate_newznab_api_path(changeset) do
+    if get_field(changeset, :type) == :newznab do
+      settings = get_field(changeset, :connection_settings) || %{}
+
+      case NewznabEndpoint.normalize_api_path(Map.get(settings, "api_path")) do
+        {:ok, api_path} ->
+          put_change(changeset, :connection_settings, Map.put(settings, "api_path", api_path))
+
+        {:error, message} ->
+          add_error(changeset, :connection_settings, message)
+      end
+    else
+      changeset
+    end
   end
 
   defp subtitle_provider_changeset(schema, attrs) do

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -692,10 +692,11 @@ defmodule Mydia.Indexers do
     resolved_config = Settings.resolve_env_inheritance(config)
 
     fields = connection_fields(resolved_config.base_url)
+    settings = resolved_config.connection_settings || %{}
 
     # Get timeout from connection_settings or use default
     timeout =
-      case resolved_config.connection_settings do
+      case settings do
         %{"timeout" => timeout} when is_integer(timeout) -> timeout
         _ -> 30_000
       end
@@ -712,7 +713,8 @@ defmodule Mydia.Indexers do
         categories: resolved_config.categories || [],
         rate_limit: resolved_config.rate_limit,
         timeout: timeout,
-        base_path: fields.base_path
+        base_path: fields.base_path,
+        api_path: Map.get(settings, "api_path", "/api")
       }
     }
   end
@@ -723,16 +725,21 @@ defmodule Mydia.Indexers do
   defp maybe_convert_base_url(%{base_url: base_url} = config) when is_binary(base_url) do
     fields = connection_fields(base_url)
 
+    # Callers that pass options explicitly (the UI's Test Connection payload)
+    # must keep every value they supplied; anything they omitted falls back to
+    # the adapter defaults rather than being silently undefined.
+    options =
+      Map.merge(
+        %{indexer_ids: [], categories: [], base_path: fields.base_path, api_path: "/api"},
+        Map.get(config, :options, %{})
+      )
+
     config
     |> Map.put(:host, fields.host)
     |> Map.put(:port, fields.port)
     |> Map.put(:use_ssl, fields.use_ssl)
     |> Map.put(:name, Map.get(config, :name, "Test"))
-    |> Map.put_new(:options, %{
-      indexer_ids: [],
-      categories: [],
-      base_path: fields.base_path
-    })
+    |> Map.put(:options, options)
   end
 
   defp maybe_convert_base_url(config), do: config

--- a/lib/mydia/indexers.ex
+++ b/lib/mydia/indexers.ex
@@ -48,7 +48,7 @@ defmodule Mydia.Indexers do
   Currently supported adapters:
     - `:prowlarr` - Prowlarr indexer aggregator
     - `:jackett` - Jackett indexer proxy
-    - `:nzbhydra2` - NZBHydra2 Usenet NZB aggregator
+    - `:newznab` - Generic Newznab Usenet indexer (including NZBHydra2)
     - `:cardigann` - Native Cardigann definition support
   """
   @spec register_adapters() :: :ok
@@ -58,7 +58,7 @@ defmodule Mydia.Indexers do
     # Register adapters
     Adapter.Registry.register(:prowlarr, Mydia.Indexers.Adapter.Prowlarr)
     Adapter.Registry.register(:jackett, Mydia.Indexers.Adapter.Jackett)
-    Adapter.Registry.register(:nzbhydra2, Mydia.Indexers.Adapter.NzbHydra2)
+    Adapter.Registry.register(:newznab, Mydia.Indexers.Adapter.Newznab)
     Adapter.Registry.register(:cardigann, Mydia.Indexers.Adapter.Cardigann)
 
     Logger.info("Indexer adapter registration complete")

--- a/lib/mydia/indexers/adapter/newznab.ex
+++ b/lib/mydia/indexers/adapter/newznab.ex
@@ -1,45 +1,50 @@
-defmodule Mydia.Indexers.Adapter.NzbHydra2 do
+defmodule Mydia.Indexers.Adapter.Newznab do
   @moduledoc """
-  NZBHydra2 indexer adapter.
+  Newznab protocol adapter.
 
-  NZBHydra2 is a meta search aggregator for Usenet NZB indexers. It provides
-  a unified Newznab-compatible API to search across multiple NZB indexers.
+  Speaks the Newznab API exposed by Usenet indexers and meta search
+  aggregators (NZBHydra2, Prowlarr-style proxies, native indexers).
+  Capabilities are discovered with `t=caps` and searches run through
+  `t=search`; both are served from the configured API path, which defaults
+  to `/api`.
 
   ## API Documentation
 
-  NZBHydra2 API: https://github.com/theotherp/nzbhydra2/wiki/API
+  Newznab documentation: https://newznab.readthedocs.io/en/latest/
 
   ## Authentication
 
   Authentication is done via the `apikey` query parameter.
 
-  ## Search Endpoint
+  ## Endpoint
 
-  The search endpoint returns results in Newznab XML format by default,
-  or JSON with `o=json` parameter:
-  - `GET /api?apikey={key}&t=search&q={query}`
-  - `GET /api?apikey={key}&t=search&q={query}&o=json`
+  Requests combine the configured base URL, the `options.base_path`
+  deployment prefix, and `options.api_path` (see
+  `Mydia.Indexers.NewznabEndpoint`):
+  - `GET {base_url}{base_path}{api_path}?apikey={key}&t=caps`
+  - `GET {base_url}{base_path}{api_path}?apikey={key}&t=search&q={query}`
 
   ## Example Usage
 
       config = %{
-        type: :nzbhydra2,
-        name: "NZBHydra2",
+        type: :newznab,
+        name: "My Indexer",
         host: "localhost",
         port: 5076,
         api_key: "your-api-key",
         use_ssl: false,
         options: %{
+          api_path: "/api",
           timeout: 30_000
         }
       }
 
-      {:ok, results} = NzbHydra2.search(config, "Ubuntu 22.04")
+      {:ok, results} = Newznab.search(config, "Ubuntu 22.04")
   """
 
   @behaviour Mydia.Indexers.Adapter
 
-  alias Mydia.Indexers.{SearchResult, QualityParser}
+  alias Mydia.Indexers.{SearchResult, QualityParser, NewznabEndpoint}
   alias Mydia.Indexers.Adapter.Error
 
   import SweetXml
@@ -53,67 +58,76 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
 
   @impl true
   def test_connection(config) do
-    url = build_url(config, "/api")
     params = [{"apikey", config.api_key}, {"t", "caps"}]
     query_string = URI.encode_query(params)
-    full_url = "#{url}?#{query_string}"
 
-    Logger.debug("NZBHydra2 test connection: #{full_url}")
+    with {:ok, url} <- build_endpoint(config) do
+      full_url = "#{url}?#{query_string}"
 
-    case Req.get(full_url, receive_timeout: 10_000, retry: false) do
-      {:ok, %Req.Response{status: 200, body: body}} ->
-        parse_caps_response(body)
+      Logger.debug("Newznab test connection: #{full_url}")
 
-      {:ok, %Req.Response{status: 401}} ->
-        {:error, Error.authentication_failed("Invalid API key")}
+      case Req.get(full_url, receive_timeout: 10_000, retry: false) do
+        {:ok, %Req.Response{status: 200, body: body}} ->
+          parse_caps_response(body)
 
-      {:ok, %Req.Response{status: 403}} ->
-        {:error, Error.authentication_failed("Access forbidden - check API key")}
+        {:ok, %Req.Response{status: 401}} ->
+          {:error, Error.authentication_failed("Invalid API key")}
 
-      {:ok, %Req.Response{status: status}} ->
-        {:error, Error.connection_failed("HTTP #{status}")}
+        {:ok, %Req.Response{status: 403}} ->
+          {:error, Error.authentication_failed("Access forbidden - check API key")}
 
-      {:error, %Req.TransportError{reason: reason}} ->
-        {:error, Error.connection_failed("Connection failed: #{inspect(reason)}")}
+        {:ok, %Req.Response{status: status}} ->
+          {:error, Error.connection_failed("HTTP #{status}")}
 
-      {:error, reason} ->
-        {:error, Error.connection_failed("Request failed: #{inspect(reason)}")}
+        {:error, %Req.TransportError{reason: reason}} ->
+          {:error, Error.connection_failed("Connection failed: #{inspect(reason)}")}
+
+        {:error, reason} ->
+          {:error, Error.connection_failed("Request failed: #{inspect(reason)}")}
+      end
+    else
+      {:error, message} ->
+        {:error, Error.connection_failed(message)}
     end
   end
 
   @impl true
   def search(config, query, opts \\ []) do
-    url = build_search_url(config, query, opts)
     timeout = get_in(config, [:options, :timeout]) || 30_000
 
-    Logger.debug("NZBHydra2 search: #{url}")
+    with {:ok, url} <- build_search_url(config, query, opts) do
+      Logger.debug("Newznab search: #{url}")
 
-    case Req.get(url,
-           receive_timeout: timeout,
-           connect_options: [timeout: @connect_timeout],
-           retry: false
-         ) do
-      {:ok, %Req.Response{status: 200, body: body}} ->
-        parse_search_response(body, config.name)
+      case Req.get(url,
+             receive_timeout: timeout,
+             connect_options: [timeout: @connect_timeout],
+             retry: false
+           ) do
+        {:ok, %Req.Response{status: 200, body: body}} ->
+          parse_search_response(body, config.name)
 
-      {:ok, %Req.Response{status: 401}} ->
-        {:error, Error.authentication_failed("Invalid API key")}
+        {:ok, %Req.Response{status: 401}} ->
+          {:error, Error.authentication_failed("Invalid API key")}
 
-      {:ok, %Req.Response{status: 403}} ->
-        {:error, Error.authentication_failed("Access forbidden")}
+        {:ok, %Req.Response{status: 403}} ->
+          {:error, Error.authentication_failed("Access forbidden")}
 
-      {:ok, %Req.Response{status: 429}} ->
-        {:error, Error.rate_limited("Rate limit exceeded")}
+        {:ok, %Req.Response{status: 429}} ->
+          {:error, Error.rate_limited("Rate limit exceeded")}
 
-      {:ok, %Req.Response{status: status, body: body}} ->
-        Logger.error("NZBHydra2 search failed with status #{status}: #{inspect(body)}")
-        {:error, Error.search_failed("HTTP #{status}")}
+        {:ok, %Req.Response{status: status, body: body}} ->
+          Logger.error("Newznab search failed with status #{status}: #{inspect(body)}")
+          {:error, Error.search_failed("HTTP #{status}")}
 
-      {:error, %Req.TransportError{reason: :timeout}} ->
-        {:error, Error.timeout("Request timeout")}
+        {:error, %Req.TransportError{reason: :timeout}} ->
+          {:error, Error.timeout("Request timeout")}
 
-      {:error, reason} ->
-        {:error, Error.search_failed("Request failed: #{inspect(reason)}")}
+        {:error, reason} ->
+          {:error, Error.search_failed("Request failed: #{inspect(reason)}")}
+      end
+    else
+      {:error, message} ->
+        {:error, Error.search_failed(message)}
     end
   end
 
@@ -133,10 +147,14 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
 
   ## Private Functions
 
-  defp build_url(config, path) do
+  defp build_endpoint(config) do
     scheme = if Map.get(config, :use_ssl, false), do: "https", else: "http"
-    base_path = get_in(config, [:options, :base_path]) || ""
-    "#{scheme}://#{config.host}:#{config.port}#{base_path}#{path}"
+    base_path = get_in(config, [:options, :base_path])
+    api_path = get_in(config, [:options, :api_path])
+
+    with {:ok, path} <- NewznabEndpoint.join(base_path, api_path) do
+      {:ok, "#{scheme}://#{config.host}:#{config.port}#{path}"}
+    end
   end
 
   defp build_search_url(config, query, opts) do
@@ -152,10 +170,11 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
       |> maybe_add_param("limit", limit)
       |> maybe_add_list_param("cat", categories)
 
-    base_url = build_url(config, "/api")
-    query_string = URI.encode_query(params)
+    with {:ok, base_url} <- build_endpoint(config) do
+      query_string = URI.encode_query(params)
 
-    "#{base_url}?#{query_string}"
+      {:ok, "#{base_url}?#{query_string}"}
+    end
   end
 
   defp maybe_add_param(params, _key, nil), do: params
@@ -177,32 +196,37 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
 
       {:ok,
        %{
-         name: if(server != "", do: server, else: "NZBHydra2"),
+         name: if(server != "", do: server, else: "Newznab"),
          version: if(version != "", do: version, else: "unknown"),
-         app_name: "NZBHydra2"
+         app_name: "Newznab"
        }}
     rescue
       error ->
-        Logger.error("Failed to parse NZBHydra2 caps response: #{inspect(error)}")
-        {:ok, %{name: "NZBHydra2", version: "unknown", app_name: "NZBHydra2"}}
+        Logger.error("Failed to parse Newznab caps response: #{inspect(error)}")
+        {:ok, %{name: "Newznab", version: "unknown", app_name: "Newznab"}}
     end
   end
 
   defp fetch_capabilities(config) do
-    url = build_url(config, "/api")
     params = [{"apikey", config.api_key}, {"t", "caps"}]
     query_string = URI.encode_query(params)
-    full_url = "#{url}?#{query_string}"
 
-    case Req.get(full_url, receive_timeout: 10_000, retry: false) do
-      {:ok, %Req.Response{status: 200, body: body}} ->
-        parse_capabilities_xml(body)
+    with {:ok, url} <- build_endpoint(config) do
+      full_url = "#{url}?#{query_string}"
 
-      {:ok, %Req.Response{status: status}} ->
-        {:error, Error.connection_failed("HTTP #{status}")}
+      case Req.get(full_url, receive_timeout: 10_000, retry: false) do
+        {:ok, %Req.Response{status: 200, body: body}} ->
+          parse_capabilities_xml(body)
 
-      {:error, reason} ->
-        {:error, Error.connection_failed("Request failed: #{inspect(reason)}")}
+        {:ok, %Req.Response{status: status}} ->
+          {:error, Error.connection_failed("HTTP #{status}")}
+
+        {:error, reason} ->
+          {:error, Error.connection_failed("Request failed: #{inspect(reason)}")}
+      end
+    else
+      {:error, message} ->
+        {:error, Error.connection_failed(message)}
     end
   end
 
@@ -235,7 +259,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
        }}
     rescue
       error ->
-        Logger.error("Failed to parse NZBHydra2 capabilities: #{inspect(error)}")
+        Logger.error("Failed to parse Newznab capabilities: #{inspect(error)}")
         {:error, Error.parse_error("Failed to parse capabilities XML")}
     end
   end
@@ -285,7 +309,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
       {:ok, results}
     rescue
       error ->
-        Logger.error("Failed to parse NZBHydra2 search response: #{inspect(error)}")
+        Logger.error("Failed to parse Newznab search response: #{inspect(error)}")
         Logger.debug("Body: #{inspect(body)}")
         {:error, Error.parse_error("Failed to parse search results XML")}
     end
@@ -408,7 +432,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
           tmdb_id: tmdb_id,
           tvdb_id: tvdb_id,
           imdb_id: imdb_id,
-          # Always NZB protocol for NZBHydra2
+          # Always NZB protocol for Newznab
           download_protocol: :nzb,
           usenet_date: usenet_date,
           nzb_completion: nzb_completion,
@@ -418,7 +442,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2 do
       end
     rescue
       error ->
-        Logger.error("Failed to parse NZBHydra2 result item: #{inspect(error)}")
+        Logger.error("Failed to parse Newznab result item: #{inspect(error)}")
         Logger.debug("Item: #{inspect(item)}")
         nil
     end

--- a/lib/mydia/indexers/newznab_endpoint.ex
+++ b/lib/mydia/indexers/newznab_endpoint.ex
@@ -1,0 +1,46 @@
+defmodule Mydia.Indexers.NewznabEndpoint do
+  @moduledoc false
+
+  # Newznab services (including meta indexers such as NZBHydra2) are usually
+  # served from `/api`, but a deployment prefix in the configured base URL and
+  # the API path itself must join without duplicating or dropping slashes.
+
+  @default_api_path "/api"
+
+  @spec normalize_api_path(term()) :: {:ok, String.t()} | {:error, String.t()}
+  def normalize_api_path(nil), do: {:ok, @default_api_path}
+
+  def normalize_api_path(path) when is_binary(path) do
+    path = String.trim(path)
+
+    if path == "" do
+      {:ok, @default_api_path}
+    else
+      cond do
+        Regex.match?(~r/^[a-z][a-z0-9+.-]*:\/\//i, path) ->
+          {:error, "must be a path, not a complete URL"}
+
+        String.contains?(path, "?") ->
+          {:error, "must not include a query string"}
+
+        String.contains?(path, "#") ->
+          {:error, "must not include a fragment"}
+
+        true ->
+          {:ok, "/" <> String.trim_leading(path, "/")}
+      end
+    end
+  end
+
+  def normalize_api_path(_path), do: {:error, "must be a path"}
+
+  @spec join(String.t() | nil, term()) :: {:ok, String.t()} | {:error, String.t()}
+  def join(base_path, api_path) do
+    with {:ok, api_path} <- normalize_api_path(api_path) do
+      prefix = base_path |> to_string() |> String.trim("/")
+      suffix = String.trim_leading(api_path, "/")
+      path = if prefix == "", do: "/#{suffix}", else: "/#{prefix}/#{suffix}"
+      {:ok, path}
+    end
+  end
+end

--- a/lib/mydia/settings/indexer_config.ex
+++ b/lib/mydia/settings/indexer_config.ex
@@ -5,6 +5,8 @@ defmodule Mydia.Settings.IndexerConfig do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Mydia.Indexers.NewznabEndpoint
+
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
@@ -28,7 +30,7 @@ defmodule Mydia.Settings.IndexerConfig do
           updated_at: DateTime.t()
         }
 
-  @indexer_types [:prowlarr, :jackett, :nzbhydra2, :public]
+  @indexer_types [:prowlarr, :jackett, :newznab, :public]
 
   schema "indexer_configs" do
     field :name, :string
@@ -69,6 +71,7 @@ defmodule Mydia.Settings.IndexerConfig do
       :env_name,
       :min_post_age_minutes
     ])
+    |> normalize_and_validate_newznab_api_path()
     |> validate_required([:name, :type])
     |> validate_base_url_or_env_name()
     |> validate_inclusion(:type, @indexer_types)
@@ -78,6 +81,25 @@ defmodule Mydia.Settings.IndexerConfig do
     |> normalize_base_url()
     |> validate_base_url()
     |> unique_constraint(:name)
+  end
+
+  # Newznab indexers address a configurable API path; store the normalized form
+  # so adapters and the UI read one representation. Other indexer types keep
+  # their connection settings exactly as supplied.
+  defp normalize_and_validate_newznab_api_path(changeset) do
+    if get_field(changeset, :type) == :newznab do
+      settings = get_field(changeset, :connection_settings) || %{}
+
+      case NewznabEndpoint.normalize_api_path(Map.get(settings, "api_path")) do
+        {:ok, api_path} ->
+          put_change(changeset, :connection_settings, Map.put(settings, "api_path", api_path))
+
+        {:error, message} ->
+          add_error(changeset, :connection_settings, message)
+      end
+    else
+      changeset
+    end
   end
 
   # Validates that either base_url or env_name is provided

--- a/lib/mydia/settings/service_configs.ex
+++ b/lib/mydia/settings/service_configs.ex
@@ -16,6 +16,7 @@ defmodule Mydia.Settings.ServiceConfigs do
     SubtitleProviderConfig
   }
 
+  alias Mydia.Indexers.NewznabEndpoint
   alias Mydia.Settings.RuntimeConfig, as: RC
   alias Mydia.Subtitles.ProviderRegistry
 
@@ -222,12 +223,38 @@ defmodule Mydia.Settings.ServiceConfigs do
     # Build environment variable names
     base_url_var = "#{env_name}_BASE_URL"
     api_key_var = "#{env_name}_API_KEY"
+    api_path_var = "#{env_name}_API_PATH"
 
     # Resolve from environment, falling back to existing values
     resolved_base_url = System.get_env(base_url_var) || config.base_url
     resolved_api_key = System.get_env(api_key_var) || config.api_key
 
-    %{config | base_url: resolved_base_url, api_key: resolved_api_key}
+    %{
+      config
+      | base_url: resolved_base_url,
+        api_key: resolved_api_key,
+        connection_settings:
+          resolve_env_api_path(config.connection_settings, System.get_env(api_path_var))
+    }
+  end
+
+  # An unset or blank `<env_name>_API_PATH` leaves the row's settings untouched,
+  # so the caller's existing value (or its own default) still applies. A value
+  # the Newznab path normalizer rejects is likewise ignored rather than
+  # injecting a bogus path.
+  defp resolve_env_api_path(settings, nil), do: settings
+
+  defp resolve_env_api_path(settings, api_path) when is_binary(api_path) do
+    case String.trim(api_path) do
+      "" ->
+        settings
+
+      trimmed ->
+        case NewznabEndpoint.normalize_api_path(trimmed) do
+          {:ok, normalized} -> Map.put(settings || %{}, "api_path", normalized)
+          {:error, _reason} -> settings
+        end
+    end
   end
 
   def list_available_env_indexers do

--- a/lib/mydia_web/live/admin_indexers_live/components.ex
+++ b/lib/mydia_web/live/admin_indexers_live/components.ex
@@ -379,6 +379,17 @@ defmodule MydiaWeb.AdminIndexersLive.Components do
     is_newznab = indexer_type == "newznab" or indexer_type == :newznab
     assigns = assign(assigns, :is_newznab, is_newznab)
 
+    # An unusable API path is recorded on :connection_settings by
+    # IndexerConfig.normalize_and_validate_newznab_api_path/1, and the API Path
+    # input is the only render site for that field, so hand its errors to the
+    # input explicitly (it renders by name, not by field).
+    api_path_errors =
+      assigns.indexer_form.source
+      |> Map.get(:errors, [])
+      |> translate_errors(:connection_settings)
+
+    assigns = assign(assigns, :api_path_errors, api_path_errors)
+
     # NZB-capable indexer types support a minimum post-age filter.
     # Prowlarr aggregates both protocols, Newznab is NZB-only, Jackett
     # historically passes Newznab attrs through for NZB definitions.
@@ -553,6 +564,7 @@ defmodule MydiaWeb.AdminIndexersLive.Components do
                       }
                       placeholder="/api"
                       hint="Newznab endpoint path; usually remains /api."
+                      errors={@api_path_errors}
                     />
                   </div>
                 </div>

--- a/lib/mydia_web/live/admin_indexers_live/components.ex
+++ b/lib/mydia_web/live/admin_indexers_live/components.ex
@@ -374,11 +374,16 @@ defmodule MydiaWeb.AdminIndexersLive.Components do
     is_prowlarr = indexer_type == "prowlarr" or indexer_type == :prowlarr
     assigns = assign(assigns, :is_prowlarr, is_prowlarr)
 
+    # Newznab indexers address a configurable API path; the form exposes it so
+    # operators can point Mydia at a deployment prefix or a non-standard endpoint.
+    is_newznab = indexer_type == "newznab" or indexer_type == :newznab
+    assigns = assign(assigns, :is_newznab, is_newznab)
+
     # NZB-capable indexer types support a minimum post-age filter.
-    # Prowlarr aggregates both protocols, NZBHydra2 is NZB-only, Jackett
+    # Prowlarr aggregates both protocols, Newznab is NZB-only, Jackett
     # historically passes Newznab attrs through for NZB definitions.
     is_nzb_capable =
-      indexer_type in ["prowlarr", :prowlarr, "nzbhydra2", :nzbhydra2, "jackett", :jackett]
+      indexer_type in ["prowlarr", :prowlarr, "newznab", :newznab, "jackett", :jackett]
 
     assigns = assign(assigns, :is_nzb_capable, is_nzb_capable)
 
@@ -440,7 +445,7 @@ defmodule MydiaWeb.AdminIndexersLive.Components do
                   options={[
                     {"Prowlarr", "prowlarr"},
                     {"Jackett", "jackett"},
-                    {"NZBHydra2", "nzbhydra2"},
+                    {"Newznab", "newznab"},
                     {"Public", "public"}
                   ]}
                   required
@@ -531,6 +536,24 @@ defmodule MydiaWeb.AdminIndexersLive.Components do
                   <div class="col-span-3 md:col-span-2 text-xs text-base-content/60 self-end pb-2">
                     Filters out NZB results posted within this many minutes. Useful for letting
                     indexers complete article propagation. Leave blank to disable.
+                  </div>
+                </div>
+                <div :if={@is_newznab} class="grid grid-cols-3 gap-3">
+                  <div class="col-span-3">
+                    <.input
+                      id="indexer-api-path"
+                      name="indexer_config[connection_settings][api_path]"
+                      type="text"
+                      label="API Path"
+                      value={
+                        get_in(
+                          Phoenix.HTML.Form.input_value(@indexer_form, :connection_settings) || %{},
+                          ["api_path"]
+                        ) || "/api"
+                      }
+                      placeholder="/api"
+                      hint="Newznab endpoint path; usually remains /api."
+                    />
                   </div>
                 </div>
               </div>

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -127,6 +127,7 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
         "indexer_ids" => indexer.indexer_ids,
         "categories" => indexer.categories,
         "rate_limit" => indexer.rate_limit,
+        "connection_settings" => indexer.connection_settings,
         "env_name" => if(matching_env, do: matching_env.env_name, else: nil),
         "base_url" => if(matching_env, do: nil, else: indexer.base_url),
         "api_key" => if(matching_env, do: nil, else: indexer.api_key)
@@ -337,37 +338,42 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
   @impl true
   def handle_event("test_indexer_connection", _params, socket) do
     changeset = socket.assigns.indexer_form.source
-    params = Ecto.Changeset.apply_changes(changeset)
 
-    type =
-      case params.type do
-        type when is_atom(type) -> type
-        type when is_binary(type) -> String.to_existing_atom(type)
+    if changeset.valid? do
+      # Passing the IndexerConfig struct reuses the central adapter conversion
+      # (Mydia.Indexers.indexer_config_to_adapter_config/1), so the unsaved test
+      # probes exactly what a save would probe — including connection_settings
+      # such as the Newznab API path.
+      case Indexers.test_connection(Ecto.Changeset.apply_changes(changeset)) do
+        {:ok, info} ->
+          version = Map.get(info, :version, "unknown")
+
+          {:noreply,
+           socket
+           |> assign(:testing_indexer_connection, false)
+           |> put_flash(:info, "Connection successful! Version: #{version}")}
+
+        {:error, error} ->
+          error_msg =
+            case error do
+              msg when is_binary(msg) -> msg
+              %{message: msg} -> msg
+              _ -> MydiaLogger.extract_error_message(error)
+            end
+
+          {:noreply,
+           socket
+           |> assign(:testing_indexer_connection, false)
+           |> put_flash(:error, "Connection failed: #{error_msg}")}
       end
-
-    test_config = %{type: type, base_url: params.base_url, api_key: params.api_key}
-
-    case Mydia.Indexers.test_connection(test_config) do
-      {:ok, info} ->
-        version = Map.get(info, :version, "unknown")
-
-        {:noreply,
-         socket
-         |> assign(:testing_indexer_connection, false)
-         |> put_flash(:info, "Connection successful! Version: #{version}")}
-
-      {:error, error} ->
-        error_msg =
-          case error do
-            msg when is_binary(msg) -> msg
-            %{message: msg} -> msg
-            _ -> MydiaLogger.extract_error_message(error)
-          end
-
-        {:noreply,
-         socket
-         |> assign(:testing_indexer_connection, false)
-         |> put_flash(:error, "Connection failed: #{error_msg}")}
+    else
+      # An invalid changeset has no connection details worth probing: reassign
+      # the form so the errors render, and never issue the request.
+      {:noreply,
+       socket
+       |> assign(:testing_indexer_connection, false)
+       |> assign(:indexer_form, to_form(Map.put(changeset, :action, :validate)))
+       |> put_flash(:error, "Fix the highlighted errors before testing the connection")}
     end
   end
 

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -1340,7 +1340,9 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
   # submitted, so merge the submitted keys over the settings the modal was
   # opened with. Keys with no input — a timeout on a row migrated from the
   # legacy Hydra indexer type, say — then survive a save instead of being
-  # silently dropped.
+  # silently dropped. Types that render no connection-settings input at all
+  # (Prowlarr, Jackett, Public) submit no such key, so the stored map has to be
+  # re-attached before it reaches the changeset.
   defp merge_connection_settings(params, assigns) do
     stored = Map.get(assigns, :indexer_connection_settings, %{})
 
@@ -1349,7 +1351,11 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
         Map.put(params, "connection_settings", Map.merge(stored, submitted))
 
       _ ->
-        params
+        if stored == %{} do
+          params
+        else
+          Map.put(params, "connection_settings", stored)
+        end
     end
   end
 

--- a/lib/mydia_web/live/admin_indexers_live/index.ex
+++ b/lib/mydia_web/live/admin_indexers_live/index.ex
@@ -101,6 +101,7 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
      |> assign(:show_indexer_modal, true)
      |> assign(:indexer_form, to_form(changeset))
      |> assign(:indexer_mode, :new)
+     |> assign(:indexer_connection_settings, %{})
      |> assign(:testing_indexer_connection, false)
      |> assign(:available_env_indexers, Settings.list_available_env_indexers())
      |> init_prowlarr_indexer_assigns([])
@@ -140,6 +141,7 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
        |> assign(:show_indexer_modal, true)
        |> assign(:indexer_form, to_form(changeset))
        |> assign(:indexer_mode, :new)
+       |> assign(:indexer_connection_settings, indexer.connection_settings || %{})
        |> assign(:testing_indexer_connection, false)
        |> assign(:available_env_indexers, available_env_indexers)
        |> init_prowlarr_indexer_assigns(existing_indexer_ids)
@@ -154,6 +156,7 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
        |> assign(:indexer_form, to_form(changeset))
        |> assign(:indexer_mode, :edit)
        |> assign(:editing_indexer, indexer)
+       |> assign(:indexer_connection_settings, indexer.connection_settings || %{})
        |> assign(:testing_indexer_connection, false)
        |> assign(:available_env_indexers, available_env_indexers)
        |> init_prowlarr_indexer_assigns(existing_indexer_ids)
@@ -171,7 +174,7 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
 
     changeset =
       indexer
-      |> IndexerConfig.changeset(params)
+      |> IndexerConfig.changeset(merge_connection_settings(params, socket.assigns))
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, :indexer_form, to_form(changeset))}
@@ -179,7 +182,10 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
 
   @impl true
   def handle_event("save_indexer", %{"indexer_config" => params}, socket) do
-    params = merge_prowlarr_indexer_ids(params, socket.assigns)
+    params =
+      params
+      |> merge_connection_settings(socket.assigns)
+      |> merge_prowlarr_indexer_ids(socket.assigns)
 
     result =
       case socket.assigns.indexer_mode do
@@ -1327,6 +1333,24 @@ defmodule MydiaWeb.AdminIndexersLive.Index do
     if type == "prowlarr",
       do: Map.put(params, "indexer_ids", indexer_ids),
       else: params
+  end
+
+  # The modal renders only a few connection settings (today just Newznab's
+  # api_path), and Ecto's cast replaces the whole map with what the form
+  # submitted, so merge the submitted keys over the settings the modal was
+  # opened with. Keys with no input — a timeout on a row migrated from the
+  # legacy Hydra indexer type, say — then survive a save instead of being
+  # silently dropped.
+  defp merge_connection_settings(params, assigns) do
+    stored = Map.get(assigns, :indexer_connection_settings, %{})
+
+    case params do
+      %{"connection_settings" => submitted} when is_map(submitted) ->
+        Map.put(params, "connection_settings", Map.merge(stored, submitted))
+
+      _ ->
+        params
+    end
   end
 
   defp format_sync_error(:rate_limit_exceeded),

--- a/lib/mydia_web/live/search_live/index.ex
+++ b/lib/mydia_web/live/search_live/index.ex
@@ -1262,13 +1262,13 @@ defmodule MydiaWeb.SearchLive.Index do
   # Indexer type helpers for the template
   defp indexer_type_badge_class(:prowlarr), do: "badge-primary"
   defp indexer_type_badge_class(:jackett), do: "badge-secondary"
-  defp indexer_type_badge_class(:nzbhydra2), do: "badge-accent"
+  defp indexer_type_badge_class(:newznab), do: "badge-accent"
   defp indexer_type_badge_class(:public), do: "badge-ghost"
   defp indexer_type_badge_class(_), do: "badge-ghost"
 
   defp indexer_type_label(:prowlarr), do: "Prowlarr"
   defp indexer_type_label(:jackett), do: "Jackett"
-  defp indexer_type_label(:nzbhydra2), do: "NZBHydra2"
+  defp indexer_type_label(:newznab), do: "Newznab"
   defp indexer_type_label(:public), do: "Public"
   defp indexer_type_label(type), do: to_string(type)
 

--- a/priv/repo/migrations/20260912205942_rename_nzbhydra2_indexer_type_to_newznab.exs
+++ b/priv/repo/migrations/20260912205942_rename_nzbhydra2_indexer_type_to_newznab.exs
@@ -1,0 +1,15 @@
+defmodule Mydia.Repo.Migrations.RenameNzbhydra2IndexerTypeToNewznab do
+  use Ecto.Migration
+
+  # `nzbhydra2` was the concrete name of what is now the generic Newznab
+  # adapter. Rewrite stored rows to the canonical type at upgrade time; the
+  # configuration loader maps any remaining legacy value, so this only has to
+  # be a straight type swap. Plain SQL works on both SQLite and PostgreSQL.
+  def up do
+    execute("UPDATE indexer_configs SET type = 'newznab' WHERE type = 'nzbhydra2'")
+  end
+
+  def down do
+    execute("UPDATE indexer_configs SET type = 'nzbhydra2' WHERE type = 'newznab'")
+  end
+end

--- a/test/mydia/config/loader_test.exs
+++ b/test/mydia/config/loader_test.exs
@@ -25,6 +25,11 @@ defmodule Mydia.Config.LoaderTest do
       |> Enum.filter(fn {key, _} -> String.starts_with?(key, "LIBRARY_PATH_") end)
       |> Enum.map(fn {key, _} -> key end)
 
+    indexer_vars =
+      System.get_env()
+      |> Enum.filter(fn {key, _} -> String.starts_with?(key, "INDEXER_") end)
+      |> Enum.map(fn {key, _} -> key end)
+
     env_vars =
       [
         "PORT",
@@ -51,7 +56,7 @@ defmodule Mydia.Config.LoaderTest do
         "HWACCEL",
         "HWACCEL_DEVICE",
         "ENABLE_REMOTE_ACCESS"
-      ] ++ download_client_vars ++ library_path_vars
+      ] ++ download_client_vars ++ library_path_vars ++ indexer_vars
 
     # Store original values
     original_env =
@@ -78,6 +83,11 @@ defmodule Mydia.Config.LoaderTest do
       # Same reasoning for LIBRARY_PATH_* vars the test itself set.
       System.get_env()
       |> Enum.filter(fn {key, _} -> String.starts_with?(key, "LIBRARY_PATH_") end)
+      |> Enum.each(fn {key, _} -> System.delete_env(key) end)
+
+      # Same reasoning for INDEXER_* vars the test itself set.
+      System.get_env()
+      |> Enum.filter(fn {key, _} -> String.starts_with?(key, "INDEXER_") end)
       |> Enum.each(fn {key, _} -> System.delete_env(key) end)
 
       # Restore original environment
@@ -263,6 +273,48 @@ defmodule Mydia.Config.LoaderTest do
       assert [path] = config.library_paths
       assert path.path == "/movies"
       refute Map.has_key?(path, :quality_profile_id)
+    end
+
+    test "loads a Newznab API path from environment configuration" do
+      System.put_env("INDEXER_1_NAME", "Custom Newznab")
+      System.put_env("INDEXER_1_TYPE", "newznab")
+      System.put_env("INDEXER_1_BASE_URL", "https://indexer.test")
+      System.put_env("INDEXER_1_API_PATH", "/custom/api")
+
+      assert {:ok, config} = Loader.load(config_file: "nonexistent.yml", sources: [:env])
+      assert [indexer] = config.indexers
+      assert indexer.type == :newznab
+      assert indexer.connection_settings == %{"api_path" => "/custom/api"}
+    end
+
+    test "normalizes the legacy nzbhydra2 runtime type forever" do
+      System.put_env("INDEXER_1_NAME", "Legacy Hydra")
+      System.put_env("INDEXER_1_TYPE", "nzbhydra2")
+      System.put_env("INDEXER_1_BASE_URL", "http://hydra:5076")
+
+      assert {:ok, config} = Loader.load(config_file: "nonexistent.yml", sources: [:env])
+      assert [indexer] = config.indexers
+      assert indexer.type == :newznab
+    end
+
+    test "normalizes a legacy nzbhydra2 indexer from YAML" do
+      yaml_content = """
+      indexers:
+        - name: Legacy Hydra
+          type: nzbhydra2
+          base_url: http://hydra:5076
+          connection_settings:
+            api_path: /custom/api
+      """
+
+      File.mkdir_p!("test/fixtures")
+      File.write!(@test_yaml_path, yaml_content)
+
+      {:ok, config} = Loader.load(config_file: @test_yaml_path)
+
+      assert [indexer] = config.indexers
+      assert indexer.type == :newznab
+      assert indexer.connection_settings["api_path"] == "/custom/api"
     end
 
     test "returns error for invalid configuration" do

--- a/test/mydia/indexers/adapter/newznab_test.exs
+++ b/test/mydia/indexers/adapter/newznab_test.exs
@@ -1,7 +1,7 @@
-defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
+defmodule Mydia.Indexers.Adapter.NewznabTest do
   use ExUnit.Case, async: true
 
-  alias Mydia.Indexers.Adapter.NzbHydra2
+  alias Mydia.Indexers.Adapter.Newznab
   alias Mydia.Indexers.Adapter.Error
   alias Mydia.Indexers.SearchResult
 
@@ -78,14 +78,16 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
 
   defp build_config(bypass, opts \\ []) do
     %{
-      type: :nzbhydra2,
-      name: Keyword.get(opts, :name, "Test NZBHydra2"),
+      type: :newznab,
+      name: Keyword.get(opts, :name, "Test Newznab"),
       host: "localhost",
       port: bypass.port,
       api_key: Keyword.get(opts, :api_key, "test-api-key"),
       use_ssl: false,
       options: %{
-        timeout: 30_000
+        timeout: 30_000,
+        base_path: Keyword.get(opts, :base_path),
+        api_path: Keyword.get(opts, :api_path)
       }
     }
   end
@@ -104,10 +106,36 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, info} = NzbHydra2.test_connection(config)
+      assert {:ok, info} = Newznab.test_connection(config)
       assert info.name == "NZBHydra2"
       assert info.version == "5.3.0"
-      assert info.app_name == "NZBHydra2"
+      assert info.app_name == "Newznab"
+    end
+
+    test "uses a custom API path for connection testing" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/proxy/newznab/api", fn conn ->
+        assert conn.query_params["t"] == "caps"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/xml")
+        |> Plug.Conn.resp(200, @sample_caps_xml)
+      end)
+
+      config = build_config(bypass, base_path: "/proxy", api_path: "/newznab/api")
+      assert {:ok, _info} = Newznab.test_connection(config)
+    end
+
+    test "returns a typed error without issuing a request for an invalid API path" do
+      bypass = Bypass.open()
+
+      config = build_config(bypass, api_path: "https://indexer.test/api")
+
+      assert {:error, %Error{type: :connection_failed, message: message}} =
+               Newznab.test_connection(config)
+
+      refute message =~ "HTTP"
     end
 
     test "returns error on authentication failure (401)" do
@@ -119,7 +147,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:error, %Error{type: :authentication_failed}} = NzbHydra2.test_connection(config)
+      assert {:error, %Error{type: :authentication_failed}} = Newznab.test_connection(config)
     end
 
     test "returns error on forbidden (403)" do
@@ -131,7 +159,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:error, %Error{type: :authentication_failed}} = NzbHydra2.test_connection(config)
+      assert {:error, %Error{type: :authentication_failed}} = Newznab.test_connection(config)
     end
 
     test "returns error on server error" do
@@ -143,14 +171,14 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:error, %Error{type: :connection_failed}} = NzbHydra2.test_connection(config)
+      assert {:error, %Error{type: :connection_failed}} = Newznab.test_connection(config)
     end
 
     test "returns error on connection refused" do
       # Use a port that is not open
       config = %{
-        type: :nzbhydra2,
-        name: "Test NZBHydra2",
+        type: :newznab,
+        name: "Test Newznab",
         host: "localhost",
         port: 59999,
         api_key: "test-key",
@@ -158,7 +186,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
         options: %{}
       }
 
-      assert {:error, %Error{type: :connection_failed}} = NzbHydra2.test_connection(config)
+      assert {:error, %Error{type: :connection_failed}} = Newznab.test_connection(config)
     end
   end
 
@@ -177,7 +205,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, results} = NzbHydra2.search(config, "test movie")
+      assert {:ok, results} = Newznab.search(config, "test movie")
 
       assert length(results) == 2
 
@@ -208,6 +236,21 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       assert result2.download_protocol == :nzb
     end
 
+    test "uses a custom API path for search" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/custom/api", fn conn ->
+        assert conn.query_params["t"] == "search"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/xml")
+        |> Plug.Conn.resp(200, @sample_search_xml)
+      end)
+
+      config = build_config(bypass, api_path: "custom/api")
+      assert {:ok, _results} = Newznab.search(config, "test")
+    end
+
     test "returns empty list on no results" do
       bypass = Bypass.open()
 
@@ -218,7 +261,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, []} = NzbHydra2.search(config, "nonexistent")
+      assert {:ok, []} = Newznab.search(config, "nonexistent")
     end
 
     test "includes category filter in request" do
@@ -233,7 +276,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, _} = NzbHydra2.search(config, "test", categories: [2000, 5000])
+      assert {:ok, _} = Newznab.search(config, "test", categories: [2000, 5000])
     end
 
     test "includes limit in request" do
@@ -248,7 +291,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, _} = NzbHydra2.search(config, "test", limit: 50)
+      assert {:ok, _} = Newznab.search(config, "test", limit: 50)
     end
 
     test "returns error on authentication failure" do
@@ -260,7 +303,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:error, %Error{type: :authentication_failed}} = NzbHydra2.search(config, "test")
+      assert {:error, %Error{type: :authentication_failed}} = Newznab.search(config, "test")
     end
 
     test "returns error on rate limit" do
@@ -272,7 +315,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:error, %Error{type: :rate_limited}} = NzbHydra2.search(config, "test")
+      assert {:error, %Error{type: :rate_limited}} = Newznab.search(config, "test")
     end
 
     test "returns error on server error" do
@@ -284,7 +327,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:error, %Error{type: :search_failed}} = NzbHydra2.search(config, "test")
+      assert {:error, %Error{type: :search_failed}} = Newznab.search(config, "test")
     end
   end
 
@@ -300,7 +343,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, capabilities} = NzbHydra2.get_capabilities(config)
+      assert {:ok, capabilities} = Newznab.get_capabilities(config)
 
       assert is_map(capabilities.searching)
       assert capabilities.searching.search.available == true
@@ -322,15 +365,15 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
     test "implements required callbacks" do
       # Ensure the module is loaded first — function_exported?/3 returns false
       # for a module that has not yet been loaded, which flakes under test
-      # orderings where no prior test has referenced NzbHydra2.
-      assert Code.ensure_loaded?(NzbHydra2)
-      assert function_exported?(NzbHydra2, :search, 3)
-      assert function_exported?(NzbHydra2, :test_connection, 1)
-      assert function_exported?(NzbHydra2, :get_capabilities, 1)
+      # orderings where no prior test has referenced Newznab.
+      assert Code.ensure_loaded?(Newznab)
+      assert function_exported?(Newznab, :search, 3)
+      assert function_exported?(Newznab, :test_connection, 1)
+      assert function_exported?(Newznab, :get_capabilities, 1)
     end
 
     test "module exists and is loaded" do
-      assert Code.ensure_loaded?(NzbHydra2)
+      assert Code.ensure_loaded?(Newznab)
     end
   end
 
@@ -359,7 +402,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, [result]} = NzbHydra2.search(config, "test")
+      assert {:ok, [result]} = Newznab.search(config, "test")
       assert result.imdb_id == "tt1234567"
     end
 
@@ -387,7 +430,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, [result]} = NzbHydra2.search(config, "test")
+      assert {:ok, [result]} = Newznab.search(config, "test")
       assert result.imdb_id == "tt9876543"
     end
   end
@@ -417,7 +460,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, [result]} = NzbHydra2.search(config, "test")
+      assert {:ok, [result]} = Newznab.search(config, "test")
 
       assert result.quality != nil
       assert result.quality.resolution == "2160p"
@@ -450,7 +493,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, [result]} = NzbHydra2.search(config, "test")
+      assert {:ok, [result]} = Newznab.search(config, "test")
       assert %DateTime{} = result.usenet_date
       assert result.usenet_date.year == 2024
       assert result.usenet_date.month == 11
@@ -481,7 +524,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, [result]} = NzbHydra2.search(config, "test")
+      assert {:ok, [result]} = Newznab.search(config, "test")
       assert result.nzb_grabs == 42
       assert result.seeders == nil
       assert result.leechers == nil
@@ -511,7 +554,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, [result]} = NzbHydra2.search(config, "test")
+      assert {:ok, [result]} = Newznab.search(config, "test")
       assert result.nzb_completion == 0.95
     end
 
@@ -538,7 +581,7 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
       end)
 
       config = build_config(bypass)
-      assert {:ok, [result]} = NzbHydra2.search(config, "test")
+      assert {:ok, [result]} = Newznab.search(config, "test")
       assert result.usenet_date == nil
       assert result.nzb_completion == nil
       assert result.nzb_grabs == nil
@@ -557,15 +600,15 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
 
       # Config WITHOUT use_ssl key - simulates web UI config
       config = %{
-        type: :nzbhydra2,
-        name: "Test NZBHydra2",
+        type: :newznab,
+        name: "Test Newznab",
         host: "localhost",
         port: bypass.port,
         api_key: "test-api-key",
         options: %{}
       }
 
-      assert {:ok, info} = NzbHydra2.test_connection(config)
+      assert {:ok, info} = Newznab.test_connection(config)
       assert info.name == "NZBHydra2"
     end
 
@@ -580,15 +623,15 @@ defmodule Mydia.Indexers.Adapter.NzbHydra2Test do
 
       # Config WITHOUT use_ssl key - simulates web UI config
       config = %{
-        type: :nzbhydra2,
-        name: "Test NZBHydra2",
+        type: :newznab,
+        name: "Test Newznab",
         host: "localhost",
         port: bypass.port,
         api_key: "test-api-key",
         options: %{}
       }
 
-      assert {:ok, results} = NzbHydra2.search(config, "test")
+      assert {:ok, results} = Newznab.search(config, "test")
       assert length(results) == 2
     end
   end

--- a/test/mydia/indexers/adapter/registry_test.exs
+++ b/test/mydia/indexers/adapter/registry_test.exs
@@ -203,5 +203,12 @@ defmodule Mydia.Indexers.Adapter.RegistryTest do
       assert {:ok, [%SearchResult{}]} = adapter1.search(config1, "test", [])
       assert {:ok, []} = adapter2.search(config2, "test", [])
     end
+
+    test "registers the canonical Newznab adapter type only" do
+      Mydia.Indexers.register_adapters()
+
+      assert {:ok, Mydia.Indexers.Adapter.Newznab} = Registry.get_adapter(:newznab)
+      refute Registry.registered?(:nzbhydra2)
+    end
   end
 end

--- a/test/mydia/indexers/newznab_endpoint_test.exs
+++ b/test/mydia/indexers/newznab_endpoint_test.exs
@@ -1,0 +1,30 @@
+defmodule Mydia.Indexers.NewznabEndpointTest do
+  use ExUnit.Case, async: true
+
+  alias Mydia.Indexers.NewznabEndpoint
+
+  test "defaults a missing or blank API path to /api" do
+    assert {:ok, "/api"} = NewznabEndpoint.normalize_api_path(nil)
+    assert {:ok, "/api"} = NewznabEndpoint.normalize_api_path("")
+    assert {:ok, "/api"} = NewznabEndpoint.normalize_api_path("  ")
+  end
+
+  test "normalizes a configured API path to one leading slash" do
+    assert {:ok, "/newznab/api"} =
+             NewznabEndpoint.normalize_api_path("  //newznab/api  ")
+  end
+
+  test "rejects URL components Mydia must own" do
+    assert {:error, _} = NewznabEndpoint.normalize_api_path("https://indexer.test/api")
+    assert {:error, _} = NewznabEndpoint.normalize_api_path("/api?t=search")
+    assert {:error, _} = NewznabEndpoint.normalize_api_path("/api#fragment")
+  end
+
+  test "joins deployment prefixes and API paths exactly once" do
+    assert {:ok, "/api"} = NewznabEndpoint.join(nil, "/api")
+    assert {:ok, "/proxy/api"} = NewznabEndpoint.join("/proxy/", "api")
+
+    assert {:ok, "/proxy/newznab/api"} =
+             NewznabEndpoint.join("/proxy", "/newznab/api")
+  end
+end

--- a/test/mydia/indexers_test.exs
+++ b/test/mydia/indexers_test.exs
@@ -784,6 +784,35 @@ defmodule Mydia.IndexersTest do
 
       assert {:ok, %{version: "1.25.0"}} = Indexers.test_connection(config)
     end
+
+    test "stored Newznab config carries API path to the adapter" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/proxy/custom/api", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("application/xml")
+        |> Plug.Conn.resp(200, sample_newznab_caps_xml())
+      end)
+
+      config = %Settings.IndexerConfig{
+        name: "Custom Newznab",
+        type: :newznab,
+        base_url: "http://localhost:#{bypass.port}/proxy",
+        api_key: "test-key",
+        connection_settings: %{"api_path" => "/custom/api"}
+      }
+
+      assert {:ok, _info} = Indexers.test_connection(config)
+    end
+
+    defp sample_newznab_caps_xml do
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <caps>
+        <server appname="Newznab" version="1.0"/>
+      </caps>
+      """
+    end
   end
 
   describe "list_prowlarr_indexers/1" do

--- a/test/mydia/repo/migrations/rename_nzbhydra2_indexer_type_to_newznab_test.exs
+++ b/test/mydia/repo/migrations/rename_nzbhydra2_indexer_type_to_newznab_test.exs
@@ -1,0 +1,63 @@
+defmodule Mydia.Repo.Migrations.RenameNzbhydra2IndexerTypeToNewznabTest do
+  use Mydia.MigrationCase
+
+  Code.require_file(
+    "priv/repo/migrations/20260912205942_rename_nzbhydra2_indexer_type_to_newznab.exs"
+  )
+
+  alias Mydia.Repo.Migrations.RenameNzbhydra2IndexerTypeToNewznab
+
+  @version 20_260_912_205_942
+
+  # The migration only rewrites `type`, so the throwaway table carries just the
+  # columns the assertions read back.
+  defp build_schema do
+    sql!("""
+    CREATE TABLE indexer_configs (
+      id TEXT PRIMARY KEY,
+      type TEXT NOT NULL,
+      base_url TEXT,
+      connection_settings TEXT
+    )
+    """)
+
+    sql!("""
+    INSERT INTO indexer_configs (id, type, base_url, connection_settings)
+    VALUES ('hydra', 'nzbhydra2', 'http://hydra:5076', '{"timeout":30000}')
+    """)
+
+    sql!("""
+    INSERT INTO indexer_configs (id, type, base_url, connection_settings)
+    VALUES ('prowlarr', 'prowlarr', 'http://prowlarr:9696', NULL)
+    """)
+  end
+
+  defp row(id) do
+    sql!("SELECT type, base_url, connection_settings FROM indexer_configs WHERE id = '#{id}'")
+  end
+
+  @tag :tmp_dir
+  test "renames stored nzbhydra2 rows to newznab and leaves other types alone" do
+    build_schema()
+
+    run_migration!(RenameNzbhydra2IndexerTypeToNewznab, @version)
+
+    assert %{rows: [["newznab", "http://hydra:5076", settings]]} = row("hydra")
+    assert settings == ~s({"timeout":30000})
+
+    assert %{rows: [["prowlarr", "http://prowlarr:9696", nil]]} = row("prowlarr")
+  end
+
+  @tag :tmp_dir
+  test "rolling back restores the nzbhydra2 type without touching other columns" do
+    build_schema()
+
+    run_migration!(RenameNzbhydra2IndexerTypeToNewznab, @version)
+    rollback_migration!(RenameNzbhydra2IndexerTypeToNewznab, @version)
+
+    assert %{rows: [["nzbhydra2", "http://hydra:5076", settings]]} = row("hydra")
+    assert settings == ~s({"timeout":30000})
+
+    assert %{rows: [["prowlarr", "http://prowlarr:9696", nil]]} = row("prowlarr")
+  end
+end

--- a/test/mydia/settings/indexer_config_test.exs
+++ b/test/mydia/settings/indexer_config_test.exs
@@ -84,6 +84,51 @@ defmodule Mydia.Settings.IndexerConfigTest do
       assert changeset.valid?
       assert get_change(changeset, :base_url) == "http://192.168.68.66:9696"
     end
+
+    test "accepts Newznab and stores the default API path" do
+      attrs = %{
+        name: "NZBGeek",
+        type: :newznab,
+        base_url: "https://api.nzbgeek.info",
+        connection_settings: %{}
+      }
+
+      changeset = IndexerConfig.changeset(%IndexerConfig{}, attrs)
+      assert changeset.valid?
+      assert get_change(changeset, :connection_settings) == %{"api_path" => "/api"}
+    end
+
+    test "normalizes a custom Newznab API path without dropping other settings" do
+      attrs = %{
+        name: "Custom Newznab",
+        type: :newznab,
+        base_url: "https://indexer.test",
+        connection_settings: %{"api_path" => " custom/api ", "timeout" => 10_000}
+      }
+
+      changeset = IndexerConfig.changeset(%IndexerConfig{}, attrs)
+      assert changeset.valid?
+
+      assert get_change(changeset, :connection_settings) == %{
+               "api_path" => "/custom/api",
+               "timeout" => 10_000
+             }
+    end
+
+    test "rejects a Newznab API path containing a URL, query, or fragment" do
+      for invalid <- ["https://indexer.test/api", "/api?t=search", "/api#fragment"] do
+        attrs = %{
+          name: "Invalid Newznab",
+          type: :newznab,
+          base_url: "https://indexer.test",
+          connection_settings: %{"api_path" => invalid}
+        }
+
+        changeset = IndexerConfig.changeset(%IndexerConfig{}, attrs)
+        refute changeset.valid?
+        assert %{connection_settings: [_message]} = errors_on(changeset)
+      end
+    end
   end
 
   describe "normalize_url/1" do

--- a/test/mydia/settings/service_configs_test.exs
+++ b/test/mydia/settings/service_configs_test.exs
@@ -1,0 +1,87 @@
+defmodule Mydia.Settings.ServiceConfigsTest do
+  use Mydia.DataCase, async: false
+
+  alias Mydia.Settings
+  alias Mydia.Settings.IndexerConfig
+
+  describe "resolve_env_inheritance/1" do
+    # Mutates the process environment, so this file must not run concurrently
+    # with other tests. Each env var is captured and restored individually to
+    # keep the surrounding suite deterministic.
+    setup do
+      env_name = "MYDIA_TEST_NEWZNAB_ENV"
+
+      vars = [
+        "#{env_name}_BASE_URL",
+        "#{env_name}_API_KEY",
+        "#{env_name}_API_PATH"
+      ]
+
+      originals = Enum.map(vars, &{&1, System.get_env(&1)})
+      Enum.each(vars, &System.delete_env/1)
+
+      on_exit(fn ->
+        Enum.each(originals, fn
+          {var, nil} -> System.delete_env(var)
+          {var, value} -> System.put_env(var, value)
+        end)
+      end)
+
+      %{env_name: env_name}
+    end
+
+    test "resolves <env_name>_API_PATH into connection_settings", %{env_name: env_name} do
+      System.put_env("#{env_name}_API_PATH", "custom/api")
+
+      config = %IndexerConfig{
+        name: "Test Newznab",
+        type: :newznab,
+        env_name: env_name,
+        connection_settings: %{"timeout" => 5_000}
+      }
+
+      resolved = Settings.resolve_env_inheritance(config)
+
+      assert resolved.connection_settings["api_path"] == "/custom/api"
+      assert resolved.connection_settings["timeout"] == 5_000
+    end
+
+    test "returns connection_settings unchanged when the API path env var is unset",
+         %{env_name: env_name} do
+      settings = %{"timeout" => 5_000}
+
+      config = %IndexerConfig{
+        name: "Test Newznab",
+        type: :newznab,
+        env_name: env_name,
+        connection_settings: settings
+      }
+
+      assert Settings.resolve_env_inheritance(config).connection_settings == settings
+    end
+
+    test "returns connection_settings unchanged when the API path env var is blank",
+         %{env_name: env_name} do
+      System.put_env("#{env_name}_API_PATH", "   ")
+
+      settings = %{"timeout" => 5_000}
+
+      config = %IndexerConfig{
+        name: "Test Newznab",
+        type: :newznab,
+        env_name: env_name,
+        connection_settings: settings
+      }
+
+      assert Settings.resolve_env_inheritance(config).connection_settings == settings
+    end
+
+    test "returns connection_settings unchanged when the env_name is nil" do
+      settings = %{"timeout" => 5_000}
+
+      config = %IndexerConfig{name: "Test Newznab", type: :newznab, connection_settings: settings}
+
+      assert Settings.resolve_env_inheritance(config).connection_settings == settings
+    end
+  end
+end

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -465,6 +465,92 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
     end
   end
 
+  describe "runtime indexer conversion" do
+    setup %{conn: conn, token: token} do
+      start_supervised!(Mydia.Indexers.Health)
+      Mydia.Indexers.register_adapters()
+
+      name = "Convert Me #{System.unique_integer([:positive])}"
+      base_url = "http://127.0.0.1:19911"
+
+      # api_key stays nil so edit_indexer skips the synchronous Prowlarr
+      # indexer fetch; connection_settings is what this test is about.
+      runtime_config = %{
+        Mydia.Config.Schema.defaults()
+        | indexers: [
+            %{
+              name: name,
+              type: :prowlarr,
+              enabled: true,
+              priority: 10,
+              base_url: base_url,
+              api_key: nil,
+              connection_settings: %{"timeout" => 60_000}
+            }
+          ]
+      }
+
+      original_runtime = Application.get_env(:mydia, :runtime_config)
+      Application.put_env(:mydia, :runtime_config, runtime_config)
+
+      on_exit(fn ->
+        if original_runtime do
+          Application.put_env(:mydia, :runtime_config, original_runtime)
+        else
+          Application.delete_env(:mydia, :runtime_config)
+        end
+      end)
+
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> put_session(:guardian_default_token, token)
+        |> put_req_header("authorization", "Bearer #{token}")
+
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+
+      %{view: view, name: name, base_url: base_url, runtime_id: "runtime::indexer::#{name}"}
+    end
+
+    test "converting a runtime indexer without a connection_settings param keeps stored settings",
+         %{view: view, name: name, base_url: base_url, runtime_id: runtime_id} do
+      view
+      |> element(~s{button[phx-click="edit_indexer"][phx-value-id="#{runtime_id}"]})
+      |> render_click()
+
+      assert has_element?(
+               view,
+               "#flash-info",
+               "Converting runtime indexer to database-managed configuration"
+             )
+
+      # Prowlarr's modal renders no connection_settings inputs, so the submitted
+      # params carry no "connection_settings" key at all.
+      refute has_element?(
+               view,
+               ~s{#indexer-form input[name^="indexer_config[connection_settings]"]}
+             )
+
+      view
+      |> form("#indexer-form",
+        indexer_config: %{
+          name: name,
+          type: "prowlarr",
+          base_url: base_url,
+          api_key: "test-api-key",
+          enabled: "true",
+          priority: "1"
+        }
+      )
+      |> render_submit()
+
+      saved = Repo.get_by(Mydia.Settings.IndexerConfig, name: name)
+
+      assert saved, "expected the converted runtime indexer to be persisted as a database row"
+      assert saved.connection_settings == %{"timeout" => 60_000}
+    end
+  end
+
   describe "FlareSolverr panel" do
     setup %{conn: conn, token: token} do
       start_supervised!(Mydia.Indexers.Health)

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -145,6 +145,106 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
       assert has_element?(view, "#flash-error", "Unexpected response")
     end
 
+    test "offers Newznab and shows its API path field", %{view: view} do
+      view |> element(~s{button[phx-click="new_indexer"]}) |> render_click()
+
+      assert has_element?(view, "#indexer-form option[value='newznab']", "Newznab")
+      refute has_element?(view, "#indexer-form option[value='nzbhydra2']")
+
+      view
+      |> form("#indexer-form", indexer_config: %{type: "newznab"})
+      |> render_change()
+
+      assert has_element?(
+               view,
+               ~s{#indexer-form input[name="indexer_config[connection_settings][api_path]"][value="/api"]}
+             )
+    end
+
+    test "unsaved Newznab connection test probes the configured API path", %{view: view} do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/proxy/custom/api", fn conn ->
+        assert conn.query_params["t"] == "caps"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/xml")
+        |> Plug.Conn.resp(200, newznab_caps_xml())
+      end)
+
+      view |> element(~s{button[phx-click="new_indexer"]}) |> render_click()
+
+      view
+      |> change_newznab_form(%{
+        name: "Custom Newznab",
+        type: "newznab",
+        base_url: "http://localhost:#{bypass.port}/proxy",
+        api_key: "test-api-key",
+        connection_settings: %{"api_path" => "/custom/api"}
+      })
+      |> render_change()
+
+      view
+      |> element(~s{button[phx-click="test_indexer_connection"]})
+      |> render_click()
+
+      assert has_element?(view, "#flash-info", "Connection successful")
+    end
+
+    test "an invalid changeset is never probed over HTTP", %{view: view} do
+      # A downed Bypass turns any accidental request into a "Connection failed"
+      # flash, so the refutation below proves no request left the LiveView.
+      bypass = Bypass.open()
+      Bypass.down(bypass)
+
+      view |> element(~s{button[phx-click="new_indexer"]}) |> render_click()
+
+      # The name is required, so this changeset can never become valid.
+      view
+      |> change_newznab_form(%{
+        type: "newznab",
+        base_url: "http://localhost:#{bypass.port}/proxy",
+        api_key: "test-api-key",
+        connection_settings: %{"api_path" => "/custom/api"}
+      })
+      |> render_change()
+
+      view
+      |> element(~s{button[phx-click="test_indexer_connection"]})
+      |> render_click()
+
+      assert has_element?(view, "#flash-error", "Fix the highlighted errors")
+      refute has_element?(view, "#flash-error", "Connection failed")
+    end
+
+    test "saves and reopens a Newznab API path", %{view: view} do
+      name = "Custom Newznab #{System.unique_integer([:positive])}"
+
+      view |> element(~s{button[phx-click="new_indexer"]}) |> render_click()
+
+      view
+      |> change_newznab_form(%{
+        name: name,
+        type: "newznab",
+        base_url: "http://localhost:5076",
+        api_key: "test-api-key",
+        connection_settings: %{"api_path" => "/custom/api"}
+      })
+      |> render_submit()
+
+      saved = Enum.find(Settings.list_indexer_configs(), &(&1.name == name))
+      assert saved.connection_settings["api_path"] == "/custom/api"
+
+      view
+      |> element(~s{button[phx-click="edit_indexer"][phx-value-id="#{saved.id}"]})
+      |> render_click()
+
+      assert has_element?(
+               view,
+               ~s{#indexer-form input[name="indexer_config[connection_settings][api_path]"][value="/custom/api"]}
+             )
+    end
+
     @tag :skip
     test "test connection succeeds with valid prowlarr server", %{view: view} do
       bypass = Bypass.open()
@@ -800,5 +900,25 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
         Jason.encode!(%{"status" => "ok", "version" => "3.3.21", "sessions" => []})
       )
     end)
+  end
+
+  defp newznab_caps_xml do
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <caps>
+      <server appname="Newznab" version="1.0"/>
+    </caps>
+    """
+  end
+
+  # The API Path input only renders once the type is Newznab, and LiveViewTest
+  # resolves form inputs against the rendered DOM, so reveal the field before
+  # building the form that fills it.
+  defp change_newznab_form(view, attrs) do
+    view
+    |> form("#indexer-form", indexer_config: %{type: "newznab"})
+    |> render_change()
+
+    form(view, "#indexer-form", indexer_config: attrs)
   end
 end

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -245,6 +245,46 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
              )
     end
 
+    test "unsaved Newznab connection test resolves an env-sourced indexer", %{view: view} do
+      bypass = Bypass.open()
+      env_name = "TEST_NEWZNAB_#{System.unique_integer([:positive])}"
+
+      # The Source dropdown is populated when the modal opens, so the env vars
+      # have to exist before the click below.
+      System.put_env("#{env_name}_BASE_URL", "http://localhost:#{bypass.port}")
+      System.put_env("#{env_name}_API_KEY", "env-api-key")
+
+      on_exit(fn ->
+        System.delete_env("#{env_name}_BASE_URL")
+        System.delete_env("#{env_name}_API_KEY")
+      end)
+
+      Bypass.expect_once(bypass, "GET", "/api", fn conn ->
+        assert conn.query_params["t"] == "caps"
+        assert conn.query_params["apikey"] == "env-api-key"
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/xml")
+        |> Plug.Conn.resp(200, newznab_caps_xml())
+      end)
+
+      view |> element(~s{button[phx-click="new_indexer"]}) |> render_click()
+
+      # The Base URL/API Key inputs are hidden for an env source, so the only
+      # connection details the form can carry are the env_name and the settings.
+      view
+      |> form("#indexer-form",
+        indexer_config: %{name: "Env Newznab", type: "newznab", env_name: env_name}
+      )
+      |> render_change()
+
+      view
+      |> element(~s{button[phx-click="test_indexer_connection"]})
+      |> render_click()
+
+      assert has_element?(view, "#flash-info", "Connection successful")
+    end
+
     test "keeps Newznab connection settings the form does not render", %{conn: conn} do
       # Legacy NZBHydra2 rows migrate to Newznab carrying their old settings
       # (the migration test pins a stored timeout), so editing one in the UI

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -161,6 +161,39 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
              )
     end
 
+    test "surfaces a rejected API Path on the field", %{view: view} do
+      view |> element(~s{button[phx-click="new_indexer"]}) |> render_click()
+
+      view
+      |> change_newznab_form(%{
+        name: "Bad Path",
+        type: "newznab",
+        base_url: "http://localhost:5076",
+        api_key: "test-api-key",
+        connection_settings: %{"api_path" => "http://localhost:5076/api"}
+      })
+      |> render_change()
+
+      # The message comes from NewznabEndpoint.normalize_api_path/1 and the
+      # class can only be on this input if it received this error list.
+      assert has_element?(view, "#indexer-api-path.input-error")
+
+      assert has_element?(
+               view,
+               "#indexer-form p.text-error",
+               "must be a path, not a complete URL"
+             )
+
+      view
+      |> form("#indexer-form",
+        indexer_config: %{connection_settings: %{"api_path" => "custom/api"}}
+      )
+      |> render_change()
+
+      refute has_element?(view, "#indexer-api-path.input-error")
+      refute has_element?(view, "#indexer-form", "must be a path, not a complete URL")
+    end
+
     test "unsaved Newznab connection test probes the configured API path", %{view: view} do
       bypass = Bypass.open()
 

--- a/test/mydia_web/live/admin_indexers_live_test.exs
+++ b/test/mydia_web/live/admin_indexers_live_test.exs
@@ -245,6 +245,37 @@ defmodule MydiaWeb.AdminIndexersLiveTest do
              )
     end
 
+    test "keeps Newznab connection settings the form does not render", %{conn: conn} do
+      # Legacy NZBHydra2 rows migrate to Newznab carrying their old settings
+      # (the migration test pins a stored timeout), so editing one in the UI
+      # must not drop keys the form has no input for.
+      {:ok, indexer} =
+        Settings.create_indexer_config(%{
+          name: "Legacy Newznab #{System.unique_integer([:positive])}",
+          type: :newznab,
+          base_url: "http://localhost:5076",
+          api_key: "test-api-key",
+          connection_settings: %{"api_path" => "/api", "timeout" => 60_000}
+        })
+
+      # Seed before mounting: the row has to be in the list the LiveView loads.
+      {:ok, view, _html} = live(conn, ~p"/admin/config/indexers")
+
+      view
+      |> element(~s{button[phx-click="edit_indexer"][phx-value-id="#{indexer.id}"]})
+      |> render_click()
+
+      view
+      |> form("#indexer-form",
+        indexer_config: %{connection_settings: %{"api_path" => "/custom/api"}}
+      )
+      |> render_submit()
+
+      saved = Settings.get_indexer_config!(indexer.id)
+      assert saved.connection_settings["api_path"] == "/custom/api"
+      assert saved.connection_settings["timeout"] == 60_000
+    end
+
     @tag :skip
     test "test connection succeeds with valid prowlarr server", %{view: view} do
       bypass = Bypass.open()


### PR DESCRIPTION
## Summary

Mydia had no generic NZB indexer. The only NZB-only adapter was NZBHydra2, whose endpoint was hard-coded to `/api`, so pointing Mydia at another Newznab-compatible server meant abusing the NZBHydra2 type. This replaces the NZBHydra2-specific presentation with a protocol-level **Newznab** indexer whose API path is configurable.

## What changed

- The adapter is now `Mydia.Indexers.Adapter.Newznab`, registered as `:newznab`. The admin UI, search labels, logs, configuration examples and docs use only the Newznab name; NZBHydra2 becomes an example of a compatible server.
- New `Mydia.Indexers.NewznabEndpoint` unit validates and joins the API path. All three request paths (`t=caps` connection test, capability discovery, `t=search`) build their URL through it, so they cannot diverge on path handling.
- New **API Path** field, shown only for Newznab, defaulting to `/api`, persisted in the existing `connection_settings["api_path"]` — no new column.
- Validation: blank resolves to `/api`; a configured path is normalized to exactly one leading slash; absolute URLs, query strings and fragments are rejected before any request, with the message rendered on the field.
- Environment: `INDEXER_<N>_API_PATH`, plus `<PREFIX>_API_PATH` resolution through the admin "Source" (env inheritance) path.
- Unchanged: Newznab XML parsing, category mapping, result mapping, ranking inputs, timeouts, retry policy, and typed HTTP errors.

## Compatibility

- Existing database rows migrate from `nzbhydra2` to `newznab` — a reversible single portable `UPDATE` that works on SQLite and PostgreSQL. No URL migration is needed, because an absent API path resolves to `/api`, leaving existing request URLs identical.
- Existing YAML and environment configurations using `type: nzbhydra2` keep working indefinitely: the loader normalizes that value to `:newznab` at the configuration boundary. New configurations and current documentation use `newznab` only.

## Verification

- `./dev mix precommit` — 11450 tests, 0 failures; compile, format, credo and unused-deps gates pass.
- New coverage: endpoint path contracts; default and custom API paths exercised through connection test, capability discovery and search with Bypass-asserted request paths; settings validation and normalization; loader environment/YAML behavior including legacy type normalization; adapter conversion reaching `/proxy/custom/api`; migration up/down behavior; admin LiveView Newznab option, API Path field, unsaved connection probe, save/edit round trip, and invalid-path error rendering; env inheritance resolution.
- Manual smoke test on the admin surface: Newznab selected shows API Path `/api`; a custom path survives validation; the field is hidden for Prowlarr; save then reopen shows the persisted path.

## Deferred (noted, not blocking)

- The PostgreSQL migration path was validated by reasoning about the portable SQL; local execution used SQLite.
- The API Path input lives inside the existing NZB-capable block. It is gated on `is_newznab`, so Prowlarr and Jackett hide it, but that hiding is covered by the smoke test rather than an automated assertion.
- Migrated `connection_settings` keys with no editor (for example `timeout`) remain uneditable in the UI; they are preserved across save.
- Pre-existing: the adapter's debug log lines interpolate the full request URL including the `apikey` query parameter. Unchanged by this PR except for the log label; worth a separate fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generic Newznab indexers with configurable API paths.
  * Added API path fields to indexer setup and connection testing.
  * Added API path validation and normalization.

* **Bug Fixes**
  * Preserved connection settings during indexer editing and conversion.
  * Displayed validation errors before connection testing.

* **Documentation**
  * Updated Newznab setup, reference, and environment variable guidance.

* **Compatibility**
  * Existing NZBHydra2 configurations remain supported and are migrated to Newznab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->