### PR TITLE
fix(player): allow manual next episode after cancelling up-next auto-play

### DIFF
--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -3025,7 +3025,9 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
 
   void _showUpNextOverlay(UpNextTarget target) {
     _upNextCountdown?.dispose();
-    final countdown = UpNextCountdown(onElapsed: _playNextEpisode);
+    final countdown = UpNextCountdown(
+      onElapsed: () => _playNextEpisode(fromAutoCountdown: true),
+    );
     _upNextCountdown = countdown;
 
     if (!mounted) return;
@@ -3067,14 +3069,23 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   }
 
   /// Play the next episode immediately.
-  void _playNextEpisode() {
+  ///
+  /// [fromAutoCountdown] is true only when the up-next countdown elapsed on
+  /// its own. Manual transport, keyboard, and remote actions pass false so
+  /// a prior dismiss of auto-play does not block explicit navigation.
+  void _playNextEpisode({bool fromAutoCountdown = false}) {
     _upNextCountdown?.cancel();
     _upNextPlayingSub?.cancel();
     _upNextPlayingSub = null;
 
     // Re-check after the countdown: `_cancelAutoPlay` may have run between
-    // the fire being scheduled and this executing.
-    if (_autoPlayCancelled) return;
+    // the fire being scheduled and this executing. Manual next is unaffected.
+    if (shouldBlockAutoPlayNext(
+      autoPlayCancelled: _autoPlayCancelled,
+      fromAutoCountdown: fromAutoCountdown,
+    )) {
+      return;
+    }
 
     final target = _upNextTarget;
     if (target != null) {

--- a/player/lib/presentation/screens/player/player_screen.dart
+++ b/player/lib/presentation/screens/player/player_screen.dart
@@ -3026,7 +3026,7 @@ class _PlayerScreenState extends ConsumerState<PlayerScreen>
   void _showUpNextOverlay(UpNextTarget target) {
     _upNextCountdown?.dispose();
     final countdown = UpNextCountdown(
-      onElapsed: () => _playNextEpisode(fromAutoCountdown: true),
+      onElapsed: bindUpNextCountdownElapsed(_playNextEpisode),
     );
     _upNextCountdown = countdown;
 
@@ -5212,6 +5212,19 @@ KeyEventResult handleEpisodeNavKey(
       return KeyEventResult.ignored;
   }
 }
+
+/// The countdown's `onElapsed` callback, bound so a fire is always marked
+/// as automatic.
+///
+/// A tear-off of `_playNextEpisode` would pass `fromAutoCountdown: false`
+/// (the default), which is exactly the regression this helper exists to
+/// prevent: after a dismiss, an elapsed countdown would navigate. Tests
+/// pin this binding independently of mounting `PlayerScreen`.
+@visibleForTesting
+VoidCallback bindUpNextCountdownElapsed(
+  void Function({bool fromAutoCountdown}) playNext,
+) =>
+    () => playNext(fromAutoCountdown: true);
 
 /// media_kit's current audio track list mapped onto the app's own model,
 /// together with the reverse lookup needed to hand a chosen track back to

--- a/player/lib/presentation/widgets/video_controls/up_next_policy.dart
+++ b/player/lib/presentation/widgets/video_controls/up_next_policy.dart
@@ -48,6 +48,18 @@ bool shouldOfferUpNext({
   return duration - position <= upNextFallbackWindow;
 }
 
+/// Whether an auto-countdown firing should be suppressed after the viewer
+/// dismissed up-next for this file.
+///
+/// Manual next-episode actions ignore [autoPlayCancelled]; only the countdown
+/// path checks it, as a belt against a fire that was scheduled before
+/// [_cancelAutoPlay] ran.
+bool shouldBlockAutoPlayNext({
+  required bool autoPlayCancelled,
+  required bool fromAutoCountdown,
+}) =>
+    fromAutoCountdown && autoPlayCancelled;
+
 /// The minimal shape [resolveInSeasonNext] and [resolveSeasonPremiere] need
 /// from an episode.
 ///

--- a/player/test/presentation/screens/player/player_screen_up_next_next_test.dart
+++ b/player/test/presentation/screens/player/player_screen_up_next_next_test.dart
@@ -1,0 +1,63 @@
+// Guards the auto-vs-manual next-episode split after Up Next is dismissed,
+// without standing up `PlayerScreen`. Mounting the screen needs a live
+// media_kit Player plus Riverpod/GraphQL (see
+// `player_screen_key_handling_test.dart`); the load-bearing wiring is the
+// countdown callback and `_playNextEpisode`'s cancel flag, which this
+// reconstructs with the same helpers the screen uses.
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:player/presentation/screens/player/player_screen.dart';
+import 'package:player/presentation/widgets/video_controls/up_next_countdown.dart';
+import 'package:player/presentation/widgets/video_controls/up_next_policy.dart';
+
+void main() {
+  group('bindUpNextCountdownElapsed', () {
+    test('marks the fire as from the auto countdown', () {
+      bool? fromAuto;
+      bindUpNextCountdownElapsed(({bool fromAutoCountdown = false}) {
+        fromAuto = fromAutoCountdown;
+      })();
+      expect(fromAuto, isTrue);
+    });
+  });
+
+  group('next episode after dismissing up-next', () {
+    test(
+        'a cancelled countdown does not navigate; a later manual next still '
+        'does', () {
+      fakeAsync((async) {
+        var autoPlayCancelled = false;
+        var navigated = 0;
+
+        void playNext({bool fromAutoCountdown = false}) {
+          if (shouldBlockAutoPlayNext(
+            autoPlayCancelled: autoPlayCancelled,
+            fromAutoCountdown: fromAutoCountdown,
+          )) {
+            return;
+          }
+          navigated++;
+        }
+
+        final countdown = UpNextCountdown(
+          onElapsed: bindUpNextCountdownElapsed(playNext),
+        );
+        countdown.start();
+        async.elapse(const Duration(seconds: 4));
+
+        // What `_cancelAutoPlay` does: stop the clock, then set the flag.
+        countdown.cancel();
+        autoPlayCancelled = true;
+        async.elapse(const Duration(seconds: 60));
+        expect(navigated, 0, reason: 'dismissed auto-play must not navigate');
+
+        // Transport / keyboard / remote: `_playNextEpisode()` default.
+        playNext();
+        expect(navigated, 1, reason: 'manual next must still navigate');
+
+        countdown.dispose();
+      });
+    });
+  });
+}

--- a/player/test/presentation/widgets/video_controls/up_next_policy_test.dart
+++ b/player/test/presentation/widgets/video_controls/up_next_policy_test.dart
@@ -118,6 +118,27 @@ void main() {
       );
     });
   });
+  group('shouldBlockAutoPlayNext', () {
+    test('blocks auto countdown after the viewer dismissed up-next', () {
+      expect(
+        shouldBlockAutoPlayNext(
+          autoPlayCancelled: true,
+          fromAutoCountdown: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('allows manual next after the viewer dismissed up-next', () {
+      expect(
+        shouldBlockAutoPlayNext(
+          autoPlayCancelled: true,
+          fromAutoCountdown: false,
+        ),
+        isFalse,
+      );
+    });
+  });
 
   group('UpNextTarget', () {
     const target = UpNextTarget(


### PR DESCRIPTION
## Summary

When a viewer dismisses the **Up Next** auto-play prompt during credits, auto-play correctly stops — but **Next Episode** (transport, keyboard, remote) also stopped working. The viewer had to leave the player and start the next episode manually.

## Root cause

`_cancelAutoPlay()` sets `_autoPlayCancelled = true` for the rest of the file. `_playNextEpisode()` returned early on that flag for **every** call, including explicit manual navigation.

## Fix

- Add `shouldBlockAutoPlayNext()` in `up_next_policy.dart` — only blocks when `fromAutoCountdown && autoPlayCancelled`
- Parameterize `_playNextEpisode({bool fromAutoCountdown = false})`
- Countdown callback passes `fromAutoCountdown: true`; all manual entry points keep the default

## Behavior after fix

| Action | After cancel auto-play |
|--------|------------------------|
| Auto countdown / auto-play | Blocked |
| Manual Next Episode | Works |
| Up Next re-offer | Blocked (unchanged) |

## Test plan

- [x] `flutter test test/presentation/widgets/video_controls/up_next_policy_test.dart`
- [x] `flutter test test/presentation/screens/player/up_next_stop_test.dart`
- [ ] Manual: dismiss Up Next → let episode finish → press Next Episode → next episode starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Up Next behavior so dismissing the countdown prevents automatic playback while still allowing manually triggered next-episode navigation.
  * Ensured next-episode actions from transport controls, keyboards, and remote controls continue to work as expected after the countdown is dismissed.
  * Prevented dismissed Up Next prompts from triggering unintended episode playback when the countdown expires.

* **Tests**
  * Added coverage for automatic and manual next-episode playback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->