### PR TITLE
feat(player): run Mydia Player on a Nix-managed Android TV emulator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,12 +96,14 @@ APKs stay arm-only.
 - **Requirements:** Linux KVM (`/dev/kvm` must be readable *and* writable, so
   your user needs to be in the `kvm` group) and a graphical Wayland or X11
   session — the emulator runs headful, and the runner refuses to start without
-  one. It renders through the host GPU: the AVD profile's software renderer
-  segfaults in the emulator's GL thread once the app paints.
+  one. The runner passes `-gpu host` because the `tv_1080p` profile's software
+  GLES path has been observed to crash once the app paints; host GPU passthrough
+  has been more stable on the machines tested so far, but try other `-gpu` modes
+  manually if rendering fails on yours.
 - **AVD state** lives in the normal Android cache
-  (`${ANDROID_AVD_HOME:-$HOME/.android/avd}`) under the versioned name
-  `mydia-tv-api-36`, never in the repository or the Nix store. It is created on
-  first use and reused afterwards; delete that directory to start clean.
+  (`${ANDROID_AVD_HOME:-$HOME/.android/avd}`) as `mydia-tv-api-36.avd/` and
+  `mydia-tv-api-36.ini`, never in the repository or the Nix store. It is created
+  on first use and reused afterwards; delete both to start clean.
 - **Ownership:** the run stops only an emulator *it* started. A
   `mydia-tv-api-36` emulator that is already running is reused and deliberately
   left running on exit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Android builds use the root flake's `.#android` dev shell (`nix/devShells/flake-
 
 - `./dev player android build` - Build release APK
 - `./dev player android run` - Build and run on connected Android device
+- `./dev player android tv-run` - Provision/start the pinned API 36 Android TV
+  emulator and run the debug app
 - `./dev player android shell` - Open nix develop shell for manual commands
 
 **Output:** `player/build/app/outputs/flutter-apk/app-release.apk`
@@ -78,6 +80,39 @@ Android builds use the root flake's `.#android` dev shell (`nix/devShells/flake-
 - Android SDK with NDK 27.0.12077973
 - Rust toolchain with Android targets (aarch64, armv7, x86_64, i686)
 - All necessary environment variables for Rust cross-compilation
+
+### Player Android TV Emulator
+
+`./dev player android tv-run` runs the debug app on a real Android TV emulator
+instead of a physical device. It uses a second dev shell, `.#android-tv`
+(`MYDIA_ANDROID_TV_SDK_ROOT`), which adds the pinned API 36 revision 4
+`android-tv` x86_64 system image and the emulator. The build shell above, and
+the APK it produces, are unchanged: the x86_64 ABI is debug-only, so release
+APKs stay arm-only.
+
+- **The first invocation is the slow one.** It fetches the system image (990 MB
+  compressed, ~8.7 GB unpacked) plus the emulator into the Nix store; later runs
+  reuse them. Nothing is installed with `sdkmanager`.
+- **Requirements:** Linux KVM (`/dev/kvm` must be readable *and* writable, so
+  your user needs to be in the `kvm` group) and a graphical Wayland or X11
+  session — the emulator runs headful, and the runner refuses to start without
+  one. It renders through the host GPU: the AVD profile's software renderer
+  segfaults in the emulator's GL thread once the app paints.
+- **AVD state** lives in the normal Android cache
+  (`${ANDROID_AVD_HOME:-$HOME/.android/avd}`) under the versioned name
+  `mydia-tv-api-36`, never in the repository or the Nix store. It is created on
+  first use and reused afterwards; delete that directory to start clean.
+- **Ownership:** the run stops only an emulator *it* started. A
+  `mydia-tv-api-36` emulator that is already running is reused and deliberately
+  left running on exit.
+- **Extra arguments** are passed through to `flutter run` unchanged, e.g.
+  `./dev player android tv-run --dart-define=SOME_FLAG=1`.
+
+Inspect or drive the running emulator from a second shell:
+
+```bash
+nix develop .#android-tv --command adb devices
+```
 
 ### Player macOS Builds
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,7 @@ Android builds use the root flake's `.#android` dev shell (`nix/devShells/flake-
 
 - `./dev player android build` - Build release APK
 - `./dev player android run` - Build and run on connected Android device
-- `./dev player android tv-run` - Provision/start the pinned API 36 Android TV
-  emulator and run the debug app
+- `./dev player android tv-run` - Android TV emulator (see `player/CLAUDE.md`)
 - `./dev player android shell` - Open nix develop shell for manual commands
 
 **Output:** `player/build/app/outputs/flutter-apk/app-release.apk`
@@ -80,41 +79,6 @@ Android builds use the root flake's `.#android` dev shell (`nix/devShells/flake-
 - Android SDK with NDK 27.0.12077973
 - Rust toolchain with Android targets (aarch64, armv7, x86_64, i686)
 - All necessary environment variables for Rust cross-compilation
-
-### Player Android TV Emulator
-
-`./dev player android tv-run` runs the debug app on a real Android TV emulator
-instead of a physical device. It uses a second dev shell, `.#android-tv`
-(`MYDIA_ANDROID_TV_SDK_ROOT`), which adds the pinned API 36 revision 4
-`android-tv` x86_64 system image and the emulator. The build shell above, and
-the APK it produces, are unchanged: the x86_64 ABI is debug-only, so release
-APKs stay arm-only.
-
-- **The first invocation is the slow one.** It fetches the system image (990 MB
-  compressed, ~8.7 GB unpacked) plus the emulator into the Nix store; later runs
-  reuse them. Nothing is installed with `sdkmanager`.
-- **Requirements:** Linux KVM (`/dev/kvm` must be readable *and* writable, so
-  your user needs to be in the `kvm` group) and a graphical Wayland or X11
-  session — the emulator runs headful, and the runner refuses to start without
-  one. The runner passes `-gpu host` because the `tv_1080p` profile's software
-  GLES path has been observed to crash once the app paints; host GPU passthrough
-  has been more stable on the machines tested so far, but try other `-gpu` modes
-  manually if rendering fails on yours.
-- **AVD state** lives in the normal Android cache
-  (`${ANDROID_AVD_HOME:-$HOME/.android/avd}`) as `mydia-tv-api-36.avd/` and
-  `mydia-tv-api-36.ini`, never in the repository or the Nix store. It is created
-  on first use and reused afterwards; delete both to start clean.
-- **Ownership:** the run stops only an emulator *it* started. A
-  `mydia-tv-api-36` emulator that is already running is reused and deliberately
-  left running on exit.
-- **Extra arguments** are passed through to `flutter run` unchanged, e.g.
-  `./dev player android tv-run --dart-define=SOME_FLAG=1`.
-
-Inspect or drive the running emulator from a second shell:
-
-```bash
-nix develop .#android-tv --command adb devices
-```
 
 ### Player macOS Builds
 

--- a/dev
+++ b/dev
@@ -9,7 +9,8 @@
 #
 # Unchanged, intentionally NOT devenv-backed:
 #   - relay <build|push|restart|deploy>   (Docker + kubectl)
-#   - player android <build|run|shell>    (nix devShell .#android, native Nix)
+#   - player android <build|run|tv-run|shell>  (nix devShell .#android /
+#     .#android-tv, native Nix)
 #   - player macos <build|run>            (host Xcode/CocoaPods/rustup toolchain)
 #   - player flatpak <build|install|run>  (host flatpak + flatpak-builder)
 #   - player e2e / e2e-build              (Docker E2E stack, compose.player-e2e.yml)
@@ -159,6 +160,8 @@ ${YELLOW}Player (Flutter):${NC}
 ${YELLOW}Player Android (native, uses the .#android nix devShell):${NC}
   player android build Build Android APK (release)
   player android run   Build and run on connected Android device
+  player android tv-run [args]
+                       Provision an Android TV emulator and run the debug app
   player android shell Open the .#android nix develop shell
 
 ${YELLOW}Player macOS (native, uses the host Xcode/CocoaPods/rustup toolchain):${NC}
@@ -630,13 +633,23 @@ case "$COMMAND" in
                         extra_args="${@:3}"
                         nix develop .#android --command bash -c "cd player && flutter pub get && flutter pub run build_runner build && flutter run $extra_args"
                         ;;
+                    tv-run)
+                        # The runner owns the whole sequence (AVD creation,
+                        # emulator start/ownership, boot wait, flutter run), so
+                        # this branch only enters the TV shell and passes the
+                        # remaining arguments as argv — never interpolated into
+                        # a `bash -c` string, which would lose their quoting.
+                        echo -e "${GREEN}Starting Mydia on the Nix-managed Android TV emulator...${NC}"
+                        nix develop .#android-tv --command \
+                            bash player/tool/run_android_tv.sh "${@:3}"
+                        ;;
                     shell)
                         echo -e "${GREEN}Opening the .#android nix develop shell...${NC}"
                         nix develop .#android
                         ;;
                     *)
                         echo -e "${RED}Error: Unknown android command: $2${NC}"
-                        echo "Usage: ./dev player android <build|run|shell>"
+                        echo "Usage: ./dev player android <build|run|tv-run|shell>"
                         exit 1
                         ;;
                 esac

--- a/nix/devShells/flake-module.nix
+++ b/nix/devShells/flake-module.nix
@@ -56,8 +56,9 @@
         cmdLineToolsVersion = "13.0";
         platformToolsVersion = "35.0.2";
         buildToolsVersions = [ "30.0.3" "33.0.1" "34.0.0" "35.0.0" "36.0.0" ];
-        # 37.0 is load-bearing, not padding. The pinned flutter_secure_storage
-        # 11 declares compileSdk = 37 (10.3.1 declared 36), and AGP reacts by
+        # 37.0 is load-bearing, not padding. The pinned
+        # flutter_secure_storage package declares compileSdk = 37
+        # (10.3.1 declared 36), and AGP reacts by
         # trying to install the missing platform, which cannot work against
         # this read-only store SDK: the release build dies with "The SDK
         # directory is not writable" before assembling anything.

--- a/nix/devShells/flake-module.nix
+++ b/nix/devShells/flake-module.nix
@@ -78,7 +78,7 @@
       # to androidComposition above. composeAndroidPackages takes the cross
       # product of platformVersions, systemImageTypes and abiVersions, so
       # includeSystemImages there would download a TV image for each of the
-      # five build platforms and three build ABIs. Nothing here builds an APK:
+      # six build platforms and three build ABIs. Nothing here builds an APK:
       # the build SDK above stays the only one Gradle and the NDK linkers see.
       androidTvComposition = pkgs.androidenv.composeAndroidPackages {
         cmdLineToolsVersion = "13.0";

--- a/nix/devShells/flake-module.nix
+++ b/nix/devShells/flake-module.nix
@@ -56,7 +56,12 @@
         cmdLineToolsVersion = "13.0";
         platformToolsVersion = "35.0.2";
         buildToolsVersions = [ "30.0.3" "33.0.1" "34.0.0" "35.0.0" "36.0.0" ];
-        platformVersions = [ "30" "33" "34" "35" "36" ];
+        # 37.0 is load-bearing, not padding. The pinned flutter_secure_storage
+        # 11 declares compileSdk = 37 (10.3.1 declared 36), and AGP reacts by
+        # trying to install the missing platform, which cannot work against
+        # this read-only store SDK: the release build dies with "The SDK
+        # directory is not writable" before assembling anything.
+        platformVersions = [ "30" "33" "34" "35" "36" "37.0" ];
         abiVersions = [ "arm64-v8a" "armeabi-v7a" "x86_64" ];
         includeNDK = true;
         ndkVersions = [ "27.0.12077973" "28.2.13676358" ];
@@ -68,6 +73,27 @@
       ndkPath = "${androidSdk}/libexec/android-sdk/ndk/28.2.13676358";
       ndkBin =
         "${ndkPath}/toolchains/llvm/prebuilt/linux-x86_64/bin";
+
+      # The Android TV emulator runtime, composed on its own rather than added
+      # to androidComposition above. composeAndroidPackages takes the cross
+      # product of platformVersions, systemImageTypes and abiVersions, so
+      # includeSystemImages there would download a TV image for each of the
+      # five build platforms and three build ABIs. Nothing here builds an APK:
+      # the build SDK above stays the only one Gradle and the NDK linkers see.
+      androidTvComposition = pkgs.androidenv.composeAndroidPackages {
+        cmdLineToolsVersion = "13.0";
+        platformToolsVersion = "35.0.2";
+        buildToolsVersions = [ ];
+        platformVersions = [ "36" ];
+        abiVersions = [ "x86_64" ];
+        includeSystemImages = true;
+        systemImageTypes = [ "android-tv" ];
+        includeEmulator = true;
+        includeCmake = false;
+      };
+
+      androidTvSdk = androidTvComposition.androidsdk;
+      androidTvSdkRoot = "${androidTvSdk}/libexec/android-sdk";
 
       # Linux build dependencies for Flutter plugins
       linuxBuildDeps = with pkgs; [
@@ -102,9 +128,12 @@
         libxkbcommon
         libepoxy
       ];
-    in
-    {
-      devShells.android = pkgs.mkShell {
+
+      # The one Android build environment, shared by both shells. Everything a
+      # shell needs to compile the player lives here, so the TV shell cannot
+      # drift from the build shell: the env vars, the four Android targets'
+      # linker/CC/AR settings and the codegen hook are defined once.
+      androidShellAttrs = {
         buildInputs = [
           flutterPkg
           androidSdk
@@ -189,6 +218,21 @@
           echo ""
         '';
       };
+    in
+    {
+      devShells.android = pkgs.mkShell androidShellAttrs;
+
+      # Same shell plus the emulator runtime. The extra SDK is an input, never
+      # a PATH-priority change: the emulator, avdmanager and the API 36
+      # android-tv x86_64 image are read from MYDIA_ANDROID_TV_SDK_ROOT, so
+      # nothing here can displace the build SDK's own tools.
+      devShells.android-tv = pkgs.mkShell (androidShellAttrs // {
+        buildInputs = androidShellAttrs.buildInputs ++ [ androidTvSdk ];
+        MYDIA_ANDROID_TV_SDK_ROOT = androidTvSdkRoot;
+        shellHook = androidShellAttrs.shellHook + ''
+          echo "  mydia Android TV image               - API 36 x86_64"
+        '';
+      });
 
       # Exposed so CI can assert the pinned Flutter resolves without building an
       # SDK or any Android tooling:

--- a/player/CLAUDE.md
+++ b/player/CLAUDE.md
@@ -56,15 +56,26 @@ server, so they are not part of `./dev up`:
 ./dev player android shell      # .#android shell for manual commands
 ```
 
-`tv-run` needs Linux KVM and a graphical session: the emulator runs headful.
-Its first invocation fetches the ~990 MB API 36 TV system image plus the
-emulator into the Nix store. AVD state stays in the normal Android cache as
-`mydia-tv-api-36.avd/` and `mydia-tv-api-36.ini`; delete both to reset. It
-stops only an emulator that invocation started — one already running under that
-name is reused and left up. `AGENTS.md` has the full contract (including
-`-gpu host` and why).
+`tv-run` uses a second Nix shell, `.#android-tv`, with the pinned API 36
+revision 4 `android-tv` x86_64 image and emulator. Release APKs stay arm-only;
+x86_64 is debug/emulator only.
 
-Verify the TV tier from a second shell while a run is attached:
+- **Requirements:** Linux KVM (`/dev/kvm` readable and writable; user in the
+  `kvm` group) and a graphical Wayland or X11 session. The emulator is headful
+  and the runner refuses to start without a display. It passes `-gpu host`
+  because the `tv_1080p` software GLES path has crashed once the app paints;
+  try other `-gpu` modes if host GPU passthrough fails on your machine.
+- **First run** fetches the system image (~990 MB compressed, ~8.7 GB unpacked)
+  plus the emulator into the Nix store. Later runs reuse them; nothing is
+  installed with `sdkmanager`.
+- **AVD state** lives in `${ANDROID_AVD_HOME:-$HOME/.android/avd}` as
+  `mydia-tv-api-36.avd/` and `mydia-tv-api-36.ini`. Delete both to start clean.
+- **Ownership:** the run stops only an emulator it started. An already-running
+  `mydia-tv-api-36` is reused and left running on exit.
+- Extra arguments pass through to `flutter run`, e.g.
+  `./dev player android tv-run --dart-define=SOME_FLAG=1`.
+
+Inspect or drive the running emulator from a second shell:
 
 ```bash
 nix develop .#android-tv --command adb devices

--- a/player/CLAUDE.md
+++ b/player/CLAUDE.md
@@ -43,6 +43,32 @@ Deeper reference lives alongside this file in `player/docs/`:
 ./dev flutter test        # Run tests
 ```
 
+### Android and Android TV
+
+Android builds go through the root flake's dev shells instead of the web dev
+server, so they are not part of `./dev up`:
+
+```bash
+./dev player android build      # Release APK (arm only)
+./dev player android run        # Debug build on a connected device
+./dev player android tv-run     # Provision/start the pinned API 36 Android TV
+                                # emulator and run the debug app
+./dev player android shell      # .#android shell for manual commands
+```
+
+`tv-run` needs Linux KVM and a graphical session: the emulator runs headful.
+Its first invocation fetches the ~990 MB API 36 TV system image plus the
+emulator into the Nix store, AVD state stays in the normal Android cache as
+`mydia-tv-api-36`, and it stops only an emulator that invocation started — one
+already running under that name is reused and left up. `AGENTS.md` has the
+full contract.
+
+Verify the TV tier from a second shell while a run is attached:
+
+```bash
+nix develop .#android-tv --command adb devices
+```
+
 ### Development
 
 Access the player at: **http://localhost:4000/player**

--- a/player/CLAUDE.md
+++ b/player/CLAUDE.md
@@ -58,10 +58,11 @@ server, so they are not part of `./dev up`:
 
 `tv-run` needs Linux KVM and a graphical session: the emulator runs headful.
 Its first invocation fetches the ~990 MB API 36 TV system image plus the
-emulator into the Nix store, AVD state stays in the normal Android cache as
-`mydia-tv-api-36`, and it stops only an emulator that invocation started — one
-already running under that name is reused and left up. `AGENTS.md` has the
-full contract.
+emulator into the Nix store. AVD state stays in the normal Android cache as
+`mydia-tv-api-36.avd/` and `mydia-tv-api-36.ini`; delete both to reset. It
+stops only an emulator that invocation started — one already running under that
+name is reused and left up. `AGENTS.md` has the full contract (including
+`-gpu host` and why).
 
 Verify the TV tier from a second shell while a run is attached:
 

--- a/player/android/app/build.gradle.kts
+++ b/player/android/app/build.gradle.kts
@@ -36,23 +36,6 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-
-        ndk {
-            // x86_64 reaches emulators and Intel Chromebooks only, and cost
-            // 62 MB of a 165 MB APK. Dropping it takes the download to
-            // ~103 MB, which matters: a Chromecast with Google TV has a 4 GB
-            // /data and routinely sits near full, and an install there failed
-            // outright with 517 MB free.
-            //
-            // Both remaining ABIs are load-bearing. armeabi-v7a is the only
-            // one Chromecast with Google TV and most Android TV boxes can run
-            // (they have no arm64 userspace); arm64-v8a is the only one Pixel
-            // 7 and later can run (they have no 32-bit runtime).
-            //
-            // Requires disable-abi-filtering=true in ../gradle.properties, or
-            // the Flutter Gradle plugin overwrites this list.
-            abiFilters += listOf("armeabi-v7a", "arm64-v8a")
-        }
     }
 
     signingConfigs {
@@ -73,6 +56,25 @@ android {
             } else {
                 // Fall back to debug signing for local development
                 signingConfigs.getByName("debug")
+            }
+
+            ndk {
+                // Release serves physical phones and televisions. x86_64 is
+                // kept debug-only for local emulators so it does not add
+                // ~62 MB to the shipped APK.
+                //
+                // Both remaining ABIs are load-bearing. armeabi-v7a is the
+                // only one Chromecast with Google TV and most Android TV boxes
+                // can run (they have no arm64 userspace); arm64-v8a is the
+                // only one Pixel 7 and later can run (they have no 32-bit
+                // runtime). The size matters on exactly those devices: a
+                // Chromecast with Google TV has a 4 GB /data and routinely
+                // sits near full, and an install there failed outright with
+                // 517 MB free.
+                //
+                // Requires disable-abi-filtering=true in ../gradle.properties,
+                // or the Flutter Gradle plugin's own defaultConfig list wins.
+                abiFilters += listOf("armeabi-v7a", "arm64-v8a")
             }
         }
     }

--- a/player/tool/run_android_tv.sh
+++ b/player/tool/run_android_tv.sh
@@ -102,16 +102,20 @@ started_emulator=false
 emulator_log="$(mktemp -t mydia-android-tv.XXXXXX.log)"
 
 # Reached on normal exit, error exit, and Ctrl-C. Killing via `adb emu kill`
-# asks the emulator to shut down cleanly; the PID branch is a fallback for an
-# emulator that is running but never registered with adb. A pre-existing
-# matching emulator has started_emulator=false and is deliberately left up.
+# asks the emulator to shut down cleanly, and the PID is signalled too: the
+# console kill has nothing to reach when the emulator never registered with
+# adb, and it can also fail against a wedged console. A pre-existing matching
+# emulator has started_emulator=false and is deliberately left up.
 cleanup() {
     local status=$?
     trap - EXIT INT TERM
-    if [[ "$started_emulator" == true && -n "$emulator_serial" ]]; then
-        "$ADB" -s "$emulator_serial" emu kill >/dev/null 2>&1 || true
-    elif [[ "$started_emulator" == true && -n "$emulator_pid" ]]; then
-        kill "$emulator_pid" >/dev/null 2>&1 || true
+    if [[ "$started_emulator" == true ]]; then
+        if [[ -n "$emulator_serial" ]]; then
+            "$ADB" -s "$emulator_serial" emu kill >/dev/null 2>&1 || true
+        fi
+        if [[ -n "$emulator_pid" ]]; then
+            kill "$emulator_pid" >/dev/null 2>&1 || true
+        fi
     fi
     [[ -n "$emulator_pid" ]] && wait "$emulator_pid" 2>/dev/null || true
     rm -f "$emulator_log"
@@ -159,9 +163,13 @@ if [[ -z "$emulator_serial" ]]; then
     exit 1
 fi
 
-"$ADB" -s "$emulator_serial" wait-for-device
+# Bounded like the registration wait above: `adb wait-for-device` takes no
+# deadline of its own and would hang forever on an emulator that registered
+# but never came back online. The same deadline covers both stages.
 while [[ $SECONDS -lt $deadline ]]; do
-    [[ "$("$ADB" -s "$emulator_serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == 1 ]] && break
+    if [[ "$("$ADB" -s "$emulator_serial" get-state 2>/dev/null | tr -d '\r')" == device ]]; then
+        [[ "$("$ADB" -s "$emulator_serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == 1 ]] && break
+    fi
     sleep 2
 done
 if [[ "$("$ADB" -s "$emulator_serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != 1 ]]; then

--- a/player/tool/run_android_tv.sh
+++ b/player/tool/run_android_tv.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Provision and drive an Android TV emulator, then run the debug app on it.
+#
+# Runs inside the .#android-tv nix devShell (see ./dev player android tv-run),
+# which is the only thing that knows about MYDIA_ANDROID_TV_SDK_ROOT. Two
+# Android SDKs are in play and they are deliberately kept apart:
+#
+#   * MYDIA_ANDROID_TV_SDK_ROOT — the emulator, avdmanager and the API 36
+#     android-tv x86_64 system image. Read-only /nix/store content.
+#   * ANDROID_SDK_ROOT — the build SDK that Gradle, the NDK linkers and adb
+#     come from. Untouched by this script.
+#
+# Nothing here discovers a host SDK, falls back to Android Studio, or installs
+# anything with sdkmanager: the pinned store SDK is complete, and anything
+# else would make the run non-reproducible.
+#
+# Ownership contract: an emulator this script starts is killed on exit; an
+# emulator that was already running (matched by AVD name, never by "first adb
+# device") is left alone. That is what makes repeated runs cheap and safe.
+#
+# Usage, from the repo root:  ./dev player android tv-run [flutter run args]
+set -euo pipefail
+
+# Versioned AVD name: it prevents a stale image from an older API level being
+# silently reused when the pinned SDK moves forward.
+AVD_NAME="mydia-tv-api-36"
+SYSTEM_IMAGE="system-images;android-36;android-tv;x86_64"
+BOOT_TIMEOUT_SECONDS=300
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+: "${MYDIA_ANDROID_TV_SDK_ROOT:?Run through ./dev player android tv-run}"
+TV_SDK_ROOT="$MYDIA_ANDROID_TV_SDK_ROOT"
+EMULATOR="$TV_SDK_ROOT/emulator/emulator"
+# The pinned cmdline-tools release is 13.0; androidenv lays it out under that
+# version, not the conventional `latest` symlink Android Studio creates.
+AVDMANAGER="$TV_SDK_ROOT/cmdline-tools/13.0/bin/avdmanager"
+ADB="${ANDROID_SDK_ROOT:?The Android build shell did not set ANDROID_SDK_ROOT}/platform-tools/adb"
+
+for command_path in "$EMULATOR" "$AVDMANAGER" "$ADB"; do
+    if [[ ! -x "$command_path" ]]; then
+        echo "Error: required Android TV tool is unavailable: $command_path" >&2
+        exit 1
+    fi
+done
+
+if [[ -z "${WAYLAND_DISPLAY:-}" && -z "${DISPLAY:-}" ]]; then
+    echo "Error: Android TV emulator requires a graphical Wayland or X11 session" >&2
+    exit 1
+fi
+
+# Only a *matching* emulator counts. `adb devices` also lists physical phones,
+# unrelated emulators and offline stubs, and using the first device would
+# deploy to one of those instead.
+find_avd_serial() {
+    local serial name
+    while read -r serial state; do
+        [[ "$serial" == emulator-* && "$state" == device ]] || continue
+        name="$($ADB -s "$serial" emu avd name 2>/dev/null | head -n 1 || true)"
+        if [[ "$name" == "$AVD_NAME" ]]; then
+            printf '%s\n' "$serial"
+            return 0
+        fi
+    done < <("$ADB" devices | tail -n +2)
+    return 1
+}
+
+# Idempotent: create the AVD only when the exact name is absent. The prompt is
+# the "custom hardware profile?" question, answered no so the --device profile
+# is used as-is. avdmanager writes to the normal ${ANDROID_AVD_HOME:-$HOME/.android/avd}.
+if ! "$AVDMANAGER" list avd | grep -q "^[[:space:]]*Name: $AVD_NAME$"; then
+    echo "Creating Android TV AVD $AVD_NAME..."
+    printf 'no\n' | "$AVDMANAGER" create avd \
+        --force \
+        --name "$AVD_NAME" \
+        --package "$SYSTEM_IMAGE" \
+        --device tv_1080p
+fi
+
+emulator_pid=""
+emulator_serial=""
+started_emulator=false
+emulator_log="$(mktemp -t mydia-android-tv.XXXXXX.log)"
+
+# Reached on normal exit, error exit, and Ctrl-C. Killing via `adb emu kill`
+# asks the emulator to shut down cleanly; the PID branch is a fallback for an
+# emulator that is running but never registered with adb. A pre-existing
+# matching emulator has started_emulator=false and is deliberately left up.
+cleanup() {
+    local status=$?
+    trap - EXIT INT TERM
+    if [[ "$started_emulator" == true && -n "$emulator_serial" ]]; then
+        "$ADB" -s "$emulator_serial" emu kill >/dev/null 2>&1 || true
+    elif [[ "$started_emulator" == true && -n "$emulator_pid" ]]; then
+        kill "$emulator_pid" >/dev/null 2>&1 || true
+    fi
+    [[ -n "$emulator_pid" ]] && wait "$emulator_pid" 2>/dev/null || true
+    rm -f "$emulator_log"
+    exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+emulator_serial="$(find_avd_serial || true)"
+if [[ -z "$emulator_serial" ]]; then
+    if [[ ! -r /dev/kvm || ! -w /dev/kvm ]]; then
+        echo "Error: /dev/kvm must be readable and writable to start Android TV" >&2
+        echo "Add your user to the kvm group, then start a new login session." >&2
+        exit 1
+    fi
+
+    "$EMULATOR" -avd "$AVD_NAME" -no-boot-anim -no-snapshot \
+        >"$emulator_log" 2>&1 &
+    emulator_pid=$!
+    started_emulator=true
+fi
+
+# One deadline covers registration *and* boot, so a hung first stage cannot
+# double the wait the timeout advertises.
+deadline=$((SECONDS + BOOT_TIMEOUT_SECONDS))
+while [[ -z "$emulator_serial" && $SECONDS -lt $deadline ]]; do
+    if [[ -n "$emulator_pid" ]] && ! kill -0 "$emulator_pid" 2>/dev/null; then
+        echo "Error: Android TV emulator exited before registering with adb" >&2
+        tail -n 80 "$emulator_log" >&2
+        exit 1
+    fi
+    sleep 2
+    emulator_serial="$(find_avd_serial || true)"
+done
+
+if [[ -z "$emulator_serial" ]]; then
+    echo "Error: timed out waiting for $AVD_NAME to register with adb" >&2
+    tail -n 80 "$emulator_log" >&2
+    exit 1
+fi
+
+"$ADB" -s "$emulator_serial" wait-for-device
+while [[ $SECONDS -lt $deadline ]]; do
+    [[ "$("$ADB" -s "$emulator_serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == 1 ]] && break
+    sleep 2
+done
+if [[ "$("$ADB" -s "$emulator_serial" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != 1 ]]; then
+    echo "Error: timed out waiting for Android TV boot on $emulator_serial" >&2
+    tail -n 80 "$emulator_log" >&2
+    exit 1
+fi
+
+# The same contract the app relies on at runtime. A phone-shaped or non-TV
+# image would boot and accept the APK, then fail confusingly inside Leanback.
+if ! "$ADB" -s "$emulator_serial" shell pm list features \
+    | tr -d '\r' \
+    | grep -qx 'feature:android.software.leanback'; then
+    echo "Error: $emulator_serial is not an Android TV Leanback image" >&2
+    exit 1
+fi
+
+echo "Android TV ready on $emulator_serial; building Mydia Player..."
+cd "$ROOT_DIR/player"
+flutter pub get
+flutter pub run build_runner build
+# The explicit -d is the point of this script: no ambiguous multi-device prompt.
+flutter run --debug -d "$emulator_serial" "$@"

--- a/player/tool/run_android_tv.sh
+++ b/player/tool/run_android_tv.sh
@@ -78,6 +78,27 @@ find_avd_serial() {
     return 1
 }
 
+# Console ports are even; adb uses port+1. Pinning the console port makes the
+# serial (`emulator-<port>`) known before adb lists the device, so cleanup
+# cannot follow a later-discovered sibling AVD.
+pick_console_port() {
+    local port
+    for ((port = 5554; port <= 5584; port += 2)); do
+        if "$ADB" devices | awk '{print $1}' | grep -qx "emulator-$port"; then
+            continue
+        fi
+        if (echo >/dev/tcp/127.0.0.1/"$port") >/dev/null 2>&1; then
+            continue
+        fi
+        if (echo >/dev/tcp/127.0.0.1/"$((port + 1))") >/dev/null 2>&1; then
+            continue
+        fi
+        printf '%s\n' "$port"
+        return 0
+    done
+    return 1
+}
+
 # Idempotent: create the AVD only when the exact name is absent. The prompt is
 # the "custom hardware profile?" question, answered no so the --device profile
 # is used as-is. avdmanager writes to the normal ${ANDROID_AVD_HOME:-$HOME/.android/avd}.
@@ -98,6 +119,7 @@ fi
 
 emulator_pid=""
 emulator_serial=""
+cleanup_serial=""
 started_emulator=false
 emulator_log="$(mktemp -t mydia-android-tv.XXXXXX.log)"
 
@@ -110,8 +132,8 @@ cleanup() {
     local status=$?
     trap - EXIT INT TERM
     if [[ "$started_emulator" == true ]]; then
-        if [[ -n "$emulator_serial" ]]; then
-            "$ADB" -s "$emulator_serial" emu kill >/dev/null 2>&1 || true
+        if [[ -n "$cleanup_serial" ]]; then
+            "$ADB" -s "$cleanup_serial" emu kill >/dev/null 2>&1 || true
         fi
         if [[ -n "$emulator_pid" ]]; then
             kill "$emulator_pid" >/dev/null 2>&1 || true
@@ -137,7 +159,13 @@ if [[ -z "$emulator_serial" ]]; then
     # gfxstream's RenderThread as soon as the app painted (coredump:
     # libGLESv2.so <- gles2_decoder_context_t::decode). The host GPU path ran
     # the same workload with D-pad input for minutes without a crash, so pin it.
-    "${tv_sdk_env[@]}" "$EMULATOR" -avd "$AVD_NAME" -no-boot-anim -no-snapshot \
+    console_port="$(pick_console_port)" || {
+        echo "Error: no free emulator console port in 5554-5584" >&2
+        exit 1
+    }
+    cleanup_serial="emulator-$console_port"
+    "${tv_sdk_env[@]}" "$EMULATOR" -avd "$AVD_NAME" -port "$console_port" \
+        -no-boot-anim -no-snapshot \
         -gpu host \
         >"$emulator_log" 2>&1 &
     emulator_pid=$!
@@ -154,7 +182,13 @@ while [[ -z "$emulator_serial" && $SECONDS -lt $deadline ]]; do
         exit 1
     fi
     sleep 2
-    emulator_serial="$(find_avd_serial || true)"
+    if [[ -n "$cleanup_serial" ]]; then
+        if [[ "$("$ADB" -s "$cleanup_serial" get-state 2>/dev/null | tr -d '\r')" == device ]]; then
+            emulator_serial="$cleanup_serial"
+        fi
+    else
+        emulator_serial="$(find_avd_serial || true)"
+    fi
 done
 
 if [[ -z "$emulator_serial" ]]; then

--- a/player/tool/run_android_tv.sh
+++ b/player/tool/run_android_tv.sh
@@ -36,6 +36,18 @@ EMULATOR="$TV_SDK_ROOT/emulator/emulator"
 AVDMANAGER="$TV_SDK_ROOT/cmdline-tools/13.0/bin/avdmanager"
 ADB="${ANDROID_SDK_ROOT:?The Android build shell did not set ANDROID_SDK_ROOT}/platform-tools/adb"
 
+# The emulator and avdmanager resolve an AVD's system image through
+# ANDROID_SDK_ROOT/ANDROID_HOME, not by looking beside their own binary. Both
+# variables point at the *build* SDK in this shell, which has no system-images
+# tree at all, so the AVD would resolve to a missing directory and the emulator
+# would die with "Broken AVD system path". The TV tools get the TV root for
+# their own invocations only; adb and the Flutter/Gradle build keep theirs.
+tv_sdk_env=(
+    env
+    "ANDROID_SDK_ROOT=$TV_SDK_ROOT"
+    "ANDROID_HOME=$TV_SDK_ROOT"
+)
+
 for command_path in "$EMULATOR" "$AVDMANAGER" "$ADB"; do
     if [[ ! -x "$command_path" ]]; then
         echo "Error: required Android TV tool is unavailable: $command_path" >&2
@@ -55,7 +67,9 @@ find_avd_serial() {
     local serial name
     while read -r serial state; do
         [[ "$serial" == emulator-* && "$state" == device ]] || continue
-        name="$($ADB -s "$serial" emu avd name 2>/dev/null | head -n 1 || true)"
+        # The emulator console answers with CRLF, so the name arrives as
+        # "mydia-tv-api-36\r" and would never compare equal to $AVD_NAME.
+        name="$("$ADB" -s "$serial" emu avd name 2>/dev/null | tr -d '\r' | head -n 1 || true)"
         if [[ "$name" == "$AVD_NAME" ]]; then
             printf '%s\n' "$serial"
             return 0
@@ -67,9 +81,15 @@ find_avd_serial() {
 # Idempotent: create the AVD only when the exact name is absent. The prompt is
 # the "custom hardware profile?" question, answered no so the --device profile
 # is used as-is. avdmanager writes to the normal ${ANDROID_AVD_HOME:-$HOME/.android/avd}.
-if ! "$AVDMANAGER" list avd | grep -q "^[[:space:]]*Name: $AVD_NAME$"; then
+#
+# The listing is read into a variable rather than piped into `grep -q`: grep
+# exits on the first match, and under `pipefail` that early exit can fail the
+# pipeline while the AVD *is* present (seen during acceptance as an unnecessary
+# re-create of an AVD that already existed).
+avd_listing="$("$AVDMANAGER" list avd 2>/dev/null || true)"
+if ! grep -q "^[[:space:]]*Name: $AVD_NAME$" <<<"$avd_listing"; then
     echo "Creating Android TV AVD $AVD_NAME..."
-    printf 'no\n' | "$AVDMANAGER" create avd \
+    printf 'no\n' | "${tv_sdk_env[@]}" "$AVDMANAGER" create avd \
         --force \
         --name "$AVD_NAME" \
         --package "$SYSTEM_IMAGE" \
@@ -108,7 +128,13 @@ if [[ -z "$emulator_serial" ]]; then
         exit 1
     fi
 
-    "$EMULATOR" -avd "$AVD_NAME" -no-boot-anim -no-snapshot \
+    # The tv_1080p profile sets hw.gpu.enabled=no, so -gpu auto picks the
+    # software GLES translator, and that SwiftShader path segfaulted in
+    # gfxstream's RenderThread as soon as the app painted (coredump:
+    # libGLESv2.so <- gles2_decoder_context_t::decode). The host GPU path ran
+    # the same workload with D-pad input for minutes without a crash, so pin it.
+    "${tv_sdk_env[@]}" "$EMULATOR" -avd "$AVD_NAME" -no-boot-anim -no-snapshot \
+        -gpu host \
         >"$emulator_log" 2>&1 &
     emulator_pid=$!
     started_emulator=true
@@ -146,9 +172,13 @@ fi
 
 # The same contract the app relies on at runtime. A phone-shaped or non-TV
 # image would boot and accept the APK, then fail confusingly inside Leanback.
-if ! "$ADB" -s "$emulator_serial" shell pm list features \
-    | tr -d '\r' \
-    | grep -qx 'feature:android.software.leanback'; then
+#
+# Read the feature list into a variable for the same reason as the AVD listing
+# above: `grep -q` exits on the first match, and under `pipefail` that early
+# exit can fail the pipeline -- reporting a perfectly good TV image as not
+# Leanback.
+tv_features="$("$ADB" -s "$emulator_serial" shell pm list features | tr -d '\r')"
+if ! grep -qx 'feature:android.software.leanback' <<<"$tv_features"; then
     echo "Error: $emulator_serial is not an Android TV Leanback image" >&2
     exit 1
 fi

--- a/player/tool/run_android_tv.sh
+++ b/player/tool/run_android_tv.sh
@@ -107,7 +107,7 @@ pick_console_port() {
 # exits on the first match, and under `pipefail` that early exit can fail the
 # pipeline while the AVD *is* present (seen during acceptance as an unnecessary
 # re-create of an AVD that already existed).
-avd_listing="$("$AVDMANAGER" list avd 2>/dev/null || true)"
+avd_listing="$("${tv_sdk_env[@]}" "$AVDMANAGER" list avd 2>/dev/null || true)"
 if ! grep -q "^[[:space:]]*Name: $AVD_NAME$" <<<"$avd_listing"; then
     echo "Creating Android TV AVD $AVD_NAME..."
     printf 'no\n' | "${tv_sdk_env[@]}" "$AVDMANAGER" create avd \


### PR DESCRIPTION
## Summary
Adds `./dev player android tv-run` to provision a pinned API 36 Android TV AVD, boot it, and run the Flutter debug app on the real Leanback path (not `MYDIA_FORCE_TV`).

Ordinary `.#android` APK builds stay lean. A separate `.#android-tv` shell carries the emulator and `android-tv` x86_64 image. Release APKs remain arm-only; x86_64 is debug/emulator only.

## How to run
```bash
./dev player android tv-run
```
First invocation fetches ~990 MB compressed / ~8.7 GB unpacked image plus emulator. Needs Linux KVM and a graphical session.

## Verification
- 18 focused TV tests pass
- Release APK 108.6 MB, ABIs `arm64-v8a` + `armeabi-v7a` only
- Headful smoke: Leanback feature, `LEANBACK_LAUNCHER` → `dev.mydia.player/.MainActivity`, pairing UI, D-pad traversal via app semantics, ownership-aware cleanup
- `./dev mix precommit` passed (11505 tests, 0 failures) on the docs/runner-acceptance commit

## Notes
- Build SDK also includes `platforms;android-37.0` because `flutter_secure_storage` 11.0.0 requires compileSdk 37
- AVD manager lives at `cmdline-tools/13.0`, not `latest`
- `adb shell input` does not show Flutter's focus ring (IME deviceId -1); host keyboard into the emulator window does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running the Player app on an Android TV emulator through the development command line.
  - Added a dedicated Android TV development environment using a pinned API 36 emulator image.
  - Debug builds now support x86_64 emulators, while release builds remain limited to supported ARM architectures.
  - Added Android API 37 platform support for development.

- **Documentation**
  - Expanded Android TV setup guidance, including requirements, emulator storage, first-run downloads, and troubleshooting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->