### PR TITLE
fix(downloads): respect seeding goals before Remove After Import

### DIFF
--- a/lib/mydia/downloads/client_removal.ex
+++ b/lib/mydia/downloads/client_removal.ex
@@ -62,10 +62,14 @@ defmodule Mydia.Downloads.ClientRemoval do
     else
       case client_info(download) do
         {:error, :missing_client} ->
-          case stamp(download) do
-            :ok -> :removed
-            {:error, _} = err -> err
-          end
+          # Leave pending: a rename/re-add/adoption may restore the client.
+          # Stamp only after remove_download :ok or a confirmed :not_found.
+          Logger.warning("Deferring client removal; download client not found",
+            download_id: download.id,
+            client: download.download_client
+          )
+
+          :deferred
 
         {:ok, %{remove_completed: false}} ->
           :skipped
@@ -137,10 +141,12 @@ defmodule Mydia.Downloads.ClientRemoval do
     else
       case client_info(download, configs) do
         {:error, :missing_client} ->
-          case stamp(download) do
-            :ok -> :removed
-            {:error, _} = err -> err
-          end
+          Logger.warning("Deferring client removal; download client not found",
+            download_id: download.id,
+            client: download.download_client
+          )
+
+          :deferred
 
         {:ok, info} ->
           if info.remove_completed || false do

--- a/lib/mydia/downloads/client_removal.ex
+++ b/lib/mydia/downloads/client_removal.ex
@@ -83,6 +83,14 @@ defmodule Mydia.Downloads.ClientRemoval do
 
                 :deferred
 
+              {:ok, %{state: state}} ->
+                Logger.info("Deferring client removal; torrent not idle yet",
+                  download_id: download.id,
+                  state: state
+                )
+
+                :deferred
+
               {:error, error} ->
                 if not_found_error?(error) do
                   stamp(download)

--- a/lib/mydia/downloads/client_removal.ex
+++ b/lib/mydia/downloads/client_removal.ex
@@ -132,46 +132,44 @@ defmodule Mydia.Downloads.ClientRemoval do
   end
 
   def finish_pending_removal(%Download{} = download, configs \\ nil) do
-    cond do
-      download.match_status == "unresolved_files" ->
-        :skipped
+    if download.match_status == "unresolved_files" do
+      :skipped
+    else
+      case client_info(download, configs) do
+        {:error, :missing_client} ->
+          case stamp(download) do
+            :ok -> :removed
+            {:error, _} = err -> err
+          end
 
-      true ->
-        case client_info(download, configs) do
-          {:error, :missing_client} ->
-            case stamp(download) do
-              :ok -> :removed
-              {:error, _} = err -> err
-            end
+        {:ok, info} ->
+          if info.remove_completed || false do
+            if seed_aware_type?(info.type) do
+              case Client.get_status(info.adapter, info.config, info.client_id) do
+                {:ok, %{state: state}} ->
+                  if removable_state?(state) do
+                    remove_and_stamp(download, info)
+                  else
+                    :still_seeding
+                  end
 
-          {:ok, info} ->
-            if info.remove_completed || false do
-              if seed_aware_type?(info.type) do
-                case Client.get_status(info.adapter, info.config, info.client_id) do
-                  {:ok, %{state: state}} ->
-                    if removable_state?(state) do
-                      remove_and_stamp(download, info)
-                    else
-                      :still_seeding
+                {:error, error} ->
+                  if not_found_error?(error) do
+                    case stamp(download) do
+                      :ok -> :removed
+                      {:error, _} = err -> err
                     end
-
-                  {:error, error} ->
-                    if not_found_error?(error) do
-                      case stamp(download) do
-                        :ok -> :removed
-                        {:error, _} = err -> err
-                      end
-                    else
-                      {:error, error}
-                    end
-                end
-              else
-                remove_and_stamp(download, info)
+                  else
+                    {:error, error}
+                  end
               end
             else
-              :skipped
+              remove_and_stamp(download, info)
             end
-        end
+          else
+            :skipped
+          end
+      end
     end
   end
 

--- a/lib/mydia/downloads/client_removal.ex
+++ b/lib/mydia/downloads/client_removal.ex
@@ -28,118 +28,158 @@ defmodule Mydia.Downloads.ClientRemoval do
   def not_found_error?(%Error{type: :not_found}), do: true
   def not_found_error?(_), do: false
 
-  def list_pending_removals do
+  def list_pending_removals(configs \\ nil) do
+    configs = configs || Settings.list_download_client_configs()
+
     remove_names =
-      Settings.list_download_client_configs()
-      |> Enum.filter(& &1.remove_completed)
+      configs
+      |> Enum.filter(&(&1.remove_completed || false))
       |> Enum.map(& &1.name)
 
     from(d in Download,
       where:
         not is_nil(d.imported_at) and is_nil(d.client_removed_at) and
-          d.download_client in ^remove_names
+          d.download_client in ^remove_names and
+          (is_nil(d.match_status) or d.match_status != "unresolved_files")
     )
     |> Repo.all()
   end
 
-  def maybe_remove_after_import(%Download{} = download) do
-    case client_info(download) do
-      {:error, :missing_client} ->
-        stamp(download)
-        :removed
+  @doc """
+  Loads client configs once and returns them with pending removal rows.
 
-      {:ok, %{remove_completed: false}} ->
+  DownloadMonitor should pass the configs into `finish_pending_removal/2`
+  so each row does not re-list settings.
+  """
+  def finish_pending_removals do
+    configs = Settings.list_download_client_configs()
+    {configs, list_pending_removals(configs)}
+  end
+
+  def maybe_remove_after_import(%Download{} = download) do
+    if download.match_status == "unresolved_files" do
+      :skipped
+    else
+      case client_info(download) do
+        {:error, :missing_client} ->
+          case stamp(download) do
+            :ok -> :removed
+            {:error, _} = err -> err
+          end
+
+        {:ok, %{remove_completed: false}} ->
+          :skipped
+
+        {:ok, info} ->
+          if seed_aware_type?(info.type) do
+            case Client.get_status(info.adapter, info.config, info.client_id) do
+              {:ok, %{state: state}} ->
+                cond do
+                  removable_state?(state) ->
+                    remove_and_stamp(download, info)
+
+                  state == :seeding ->
+                    Logger.info("Deferring client removal until seeding finishes",
+                      download_id: download.id
+                    )
+
+                    :deferred
+
+                  state in [:downloading, :checking] ->
+                    Logger.info("Deferring client removal; torrent not idle yet",
+                      download_id: download.id,
+                      state: state
+                    )
+
+                    :deferred
+
+                  state == :error ->
+                    Logger.warning("Not auto-removing errored torrent after import",
+                      download_id: download.id
+                    )
+
+                    :deferred
+
+                  true ->
+                    Logger.info("Deferring client removal; torrent not idle yet",
+                      download_id: download.id,
+                      state: state
+                    )
+
+                    :deferred
+                end
+
+              {:error, error} ->
+                if not_found_error?(error) do
+                  case stamp(download) do
+                    :ok -> :removed
+                    {:error, _} = err -> err
+                  end
+                else
+                  Logger.warning("Could not read status for post-import removal",
+                    download_id: download.id,
+                    error: inspect(error)
+                  )
+
+                  :deferred
+                end
+            end
+          else
+            remove_and_stamp(download, info)
+          end
+      end
+    end
+  end
+
+  def finish_pending_removal(%Download{} = download, configs \\ nil) do
+    cond do
+      download.match_status == "unresolved_files" ->
         :skipped
 
-      {:ok, info} ->
-        if seed_aware_type?(info.type) do
-          case Client.get_status(info.adapter, info.config, info.client_id) do
-            {:ok, %{state: state}} when state in [:paused, :completed] ->
-              remove_and_stamp(download, info)
+      true ->
+        case client_info(download, configs) do
+          {:error, :missing_client} ->
+            case stamp(download) do
+              :ok -> :removed
+              {:error, _} = err -> err
+            end
 
-            {:ok, %{state: :seeding}} ->
-              Logger.info("Deferring client removal until seeding finishes",
-                download_id: download.id
-              )
+          {:ok, info} ->
+            if info.remove_completed || false do
+              if seed_aware_type?(info.type) do
+                case Client.get_status(info.adapter, info.config, info.client_id) do
+                  {:ok, %{state: state}} ->
+                    if removable_state?(state) do
+                      remove_and_stamp(download, info)
+                    else
+                      :still_seeding
+                    end
 
-              :deferred
-
-            {:ok, %{state: state}} when state in [:downloading, :checking] ->
-              Logger.info("Deferring client removal; torrent not idle yet",
-                download_id: download.id,
-                state: state
-              )
-
-              :deferred
-
-            {:ok, %{state: :error}} ->
-              Logger.warning("Not auto-removing errored torrent after import",
-                download_id: download.id
-              )
-
-              :deferred
-
-            {:ok, %{state: state}} ->
-              Logger.info("Deferring client removal; torrent not idle yet",
-                download_id: download.id,
-                state: state
-              )
-
-              :deferred
-
-            {:error, error} ->
-              if not_found_error?(error) do
-                stamp(download)
-                :removed
+                  {:error, error} ->
+                    if not_found_error?(error) do
+                      case stamp(download) do
+                        :ok -> :removed
+                        {:error, _} = err -> err
+                      end
+                    else
+                      {:error, error}
+                    end
+                end
               else
-                Logger.warning("Could not read status for post-import removal",
-                  download_id: download.id,
-                  error: inspect(error)
-                )
-
-                :deferred
-              end
-          end
-        else
-          remove_and_stamp(download, info)
-        end
-    end
-  end
-
-  def finish_pending_removal(%Download{} = download) do
-    case client_info(download) do
-      {:error, :missing_client} ->
-        stamp(download)
-        :removed
-
-      {:ok, info} ->
-        if info.remove_completed do
-          case Client.get_status(info.adapter, info.config, info.client_id) do
-            {:ok, %{state: state}} ->
-              if removable_state?(state) do
                 remove_and_stamp(download, info)
-              else
-                :still_seeding
               end
-
-            {:error, error} ->
-              if not_found_error?(error) do
-                stamp(download)
-                :removed
-              else
-                {:error, error}
-              end
-          end
-        else
-          :skipped
+            else
+              :skipped
+            end
         end
     end
   end
 
-  defp client_info(%Download{} = download) do
+  defp client_info(%Download{} = download, configs \\ nil) do
     if download.download_client && download.download_client_id do
-      case Settings.list_download_client_configs()
-           |> Enum.find(&(&1.name == download.download_client)) do
+      configs = configs || Settings.list_download_client_configs()
+
+      case Enum.find(configs, &(&1.name == download.download_client)) do
         nil ->
           {:error, :missing_client}
 
@@ -152,7 +192,7 @@ defmodule Mydia.Downloads.ClientRemoval do
              adapter: adapter,
              config: build_client_config(client_config),
              client_id: download.download_client_id,
-             remove_completed: Map.get(client_config, :remove_completed, false)
+             remove_completed: Map.get(client_config, :remove_completed, false) || false
            }}
       end
     else
@@ -204,13 +244,17 @@ defmodule Mydia.Downloads.ClientRemoval do
            delete_files: true
          ) do
       :ok ->
-        stamp(download)
-        :removed
+        case stamp(download) do
+          :ok -> :removed
+          {:error, _} = err -> err
+        end
 
       {:error, error} ->
         if not_found_error?(error) do
-          stamp(download)
-          :removed
+          case stamp(download) do
+            :ok -> :removed
+            {:error, _} = err -> err
+          end
         else
           {:error, error}
         end
@@ -218,9 +262,19 @@ defmodule Mydia.Downloads.ClientRemoval do
   end
 
   defp stamp(download) do
-    {:ok, _} =
-      Downloads.update_download(download, %{
-        client_removed_at: DateTime.utc_now() |> DateTime.truncate(:second)
-      })
+    case Downloads.update_download(download, %{
+           client_removed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+         }) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} = err ->
+        Logger.warning("Failed to stamp client_removed_at",
+          download_id: download.id,
+          error: inspect(reason)
+        )
+
+        err
+    end
   end
 end

--- a/lib/mydia/downloads/client_removal.ex
+++ b/lib/mydia/downloads/client_removal.ex
@@ -1,0 +1,220 @@
+defmodule Mydia.Downloads.ClientRemoval do
+  @moduledoc """
+  Deferred Remove After Import cleanup.
+
+  Seed-aware torrent clients keep seeding until paused/completed/gone;
+  other clients remove immediately when `remove_completed` is set.
+  """
+
+  require Logger
+
+  import Ecto.Query
+
+  alias Mydia.Downloads
+  alias Mydia.Downloads.Client
+  alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Registry
+  alias Mydia.Downloads.Download
+  alias Mydia.Repo
+  alias Mydia.Settings
+
+  @seed_aware ~w(qbittorrent transmission rtorrent)a
+
+  def seed_aware_type?(type) when is_atom(type), do: type in @seed_aware
+
+  def removable_state?(state) when state in [:paused, :completed], do: true
+  def removable_state?(_), do: false
+
+  def not_found_error?(%Error{type: :not_found}), do: true
+  def not_found_error?(_), do: false
+
+  def list_pending_removals do
+    remove_names =
+      Settings.list_download_client_configs()
+      |> Enum.filter(& &1.remove_completed)
+      |> Enum.map(& &1.name)
+
+    from(d in Download,
+      where:
+        not is_nil(d.imported_at) and is_nil(d.client_removed_at) and
+          d.download_client in ^remove_names
+    )
+    |> Repo.all()
+  end
+
+  def maybe_remove_after_import(%Download{} = download) do
+    case client_info(download) do
+      {:error, :missing_client} ->
+        stamp(download)
+        :removed
+
+      {:ok, %{remove_completed: false}} ->
+        :skipped
+
+      {:ok, info} ->
+        cond do
+          not seed_aware_type?(info.type) ->
+            remove_and_stamp(download, info)
+
+          true ->
+            case Client.get_status(info.adapter, info.config, info.client_id) do
+              {:ok, %{state: state}} when state in [:paused, :completed] ->
+                remove_and_stamp(download, info)
+
+              {:ok, %{state: :seeding}} ->
+                Logger.info("Deferring client removal until seeding finishes",
+                  download_id: download.id
+                )
+
+                :deferred
+
+              {:ok, %{state: state}} when state in [:downloading, :checking] ->
+                Logger.info("Deferring client removal; torrent not idle yet",
+                  download_id: download.id,
+                  state: state
+                )
+
+                :deferred
+
+              {:ok, %{state: :error}} ->
+                Logger.warning("Not auto-removing errored torrent after import",
+                  download_id: download.id
+                )
+
+                :deferred
+
+              {:error, error} ->
+                if not_found_error?(error) do
+                  stamp(download)
+                  :removed
+                else
+                  Logger.warning("Could not read status for post-import removal",
+                    download_id: download.id,
+                    error: inspect(error)
+                  )
+
+                  :deferred
+                end
+            end
+        end
+    end
+  end
+
+  def finish_pending_removal(%Download{} = download) do
+    case client_info(download) do
+      {:error, :missing_client} ->
+        stamp(download)
+        :removed
+
+      {:ok, info} ->
+        unless info.remove_completed do
+          :skipped
+        else
+          case Client.get_status(info.adapter, info.config, info.client_id) do
+            {:ok, %{state: state}} ->
+              if removable_state?(state) do
+                remove_and_stamp(download, info)
+              else
+                :still_seeding
+              end
+
+            {:error, error} ->
+              if not_found_error?(error) do
+                stamp(download)
+                :removed
+              else
+                {:error, error}
+              end
+          end
+        end
+    end
+  end
+
+  defp client_info(%Download{} = download) do
+    if download.download_client && download.download_client_id do
+      case Settings.list_download_client_configs()
+           |> Enum.find(&(&1.name == download.download_client)) do
+        nil ->
+          {:error, :missing_client}
+
+        client_config ->
+          adapter = Registry.lookup(client_config.type)
+
+          {:ok,
+           %{
+             type: client_config.type,
+             adapter: adapter,
+             config: build_client_config(client_config),
+             client_id: download.download_client_id,
+             remove_completed: Map.get(client_config, :remove_completed, false)
+           }}
+      end
+    else
+      {:error, :missing_client}
+    end
+  end
+
+  defp build_client_config(client_config) do
+    case client_config.type do
+      :blackhole ->
+        %{
+          type: :blackhole,
+          connection_settings: client_config.connection_settings || %{}
+        }
+
+      :debrid ->
+        %{
+          type: :debrid,
+          api_key: client_config.api_key,
+          download_directory: client_config.download_directory,
+          connection_settings: client_config.connection_settings || %{}
+        }
+
+      _ ->
+        %{
+          type: client_config.type,
+          host: client_config.host,
+          port: client_config.port,
+          username: client_config.username,
+          password: client_config.password,
+          use_ssl: client_config.use_ssl || false,
+          options:
+            %{}
+            |> maybe_put(:url_base, client_config.url_base)
+            |> maybe_put(:api_key, client_config.api_key)
+        }
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, _key, ""), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp remove_and_stamp(download, info) do
+    case Client.remove_download(
+           info.adapter,
+           info.config,
+           info.client_id,
+           delete_files: true
+         ) do
+      :ok ->
+        stamp(download)
+        :removed
+
+      {:error, error} ->
+        if not_found_error?(error) do
+          stamp(download)
+          :removed
+        else
+          {:error, error}
+        end
+    end
+  end
+
+  defp stamp(download) do
+    {:ok, _} =
+      Downloads.update_download(download, %{
+        client_removed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+  end
+end

--- a/lib/mydia/downloads/client_removal.ex
+++ b/lib/mydia/downloads/client_removal.ex
@@ -52,58 +52,56 @@ defmodule Mydia.Downloads.ClientRemoval do
         :skipped
 
       {:ok, info} ->
-        cond do
-          not seed_aware_type?(info.type) ->
-            remove_and_stamp(download, info)
+        if seed_aware_type?(info.type) do
+          case Client.get_status(info.adapter, info.config, info.client_id) do
+            {:ok, %{state: state}} when state in [:paused, :completed] ->
+              remove_and_stamp(download, info)
 
-          true ->
-            case Client.get_status(info.adapter, info.config, info.client_id) do
-              {:ok, %{state: state}} when state in [:paused, :completed] ->
-                remove_and_stamp(download, info)
+            {:ok, %{state: :seeding}} ->
+              Logger.info("Deferring client removal until seeding finishes",
+                download_id: download.id
+              )
 
-              {:ok, %{state: :seeding}} ->
-                Logger.info("Deferring client removal until seeding finishes",
-                  download_id: download.id
-                )
+              :deferred
 
-                :deferred
+            {:ok, %{state: state}} when state in [:downloading, :checking] ->
+              Logger.info("Deferring client removal; torrent not idle yet",
+                download_id: download.id,
+                state: state
+              )
 
-              {:ok, %{state: state}} when state in [:downloading, :checking] ->
-                Logger.info("Deferring client removal; torrent not idle yet",
+              :deferred
+
+            {:ok, %{state: :error}} ->
+              Logger.warning("Not auto-removing errored torrent after import",
+                download_id: download.id
+              )
+
+              :deferred
+
+            {:ok, %{state: state}} ->
+              Logger.info("Deferring client removal; torrent not idle yet",
+                download_id: download.id,
+                state: state
+              )
+
+              :deferred
+
+            {:error, error} ->
+              if not_found_error?(error) do
+                stamp(download)
+                :removed
+              else
+                Logger.warning("Could not read status for post-import removal",
                   download_id: download.id,
-                  state: state
+                  error: inspect(error)
                 )
 
                 :deferred
-
-              {:ok, %{state: :error}} ->
-                Logger.warning("Not auto-removing errored torrent after import",
-                  download_id: download.id
-                )
-
-                :deferred
-
-              {:ok, %{state: state}} ->
-                Logger.info("Deferring client removal; torrent not idle yet",
-                  download_id: download.id,
-                  state: state
-                )
-
-                :deferred
-
-              {:error, error} ->
-                if not_found_error?(error) do
-                  stamp(download)
-                  :removed
-                else
-                  Logger.warning("Could not read status for post-import removal",
-                    download_id: download.id,
-                    error: inspect(error)
-                  )
-
-                  :deferred
-                end
-            end
+              end
+          end
+        else
+          remove_and_stamp(download, info)
         end
     end
   end
@@ -115,9 +113,7 @@ defmodule Mydia.Downloads.ClientRemoval do
         :removed
 
       {:ok, info} ->
-        unless info.remove_completed do
-          :skipped
-        else
+        if info.remove_completed do
           case Client.get_status(info.adapter, info.config, info.client_id) do
             {:ok, %{state: state}} ->
               if removable_state?(state) do
@@ -134,6 +130,8 @@ defmodule Mydia.Downloads.ClientRemoval do
                 {:error, error}
               end
           end
+        else
+          :skipped
         end
     end
   end

--- a/lib/mydia/downloads/download.ex
+++ b/lib/mydia/downloads/download.ex
@@ -27,6 +27,7 @@ defmodule Mydia.Downloads.Download do
           import_reported_path: String.t() | nil,
           import_next_retry_at: DateTime.t() | nil,
           import_failed_at: DateTime.t() | nil,
+          client_removed_at: DateTime.t() | nil,
           last_progress_at: DateTime.t() | nil,
           last_known_bytes: integer(),
           last_observed_at: DateTime.t() | nil,
@@ -63,6 +64,7 @@ defmodule Mydia.Downloads.Download do
     field :import_reported_path, :string
     field :import_next_retry_at, :utc_datetime
     field :import_failed_at, :utc_datetime
+    field :client_removed_at, :utc_datetime
 
     # Stall-detection / progress tracking fields. `last_progress_at` is the
     # timestamp of the last observed bytes-downloaded increment; `last_known_bytes`
@@ -158,6 +160,7 @@ defmodule Mydia.Downloads.Download do
       :import_reported_path,
       :import_next_retry_at,
       :import_failed_at,
+      :client_removed_at,
       :last_progress_at,
       :last_known_bytes,
       :last_observed_at,

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -227,11 +227,11 @@ defmodule Mydia.Jobs.DownloadMonitor do
     Logger.info("Found #{length(stuck)} stuck downloads")
     Enum.each(stuck, &handle_stuck/1)
 
-    pending_removals = ClientRemoval.list_pending_removals()
+    {removal_configs, pending_removals} = ClientRemoval.finish_pending_removals()
 
     Enum.each(pending_removals, fn download ->
       with_download(download, :client_removal, [], fn live ->
-        case ClientRemoval.finish_pending_removal(live) do
+        case ClientRemoval.finish_pending_removal(live, removal_configs) do
           :removed ->
             Logger.info("Finished deferred client removal", download_id: live.id)
 

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -238,6 +238,9 @@ defmodule Mydia.Jobs.DownloadMonitor do
           :still_seeding ->
             :ok
 
+          :deferred ->
+            :ok
+
           :skipped ->
             :ok
 

--- a/lib/mydia/jobs/download_monitor.ex
+++ b/lib/mydia/jobs/download_monitor.ex
@@ -56,6 +56,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
   alias Mydia.Downloads.Download
   alias Mydia.Downloads.Client
   alias Mydia.Downloads.ClientAdoption
+  alias Mydia.Downloads.ClientRemoval
   alias Mydia.Downloads.Client.FailureCategory
   alias Mydia.Downloads.ImportCandidates
   alias Mydia.Downloads.Queue
@@ -226,6 +227,29 @@ defmodule Mydia.Jobs.DownloadMonitor do
     Logger.info("Found #{length(stuck)} stuck downloads")
     Enum.each(stuck, &handle_stuck/1)
 
+    pending_removals = ClientRemoval.list_pending_removals()
+
+    Enum.each(pending_removals, fn download ->
+      with_download(download, :client_removal, [], fn live ->
+        case ClientRemoval.finish_pending_removal(live) do
+          :removed ->
+            Logger.info("Finished deferred client removal", download_id: live.id)
+
+          :still_seeding ->
+            :ok
+
+          :skipped ->
+            :ok
+
+          {:error, reason} ->
+            Logger.warning("Deferred client removal failed",
+              download_id: live.id,
+              error: inspect(reason)
+            )
+        end
+      end)
+    end)
+
     duration = System.monotonic_time(:millisecond) - start_time
 
     Logger.info("Download monitoring completed",
@@ -237,6 +261,7 @@ defmodule Mydia.Jobs.DownloadMonitor do
       stalled_count: stalled_count,
       stall_update_failures: stall_update_failures,
       stuck_count: length(stuck),
+      pending_removals_count: length(pending_removals),
       untracked_matched: length(untracked_downloads),
       external_needs_matching: length(external_scan.needs_matching),
       external_other: length(external_scan.external)

--- a/lib/mydia/jobs/media_import.ex
+++ b/lib/mydia/jobs/media_import.ex
@@ -35,6 +35,7 @@ defmodule Mydia.Jobs.MediaImport do
   require Logger
   alias Mydia.{Downloads, Library, Media, Settings}
   alias Mydia.Downloads.Client
+  alias Mydia.Downloads.ClientRemoval
   alias Mydia.Downloads.ImportCandidates
   alias Mydia.Library.{FileNamer, FileOrganizer, SampleDetector}
   alias Mydia.Library.ReleaseParser
@@ -500,21 +501,27 @@ defmodule Mydia.Jobs.MediaImport do
         # download in the client when some files remain unmatched so
         # the user can manually retry after fixing the matches.
         unless has_unresolved do
-          client_info = get_client_info(download)
-          should_cleanup = client_info && client_info.remove_completed
+          case ClientRemoval.maybe_remove_after_import(download) do
+            :removed ->
+              Logger.info("Removed download from client after import",
+                download_id: download.id
+              )
 
-          if should_cleanup do
-            Logger.info("Removing download from client (remove_completed enabled)",
-              download_id: download.id,
-              client: download.download_client
-            )
+            :deferred ->
+              Logger.info("Keeping download in client until seeding finishes",
+                download_id: download.id
+              )
 
-            cleanup_download_client(download)
-          else
-            Logger.info("Keeping download in client for seeding (remove_completed disabled)",
-              download_id: download.id,
-              client: download.download_client
-            )
+            :skipped ->
+              Logger.info("Keeping download in client (remove_completed disabled)",
+                download_id: download.id
+              )
+
+            {:error, reason} ->
+              Logger.warning("Post-import client removal failed",
+                download_id: download.id,
+                error: inspect(reason)
+              )
           end
         end
 
@@ -1842,28 +1849,6 @@ defmodule Mydia.Jobs.MediaImport do
   # both of which clear the pointer and keep the new file.
   defp resolve_supersede_target(target_id, media_item_id, nil) do
     Upgrades.current_best_file_id(media_item_id, nil) || target_id
-  end
-
-  defp cleanup_download_client(download) do
-    client_info = get_client_info(download)
-
-    if client_info do
-      case Client.remove_download(
-             client_info.adapter,
-             client_info.config,
-             client_info.client_id,
-             delete_files: true
-           ) do
-        :ok ->
-          Logger.info("Removed download from client", download_id: download.id)
-
-        {:error, error} ->
-          Logger.warning("Failed to remove download from client",
-            download_id: download.id,
-            error: inspect(error)
-          )
-      end
-    end
   end
 
   defp build_client_config(client_config) do

--- a/lib/mydia_web/live/admin_download_clients_live/components.ex
+++ b/lib/mydia_web/live/admin_download_clients_live/components.ex
@@ -893,7 +893,10 @@ defmodule MydiaWeb.AdminDownloadClientsLive.Components do
                   <div>
                     <span class="text-sm font-medium">Remove After Import</span>
                     <p class="text-xs text-base-content/50">
-                      Remove downloads from client after importing
+                      Remove downloads from the client after importing. Torrent clients
+                      that support seeding wait until the torrent is stopped or paused
+                      (seed ratio/time), then remove. Usenet and similar clients remove
+                      immediately.
                     </p>
                   </div>
                 </div>

--- a/priv/repo/migrations/20260912232615_add_client_removed_at_to_downloads.exs
+++ b/priv/repo/migrations/20260912232615_add_client_removed_at_to_downloads.exs
@@ -1,0 +1,11 @@
+defmodule Mydia.Repo.Migrations.AddClientRemovedAtToDownloads do
+  use Ecto.Migration
+
+  # Purely additive: one new column. No ALTER COLUMN, so this needs no
+  # SQLite/Postgres branching.
+  def change do
+    alter table(:downloads) do
+      add :client_removed_at, :utc_datetime
+    end
+  end
+end

--- a/test/mydia/downloads/client_removal_test.exs
+++ b/test/mydia/downloads/client_removal_test.exs
@@ -140,7 +140,7 @@ defmodule Mydia.Downloads.ClientRemovalTest do
     assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
   end
 
-  test "finish_pending_removal stamps when client config is missing" do
+  test "finish_pending_removal leaves row pending when client config is missing" do
     download =
       download_fixture(%{
         download_client: "does-not-exist-#{System.unique_integer([:positive])}",
@@ -148,8 +148,20 @@ defmodule Mydia.Downloads.ClientRemovalTest do
         imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
       })
 
-    assert :removed = ClientRemoval.finish_pending_removal(download)
-    assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
+    assert :deferred = ClientRemoval.finish_pending_removal(download)
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
+  end
+
+  test "maybe_remove_after_import leaves row pending when client config is missing" do
+    download =
+      download_fixture(%{
+        download_client: "does-not-exist-#{System.unique_integer([:positive])}",
+        download_client_id: "x",
+        imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    assert :deferred = ClientRemoval.maybe_remove_after_import(download)
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
   end
 
   test "list_pending_removals excludes unresolved_files downloads" do

--- a/test/mydia/downloads/client_removal_test.exs
+++ b/test/mydia/downloads/client_removal_test.exs
@@ -1,0 +1,188 @@
+defmodule Mydia.Downloads.ClientRemovalTest do
+  use Mydia.DataCase, async: false
+
+  import Mydia.DownloadsFixtures
+
+  alias Mydia.Downloads
+  alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Registry
+  alias Mydia.Downloads.ClientRemoval
+  alias Mydia.Downloads.Structs.DownloadStatus
+  alias Mydia.Settings
+
+  defmodule StubAdapter do
+    @behaviour Mydia.Downloads.Client
+
+    def put(status_or_error), do: :persistent_term.put({__MODULE__, :result}, status_or_error)
+    def take_removes, do: :persistent_term.get({__MODULE__, :removes}, [])
+
+    @impl true
+    def get_status(_config, _id) do
+      case :persistent_term.get({__MODULE__, :result}, nil) do
+        {:error, _} = err -> err
+        %DownloadStatus{} = s -> {:ok, s}
+        nil -> {:error, Error.not_found("missing")}
+      end
+    end
+
+    @impl true
+    def remove_torrent(_config, id, opts) do
+      list = :persistent_term.get({__MODULE__, :removes}, [])
+      :persistent_term.put({__MODULE__, :removes}, [{id, opts} | list])
+      :ok
+    end
+
+    @impl true
+    def test_connection(_), do: {:error, :not_implemented}
+    @impl true
+    def add_torrent(_, _, _), do: {:error, :not_implemented}
+    @impl true
+    def list_torrents(_, _), do: {:ok, []}
+    @impl true
+    def pause_torrent(_, _), do: :ok
+    @impl true
+    def resume_torrent(_, _), do: :ok
+    @impl true
+    def supported_protocols, do: [:torrent]
+  end
+
+  setup do
+    previous = Registry.lookup(:qbittorrent)
+    Registry.register(:qbittorrent, StubAdapter)
+    :persistent_term.put({StubAdapter, :removes}, [])
+
+    on_exit(fn ->
+      :persistent_term.erase({StubAdapter, :result})
+      :persistent_term.erase({StubAdapter, :removes})
+      if previous, do: Registry.register(:qbittorrent, previous)
+    end)
+
+    :ok
+  end
+
+  test "seed_aware_type?/1" do
+    assert ClientRemoval.seed_aware_type?(:qbittorrent)
+    assert ClientRemoval.seed_aware_type?(:transmission)
+    assert ClientRemoval.seed_aware_type?(:rtorrent)
+    refute ClientRemoval.seed_aware_type?(:rqbit)
+    refute ClientRemoval.seed_aware_type?(:sabnzbd)
+    refute ClientRemoval.seed_aware_type?(:debrid)
+  end
+
+  test "removable_state?/1" do
+    assert ClientRemoval.removable_state?(:paused)
+    assert ClientRemoval.removable_state?(:completed)
+    refute ClientRemoval.removable_state?(:seeding)
+    refute ClientRemoval.removable_state?(:error)
+    refute ClientRemoval.removable_state?(:downloading)
+  end
+
+  test "maybe_remove_after_import defers while seeding on seed-aware client" do
+    client = client!(type: :qbittorrent, remove_completed: true)
+    download = download!(client, imported: true)
+    StubAdapter.put(status(:seeding, download.download_client_id))
+
+    assert :deferred = ClientRemoval.maybe_remove_after_import(download)
+    assert StubAdapter.take_removes() == []
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
+  end
+
+  test "maybe_remove_after_import skips when remove_completed is false" do
+    client = client!(type: :qbittorrent, remove_completed: false)
+    download = download!(client, imported: true)
+    StubAdapter.put(status(:paused, download.download_client_id))
+
+    assert :skipped = ClientRemoval.maybe_remove_after_import(download)
+    assert StubAdapter.take_removes() == []
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
+  end
+
+  test "maybe_remove_after_import removes immediately when paused" do
+    client = client!(type: :qbittorrent, remove_completed: true)
+    download = download!(client, imported: true)
+    StubAdapter.put(status(:paused, download.download_client_id))
+
+    assert :removed = ClientRemoval.maybe_remove_after_import(download)
+    assert [{_, [delete_files: true]}] = StubAdapter.take_removes()
+    assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
+  end
+
+  test "maybe_remove_after_import removes immediately for non-seed-aware types" do
+    previous = Registry.lookup(:rqbit)
+    Registry.register(:rqbit, StubAdapter)
+    on_exit(fn -> if previous, do: Registry.register(:rqbit, previous) end)
+
+    client = client!(type: :rqbit, remove_completed: true)
+    download = download!(client, imported: true)
+    StubAdapter.put(status(:seeding, download.download_client_id))
+
+    assert :removed = ClientRemoval.maybe_remove_after_import(download)
+    assert [{_, [delete_files: true]}] = StubAdapter.take_removes()
+  end
+
+  test "finish_pending_removal stamps on not_found without calling remove twice" do
+    client = client!(type: :qbittorrent, remove_completed: true)
+    download = download!(client, imported: true)
+    StubAdapter.put({:error, Error.not_found("gone")})
+
+    assert :removed = ClientRemoval.finish_pending_removal(download)
+    assert StubAdapter.take_removes() == []
+    assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
+  end
+
+  test "finish_pending_removal stamps when client config is missing" do
+    download =
+      download_fixture(%{
+        download_client: "does-not-exist-#{System.unique_integer([:positive])}",
+        download_client_id: "x",
+        imported_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    assert :removed = ClientRemoval.finish_pending_removal(download)
+    assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
+  end
+
+  defp client!(opts) do
+    unique = System.unique_integer([:positive])
+
+    {:ok, client} =
+      Settings.create_download_client_config(
+        Enum.into(opts, %{
+          name: "client-#{unique}",
+          host: "localhost",
+          port: 8080,
+          enabled: true,
+          priority: 1
+        })
+      )
+
+    client
+  end
+
+  defp download!(client, opts) do
+    imported = Keyword.get(opts, :imported, true)
+
+    attrs = %{
+      download_client: client.name,
+      download_client_id: "dl-#{System.unique_integer([:positive])}"
+    }
+
+    attrs =
+      if imported do
+        Map.put(attrs, :imported_at, DateTime.utc_now() |> DateTime.truncate(:second))
+      else
+        attrs
+      end
+
+    download_fixture(attrs)
+  end
+
+  defp status(state, client_id) do
+    DownloadStatus.new(%{
+      id: client_id,
+      name: "test",
+      state: state,
+      progress: 100.0
+    })
+  end
+end

--- a/test/mydia/downloads/client_removal_test.exs
+++ b/test/mydia/downloads/client_removal_test.exs
@@ -152,6 +152,41 @@ defmodule Mydia.Downloads.ClientRemovalTest do
     assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
   end
 
+  test "list_pending_removals excludes unresolved_files downloads" do
+    client = client!(type: :qbittorrent, remove_completed: true)
+    unresolved = download!(client, imported: true, match_status: "unresolved_files")
+    pending = download!(client, imported: true)
+
+    ids = ClientRemoval.list_pending_removals() |> Enum.map(& &1.id)
+
+    assert pending.id in ids
+    refute unresolved.id in ids
+  end
+
+  test "finish_pending_removal removes non-seed-aware client immediately while seeding" do
+    previous = Registry.lookup(:rqbit)
+    Registry.register(:rqbit, StubAdapter)
+    on_exit(fn -> if previous, do: Registry.register(:rqbit, previous) end)
+
+    client = client!(type: :rqbit, remove_completed: true)
+    download = download!(client, imported: true)
+    StubAdapter.put(status(:seeding, download.download_client_id))
+
+    assert :removed = ClientRemoval.finish_pending_removal(download)
+    assert [{_, [delete_files: true]}] = StubAdapter.take_removes()
+    assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
+  end
+
+  test "maybe_remove_after_import skips unresolved_files downloads" do
+    client = client!(type: :qbittorrent, remove_completed: true)
+    download = download!(client, imported: true, match_status: "unresolved_files")
+    StubAdapter.put(status(:paused, download.download_client_id))
+
+    assert :skipped = ClientRemoval.maybe_remove_after_import(download)
+    assert StubAdapter.take_removes() == []
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
+  end
+
   defp client!(opts) do
     unique = System.unique_integer([:positive])
 
@@ -171,6 +206,7 @@ defmodule Mydia.Downloads.ClientRemovalTest do
 
   defp download!(client, opts) do
     imported = Keyword.get(opts, :imported, true)
+    match_status = Keyword.get(opts, :match_status)
 
     attrs = %{
       download_client: client.name,
@@ -180,6 +216,13 @@ defmodule Mydia.Downloads.ClientRemovalTest do
     attrs =
       if imported do
         Map.put(attrs, :imported_at, DateTime.utc_now() |> DateTime.truncate(:second))
+      else
+        attrs
+      end
+
+    attrs =
+      if match_status do
+        Map.put(attrs, :match_status, match_status)
       else
         attrs
       end

--- a/test/mydia/downloads/client_removal_test.exs
+++ b/test/mydia/downloads/client_removal_test.exs
@@ -87,6 +87,16 @@ defmodule Mydia.Downloads.ClientRemovalTest do
     assert is_nil(Downloads.get_download!(download.id).client_removed_at)
   end
 
+  test "maybe_remove_after_import defers on unexpected seed-aware states" do
+    client = client!(type: :qbittorrent, remove_completed: true)
+    download = download!(client, imported: true)
+    StubAdapter.put(status(:unknown, download.download_client_id))
+
+    assert :deferred = ClientRemoval.maybe_remove_after_import(download)
+    assert StubAdapter.take_removes() == []
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
+  end
+
   test "maybe_remove_after_import skips when remove_completed is false" do
     client = client!(type: :qbittorrent, remove_completed: false)
     download = download!(client, imported: true)

--- a/test/mydia/jobs/download_monitor_client_removal_test.exs
+++ b/test/mydia/jobs/download_monitor_client_removal_test.exs
@@ -1,0 +1,145 @@
+defmodule Mydia.Jobs.DownloadMonitorClientRemovalTest do
+  @moduledoc """
+  DownloadMonitor poll pass for deferred Remove After Import cleanup.
+
+  `async: false`: the adapter registry is a process-wide Agent.
+  """
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Mydia.DownloadsFixtures
+
+  alias Mydia.Downloads
+  alias Mydia.Downloads.Client.Error
+  alias Mydia.Downloads.Client.Registry
+  alias Mydia.Downloads.ClientRemoval
+  alias Mydia.Downloads.Structs.DownloadStatus
+  alias Mydia.Jobs.DownloadMonitor
+  alias Mydia.Settings
+
+  defmodule StubAdapter do
+    @behaviour Mydia.Downloads.Client
+
+    def put(status_or_error), do: :persistent_term.put({__MODULE__, :result}, status_or_error)
+    def take_removes, do: :persistent_term.get({__MODULE__, :removes}, [])
+
+    @impl true
+    def get_status(_config, _id) do
+      case :persistent_term.get({__MODULE__, :result}, nil) do
+        {:error, _} = err -> err
+        %DownloadStatus{} = s -> {:ok, s}
+        nil -> {:error, Error.not_found("missing")}
+      end
+    end
+
+    @impl true
+    def remove_torrent(_config, id, opts) do
+      list = :persistent_term.get({__MODULE__, :removes}, [])
+      :persistent_term.put({__MODULE__, :removes}, [{id, opts} | list])
+      :ok
+    end
+
+    @impl true
+    def test_connection(_), do: {:error, :not_implemented}
+    @impl true
+    def add_torrent(_, _, _), do: {:error, :not_implemented}
+    @impl true
+    def list_torrents(_, _), do: {:ok, []}
+    @impl true
+    def pause_torrent(_, _), do: :ok
+    @impl true
+    def resume_torrent(_, _), do: :ok
+    @impl true
+    def supported_protocols, do: [:torrent]
+  end
+
+  setup do
+    previous = Registry.lookup(:qbittorrent)
+    Registry.register(:qbittorrent, StubAdapter)
+    :persistent_term.put({StubAdapter, :removes}, [])
+
+    on_exit(fn ->
+      :persistent_term.erase({StubAdapter, :result})
+      :persistent_term.erase({StubAdapter, :removes})
+      if previous, do: Registry.register(:qbittorrent, previous)
+    end)
+
+    :ok
+  end
+
+  test "finishes deferred removal when torrent is paused" do
+    client = client!(remove_completed: true)
+    download = pending_download!(client)
+    StubAdapter.put(status(:paused, download.download_client_id))
+
+    assert [pending] = ClientRemoval.list_pending_removals()
+    assert pending.id == download.id
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    assert [{_, [delete_files: true]}] = StubAdapter.take_removes()
+    assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
+  end
+
+  test "leaves pending removal while torrent is still seeding" do
+    client = client!(remove_completed: true)
+    download = pending_download!(client)
+    StubAdapter.put(status(:seeding, download.download_client_id))
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    assert StubAdapter.take_removes() == []
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
+  end
+
+  test "stamps pending removal when torrent is not found in client" do
+    client = client!(remove_completed: true)
+    download = pending_download!(client)
+    StubAdapter.put({:error, Error.not_found("gone")})
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    assert StubAdapter.take_removes() == []
+    assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
+  end
+
+  defp client!(opts) do
+    unique = System.unique_integer([:positive])
+
+    {:ok, client} =
+      Settings.create_download_client_config(
+        Enum.into(opts, %{
+          name: "client-#{unique}",
+          type: :qbittorrent,
+          host: "localhost",
+          port: 8080,
+          enabled: true,
+          priority: 1,
+          remove_completed: true
+        })
+      )
+
+    client
+  end
+
+  defp pending_download!(client) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    download_fixture(%{
+      download_client: client.name,
+      download_client_id: "dl-#{System.unique_integer([:positive])}",
+      completed_at: now,
+      imported_at: now,
+      client_removed_at: nil
+    })
+  end
+
+  defp status(state, client_id) do
+    DownloadStatus.new(%{
+      id: client_id,
+      name: "test",
+      state: state,
+      progress: 100.0
+    })
+  end
+end

--- a/test/mydia/jobs/download_monitor_client_removal_test.exs
+++ b/test/mydia/jobs/download_monitor_client_removal_test.exs
@@ -103,6 +103,19 @@ defmodule Mydia.Jobs.DownloadMonitorClientRemovalTest do
     assert %DateTime{} = Downloads.get_download!(download.id).client_removed_at
   end
 
+  test "leaves unresolved_files pending removal alone on monitor pass" do
+    client = client!(remove_completed: true)
+    download = pending_download!(client, match_status: "unresolved_files")
+    StubAdapter.put(status(:paused, download.download_client_id))
+
+    refute Enum.any?(ClientRemoval.list_pending_removals(), &(&1.id == download.id))
+
+    assert :ok = perform_job(DownloadMonitor, %{})
+
+    assert StubAdapter.take_removes() == []
+    assert is_nil(Downloads.get_download!(download.id).client_removed_at)
+  end
+
   defp client!(opts) do
     unique = System.unique_integer([:positive])
 
@@ -122,16 +135,26 @@ defmodule Mydia.Jobs.DownloadMonitorClientRemovalTest do
     client
   end
 
-  defp pending_download!(client) do
+  defp pending_download!(client, opts \\ []) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
+    match_status = Keyword.get(opts, :match_status)
 
-    download_fixture(%{
+    attrs = %{
       download_client: client.name,
       download_client_id: "dl-#{System.unique_integer([:positive])}",
       completed_at: now,
       imported_at: now,
       client_removed_at: nil
-    })
+    }
+
+    attrs =
+      if match_status do
+        Map.put(attrs, :match_status, match_status)
+      else
+        attrs
+      end
+
+    download_fixture(attrs)
   end
 
   defp status(state, client_id) do

--- a/test/mydia/jobs/media_import_client_removal_test.exs
+++ b/test/mydia/jobs/media_import_client_removal_test.exs
@@ -1,0 +1,245 @@
+defmodule Mydia.Jobs.MediaImportClientRemovalTest do
+  @moduledoc """
+  Integration coverage for post-import client removal via `ClientRemoval`.
+
+  Drives the real MediaImport job through a stub adapter so seed-aware
+  deferral (qBittorrent while `:seeding`) and immediate removal (rqbit,
+  paused torrents) are exercised end-to-end.
+
+  `async: false`: the adapter registry is a process-wide Agent.
+  """
+  use Mydia.DataCase, async: false
+  use Oban.Testing, repo: Mydia.Repo
+
+  import Mydia.DownloadsFixtures
+  import Mydia.MediaFixtures
+
+  alias Mydia.Downloads
+  alias Mydia.Downloads.Client.Registry
+  alias Mydia.Downloads.Structs.DownloadStatus
+  alias Mydia.Jobs.MediaImport
+  alias Mydia.Settings
+
+  @moduletag :tmp_dir
+
+  defmodule StubAdapter do
+    @behaviour Mydia.Downloads.Client
+
+    def put_status(status), do: :persistent_term.put({__MODULE__, :status}, status)
+    def take_removes, do: :persistent_term.get({__MODULE__, :removes}, [])
+
+    @impl true
+    def get_status(_config, _client_id) do
+      case :persistent_term.get({__MODULE__, :status}, nil) do
+        nil -> {:error, :not_found}
+        status -> {:ok, status}
+      end
+    end
+
+    @impl true
+    def remove_torrent(_config, id, opts) do
+      list = :persistent_term.get({__MODULE__, :removes}, [])
+      :persistent_term.put({__MODULE__, :removes}, [{id, opts} | list])
+      :ok
+    end
+
+    @impl true
+    def test_connection(_config), do: {:error, :not_implemented}
+    @impl true
+    def add_torrent(_config, _torrent, _opts), do: {:error, :not_implemented}
+    @impl true
+    def list_torrents(_config, _opts), do: {:ok, []}
+    @impl true
+    def pause_torrent(_config, _client_id), do: :ok
+    @impl true
+    def resume_torrent(_config, _client_id), do: :ok
+    @impl true
+    def supported_protocols, do: [:torrent]
+  end
+
+  describe "qbittorrent with remove_completed" do
+    setup do
+      previous = Registry.lookup(:qbittorrent)
+      Registry.register(:qbittorrent, StubAdapter)
+      :persistent_term.put({StubAdapter, :removes}, [])
+
+      on_exit(fn ->
+        :persistent_term.erase({StubAdapter, :status})
+        :persistent_term.erase({StubAdapter, :removes})
+        if previous, do: Registry.register(:qbittorrent, previous)
+      end)
+
+      :ok
+    end
+
+    test "defers removal while seeding after import", ctx do
+      %{shared_dir: shared_dir} = setup_import_dirs(ctx.tmp_dir)
+      video = Path.join(shared_dir, "Silo.S01E01.Pilot.1080p.mkv")
+      File.write!(video, "silo video payload")
+
+      {media_item, episode} = tv_fixture("Silo", 2023)
+      client = client_fixture("QBRemoval", :qbittorrent)
+
+      StubAdapter.put_status(
+        status(client_id: "qb-seeding-1", save_path: shared_dir, files: [video], state: :seeding)
+      )
+
+      download = download_for(media_item, episode, client, "qb-seeding-1")
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => shared_dir
+               })
+
+      updated = Downloads.get_download!(download.id)
+      assert %DateTime{} = updated.imported_at
+      assert is_nil(updated.client_removed_at)
+      assert StubAdapter.take_removes() == []
+    end
+
+    test "removes when paused after import", ctx do
+      %{shared_dir: shared_dir} = setup_import_dirs(ctx.tmp_dir)
+      video = Path.join(shared_dir, "Silo.S01E01.Pilot.1080p.mkv")
+      File.write!(video, "silo video payload")
+
+      {media_item, episode} = tv_fixture("Silo", 2023)
+      client = client_fixture("QBRemovalPaused", :qbittorrent)
+
+      StubAdapter.put_status(
+        status(client_id: "qb-paused-1", save_path: shared_dir, files: [video], state: :paused)
+      )
+
+      download = download_for(media_item, episode, client, "qb-paused-1")
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => shared_dir
+               })
+
+      updated = Downloads.get_download!(download.id)
+      assert %DateTime{} = updated.imported_at
+      assert %DateTime{} = updated.client_removed_at
+      assert [{_, [delete_files: true]}] = StubAdapter.take_removes()
+    end
+  end
+
+  describe "rqbit with remove_completed" do
+    setup do
+      previous = Registry.lookup(:rqbit)
+      Registry.register(:rqbit, StubAdapter)
+      :persistent_term.put({StubAdapter, :removes}, [])
+
+      on_exit(fn ->
+        :persistent_term.erase({StubAdapter, :status})
+        :persistent_term.erase({StubAdapter, :removes})
+        if previous, do: Registry.register(:rqbit, previous)
+      end)
+
+      :ok
+    end
+
+    test "removes immediately while seeding after import", ctx do
+      %{shared_dir: shared_dir} = setup_import_dirs(ctx.tmp_dir)
+      video = Path.join(shared_dir, "Silo.S01E01.Pilot.1080p.mkv")
+      File.write!(video, "silo video payload")
+
+      {media_item, episode} = tv_fixture("Silo", 2023)
+      client = client_fixture("RqRemoval", :rqbit, port: 3030)
+
+      StubAdapter.put_status(
+        status(client_id: "rq-seeding-1", save_path: shared_dir, files: [video], state: :seeding)
+      )
+
+      download = download_for(media_item, episode, client, "rq-seeding-1")
+
+      assert {:ok, :imported} =
+               perform_job(MediaImport, %{
+                 "download_id" => download.id,
+                 "save_path" => shared_dir
+               })
+
+      updated = Downloads.get_download!(download.id)
+      assert %DateTime{} = updated.imported_at
+      assert %DateTime{} = updated.client_removed_at
+      assert [{_, [delete_files: true]}] = StubAdapter.take_removes()
+    end
+  end
+
+  ## Helpers
+
+  defp setup_import_dirs(tmp_dir) do
+    library_root = Path.join(tmp_dir, "library")
+    File.mkdir_p!(library_root)
+    {:ok, _} = Settings.create_library_path(%{path: library_root, type: :series, monitored: true})
+
+    shared_dir = Path.join(tmp_dir, "downloads")
+    File.mkdir_p!(shared_dir)
+
+    %{library_root: library_root, shared_dir: shared_dir}
+  end
+
+  defp tv_fixture(title, year) do
+    media_item = media_item_fixture(%{type: "tv_show", title: title, year: year})
+
+    episode =
+      episode_fixture(%{
+        media_item_id: media_item.id,
+        season_number: 1,
+        episode_number: 1,
+        title: "Pilot"
+      })
+
+    {media_item, episode}
+  end
+
+  defp client_fixture(name, type, opts \\ []) do
+    {:ok, client} =
+      Settings.create_download_client_config(
+        Enum.into(opts, %{
+          name: name,
+          type: type,
+          host: "localhost",
+          port: 8080,
+          enabled: true,
+          priority: 1,
+          remove_completed: true
+        })
+      )
+
+    client
+  end
+
+  defp download_for(media_item, episode, client, client_id) do
+    download_fixture(%{
+      media_item_id: media_item.id,
+      episode_id: episode.id,
+      status: "completed",
+      completed_at: DateTime.utc_now(),
+      download_client: client.name,
+      download_client_id: client_id,
+      title: "Silo.S01E01.Pilot.1080p"
+    })
+  end
+
+  defp status(opts) do
+    DownloadStatus.new(%{
+      id: Keyword.fetch!(opts, :client_id),
+      name: "stub",
+      state: Keyword.get(opts, :state, :completed),
+      progress: 100.0,
+      download_speed: 0,
+      upload_speed: 0,
+      downloaded: 0,
+      uploaded: 0,
+      size: 0,
+      eta: nil,
+      ratio: 0.0,
+      save_path: Keyword.fetch!(opts, :save_path),
+      files: Keyword.get(opts, :files),
+      added_at: nil,
+      completed_at: nil
+    })
+  end
+end


### PR DESCRIPTION
## Summary
- When **Remove After Import** is enabled, seed-aware clients (qBittorrent, Transmission, rTorrent) keep seeding until the torrent is paused/completed/gone, then Mydia removes it (`delete_files: true`).
- Non-seed clients (rqbit, Usenet, debrid, blackhole) still remove immediately after import.
- Tracks completion with `downloads.client_removed_at`; `DownloadMonitor` finishes deferred removals. Unresolved-file imports are never auto-cleaned. Fixes #779.

## Test plan
- [ ] `./dev mix test test/mydia/downloads/client_removal_test.exs test/mydia/jobs/media_import_client_removal_test.exs test/mydia/jobs/download_monitor_client_removal_test.exs`
- [ ] Import with Remove After Import on + qBittorrent still seeding → torrent remains; after client pauses (ratio/time), next monitor poll removes it
- [ ] Import with rqbit / SABnzbd → removes immediately
- [ ] Partial import with unresolved files → source left in client
- [ ] Clear Completed while seeding → still force-removes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic removal of completed downloads from configured clients after media import.
  * Torrent downloads may remain pending while seeding; Usenet and similar downloads are removed immediately.
  * Deferred removals are retried during download monitoring, with files deleted and completion recorded.
  * Downloads with unresolved matches or unavailable client configurations remain pending for later processing.

* **Documentation**
  * Expanded help text to explain seeding-related removal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->